### PR TITLE
fix(github): call API serially

### DIFF
--- a/apps/backend/src/build-notification/notifications.ts
+++ b/apps/backend/src/build-notification/notifications.ts
@@ -324,19 +324,18 @@ const sendGithubNotification = async (ctx: Context) => {
     });
   };
 
-  await Promise.all([
-    createGhCommitStatus({
-      buildName: build.name,
-      buildUrl,
-      commit: build.prHeadCommit ?? compareScreenshotBucket.commit,
-      description: notification.description,
-      githubAccountLogin: githubAccount.login,
-      octokit,
-      repositoryName: githubRepository.name,
-      state: notification.githubState,
-    }),
-    createGhComment(),
-  ]);
+  await createGhCommitStatus({
+    buildName: build.name,
+    buildUrl,
+    commit: build.prHeadCommit ?? compareScreenshotBucket.commit,
+    description: notification.description,
+    githubAccountLogin: githubAccount.login,
+    octokit,
+    repositoryName: githubRepository.name,
+    state: notification.githubState,
+  });
+
+  await createGhComment();
 };
 
 const sendGitlabNotification = async (ctx: Context) => {


### PR DESCRIPTION
To avoid secondary rate limit, following guidelines https://docs.github.com/en/rest/guides/best-practices-for-using-the-rest-api\?apiVersion\=2022-11-28\#dealing-with-secondary-rate-limits

Fix ARGOS-SERVER-XJX
Fix ARGOS-SERVER-XJT
Fix ARGOS-SERVER-XJV
