### PR TITLE
fix: do not block if argos fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "yarn lint && yarn test:unit && yarn argos",
     "test:unit": "jest --runInBand",
     "test:watch": "yarn test:unit -- --watch",
-    "argos": "ARGOS_COMMIT=$TRAVIS_COMMIT ARGOS_BRANCH=$TRAVIS_BRANCH argos upload sandbox/argos/screenshots --token $ARGOS_TOKEN",
+    "argos": "ARGOS_COMMIT=$TRAVIS_COMMIT ARGOS_BRANCH=$TRAVIS_BRANCH argos upload sandbox/argos/screenshots --token $ARGOS_TOKEN || true",
     "lint": "eslint . --cache && echo \"eslint: no lint errors\"",
     "db:migrate:latest": "knex migrate:latest",
     "db:migrate:rollback": "knex migrate:rollback",


### PR DESCRIPTION
```sh
Sorry an error happened:
request to http://api.argos-ci.com/builds failed, reason: getaddrinfo ENOTFOUND api.argos-ci.com api.argos-ci.com:80
```