### PR TITLE
fix(stripe): payment method can't be detached

### DIFF
--- a/apps/backend/src/stripe/index.ts
+++ b/apps/backend/src/stripe/index.ts
@@ -379,15 +379,6 @@ export const handleStripeEvent = async ({
       await updateSubscriptionsFromCustomer(paymentMethod.customer);
       return;
     }
-    case "payment_method.detached": {
-      const paymentMethod = data.object as Stripe.PaymentMethod;
-      invariant(
-        typeof paymentMethod.customer === "string",
-        "customer is not a string",
-      );
-      await updateSubscriptionsFromCustomer(paymentMethod.customer);
-      return;
-    }
     case "customer.deleted": {
       const customer = data.object as Stripe.Customer;
 

--- a/apps/backend/src/web/api/stripe.ts
+++ b/apps/backend/src/web/api/stripe.ts
@@ -1,6 +1,6 @@
 import bodyParser from "body-parser";
 import express from "express";
-
+import * as Sentry from "@sentry/node";
 import config from "@/config/index.js";
 import { Account } from "@/database/models/index.js";
 import logger from "@/logger/index.js";
@@ -42,6 +42,8 @@ router.post(
     try {
       await handleStripeEvent(event);
     } catch (error) {
+      Sentry.setContext("stripeEvent", event);
+
       throw new HTTPError(
         500,
         "An error occurred while handling Stripe event.",


### PR DESCRIPTION
So no need to listen the event anymore

Also add event to the context for quicker debugging

Fix ARGOS-SERVER-XMX