### PR TITLE
fix summary checks link

### DIFF
--- a/apps/frontend/src/containers/Project/StatusChecks.tsx
+++ b/apps/frontend/src/containers/Project/StatusChecks.tsx
@@ -107,7 +107,7 @@ export const ProjectStatusChecks = (props: {
           </CardBody>
           <FormCardFooter>
             Learn more about{" "}
-            <Anchor href="https://argos-ci.com/docs/summary-check" external>
+            <Anchor href="https://argos-ci.com/docs/summary-checks" external>
               summary checks
             </Anchor>
             .


### PR DESCRIPTION
Clicking summary checks link on "Settings" page takes you to Page not found.
<img width="896" alt="Screenshot 2024-01-25 at 12 12 45 AM" src="https://github.com/argos-ci/argos/assets/22205721/7eebc9ab-45eb-400e-8eb4-250dcb20151e">

Corrected the link.