### PR TITLE
fix(firefox): fix diff display on Firefox

### DIFF
--- a/apps/frontend/src/pages/Build/BuildDetail.tsx
+++ b/apps/frontend/src/pages/Build/BuildDetail.tsx
@@ -145,7 +145,7 @@ function getImgAttributes({
   };
 }
 
-const ScreenshotPlaceholder = ({
+function ScreenshotContainer({
   dimensions,
   contained,
   children,
@@ -156,10 +156,10 @@ const ScreenshotPlaceholder = ({
   };
   contained: boolean;
   children: React.ReactNode;
-}) => {
+}) {
   return (
     <div
-      className="relative"
+      className="relative min-w-0 min-h-0"
       style={{
         aspectRatio: contained ? getAspectRatio(dimensions) : undefined,
       }}
@@ -167,7 +167,7 @@ const ScreenshotPlaceholder = ({
       {children}
     </div>
   );
-};
+}
 
 const BaseScreenshot = ({ diff }: { diff: Diff }) => {
   const { contained } = useBuildDiffFitState();
@@ -220,16 +220,16 @@ const BaseScreenshot = ({ diff }: { diff: Diff }) => {
             />
           }
         >
-          <ScreenshotPlaceholder
+          <ScreenshotContainer
             dimensions={diff.baseScreenshot!}
             contained={contained}
           >
             <img
-              className={clsx("mx-auto", contained && "max-h-full")}
+              className={clsx(contained && "max-h-full")}
               alt="Baseline screenshot"
               {...getImgAttributes(diff.baseScreenshot!)}
             />
-          </ScreenshotPlaceholder>
+          </ScreenshotContainer>
         </ZoomPane>
       );
     case "changed":
@@ -242,12 +242,9 @@ const BaseScreenshot = ({ diff }: { diff: Diff }) => {
             />
           }
         >
-          <ScreenshotPlaceholder dimensions={diff} contained={contained}>
+          <ScreenshotContainer dimensions={diff} contained={contained}>
             <img
-              className={clsx(
-                "relative opacity-0 mx-auto",
-                contained && "max-h-full",
-              )}
+              className={clsx("relative opacity-0", contained && "max-h-full")}
               {...getImgAttributes({
                 url: diff.url!,
                 width: diff.width,
@@ -255,11 +252,11 @@ const BaseScreenshot = ({ diff }: { diff: Diff }) => {
               })}
             />
             <img
-              className="absolute left-0 top-0 right-0 mx-auto"
+              className="absolute left-0 top-0"
               alt="Baseline screenshot"
               {...getImgAttributes(diff.baseScreenshot!)}
             />
-          </ScreenshotPlaceholder>
+          </ScreenshotContainer>
         </ZoomPane>
       );
     default:
@@ -282,16 +279,16 @@ const CompareScreenshot = ({ diff }: { diff: Diff }) => {
             />
           }
         >
-          <ScreenshotPlaceholder
+          <ScreenshotContainer
             dimensions={diff.compareScreenshot!}
             contained={contained}
           >
             <img
-              className={clsx("mx-auto", contained && "max-h-full")}
+              className={clsx(contained && "max-h-full max-w-full")}
               alt="Changes screenshot"
               {...getImgAttributes(diff.compareScreenshot!)}
             />
-          </ScreenshotPlaceholder>
+          </ScreenshotContainer>
         </ZoomPane>
       );
     case "failure":
@@ -304,16 +301,16 @@ const CompareScreenshot = ({ diff }: { diff: Diff }) => {
             />
           }
         >
-          <ScreenshotPlaceholder
+          <ScreenshotContainer
             dimensions={diff.compareScreenshot!}
             contained={contained}
           >
             <img
-              className={clsx("mx-auto", contained && "max-h-full")}
+              className={clsx(contained && "max-h-full")}
               alt="Failure screenshot"
               {...getImgAttributes(diff.compareScreenshot!)}
             />
-          </ScreenshotPlaceholder>
+          </ScreenshotContainer>
         </ZoomPane>
       );
     case "unchanged":
@@ -326,16 +323,16 @@ const CompareScreenshot = ({ diff }: { diff: Diff }) => {
             />
           }
         >
-          <ScreenshotPlaceholder
+          <ScreenshotContainer
             dimensions={diff.compareScreenshot!}
             contained={contained}
           >
             <img
-              className={clsx("mx-auto", contained && "max-h-full")}
+              className={clsx(contained && "max-h-full")}
               alt="Baseline screenshot"
               {...getImgAttributes(diff.compareScreenshot!)}
             />
-          </ScreenshotPlaceholder>
+          </ScreenshotContainer>
         </ZoomPane>
       );
     case "removed":
