### PR TITLE
fix links in welcome email template

### DIFF
--- a/apps/backend/src/email/welcome.tsx
+++ b/apps/backend/src/email/welcome.tsx
@@ -103,10 +103,7 @@ export const WelcomeEmail = ({ baseUrl }: { baseUrl: string }) => {
           </Section>
           <Section style={guideSection}>
             <Heading as="h2" style={h2}>
-              <Link
-                style={link}
-                href="https://argos-ci.com/docs/argos-cli"
-              >
+              <Link style={link} href="https://argos-ci.com/docs/argos-cli">
                 Setup Argos in your CI →
               </Link>
             </Heading>
@@ -117,10 +114,7 @@ export const WelcomeEmail = ({ baseUrl }: { baseUrl: string }) => {
           </Section>
           <Section style={guideSection}>
             <Heading as="h2" style={h2}>
-              <Link
-                style={link}
-                href="https://argos-ci.com/docs/notifications"
-              >
+              <Link style={link} href="https://argos-ci.com/docs/notifications">
                 Review changes in Argos →
               </Link>
             </Heading>

--- a/apps/backend/src/email/welcome.tsx
+++ b/apps/backend/src/email/welcome.tsx
@@ -91,7 +91,7 @@ export const WelcomeEmail = ({ baseUrl }: { baseUrl: string }) => {
             <Heading as="h2" style={h2}>
               <Link
                 style={link}
-                href="https://argos-ci.com/docs/capture-screenshots"
+                href="https://argos-ci.com/docs/screenshot-pages-script"
               >
                 Capture your first screenshot →
               </Link>
@@ -105,7 +105,7 @@ export const WelcomeEmail = ({ baseUrl }: { baseUrl: string }) => {
             <Heading as="h2" style={h2}>
               <Link
                 style={link}
-                href="https://argos-ci.com/docs/capture-screenshots"
+                href="https://argos-ci.com/docs/argos-cli"
               >
                 Setup Argos in your CI →
               </Link>
@@ -119,7 +119,7 @@ export const WelcomeEmail = ({ baseUrl }: { baseUrl: string }) => {
             <Heading as="h2" style={h2}>
               <Link
                 style={link}
-                href="https://argos-ci.com/docs/capture-screenshots"
+                href="https://argos-ci.com/docs/notifications"
               >
                 Review changes in Argos →
               </Link>


### PR DESCRIPTION
The email that is sent to new users contain incorrect links.

Tried to reference the correct pages based on the wording. Let me know if it needs polishing.