### PR TITLE
refactor: make `Build.getUrl` safe

### DIFF
--- a/apps/build-notification/src/notifications.ts
+++ b/apps/build-notification/src/notifications.ts
@@ -119,7 +119,7 @@ export const processBuildNotification = async (
   buildNotification: BuildNotification
 ) => {
   await buildNotification.$fetchGraph(
-    `build.[project.githubRepository.[githubAccount,activeInstallation], compareScreenshotBucket]`
+    `build.[project.[githubRepository.[githubAccount,activeInstallation], account], compareScreenshotBucket]`
   );
 
   const { build } = buildNotification;
@@ -151,14 +151,14 @@ export const processBuildNotification = async (
   const installation = githubRepository.activeInstallation;
 
   if (!installation) {
-    return null;
+    return;
   }
 
   const notification = await getNotificationPayload(buildNotification);
   const octokit = await getInstallationOctokit(installation.id);
 
   if (!octokit) {
-    return null;
+    return;
   }
 
   const buildUrl = await build.getUrl();

--- a/apps/database/src/models/Build.test.ts
+++ b/apps/database/src/models/Build.test.ts
@@ -340,9 +340,12 @@ describe("models/Build", () => {
     it("should return url", async () => {
       const build = await factory.create<Build>("Build");
       const url = await build.getUrl();
+      const project = await build
+        .$relatedQuery("project")
+        .withGraphFetched("account");
       expect(url).toMatch(
-        `http://localhost:4001/${build.project!.account!.slug}/${
-          build.project!.name
+        `http://localhost:4001/${project!.account!.slug}/${
+          project!.name
         }/builds/${build.number}`
       );
     });

--- a/apps/database/src/models/Build.ts
+++ b/apps/database/src/models/Build.ts
@@ -304,18 +304,15 @@ export class Build extends Model {
   }
 
   async getUrl({ trx }: { trx?: TransactionOrKnex } = {}) {
-    if (!this.project?.account) {
-      await this.$fetchGraph(
-        "project.account",
-        trx ? { transaction: trx } : undefined
-      );
-    }
+    const project =
+      this.project ??
+      (await this.$relatedQuery("project", trx).withGraphFetched("account"));
 
-    if (!this.project?.account) {
+    if (!project?.account) {
       throw new Error("Account not found");
     }
 
-    const pathname = `/${this.project.account.slug}/${this.project.name}/builds/${this.number}`;
+    const pathname = `/${project.account.slug}/${project.name}/builds/${this.number}`;
 
     return `${config.get("server.url")}${pathname}`;
   }

--- a/apps/github/src/client.ts
+++ b/apps/github/src/client.ts
@@ -39,12 +39,9 @@ export const getInstallationOctokit = async (
   installationId: string,
   appOctokit = getAppOctokit()
 ): Promise<Octokit | null> => {
-  const installation = await GithubInstallation.query().findById(
-    installationId
-  );
-  if (!installation) {
-    throw new Error(`GithubInstallation not found for id "${installationId}"`);
-  }
+  const installation = await GithubInstallation.query()
+    .findById(installationId)
+    .throwIfNotFound();
   if (installation.githubToken && installation.githubTokenExpiresAt) {
     const expiredAt = Number(new Date(installation.githubTokenExpiresAt));
     const now = Date.now();


### PR DESCRIPTION
$fetchGraph resets other fields