@@ -361,19 +358,18 @@ const CompareScreenshot = ({ diff }: { diff: Diff }) => {
             />
           }
         >
-          <ScreenshotPlaceholder dimensions={diff} contained={contained}>
+          <ScreenshotContainer dimensions={diff} contained={contained}>
             <img
               className={clsx(
-                "absolute left-0 right-0 mx-auto",
+                "absolute left-0 top-0",
                 visible && "opacity-disabled",
-                contained && "max-h-full",
               )}
               {...getImgAttributes(diff.compareScreenshot!)}
             />
             <img
               className={clsx(
                 opacity,
-                "relative z-10 mx-auto",
+                "relative z-10",
                 contained && "max-h-full",
               )}
               alt="Changes screenshot"
@@ -383,7 +379,7 @@ const CompareScreenshot = ({ diff }: { diff: Diff }) => {
                 height: diff.height,
               })}
             />
-          </ScreenshotPlaceholder>
+          </ScreenshotContainer>
         </ZoomPane>
       );
     default:

--- a/apps/frontend/src/pages/Build/BuildDetail.tsx
+++ b/apps/frontend/src/pages/Build/BuildDetail.tsx
@@ -119,7 +119,17 @@ const MissingScreenshotInfo = memo(
   },
 );
 
-const getImgAttributes = ({
+function getAspectRatio({
+  width,
+  height,
+}: {
+  width?: number | null | undefined;
+  height?: number | null | undefined;
+}) {
+  return width && height ? `${width}/${height}` : undefined;
+}
+
+function getImgAttributes({
   url,
   width,
   height,
@@ -127,13 +137,13 @@ const getImgAttributes = ({
   url: string;
   width?: number | null | undefined;
   height?: number | null | undefined;
-}) => {
+}) {
   return {
     key: url,
     src: `${url}?tr=lo-true`,
-    style: { aspectRatio: width && height ? `${width}/${height}` : undefined },
+    style: { aspectRatio: getAspectRatio({ width, height }) },
   };
-};
+}
 
 const NeutralLink = ({
   href,
@@ -215,19 +225,31 @@ const BaseScreenshot = ({ diff }: { diff: Diff }) => {
             />
           }
         >
-          <img
-            className={clsx("relative opacity-0", contained && "max-h-full")}
-            {...getImgAttributes({
-              url: diff.url!,
-              width: diff.width,
-              height: diff.height,
-            })}
-          />
-          <img
-            className="absolute left-0 top-0"
-            alt="Baseline screenshot"
-            {...getImgAttributes(diff.baseScreenshot!)}
-          />
+          <div
+            className="relative"
+            style={{
+              aspectRatio: contained
+                ? getAspectRatio({
+                    width: diff.width,
+                    height: diff.height,
+                  })
+                : undefined,
+            }}
+          >
+            <img
+              className={clsx("relative opacity-0", contained && "max-h-full")}
+              {...getImgAttributes({
+                url: diff.url!,
+                width: diff.width,
+                height: diff.height,
+              })}
+            />
+            <img
+              className="absolute left-0 top-0"
+              alt="Baseline screenshot"
+              {...getImgAttributes(diff.baseScreenshot!)}
+            />
+          </div>
         </ZoomPane>
       );
     default:
@@ -316,23 +338,30 @@ const CompareScreenshot = ({ diff }: { diff: Diff }) => {
             />
           }
         >
-          <img
-            className={clsx("absolute", visible && "opacity-disabled")}
-            {...getImgAttributes(diff.compareScreenshot!)}
-          />
-          <img
-            className={clsx(
-              opacity,
-              "relative z-10",
-              contained && "max-h-full",
-            )}
-            alt="Changes screenshot"
-            {...getImgAttributes({
-              url: diff.url!,
-              width: diff.width,
-              height: diff.height,
-            })}
-          />
+          <div
+            className="relative"
+            style={
+              contained ? { aspectRatio: getAspectRatio(diff) } : undefined
+            }
+          >
+            <img
+              className={clsx("absolute", visible && "opacity-disabled")}
+              {...getImgAttributes(diff.compareScreenshot!)}
+            />
+            <img
+              className={clsx(
+                opacity,
+                "relative z-10",
+                contained && "max-h-full",
+              )}
+              alt="Changes screenshot"
+              {...getImgAttributes({
+                url: diff.url!,
+                width: diff.width,
+                height: diff.height,
+              })}
+            />
+          </div>
         </ZoomPane>
       );
     default:

--- a/apps/frontend/src/pages/Build/BuildDetail.tsx
+++ b/apps/frontend/src/pages/Build/BuildDetail.tsx
@@ -145,17 +145,29 @@ function getImgAttributes({
   };
 }
 
-const NeutralLink = ({
-  href,
+const ScreenshotPlaceholder = ({
+  dimensions,
+  contained,
   children,
 }: {
-  href: string;
+  dimensions: {
+    width?: number | null;
+    height?: number | null;
+  };
+  contained: boolean;
   children: React.ReactNode;
-}) => (
-  <a href={href} rel="noopener noreferrer" target="_blank">
-    {children}
-  </a>
-);
+}) => {
+  return (
+    <div
+      className="relative"
+      style={{
+        aspectRatio: contained ? getAspectRatio(dimensions) : undefined,
+      }}
+    >
+      {children}
+    </div>
+  );
+};
 
 const BaseScreenshot = ({ diff }: { diff: Diff }) => {
   const { contained } = useBuildDiffFitState();
@@ -208,11 +220,16 @@ const BaseScreenshot = ({ diff }: { diff: Diff }) => {
             />
           }
         >
-          <img
-            className={clsx(contained && "max-h-full")}
-            alt="Baseline screenshot"
-            {...getImgAttributes(diff.baseScreenshot!)}
-          />
+          <ScreenshotPlaceholder
+            dimensions={diff.baseScreenshot!}
+            contained={contained}
+          >
+            <img
+              className={clsx("mx-auto", contained && "max-h-full")}
+              alt="Baseline screenshot"
+              {...getImgAttributes(diff.baseScreenshot!)}
+            />
+          </ScreenshotPlaceholder>
         </ZoomPane>
       );
     case "changed":
@@ -225,19 +242,12 @@ const BaseScreenshot = ({ diff }: { diff: Diff }) => {
             />
           }
         >
-          <div
-            className="relative"
-            style={{
-              aspectRatio: contained
-                ? getAspectRatio({
-                    width: diff.width,
-                    height: diff.height,
-                  })
-                : undefined,
-            }}
-          >
+          <ScreenshotPlaceholder dimensions={diff} contained={contained}>
             <img
-              className={clsx("relative opacity-0", contained && "max-h-full")}
+              className={clsx(
+                "relative opacity-0 mx-auto",
+                contained && "max-h-full",
+              )}
               {...getImgAttributes({
                 url: diff.url!,
                 width: diff.width,
@@ -245,11 +255,11 @@ const BaseScreenshot = ({ diff }: { diff: Diff }) => {
               })}
             />
             <img
-              className="absolute left-0 top-0"
+              className="absolute left-0 top-0 right-0 mx-auto"
               alt="Baseline screenshot"
               {...getImgAttributes(diff.baseScreenshot!)}
             />
-          </div>
+          </ScreenshotPlaceholder>
         </ZoomPane>
       );
     default:
@@ -272,11 +282,16 @@ const CompareScreenshot = ({ diff }: { diff: Diff }) => {
             />
           }
         >
-          <img
-            className={clsx(contained && "max-h-full")}
-            alt="Changes screenshot"
-            {...getImgAttributes(diff.compareScreenshot!)}
-          />
+          <ScreenshotPlaceholder
+            dimensions={diff.compareScreenshot!}
+            contained={contained}
+          >
+            <img
+              className={clsx("mx-auto", contained && "max-h-full")}
+              alt="Changes screenshot"
+              {...getImgAttributes(diff.compareScreenshot!)}
+            />
+          </ScreenshotPlaceholder>
         </ZoomPane>
       );
     case "failure":
@@ -289,11 +304,16 @@ const CompareScreenshot = ({ diff }: { diff: Diff }) => {
             />
           }
         >
-          <img
-            className={clsx(contained && "max-h-full")}
-            alt="Failure screenshot"
-            {...getImgAttributes(diff.compareScreenshot!)}
-          />
+          <ScreenshotPlaceholder
+            dimensions={diff.compareScreenshot!}
+            contained={contained}
+          >
+            <img
+              className={clsx("mx-auto", contained && "max-h-full")}
+              alt="Failure screenshot"
+              {...getImgAttributes(diff.compareScreenshot!)}
+            />
+          </ScreenshotPlaceholder>
         </ZoomPane>
       );
     case "unchanged":
