### PR TITLE
fix: increase api limit

### DIFF
--- a/apps/backend/src/api/util.ts
+++ b/apps/backend/src/api/util.ts
@@ -148,7 +148,7 @@ function handler<TMethod extends "get" | "post" | "put">(
       convertPath(path),
       // Temporary increase the limit
       // we should find a way to split the upload in several requests
-      express.json({ limit: "2mb" }),
+      express.json({ limit: "3mb" }),
       asyncHandler((req, res, next) => {
         const ctx: RequestCtx<ZodOpenApiOperationObject> = {
           params: null,


### PR DESCRIPTION
E2E test [Failed again](https://github.com/mermaid-js/mermaid/actions/runs/11161194204/job/31023256387). 

I am not sure what the actual size we sent is. 
In case you have logs with this info, please update the size. 

Based on #1380
 
