### PR TITLE
fix: support big images

### DIFF
--- a/apps/backend/src/graphql/definitions/Screenshot.ts
+++ b/apps/backend/src/graphql/definitions/Screenshot.ts
@@ -1,7 +1,11 @@
 import { invariant } from "@argos/util/invariant";
 import gqlTag from "graphql-tag";
 
-import { getPublicImageUrl, getPublicUrl } from "@/storage/index.js";
+import {
+  getPublicImageFileUrl,
+  getPublicUrl,
+  getTwicPicsUrl,
+} from "@/storage/index.js";
 
 import type { IResolvers } from "../__generated__/resolver-types.js";
 
@@ -77,8 +81,13 @@ export const typeDefs = gql`
 
 export const resolvers: IResolvers = {
   Screenshot: {
-    url: async (screenshot) => {
-      return getPublicImageUrl(screenshot.s3Id);
+    url: async (screenshot, _args, ctx) => {
+      if (!screenshot.fileId) {
+        return getTwicPicsUrl(screenshot.s3Id);
+      }
+      const file = await ctx.loaders.File.load(screenshot.fileId);
+      invariant(file, "File not found");
+      return getPublicImageFileUrl(file);
     },
     width: async (screenshot, _args, ctx) => {
       if (!screenshot.fileId) {

--- a/apps/backend/src/graphql/definitions/ScreenshotDiff.ts
+++ b/apps/backend/src/graphql/definitions/ScreenshotDiff.ts
@@ -1,7 +1,7 @@
 import { invariant } from "@argos/util/invariant";
 import gqlTag from "graphql-tag";
 
-import { getPublicImageUrl } from "@/storage/index.js";
+import { getPublicImageFileUrl, getTwicPicsUrl } from "@/storage/index.js";
 
 import type {
   IResolvers,
@@ -56,11 +56,16 @@ export const resolvers: IResolvers = {
       }
       return ctx.loaders.Screenshot.load(screenshotDiff.compareScreenshotId);
     },
-    url: async (screenshotDiff) => {
-      if (!screenshotDiff.s3Id) {
-        return null;
+    url: async (screenshotDiff, _args, ctx) => {
+      if (!screenshotDiff.fileId) {
+        if (!screenshotDiff.s3Id) {
+          return null;
+        }
+        return getTwicPicsUrl(screenshotDiff.s3Id);
       }
-      return getPublicImageUrl(screenshotDiff.s3Id);
+      const file = await ctx.loaders.File.load(screenshotDiff.fileId);
+      invariant(file, "File not found");
+      return getPublicImageFileUrl(file);
     },
     name: async (screenshotDiff, _args, ctx) => {
       const [baseScreenshot, compareScreenshot] = await Promise.all([

--- a/apps/frontend/src/ui/TwicPicture.tsx
+++ b/apps/frontend/src/ui/TwicPicture.tsx
@@ -6,11 +6,22 @@ export type TwicPictureProps = React.ImgHTMLAttributes<HTMLImageElement> & {
   original?: boolean;
 };
 
+const TWIC_PICS_DOMAIN = "argos.twic.pics";
+
+function checkIsTwicPicsUrl(url: string) {
+  return new URL(url).hostname === TWIC_PICS_DOMAIN;
+}
+
 export const TwicPicture = forwardRef(function TwicPicture(
   props: TwicPictureProps,
   ref: React.ForwardedRef<HTMLImageElement>,
 ) {
   const { src, transforms = [], original, ...rest } = props;
+
+  if (!checkIsTwicPicsUrl(src)) {
+    return <img ref={ref} src={src} {...rest} />;
+  }
+
   if (original) {
     return (
       <img


### PR DESCRIPTION
Twipics has a limit of 36M pixels for an image.

So for image bigger than that we directly use S3 to display it.
