### PR TITLE
feat(build): use progress bar as pregression indicator

### DIFF
--- a/apps/app/src/components/ProgressBar.js
+++ b/apps/app/src/components/ProgressBar.js
@@ -1,9 +1,21 @@
 import * as React from "react";
 import { x } from "@xstyled/styled-components";
 
-export function ProgressBar({ score, total, ...props }) {
+export function ProgressBar({
+  score,
+  total,
+  progressColor = "primary",
+  updateColor = false,
+  ...props
+}) {
   const progression = Math.min(1, score / total);
   const value = Math.floor(progression * 100);
+  const progressiveColor =
+    progression === 1
+      ? "danger"
+      : progression > 0.75
+      ? "warning"
+      : progressColor;
 
   return (
     <x.div
@@ -23,13 +35,7 @@ export function ProgressBar({ score, total, ...props }) {
         minW={2}
         h={1}
         borderRadius="md"
-        backgroundColor={
-          progression === 1
-            ? "danger"
-            : progression > 0.75
-            ? "warning"
-            : "primary"
-        }
+        backgroundColor={updateColor ? progressiveColor : progressColor}
       />
     </x.div>
   );

--- a/apps/app/src/components/Theme.js
+++ b/apps/app/src/components/Theme.js
@@ -26,6 +26,9 @@ export const theme = {
     "primary-text": "white",
     "secondary-text": defaultTheme.colors["gray-400"],
     tooltip: defaultTheme.colors["gray-700"],
+
+    warning: defaultTheme.colors["orange-500"],
+    danger: defaultTheme.colors["red-500"],
   },
   sizes: {
     ...defaultTheme.sizes,

--- a/apps/app/src/pages/Build/SummaryCard.js
+++ b/apps/app/src/pages/Build/SummaryCard.js
@@ -15,10 +15,7 @@ import {
   Link,
   IllustratedText,
   Time,
-  Icon,
-  Tooltip,
-  TooltipAnchor,
-  useTooltipState,
+  ProgressBar,
 } from "@argos-ci/app/src/components";
 import {
   UpdateStatusButton,
@@ -108,29 +105,27 @@ export function StickySummaryMenu({ repository, build, ...props }) {
   );
 }
 
-function ExpectedBatch() {
-  const tooltip = useTooltipState();
+function ProgressField({ build: { batchCount, totalBatch } }) {
+  if (batchCount === totalBatch) {
+    return (
+      <IllustratedText field icon={FileZipIcon} color="primary-text">
+        All batches received
+      </IllustratedText>
+    );
+  }
 
   return (
-    <>
-      <TooltipAnchor state={tooltip}>
-        <Icon as={FileZipIcon} color="secondary-text" title="received batch" />
-      </TooltipAnchor>
-      <Tooltip state={tooltip}>Expected batch</Tooltip>
-    </>
-  );
-}
-
-function ReceivedBatch() {
-  const tooltip = useTooltipState();
-
-  return (
-    <>
-      <TooltipAnchor state={tooltip}>
-        <Icon as={FileZipIcon} color="primary-text" title="received batch" />
-      </TooltipAnchor>
-      <Tooltip state={tooltip}>Received batch</Tooltip>
-    </>
+    <x.div maxW={250}>
+      <x.div display="flex" justifyContent="space-between">
+        <IllustratedText field icon={FileZipIcon}>
+          Batch received
+        </IllustratedText>
+        <div>
+          {batchCount} / {totalBatch}
+        </div>
+      </x.div>
+      <ProgressBar score={batchCount} total={totalBatch} mt={1} />
+    </x.div>
   );
 }
 
@@ -152,28 +147,7 @@ export function SummaryCard({ build }) {
 
         <CommitFields build={build} />
 
-        {build.totalBatch ? (
-          <x.div whiteSpace="nowrap" gridColumn="1 / span 2">
-            {build.batchCount === build.totalBatch ? (
-              <>
-                <IllustratedText field icon={FileZipIcon} color="primary-text">
-                  All batches received
-                </IllustratedText>
-              </>
-            ) : (
-              <x.div display="flex" gap={2} flexWrap="wrap">
-                Batch received:
-                {Array.from({ length: build.totalBatch }, (_, index) =>
-                  index < build.batchCount ? (
-                    <ReceivedBatch key={index} />
-                  ) : (
-                    <ExpectedBatch key={index} />
-                  )
-                )}
-              </x.div>
-            )}
-          </x.div>
-        ) : null}
+        {build.totalBatch ? <ProgressField build={build} /> : null}
       </CardBody>
     </Card>
   );

--- a/apps/app/src/pages/Owner/GeneralSettings.js
+++ b/apps/app/src/pages/Owner/GeneralSettings.js
@@ -128,6 +128,7 @@ function UsageCard({
         <ProgressBar
           score={currentMonthUsedScreenshots}
           total={screenshotsLimitPerMonth}
+          updateColor
           mt={2}
         />
         <CardTitle mt={4} mb={2}>


### PR DESCRIPTION
I took some screenshots to help review
<img width="945" alt="Capture d’écran 2022-09-15 à 10 26 34" src="https://user-images.githubusercontent.com/15954562/190390237-206966d5-0020-4bab-832d-045365b78835.png">
<img width="834" alt="Capture d’écran 2022-09-15 à 10 27 11" src="https://user-images.githubusercontent.com/15954562/190390246-9649b646-e015-4028-89b6-c25becf280a3.png">
<img width="478" alt="Capture d’écran 2022-09-15 à 10 26 39" src="https://user-images.githubusercontent.com/15954562/190390249-07340a0a-970f-4971-a252-8046f8e40032.png">
