### PR TITLE
fix: make `deleteProject` idempotent

### DIFF
--- a/apps/backend/src/graphql/definitions/Project.ts
+++ b/apps/backend/src/graphql/definitions/Project.ts
@@ -848,6 +848,10 @@ export const resolvers: IResolvers = {
       });
     },
     deleteProject: async (_root, args, ctx) => {
+      const project = await Project.query().findById(args.id).select("id");
+      if (!project) {
+        return true;
+      }
       await deleteProject({ id: args.id, user: ctx.auth?.user });
       return true;
     },


### PR DESCRIPTION
In order to avoid user clicking on it after a timeout.

Fix ARGOS-SERVER-XRN
