### PR TITLE
fix: fix build diff display on Safari

### DIFF
--- a/apps/frontend/src/pages/Build/BuildDetail.tsx
+++ b/apps/frontend/src/pages/Build/BuildDetail.tsx
@@ -159,10 +159,18 @@ function ScreenshotContainer({
 }) {
   return (
     <div
-      className="relative min-w-0 min-h-0"
-      style={{
-        aspectRatio: contained ? getAspectRatio(dimensions) : undefined,
-      }}
+      className={clsx(
+        "relative min-w-0 min-h-0",
+        contained && "max-h-full max-w-full",
+      )}
+      style={
+        contained
+          ? {
+              aspectRatio: getAspectRatio(dimensions),
+              height: dimensions.height ?? undefined,
+            }
+          : undefined
+      }
     >
       {children}
     </div>


### PR DESCRIPTION
Fix the build diff display on Safari.

**Before**
![CleanShot 2024-01-26 at 13 54 24@2x](https://github.com/argos-ci/argos/assets/266302/f890440d-0fad-4ac3-9f01-7562def4a0c2)


**After**
![CleanShot 2024-01-26 at 13 54 36@2x](https://github.com/argos-ci/argos/assets/266302/3fb1bf6a-3d40-4291-9ff3-77101977b6e7)
