### PR TITLE
fix(batch): Cast batchCount String to Int before comparison

### DIFF
--- a/src/server/routes/api.js
+++ b/src/server/routes/api.js
@@ -142,7 +142,7 @@ router.post(
 
     const buildUrl = await formatUrlFromBuild(build)
 
-    if (!data.batchCount || data.batchCount === build.batchCount) {
+    if (!data.batchCount || Number(data.batchCount) === build.batchCount) {
       await buildJob.push(build.id)
     }
 


### PR DESCRIPTION
`batchCount` may be a string if it was fetched from a system env.
This resulted in forever pending builds because of the strict comparison made with the actual batchCount in db.

I hesitated for a while about directly casting the value in the cli instead. Wasn't too sure. What do you think? @neoziro  
It would be cleaner from a server standpoint, but not too sure we can trust to client, since it may not always be the argos-cli.