### PR TITLE
Hide passing screenshots by default

### DIFF
--- a/apps/app/src/pages/Repository/BuildDetail/Screenshots.js
+++ b/apps/app/src/pages/Repository/BuildDetail/Screenshots.js
@@ -84,6 +84,9 @@ function ScreenshotDiffItem({
 }
 
 export default function BuildDetailScreenshots({ build }) {
+  const [showPassingScreenshots, setShowPassingScreenshots] = React.useState(
+    false,
+  )
   const { screenshotDiffs } = build
   screenshotDiffs.sort((itemA, itemB) =>
     itemA.validationStatus > itemB.validationStatus
@@ -100,10 +103,25 @@ export default function BuildDetailScreenshots({ build }) {
           <CardHeader>
             <CardTitle>Screenshots</CardTitle>
           </CardHeader>
-          {screenshotDiffs.map((screenshotDiff, index) => (
-            <ScreenshotDiffItem key={index} screenshotDiff={screenshotDiff} />
-          ))}
+          {screenshotDiffs.map(
+            (screenshotDiff, index) =>
+              (showPassingScreenshots || screenshotDiff.score !== 0) && (
+                <ScreenshotDiffItem
+                  key={index}
+                  screenshotDiff={screenshotDiff}
+                />
+              ),
+          )}
         </Card>
+        <Box mt={{ xs: 3 }}>
+          <Button
+            onClick={() => setShowPassingScreenshots(!showPassingScreenshots)}
+          >
+            {showPassingScreenshots
+              ? 'Hide passing screenshots'
+              : 'Show passing screenshots'}
+          </Button>
+        </Box>
       </Box>
     </Box>
   )


### PR DESCRIPTION
Hi Greg,

On our builds for Doctolib, we now have something like 3k screenshots and the page takes a while to load. Some of the time is spent waiting for the server payload to arrive but it seems there is also quite some time spent client side building the UI once the payload has arrived. The loading animation actually freezes on my computer. This PR hopes to alleviate that by hiding passing screenshots by default (while still providing a link to toggle them). In my experience using Argos, passing screenshots are rarely useful, that would be one extra click for the rare cases when you need them.
What do you think?