### PR TITLE
perf: run diffs sequentially

### DIFF
--- a/apps/backend/src/screenshot-diff/util/image-diff/index.ts
+++ b/apps/backend/src/screenshot-diff/util/image-diff/index.ts
@@ -103,21 +103,19 @@ export async function diffImages(
     compareImage.enlarge(maxDimensions),
   ]);
 
-  // Compute differences for base and color sensitive
-  const [baseScore, colorSensitiveScore] = await Promise.all([
-    computeDiff({
-      basePath,
-      comparePath,
-      diffPath: baseDiffPath,
-      threshold: BASE_THRESHOLD,
-    }),
-    computeDiff({
-      basePath,
-      comparePath,
-      diffPath: colorDiffPath,
-      threshold: COLOR_SENSIBLE_THRESHOLD,
-    }),
-  ]);
+  // Compute diff sequentiall to avoid memory issues
+  const baseScore = await computeDiff({
+    basePath,
+    comparePath,
+    diffPath: baseDiffPath,
+    threshold: BASE_THRESHOLD,
+  });
+  const colorSensitiveScore = await computeDiff({
+    basePath,
+    comparePath,
+    diffPath: colorDiffPath,
+    threshold: COLOR_SENSIBLE_THRESHOLD,
+  });
 
   const maxBaseScore = Math.min(
     BASE_MAX_SCORE,

--- a/apps/backend/src/screenshot-diff/util/image-diff/test/diff.test.ts
+++ b/apps/backend/src/screenshot-diff/util/image-diff/test/diff.test.ts
@@ -112,7 +112,7 @@ describe("diff E2E", () => {
     const { filepath: _diffFilepath, ...scoreAndDimensions } = result;
 
     expect(scoreAndDimensions).toMatchSnapshot();
-  });
+  }, 10000);
 
   it("takes into account colors in comparison", async () => {
     const baseFilename = "violet-square.png";


### PR DESCRIPTION
As observed, sometimes dynos are out of memory. We try to mitigate this
by running diffs sequentially instead of in parallel.
