### PR TITLE
fix(google-auth): redirect if query params are invalid

### DIFF
--- a/apps/backend/src/web/app-router.ts
+++ b/apps/backend/src/web/app-router.ts
@@ -91,9 +91,12 @@ export const installAppRouter = async (app: express.Application) => {
   });
 
   router.get("/auth/google/login", (req, res) => {
-    const { state, redirect_uri: redirectUri } = OAuthQueryParamsSchema.parse(
-      req.query,
-    );
+    const parsed = OAuthQueryParamsSchema.safeParse(req.query);
+    if (!parsed.success) {
+      res.redirect("/");
+      return;
+    }
+    const { state, redirect_uri: redirectUri } = parsed.data;
     res.redirect(
       getGoogleAuthUrl({
         clientId: config.get("google.clientId"),


### PR DESCRIPTION
Fix ARGOS-SERVER-XQX