@@ -306,13 +326,16 @@ const CompareScreenshot = ({ diff }: { diff: Diff }) => {
             />
           }
         >
-          <NeutralLink href={diff.compareScreenshot!.url}>
+          <ScreenshotPlaceholder
+            dimensions={diff.compareScreenshot!}
+            contained={contained}
+          >
             <img
-              className={clsx(contained && "max-h-full")}
+              className={clsx("mx-auto", contained && "max-h-full")}
               alt="Baseline screenshot"
               {...getImgAttributes(diff.compareScreenshot!)}
             />
-          </NeutralLink>
+          </ScreenshotPlaceholder>
         </ZoomPane>
       );
     case "removed":
@@ -338,20 +361,19 @@ const CompareScreenshot = ({ diff }: { diff: Diff }) => {
             />
           }
         >
-          <div
-            className="relative"
-            style={
-              contained ? { aspectRatio: getAspectRatio(diff) } : undefined
-            }
-          >
+          <ScreenshotPlaceholder dimensions={diff} contained={contained}>
             <img
-              className={clsx("absolute", visible && "opacity-disabled")}
+              className={clsx(
+                "absolute left-0 right-0 mx-auto",
+                visible && "opacity-disabled",
+                contained && "max-h-full",
+              )}
               {...getImgAttributes(diff.compareScreenshot!)}
             />
             <img
               className={clsx(
                 opacity,
-                "relative z-10",
+                "relative z-10 mx-auto",
                 contained && "max-h-full",
               )}
               alt="Changes screenshot"
