### PR TITLE
Fix race condition when incrementing batchCount

### DIFF
--- a/src/server/routes/api.js
+++ b/src/server/routes/api.js
@@ -1,4 +1,4 @@
-import { transaction } from 'objection'
+import { transaction, raw } from 'objection'
 import { HttpError, formatters } from 'express-err'
 import express from 'express'
 import multer from 'multer'
@@ -75,7 +75,7 @@ async function useExistingBuild({ Build, ScreenshotBucket, data, repository }) {
   // @TODO Throw an error if batchCount is superior to expected
 
   if (build) {
-    await build.$query().patch({ batchCount: build.batchCount + 1 })
+    await build.$query().patch({ batchCount: raw('"batchCount" + 1')})
     return build
   }
 


### PR DESCRIPTION
Some Argos builds were forever pending because of a race condition in the way we incremented the batch counter.
There was a quick time gap between the fetching of the current batchCount and the update of the column.