### PR TITLE
fix: no active purchase for forcedPlan

### DIFF
--- a/apps/database/src/models/Account.ts
+++ b/apps/database/src/models/Account.ts
@@ -145,6 +145,7 @@ export class Account extends Model {
 
   async $getActivePurchase() {
     if (!this.id) return null;
+    if (this.forcedPlanId) return null;
 
     const query = Purchase.query()
       .where("accountId", this.id)


### PR DESCRIPTION
When there is a `forcedPlan` we don't want to show anything about an active purchase.