@@ -361,7 +383,7 @@ const CompareScreenshot = ({ diff }: { diff: Diff }) => {
                 height: diff.height,
               })}
             />
-          </div>
+          </ScreenshotPlaceholder>
         </ZoomPane>
       );
     default:

--- a/apps/frontend/src/pages/Build/Zoomer.tsx
+++ b/apps/frontend/src/pages/Build/Zoomer.tsx
@@ -312,7 +312,7 @@ export const ZoomPane = (props: {
     >
       <div
         ref={contentRef}
-        className="flex min-h-0 flex-1 origin-top-left justify-center"
+        className="flex min-h-0 min-w-0 flex-1 origin-top-left justify-center"
         style={{ transform: transformToCss(transform) }}
       >
         {props.children}

--- a/apps/frontend/src/pages/Build/Zoomer.tsx
+++ b/apps/frontend/src/pages/Build/Zoomer.tsx
@@ -315,7 +315,7 @@ export const ZoomPane = (props: {
         className="flex min-h-0 flex-1 origin-top-left justify-center"
         style={{ transform: transformToCss(transform) }}
       >
-        <div className="relative">{props.children}</div>
+        {props.children}
       </div>
       {props.controls && (
         <div className="opacity-0 transition group-focus-within/pane:opacity-100 group-hover/pane:opacity-100">

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -61,6 +61,12 @@ const config = {
         ...devices["Desktop Chrome"],
       },
     },
+    {
+      name: "firefox",
+      use: {
+        ...devices["Desktop Firefox"],
+      },
+    },
   ],
 
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */


### PR DESCRIPTION
Firefox has a bug measuring the content of a "relative" div. It does not give the size of its children. To fix this problem we size correctly the parent div.

**Before**
![CleanShot 2024-01-26 at 09 20 45@2x](https://github.com/argos-ci/argos/assets/266302/7837e984-87ad-4fc6-84ab-026baff6a262)

**After**
![CleanShot 2024-01-26 at 09 21 03@2x](https://github.com/argos-ci/argos/assets/266302/c690aa8b-6469-4639-bca7-2592b6fede08)
