### PR TITLE
feat: logger throws prod errors

### DIFF
--- a/apps/logger/src/index.js
+++ b/apps/logger/src/index.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-console */
+import * as Sentry from "@sentry/node";
+
 const logger = {
   info: (...args) => {
     if (process.env.NODE_ENV === "test") {
@@ -12,6 +14,11 @@ const logger = {
       throw new Error(args);
     }
 
+    if (args[0] instanceof Error) {
+      Sentry.captureException(args[0]);
+    } else if (typeof args[0] === "string") {
+      Sentry.captureMessage(args[0]);
+    }
     console.error(...args);
   },
   success: (...args) => {


### PR DESCRIPTION
I need to monitor production errors on Sentry. The previous logger hides the errors.
@gregberge can you confirm if that's a good fix?