### PR TITLE
fix(argos): increase signed URL validity duration

### DIFF
--- a/apps/web/src/api/v2/builds/create.ts
+++ b/apps/web/src/api/v2/builds/create.ts
@@ -106,7 +106,7 @@ const getScreenshots = async (keys: string[]) => {
         s3,
         Key: key,
         Bucket: screenshotsBucket,
-        expiresIn: 180,
+        expiresIn: 1800, // 30 minutes
       })
     )
   );


### PR DESCRIPTION
We increase the signed URL validity duration to 30 minutes. The upload of screenshots could be significantly longer than 3 minutes. Also it is not a security problem to authorize it for 30 minutes.