### PR TITLE
fix: fix auth error handling

### DIFF
--- a/apps/backend/src/graphql/context.ts
+++ b/apps/backend/src/graphql/context.ts
@@ -2,11 +2,8 @@ import type { BaseContext } from "@apollo/server";
 import type { Request } from "express";
 import { GraphQLError } from "graphql";
 
-import {
-  AuthError,
-  AuthPayload,
-  getAuthPayloadFromRequest,
-} from "@/auth/request.js";
+import { AuthPayload, getAuthPayloadFromRequest } from "@/auth/request.js";
+import { HTTPError } from "@/web/util.js";
 
 import { createLoaders } from "./loaders.js";
 
@@ -28,7 +25,7 @@ export async function getContext(request: Request): Promise<Context> {
     const auth = await getContextAuth(request);
     return { auth, loaders: createLoaders() };
   } catch (error) {
-    if (error instanceof AuthError) {
+    if (error instanceof HTTPError && error.statusCode === 401) {
       throw new GraphQLError("User is not authenticated", {
         originalError: error,
         extensions: {

--- a/apps/backend/src/web/middlewares/auth.ts
+++ b/apps/backend/src/web/middlewares/auth.ts
@@ -4,7 +4,7 @@ import type { RequestHandler } from "express";
 
 import { AuthPayload, getAuthPayloadFromRequest } from "@/auth/request.js";
 
-import { asyncHandler } from "../util.js";
+import { asyncHandler, HTTPError } from "../util.js";
 
 declare global {
   namespace Express {
@@ -15,7 +15,13 @@ declare global {
 }
 
 export const auth: RequestHandler = asyncHandler(async (req, _res, next) => {
-  const account = await getAuthPayloadFromRequest(req);
+  const account = await getAuthPayloadFromRequest(req).catch((error) => {
+    if (error instanceof HTTPError && error.statusCode === 401) {
+      return null;
+    }
+
+    throw error;
+  });
   req.auth = account;
   next();
 });

--- a/apps/backend/src/web/util.ts
+++ b/apps/backend/src/web/util.ts
@@ -11,7 +11,11 @@ import config from "@/config/index.js";
 export const asyncHandler =
   (requestHandler: RequestHandler): RequestHandler =>
   (req, res, next) => {
-    Promise.resolve(requestHandler(req, res, next)).catch(next);
+    try {
+      Promise.resolve(requestHandler(req, res, next)).catch(next);
+    } catch (error) {
+      next(error);
+    }
   };
 
 export const subdomain =
@@ -49,7 +53,7 @@ type HttpErrorOptions = ErrorOptions & {
 /**
  * HTTPError is a subclass of Error that includes an HTTP status code.
  */
-class HTTPError extends Error {
+export class HTTPError extends Error {
   public statusCode: number;
   public details:
     | {


### PR DESCRIPTION
- No error if used as middleware
- In GraphQL throws error only if the user or if the JWT is invalid
  (ignore invalid scheme)

Fix ARGOS-SERVER-XQ3
Fix ARGOS-SERVER-XQC
Fix ARGOS-SERVER-XQD
