### PR TITLE
fix(tokenless): use HTTP 400 for multiple repo

### DIFF
--- a/apps/web/src/middlewares/tokenless-strategies/github-actions.ts
+++ b/apps/web/src/middlewares/tokenless-strategies/github-actions.ts
@@ -63,7 +63,7 @@ const strategy = {
 
     if (repository.projects.length > 1) {
       throw new HttpError(
-        500,
+        400,
         `Multiple projects found for GitHub repository (token: "${bearerToken}"). Please specify a Project token.`,
       );
     }


### PR DESCRIPTION
Fix ARGOS-SERVER-XJB