### PR TITLE
examples(vrtest): add a new integration example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@ node_modules/
 .env
 !db/structure.sql
 .eslintcache
-examples/**/yarn.lock
-examples/**/screenshots

--- a/examples/with-vrtest/.eslintrc.js
+++ b/examples/with-vrtest/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'import/extensions': 'off',
+  }
+}

--- a/examples/with-vrtest/.gitignore
+++ b/examples/with-vrtest/.gitignore
@@ -1,0 +1,3 @@
+/yarn.lock
+/screenshots
+.vrtest

--- a/examples/with-vrtest/README.md
+++ b/examples/with-vrtest/README.md
@@ -1,0 +1,40 @@
+# vrtest example
+
+## How to use
+
+Download the example [or clone the repo](https://github.com/argos-ci/argos):
+
+```bash
+curl https://codeload.github.com/argos-ci/argos/tar.gz/master | tar -xz --strip=2 argos-master/examples/with-vrtest
+cd with-vrtest
+```
+
+Install it and run:
+
+```bash
+docker-compose -f ../docker-compose.yml up
+npm install
+npm run test
+npm run argos
+```
+
+### OS X
+
+Due to issues with networking in OS X, getting the container to see the
+test page may require additional configuration as the `docker0` interface
+does not exist.
+
+You can create an alias for the loopback interface using the instructions
+provided at https://docs.docker.com/docker-for-mac/networking/#/there-is-no-docker0-bridge-on-macos
+
+```
+sudo ifconfig lo0 alias 10.200.10.1/24
+```
+
+## The idea behind the example
+
+This example features how to use [vrtest](https://github.com/nathanmarks/vrtest) with Argos CI.
+This is a test runner that allow to take screenshots of components in isolation.
+What do we mean by **component**?
+It's a piece of interface usable in different contexts.
+We are demonstrating components in the world of React, Angular and Vue.

--- a/examples/with-vrtest/components/angular/Button.js
+++ b/examples/with-vrtest/components/angular/Button.js
@@ -1,0 +1,19 @@
+/* eslint-disable max-len */
+import { Component } from '@angular/core'
+
+class Button {}
+Button.annotations = [
+  new Component({
+    selector: 'my-button',
+    template: `
+      <button
+        type="button"
+        style="background: linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%); border-radius: 3px; border: 0; color: white; height: 48px; font-size: 14px; padding: 0 30px; box-shadow: 0 3px 5px 2px rgba(255, 105, 135, .30)"
+      >
+        Angular
+      </button>
+    `,
+  }),
+]
+
+export default Button

--- a/examples/with-vrtest/components/react/Button.js
+++ b/examples/with-vrtest/components/react/Button.js
@@ -1,0 +1,22 @@
+import React from 'react'
+
+const style = {
+  background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
+  borderRadius: 3,
+  border: 0,
+  color: 'white',
+  height: 48,
+  fontSize: 14,
+  padding: '0 30px',
+  boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .30)',
+}
+
+function Button() {
+  return (
+    <button type="button" style={style}>
+      {'React'}
+    </button>
+  )
+}
+
+export default Button

--- a/examples/with-vrtest/components/vue/Button.vue
+++ b/examples/with-vrtest/components/vue/Button.vue
@@ -1,0 +1,16 @@
+<template>
+  <button
+    type="button"
+    v-bind:style="{
+      background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
+      borderRadius: '3px',
+      border: 0,
+      color: 'white',
+      height: '48px',
+      fontSize: '14px',
+      padding: '0 30px',
+      boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .30)',
+    }">
+    Vue
+  </button>
+</template>

--- a/examples/with-vrtest/package.json
+++ b/examples/with-vrtest/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "with-vrtest",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "webpack --config test/webpack.config.js && vrtest run --config vrtest.conf.js --record",
+    "argos": "argos upload screenshots --token $ARGOS_TOKEN || true"
+  },
+  "dependencies": {
+    "@angular/common": "^4.1.3",
+    "@angular/compiler": "^4.1.3",
+    "@angular/core": "^4.1.3",
+    "@angular/platform-browser": "^4.1.3",
+    "@angular/platform-browser-dynamic": "^4.1.3",
+    "argos-cli": "latest",
+    "babel-loader": "^7.0.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
+    "babel-preset-react": "^6.24.1",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
+    "reflect-metadata": "^0.1.10",
+    "vrtest": "^0.2.0",
+    "vue": "^2.3.3",
+    "vue-loader": "^12.2.0",
+    "vue-template-compiler": "^2.3.3",
+    "webpack": "^2.6.1",
+    "zone.js": "^0.8.11"
+  },
+  "license": "MIT"
+}

--- a/examples/with-vrtest/test/.babelrc
+++ b/examples/with-vrtest/test/.babelrc
@@ -1,0 +1,9 @@
+{
+  "presets": [
+    "react"
+  ],
+  plugins: [
+    'transform-object-rest-spread',
+    'transform-class-properties'
+  ]
+}

