### PR TITLE
feat(build): put GitHub status in failure on diff

### DIFF
--- a/apps/build-notification/src/notifications.ts
+++ b/apps/build-notification/src/notifications.ts
@@ -73,7 +73,7 @@ const getNotificationStatus = (
       return {
         githubState: isReference
           ? GithubNotificationState.Success
-          : GithubNotificationState.Pending,
+          : GithubNotificationState.Failure,
         vercelStatus: VercelStatus.Completed,
         vercelConclusion: isReference
           ? VercelConclusion.Succeeded


### PR DESCRIPTION
When a diff is detected we should put it in failure instead of pending.

Pending means: it is not finished, I am awaiting for something.

Actually the Argos build is finished and an error has been detected.

It was the original behaviour of Argos and it was better.
