### PR TITLE
collaboration warning dialog

### DIFF
--- a/apps/app/src/containers/Breadcrumb/AccountBreadcrumbMenu.tsx
+++ b/apps/app/src/containers/Breadcrumb/AccountBreadcrumbMenu.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@apollo/client";
-import { UserPlus2Icon } from "lucide-react";
+import { PlusCircleIcon } from "lucide-react";
 import { Link as RouterLink, matchPath, useLocation } from "react-router-dom";
 
 import { FragmentType, graphql, useFragment } from "@/gql";
@@ -85,7 +85,7 @@ const MenuContent = (props: { menu: MenuState }) => {
         {(menuItemProps) => (
           <RouterLink {...menuItemProps} to="/teams/new">
             <MenuItemIcon>
-              <UserPlus2Icon />
+              <PlusCircleIcon />
             </MenuItemIcon>
             Create a Team
           </RouterLink>

--- a/apps/app/src/containers/NavUserControl.tsx
+++ b/apps/app/src/containers/NavUserControl.tsx
@@ -4,7 +4,6 @@ import {
   MonitorIcon,
   MoonIcon,
   SunIcon,
-  UserPlus2Icon,
   PlusCircleIcon,
 } from "lucide-react";
 
@@ -157,7 +156,7 @@ const UserMenu = () => {
           {(menuItemProps) => (
             <RouterLink {...menuItemProps} to={`/teams/new`}>
               <MenuItemIcon>
-                <UserPlus2Icon />
+                <PlusCircleIcon />
               </MenuItemIcon>
               New Team
             </RouterLink>

--- a/apps/app/src/containers/PlanCard.tsx
+++ b/apps/app/src/containers/PlanCard.tsx
@@ -1,8 +1,14 @@
 import { FetchResult, useMutation } from "@apollo/client";
-import { UserPlus2Icon, ChevronDownIcon, ChevronRightIcon } from "lucide-react";
+import {
+  UserPlus2Icon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  PlusCircleIcon,
+} from "lucide-react";
 import {
   Disclosure,
   DisclosureContent,
+  DisclosureState,
   useDisclosureState,
 } from "ariakit/disclosure";
 import { clsx } from "clsx";
@@ -28,6 +34,7 @@ import { ContactLink } from "@/ui/ContactLink";
 import {
   Dialog,
   DialogBody,
+  DialogDisclosure,
   DialogDismiss,
   DialogFooter,
   DialogState,
@@ -425,7 +432,7 @@ const PrimaryCta = ({
         {(buttonProps) => (
           <RouterLink to="/teams/new" {...buttonProps}>
             <ButtonIcon>
-              <UserPlus2Icon />
+              <PlusCircleIcon />
             </ButtonIcon>
             Create a Team
           </RouterLink>
@@ -492,7 +499,57 @@ const ManageSubscriptionButton = ({
   return null;
 };
 
-export const PlanCard = (props: { account: AccountFragment }) => {
+const CollaborationWarningButton = ({
+  dialog,
+}: {
+  dialog: DisclosureState;
+}) => {
+  return (
+    <>
+      <DialogDisclosure state={dialog}>
+        {(disclosureProps) => (
+          <Button {...disclosureProps} color="neutral" variant="outline">
+            <ButtonIcon>
+              <UserPlus2Icon />
+            </ButtonIcon>
+            Invite member
+          </Button>
+        )}
+      </DialogDisclosure>
+      <Dialog
+        state={dialog}
+        style={{ width: 560 }}
+        aria-label="Collaboration Warning"
+      >
+        <DialogBody>
+          <DialogTitle>Let's create a Team!</DialogTitle>
+          <DialogText>
+            You are on a personal account. To invite members and collaborate,
+            create a team and transfer your project there.
+          </DialogText>
+        </DialogBody>
+        <DialogFooter>
+          <DialogDismiss>Maybe Later</DialogDismiss>
+          <Button>
+            {(buttonProps) => (
+              <RouterLink to="/teams/new" {...buttonProps}>
+                <ButtonIcon>
+                  <PlusCircleIcon />
+                </ButtonIcon>
+                Create a Team
+              </RouterLink>
+            )}
+          </Button>
+        </DialogFooter>
+      </Dialog>
+    </>
+  );
+};
+
+export const PlanCard = (props: {
+  account: AccountFragment;
+  isTeam: boolean;
+}) => {
   const account = useFragment(PlanCardFragment, props.account);
   const {
     plan,
@@ -504,6 +561,8 @@ export const PlanCard = (props: { account: AccountFragment }) => {
     trialStatus,
     paymentProvider,
   } = account;
+
+  const collaborationWarningDialog = useDialogState();
 
   const [showTrialEndDialog, setShowTrialEndDialog] = useState(false);
   const confirmTrialEndDialogState = useDialogState({
@@ -584,22 +643,37 @@ export const PlanCard = (props: { account: AccountFragment }) => {
               />
             </div>
 
-            <div className="flex items-center gap-4">
-              Custom needs?
-              <Button color="neutral" variant="outline">
-                {(buttonProps) => (
-                  <a
-                    href={`mailto:${config.get("contactEmail")}`}
-                    {...buttonProps}
-                  >
-                    Contact Sales
-                  </a>
+            <div
+              className={clsx(
+                "flex items-center gap-4",
+                !props.isTeam && "w-full justify-between",
+              )}
+            >
+              <div className="flex items-center gap-4">
+                Custom needs?
+                <Button color="neutral" variant="outline">
+                  {(buttonProps) => (
+                    <a
+                      href={`mailto:${config.get("contactEmail")}`}
+                      {...buttonProps}
+                    >
+                      Contact Sales
+                    </a>
+                  )}
+                </Button>
+              </div>
+
+              <div className="flex items-center gap-4">
+                {!props.isTeam && (
+                  <CollaborationWarningButton
+                    dialog={collaborationWarningDialog}
+                  />
                 )}
-              </Button>
-              <PrimaryCta
-                purchaseStatus={purchaseStatus}
-                accountId={account.id}
-              />
+                <PrimaryCta
+                  purchaseStatus={purchaseStatus}
+                  accountId={account.id}
+                />
+              </div>
             </div>
           </div>
         )}

--- a/apps/app/src/containers/PlanCard.tsx
+++ b/apps/app/src/containers/PlanCard.tsx
@@ -1,6 +1,5 @@
 import { FetchResult, useMutation } from "@apollo/client";
 import {
-  UserPlus2Icon,
   ChevronDownIcon,
   ChevronRightIcon,
   PlusCircleIcon,
@@ -8,7 +7,6 @@ import {
 import {
   Disclosure,
   DisclosureContent,
-  DisclosureState,
   useDisclosureState,
 } from "ariakit/disclosure";
 import { clsx } from "clsx";
@@ -34,7 +32,6 @@ import { ContactLink } from "@/ui/ContactLink";
 import {
   Dialog,
   DialogBody,
-  DialogDisclosure,
   DialogDismiss,
   DialogFooter,
   DialogState,
@@ -499,53 +496,6 @@ const ManageSubscriptionButton = ({
   return null;
 };
 
-const CollaborationWarningButton = ({
-  dialog,
-}: {
-  dialog: DisclosureState;
-}) => {
-  return (
-    <>
-      <DialogDisclosure state={dialog}>
-        {(disclosureProps) => (
-          <Button {...disclosureProps} color="neutral" variant="outline">
-            <ButtonIcon>
-              <UserPlus2Icon />
-            </ButtonIcon>
-            Invite member
-          </Button>
-        )}
-      </DialogDisclosure>
-      <Dialog
-        state={dialog}
-        style={{ width: 560 }}
-        aria-label="Collaboration Warning"
-      >
-        <DialogBody>
-          <DialogTitle>Let's create a Team!</DialogTitle>
-          <DialogText>
-            You are on a personal account. To invite members and collaborate,
-            create a team and transfer your project there.
-          </DialogText>
-        </DialogBody>
-        <DialogFooter>
-          <DialogDismiss>Maybe Later</DialogDismiss>
-          <Button>
-            {(buttonProps) => (
-              <RouterLink to="/teams/new" {...buttonProps}>
-                <ButtonIcon>
-                  <PlusCircleIcon />
-                </ButtonIcon>
-                Create a Team
-              </RouterLink>
-            )}
-          </Button>
-        </DialogFooter>
-      </Dialog>
-    </>
-  );
-};
-
 export const PlanCard = (props: {
   account: AccountFragment;
   isTeam: boolean;
@@ -561,8 +511,6 @@ export const PlanCard = (props: {
     trialStatus,
     paymentProvider,
   } = account;
-
-  const collaborationWarningDialog = useDialogState();
 
   const [showTrialEndDialog, setShowTrialEndDialog] = useState(false);
   const confirmTrialEndDialogState = useDialogState({
@@ -628,6 +576,20 @@ export const PlanCard = (props: {
             </div>
           </>
         ) : null}
+        {!props.isTeam && (
+          <>
+            <CardSeparator className="my-6" />
+            <p className="my-4 text-sm text-low">
+              Your plan includes a limited amount of free screenshots. If the
+              usage on your projects exceeds the allotted limit, you will need
+              to upgrade to a Pro team.
+            </p>
+            <div className="border rounded p-2 mt-4 text-sm">
+              To take advantage of collaboration, create a new Pro team and
+              transfer your projects.
+            </div>
+          </>
+        )}
       </CardBody>
 
       <CardFooter>
@@ -649,31 +611,26 @@ export const PlanCard = (props: {
                 !props.isTeam && "w-full justify-between",
               )}
             >
-              <div className="flex items-center gap-4">
-                Custom needs?
-                <Button color="neutral" variant="outline">
-                  {(buttonProps) => (
-                    <a
-                      href={`mailto:${config.get("contactEmail")}`}
-                      {...buttonProps}
-                    >
-                      Contact Sales
-                    </a>
-                  )}
-                </Button>
-              </div>
-
-              <div className="flex items-center gap-4">
-                {!props.isTeam && (
-                  <CollaborationWarningButton
-                    dialog={collaborationWarningDialog}
-                  />
+              <Button color="neutral" variant="outline">
+                {(buttonProps) => (
+                  <a
+                    href={`mailto:${config.get("contactEmail")}`}
+                    {...buttonProps}
+                  >
+                    Contact Sales
+                  </a>
                 )}
-                <PrimaryCta
-                  purchaseStatus={purchaseStatus}
-                  accountId={account.id}
-                />
-              </div>
+              </Button>
+
+              {!props.isTeam && (
+                <div className="flex items-center gap-4">
+                  Want to collaborate?{" "}
+                  <PrimaryCta
+                    purchaseStatus={purchaseStatus}
+                    accountId={account.id}
+                  />
+                </div>
+              )}
             </div>
           </div>
         )}

--- a/apps/app/src/pages/Account/Settings.tsx
+++ b/apps/app/src/pages/Account/Settings.tsx
@@ -117,7 +117,9 @@ export const AccountSettings = () => {
                   return null;
                 })()}
               {/* <AccountVercel account={account} /> */}
-              {writable && account.plan && <PlanCard account={account} />}
+              {writable && account.plan && (
+                <PlanCard account={account} isTeam={isTeam} />
+              )}
               {isTeam && <TeamMembers team={account} />}
               <AccountGitLab account={account} />
               {isTeam && writable && <TeamDelete team={account} />}


### PR DESCRIPTION
Our tunnel is confusing. I've added an "Add Member" button to personal settings. This button opens a modal explaining that collaboration is only possible within a team setting.

- feat: update create team icon
- feat: add collaboration-warning-dialog

Fix [#1044](https://github.com/argos-ci/argos/issues/1044)

<img width="594" alt="Capture d’écran 2023-09-27 à 22 53 07" src="https://github.com/argos-ci/argos/assets/15954562/4f454903-f8d5-44bd-b244-9ff4a59f0dad">

<img width="761" alt="Capture d’écran 2023-09-27 à 22 52 51" src="https://github.com/argos-ci/argos/assets/15954562/0bc8e256-1a52-4026-8674-2b1400c60f50">