--- a/examples/with-vrtest/test/debug.html
+++ b/examples/with-vrtest/test/debug.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <title>vrtest</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0, maximum-scale=1, minimum-scale=1">
+    <style>body { background-color: white; }</style>
+    <script src="../.vrtest/tests.js"></script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/examples/with-vrtest/test/index.js
+++ b/examples/with-vrtest/test/index.js
@@ -1,0 +1,98 @@
+import 'reflect-metadata' // For Angular
+import 'zone.js' // For Angular
+import vrtest from 'vrtest/client'
+import React from 'react'
+import { render } from 'react-dom'
+import Vue from 'vue'
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic'
+import { NgModule, Component } from '@angular/core'
+import { BrowserModule } from '@angular/platform-browser'
+
+const requireTests = require.context('../components', true, /(js|vue)$/)
+const tests = requireTests.keys().reduce((res, path) => {
+  const [suite, name] = path.replace('./', '').replace(/.(js|vue)$/, '').split('/')
+  res.push({
+    path,
+    suite,
+    name,
+    case: requireTests(path),
+  })
+  return res
+}, [])
+
+function getElements() {
+  const rootEl = document.createElement('div')
+  rootEl.style.display = 'inline-block'
+  rootEl.style.padding = '8px'
+  const root2El = document.createElement('div')
+  rootEl.style.display = 'inline-block'
+  rootEl.appendChild(root2El)
+
+  return {
+    rootEl,
+    root2El,
+  }
+}
+
+let suite
+
+let elements = getElements()
+
+function cleanUp() {
+  const newElements = getElements()
+  elements.rootEl.remove()
+  document.body.appendChild(newElements.rootEl)
+
+  elements = newElements
+}
+
+tests.forEach(test => {
+  if (!suite || suite.name !== test.suite) {
+    suite = vrtest.createSuite(test.suite)
+  }
+
+  suite.createTest(test.name, () => {
+    cleanUp()
+
+    switch (test.suite) {
+      case 'react': {
+        // No need to use unmountComponentAtNode
+        // It's managed by React internally
+        const TestCase = test.case.default
+        render(<TestCase />, elements.root2El)
+        break
+      }
+      case 'vue':
+        // eslint-disable-next-line no-new
+        new Vue({
+          el: elements.root2El,
+          ...test.case,
+        })
+        break
+      case 'angular': {
+        const selector = test.case.default.annotations[0].selector
+        class AppComponent {}
+        AppComponent.annotations = [
+          new Component({
+            selector: elements.root2El,
+            template: `<${selector}></${selector}>`,
+          }),
+        ]
+
+        class AppModule {}
+        AppModule.annotations = [
+          new NgModule({
+            imports: [BrowserModule],
+            declarations: [AppComponent, test.case.default],
+            bootstrap: [AppComponent],
+          }),
+        ]
+
+        platformBrowserDynamic().bootstrapModule(AppModule)
+        break
+      }
+      default:
+        throw new Error('Framework not supported')
+    }
+  })
+})

--- a/examples/with-vrtest/test/webpack.config.js
+++ b/examples/with-vrtest/test/webpack.config.js
@@ -1,0 +1,25 @@
+const path = require('path')
+
+module.exports = {
+  entry: path.resolve(__dirname, 'index.js'),
+  output: {
+    path: path.resolve(__dirname, '../.vrtest'),
+    filename: 'tests.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+        query: {
+          cacheDirectory: true,
+        },
+      },
+      {
+        test: /\.vue$/,
+        loader: 'vue-loader',
+      },
+    ],
+  },
+}

--- a/examples/with-vrtest/vrtest.conf.js
+++ b/examples/with-vrtest/vrtest.conf.js
@@ -1,0 +1,31 @@
+const path = require('path')
+
+module.exports = {
+  tests: path.resolve(__dirname, '.vrtest/tests.js'),
+  testUrl: process.env.DOCKER_TEST_URL || 'http://10.200.10.1:3090',
+  storage: {
+    output: path.resolve(__dirname, '.vrtest'),
+    baseline: path.resolve(__dirname, 'screenshots'),
+  },
+  selenium: {
+    server: 'http://127.0.0.1:4444/wd/hub',
+  },
+  server: {
+    host: '0.0.0.0',
+    port: 3090,
+  },
+  profiles: [
+    {
+      name: 'chrome',
+      desiredCapabilities: {
+        browserName: 'chrome',
+      },
+    },
+    {
+      name: 'firefox',
+      desiredCapabilities: {
+        browserName: 'firefox',
+      },
+    },
+  ],
+}

--- a/examples/with-wdio/.gitignore
+++ b/examples/with-wdio/.gitignore
@@ -1,0 +1,2 @@
+/yarn.lock
+/screenshots


### PR DESCRIPTION
Use [vrtest](https://github.com/nathanmarks/vrtest) of @nathanmarks.

Input a component (React or Angular and Vue). For instance:
```jsx
import React from 'react'

const style = {
  background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
  borderRadius: 3,
  border: 0,
  color: 'white',
  height: 48,
  padding: '0 30px',
  boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .30)',
}

function Button() {
  return (
    <button type="button" style={style}>
      {'vrtest'}
    </button>
  )
}

export default Button
```

Output a screenshots:
![capture d ecran 2017-05-28 a 18 15 24](https://cloud.githubusercontent.com/assets/3165635/26530248/b4040ba2-43d1-11e7-8cfb-b59b5fd3eaf5.png)

For instance:
![capture d ecran 2017-05-28 a 15 01 19](https://cloud.githubusercontent.com/assets/3165635/26528935/9f0025f8-43b6-11e7-8618-0bd549a413da.png)
