### PR TITLE
feat: diff indicator

### DIFF
--- a/apps/frontend/src/pages/Build/Zoomer.tsx
+++ b/apps/frontend/src/pages/Build/Zoomer.tsx
@@ -129,6 +129,15 @@ class Zoomer {
     this.zoom.scaleBy(this.selection, 1 / 1.2);
   }
 
+  getTransform(): Transform {
+    const t = this.selection.property("__zoom");
+    return {
+      scale: t.k,
+      x: t.x,
+      y: t.y,
+    };
+  }
+
   subscribe(
     fn: ZoomPaneListener["fn"],
     options?: {
@@ -147,9 +156,12 @@ class Zoomer {
   }
 }
 
+type ZoomerSyncCallback = (transform: Transform) => void;
+
 type ZoomerSyncContextValue = {
   register: (instance: Zoomer) => () => void;
-  getInitialTransform: () => Transform | null;
+  subscribe: (callback: ZoomerSyncCallback) => () => void;
+  getInitialTransform: () => Transform;
   reset: () => void;
   zoomIn: () => void;
   zoomOut: () => void;
@@ -157,12 +169,26 @@ type ZoomerSyncContextValue = {
 
 const ZoomerSyncContext = createContext<ZoomerSyncContextValue | null>(null);
 
+const initialTransform = { scale: 1, x: 0, y: 0 };
+
 export const ZoomerSyncProvider = (props: {
   children: React.ReactNode;
   id: string;
 }) => {
   const refInstances = useRef<Zoomer[]>([]);
-  const transformRef = useRef<Transform | null>(null);
+  const subscribersRef = useRef<ZoomerSyncCallback[]>([]);
+  const transformRef = useRef<Transform>(initialTransform);
+  const subscribe = useCallback((callback: ZoomerSyncCallback) => {
+    const handler = (transform: Transform) => {
+      callback(transform);
+    };
+    subscribersRef.current.push(handler);
+    return () => {
+      subscribersRef.current = subscribersRef.current.filter(
+        (f) => f !== handler,
+      );
+    };
+  }, []);
   const register = useCallback((zoomer: Zoomer) => {
     refInstances.current.push(zoomer);
     const unsubscribe = zoomer.subscribe(
@@ -173,6 +199,9 @@ export const ZoomerSyncProvider = (props: {
             i.update(event.state);
           }
         });
+        subscribersRef.current.forEach((fn) => {
+          fn(event.state);
+        });
       },
       { ignoreUpdate: true },
     );
@@ -181,16 +210,18 @@ export const ZoomerSyncProvider = (props: {
       refInstances.current = refInstances.current.filter((i) => i !== zoomer);
     };
   }, []);
-  useEffect(() => {
-    return () => {
-      refInstances.current.forEach((i) => i.reset());
-    };
-  }, [props.id]);
-  const getInitialTransform = useCallback(() => {
-    return transformRef.current;
-  }, []);
   const reset = useCallback(() => {
     refInstances.current.forEach((i) => i.reset());
+    transformRef.current = initialTransform;
+    subscribersRef.current.forEach((fn) => {
+      fn(initialTransform);
+    });
+  }, []);
+  useEffect(() => {
+    return reset;
+  }, [props.id, reset]);
+  const getInitialTransform = useCallback(() => {
+    return transformRef.current;
   }, []);
   const zoomIn = useCallback(() => {
     refInstances.current.forEach((i) => i.zoomIn());
@@ -199,8 +230,15 @@ export const ZoomerSyncProvider = (props: {
     refInstances.current.forEach((i) => i.zoomOut());
   }, []);
   const value = useMemo(
-    () => ({ register, getInitialTransform, reset, zoomIn, zoomOut }),
-    [register, getInitialTransform, reset, zoomIn, zoomOut],
+    () => ({
+      register,
+      subscribe,
+      getInitialTransform,
+      reset,
+      zoomIn,
+      zoomOut,
+    }),
+    [register, subscribe, getInitialTransform, reset, zoomIn, zoomOut],
   );
   return (
     <ZoomerSyncContext.Provider value={value}>
@@ -214,6 +252,20 @@ export const useZoomerSyncContext = () => {
   invariant(ctx, "Missing ZoomerSyncProvider");
   return ctx;
 };
+
+/**
+ * Hook to get the current transform of the zoomer.
+ */
+export function useZoomTransform() {
+  const { subscribe, getInitialTransform } = useZoomerSyncContext();
+  const [transform, setTransform] = useState(getInitialTransform);
+  useLayoutEffect(() => {
+    return subscribe((t) => {
+      setTransform(t);
+    });
+  }, [subscribe]);
+  return transform;
+}
 
 type Transform = {
   scale: number;
@@ -283,14 +335,6 @@ const ZoomOutButton = memo((props: { disabled: boolean }) => {
   );
 });
 
-const TransformContext = createContext<Transform | null>(null);
-
-export function useZoomTransform(): Transform {
-  const ctx = useContext(TransformContext);
-  invariant(ctx, "Missing TransformProvider");
-  return ctx;
-}
-
 export function ZoomPane(props: {
   children: React.ReactNode;
   controls?: React.ReactNode;
@@ -311,9 +355,7 @@ export function ZoomPane(props: {
       });
     });
     const initialTransform = getInitialTransform();
-    if (initialTransform) {
-      zoomer.update(initialTransform);
-    }
+    zoomer.update(initialTransform);
     return register(zoomer);
   }, [register, getInitialTransform]);
   return (
@@ -321,25 +363,23 @@ export function ZoomPane(props: {
       ref={paneRef}
       className="group/pane bg-app flex min-h-0 flex-1 cursor-grab select-none overflow-hidden rounded border"
     >
-      <TransformContext.Provider value={transform}>
-        <div
-          ref={contentRef}
-          className="flex min-h-0 min-w-0 flex-1 origin-top-left justify-center"
-          style={{ transform: transformToCss(transform) }}
-        >
-          {props.children}
-        </div>
-        {props.controls && (
-          <div className="opacity-0 transition group-focus-within/pane:opacity-100 group-hover/pane:opacity-100">
-            <div className="zoomer-controls absolute bottom-2 right-2 flex flex-col items-center gap-1">
-              {props.controls}
-              <FitViewButton />
-              <ZoomInButton disabled={transform.scale >= MAX_ZOOM_SCALE} />
-              <ZoomOutButton disabled={transform.scale <= MIN_ZOOM_SCALE} />
-            </div>
+      <div
+        ref={contentRef}
+        className="flex min-h-0 min-w-0 flex-1 origin-top-left justify-center"
+        style={{ transform: transformToCss(transform) }}
+      >
+        {props.children}
+      </div>
+      {props.controls && (
+        <div className="opacity-0 transition group-focus-within/pane:opacity-100 group-hover/pane:opacity-100">
+          <div className="zoomer-controls absolute bottom-2 right-2 flex flex-col items-center gap-1">
+            {props.controls}
+            <FitViewButton />
+            <ZoomInButton disabled={transform.scale >= MAX_ZOOM_SCALE} />
+            <ZoomOutButton disabled={transform.scale <= MIN_ZOOM_SCALE} />
           </div>
-        )}
-      </TransformContext.Provider>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/util/color-detection/hook.ts
+++ b/apps/frontend/src/util/color-detection/hook.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+import type { Rect } from "./types";
+
+/**
+ * Detects colored areas in the image provided by the URL.
+ */
+export function useColoredRects(input: { url: string }): null | Rect[] {
+  const [rects, setRects] = useState<null | Rect[]>(null);
+  useEffect(() => {
+    const worker = new Worker(new URL("./worker.ts", import.meta.url));
+    worker.onmessage = (event) => {
+      setRects(event.data);
+    };
+    worker.postMessage({ url: input.url });
+  }, [input.url]);
+  return rects;
+}

--- a/apps/frontend/src/util/color-detection/types.ts
+++ b/apps/frontend/src/util/color-detection/types.ts
@@ -1,0 +1,9 @@
+/**
+ * Represents a rectangle with a position and size.
+ */
+export type Rect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};

--- a/apps/frontend/src/util/color-detection/worker.ts
+++ b/apps/frontend/src/util/color-detection/worker.ts
@@ -1,0 +1,160 @@
+import type { Rect } from "./types";
+
+/**
+ * The size of the blocks to use when detecting colored zones.
+ */
+const BLOCK_SIZE = 5;
+
+// Listens for messages from the main thread and detects colored zones in an image.
+self.onmessage = (event) => {
+  const url = event.data.url;
+  if (typeof url !== "string") {
+    throw new Error("Expected url to be a string");
+  }
+  detectColoredZones({ url }).then((rects) => {
+    self.postMessage(rects);
+  });
+};
+
+/**
+ * Fetches a bitmap from a URL.
+ */
+async function fetchBitmapFromURL(url: string) {
+  const response = await fetch(url);
+  const blob = await response.blob();
+  const bmp = await createImageBitmap(blob);
+  return bmp;
+}
+
+/**
+ * Detects colored zones in an image.
+ */
+async function detectColoredZones(input: { url: string }): Promise<Rect[]> {
+  const { url } = input;
+
+  // Create an offscreen canvas to draw the image.
+  const canvas = new OffscreenCanvas(1, 1);
+
+  // Get the 2d context of the canvas.
+  const context = canvas.getContext("2d");
+  if (!context) {
+    throw new Error("Expected canvas to have a 2d context");
+  }
+
+  // Fetch the image and draw it on the canvas.
+  const bitmap = await fetchBitmapFromURL(url);
+  canvas.width = bitmap.width;
+  canvas.height = bitmap.height;
+  context.drawImage(bitmap, 0, 0);
+  bitmap.close();
+
+  // Get the image data.
+  const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+  const data = imageData.data;
+
+  // Create a 2d array to store the detected blocks.
+  const rows = Math.ceil(canvas.height / BLOCK_SIZE);
+  const cols = Math.ceil(canvas.width / BLOCK_SIZE);
+  const grid: boolean[][] = Array.from({ length: rows }, () => []);
+
+  /**
+   * Checks if a block contains any color.
+   */
+  const containsColor = (x: number, y: number) => {
+    for (let i = y; i < y + BLOCK_SIZE; i++) {
+      for (let j = x; j < x + BLOCK_SIZE; j++) {
+        const index = (i * canvas.width + j) * 4;
+        const red = data[index];
+
+        if (red) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  // Fill the grid with the detected blocks.
+  for (let y = 0; y < canvas.height; y += BLOCK_SIZE) {
+    for (let x = 0; x < canvas.width; x += BLOCK_SIZE) {
+      const row = Math.floor(y / BLOCK_SIZE);
+      const col = Math.floor(x / BLOCK_SIZE);
+      grid[row]![col] = containsColor(x, y);
+    }
+  }
+
+  const visited = Array.from({ length: rows }, () => Array(cols).fill(false));
+  const groups: Rect[] = [];
+
+  const directions = [
+    { dx: 0, dy: 1 },
+    { dx: 1, dy: 0 },
+    { dx: 0, dy: -1 },
+    { dx: -1, dy: 0 },
+  ];
+
+  /**
+   * Flood fills a group of blocks and calculates the bounding rectangle.
+   */
+  const floodFill = (row: number, col: number) => {
+    const stack = [{ row, col }];
+    let minX = col * BLOCK_SIZE;
+    let minY = row * BLOCK_SIZE;
+    let maxX = minX;
+    let maxY = minY;
+
+    while (stack.length > 0) {
+      const { row, col } = stack.pop()!;
+      if (
+        row < 0 ||
+        col < 0 ||
+        row >= rows ||
+        col >= cols ||
+        visited[row]![col] ||
+        !grid[row]![col]
+      ) {
+        continue;
+      }
+      visited[row]![col] = true;
+
+      const x = col * BLOCK_SIZE;
+      const y = row * BLOCK_SIZE;
+      if (x < minX) {
+        minX = x;
+      }
+      if (y < minY) {
+        minY = y;
+      }
+      if (x > maxX) {
+        maxX = x;
+      }
+      if (y > maxY) {
+        maxY = y;
+      }
+
+      for (const { dx, dy } of directions) {
+        stack.push({ row: row + dy, col: col + dx });
+      }
+    }
+
+    groups.push({
+      x: minX,
+      y: minY,
+      width: maxX - minX + BLOCK_SIZE,
+      height: maxY - minY + BLOCK_SIZE,
+    });
+  };
+
+  /**
+   * Iterate over each block and find groups.
+   */
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      if (grid[row]![col] && !visited[row]![col]) {
+        floodFill(row, col);
+      }
+    }
+  }
+
+  return groups;
+}

--- a/knip.json
+++ b/knip.json
@@ -17,7 +17,11 @@
       "ignoreDependencies": ["pg"]
     },
     "apps/frontend": {
-      "ignore": ["src/gql/**/*", "vite.config.ts"],
+      "ignore": [
+        "src/gql/**/*",
+        "vite.config.ts",
+        "src/util/color-detection/worker.ts"
+      ],
       "ignoreDependencies": [
         "@radix-ui/colors",
         "@vitejs/plugin-react",


### PR DESCRIPTION
## Add a diff indicator

![CleanShot 2024-06-18 at 22 10 02@2x](https://github.com/argos-ci/argos/assets/266302/9291be98-9de0-4e15-a5e3-f44651a5c1cf)

## Technical

We compute the groups of differences on the fly by analyzing the image in an [OffscreenCanvas](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas) in a [Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers). This way the main thread is not blocked during the computation of diff rects.

Once done, we display a lateral bar by getting the initial scale of the image and subscribing to the zoom level.