### PR TITLE
chore: add middlewares to auth as repo

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "@octokit/rest": "^19.0.3",
     "@octokit/webhooks": "^10.1.2",
     "@sentry/node": "^7.9.0",
+    "auth-header": "^1.0.0",
     "axios": "^0.27.2",
     "body-parser": "^1.20.0",
     "compression": "^1.7.4",

--- a/apps/web/src/authorizations/bearerAuth.js
+++ b/apps/web/src/authorizations/bearerAuth.js
@@ -1,0 +1,31 @@
+import * as authorization from "auth-header";
+import { HttpError } from "express-err";
+
+const parseAuthHeader = (authHeader) => {
+  try {
+    return authorization.parse(authHeader);
+  } catch (error) {
+    const httpError = new HttpError(400, `Invalid authorization header`);
+    httpError.cause = httpError;
+    throw httpError;
+  }
+};
+
+export const bearerAuth = (req, _res, next) => {
+  const authHeader = req.get("authorization");
+
+  if (!authHeader) {
+    throw new HttpError(400, `Authorization header is missing`);
+  }
+
+  const authorization = parseAuthHeader(authHeader);
+
+  if (authorization.scheme !== "Bearer") {
+    throw new HttpError(
+      400,
+      `Invalid authorization header scheme "${authorization.scheme}", please use "Bearer"`
+    );
+  }
+  req.bearerToken = authorization.token;
+  next();
+};

--- a/apps/web/src/authorizations/bearerAuth.test.js
+++ b/apps/web/src/authorizations/bearerAuth.test.js
@@ -1,0 +1,61 @@
+import request from "supertest";
+import express from "express";
+import { bearerAuth } from "./bearerAuth";
+
+const app = express();
+app.use(
+  bearerAuth,
+  (req, res) => {
+    res.send({ bearerToken: req.bearerToken });
+  },
+  // eslint-disable-next-line no-unused-vars
+  (_err, _req, res, _next) => {
+    if (_err.statusCode) {
+      res.status(_err.statusCode);
+    }
+
+    res.send(_err.message);
+  }
+);
+
+describe("bearerAuth", () => {
+  it("returns 400 without auth token", async () => {
+    await request(app)
+      .get("/")
+      .expect((res) => {
+        expect(res.text).toBe("Authorization header is missing");
+      })
+      .expect(400);
+  });
+
+  it("returns 400 with an invalid token", async () => {
+    await request(app)
+      .get("/")
+      .set("Authorization", "xxx")
+      .expect((res) => {
+        expect(res.text).toBe("Invalid authorization header");
+      })
+      .expect(400);
+  });
+
+  it("returns 400 with an invalid scheme", async () => {
+    await request(app)
+      .get("/")
+      .set("Authorization", "Beee xx")
+      .expect((res) => {
+        expect(res.text).toBe(
+          `Invalid authorization header scheme "Beee", please use "Bearer"`
+        );
+      })
+      .expect(400);
+  });
+
+  // eslint-disable-next-line jest/expect-expect
+  it("puts bearerToken in req if everything good", async () => {
+    await request(app)
+      .get("/")
+      .set("Authorization", "Bearer cred-x")
+      .expect({ bearerToken: "cred-x" })
+      .expect(200);
+  });
+});

--- a/apps/web/src/authorizations/repoAuth.js
+++ b/apps/web/src/authorizations/repoAuth.js
@@ -1,0 +1,23 @@
+import { HttpError } from "express-err";
+import { Repository } from "@argos-ci/database/models";
+import { bearerAuth } from "./bearerAuth";
+import { asyncHandler } from "../util";
+
+export const repoAuth = [
+  bearerAuth,
+  asyncHandler(async (req, _res, next) => {
+    const repository = await Repository.query().findOne({
+      token: req.bearerToken,
+    });
+
+    if (!repository) {
+      throw new HttpError(
+        401,
+        `Repository not found (token: "${req.bearerToken}")`
+      );
+    }
+
+    req.authRepository = repository;
+    next();
+  }),
+];

--- a/apps/web/src/authorizations/repoAuth.test.js
+++ b/apps/web/src/authorizations/repoAuth.test.js
@@ -1,0 +1,55 @@
+import request from "supertest";
+import express from "express";
+import { repoAuth } from "./repoAuth";
+import { useDatabase, factory } from "@argos-ci/database/testing";
+
+const app = express();
+app.use(
+  repoAuth,
+  (req, res) => {
+    res.send({ authRepository: req.authRepository });
+  },
+  // eslint-disable-next-line no-unused-vars
+  (_err, _req, res, _next) => {
+    if (_err.statusCode) {
+      res.status(_err.statusCode);
+    }
+
+    res.send(_err.message);
+  }
+);
+
+describe("repoAuth", () => {
+  let repository;
+
+  useDatabase();
+
+  beforeEach(async () => {
+    repository = await factory.create("Repository", {
+      enabled: false,
+      name: "foo",
+      token: "the-awesome-token",
+    });
+  });
+
+  it("returns 401 without a valid token", async () => {
+    await request(app)
+      .get("/")
+      .set("Authorization", "Bearer invalid-token")
+      .expect((res) => {
+        expect(res.text).toBe(`Repository not found (token: "invalid-token")`);
+      })
+      .expect(401);
+  });
+
+  // eslint-disable-next-line jest/expect-expect
+  it("puts authRepository in req with a valid token", async () => {
+    await request(app)
+      .get("/")
+      .set("Authorization", "Bearer the-awesome-token")
+      .expect((res) => {
+        expect(res.body.authRepository.id).toBe(repository.id);
+      })
+      .expect(200);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -262,6 +262,7 @@
         "@octokit/rest": "^19.0.3",
         "@octokit/webhooks": "^10.1.2",
         "@sentry/node": "^7.9.0",
+        "auth-header": "^1.0.0",
         "axios": "^0.27.2",
         "body-parser": "^1.20.0",
         "compression": "^1.7.4",
@@ -6592,6 +6593,11 @@
       "engines": {
         "node": ">= 4.5.0"
       }
+    },
+    "node_modules/auth-header": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/auth-header/-/auth-header-1.0.0.tgz",
+      "integrity": "sha512-CPPazq09YVDUNNVWo4oSPTQmtwIzHusZhQmahCKvIsk0/xH6U3QsMAv3sM+7+Q0B1K2KJ/Q38OND317uXs4NHA=="
     },
     "node_modules/axios": {
       "version": "0.27.2",
@@ -18869,6 +18875,7 @@
         "@octokit/rest": "^19.0.3",
         "@octokit/webhooks": "^10.1.2",
         "@sentry/node": "^7.9.0",
+        "auth-header": "^1.0.0",
         "axios": "^0.27.2",
         "body-parser": "^1.20.0",
         "compression": "^1.7.4",
@@ -23584,6 +23591,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+    },
+    "auth-header": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/auth-header/-/auth-header-1.0.0.tgz",
+      "integrity": "sha512-CPPazq09YVDUNNVWo4oSPTQmtwIzHusZhQmahCKvIsk0/xH6U3QsMAv3sM+7+Q0B1K2KJ/Q38OND317uXs4NHA=="
     },
     "axios": {
       "version": "0.27.2",


### PR DESCRIPTION
These middlewares will be used in the new upload API to handle authorization from the repository token.