### PR TITLE
fix: avoid processing non-jpg images in worker

### DIFF
--- a/apps/frontend/src/util/color-detection/hook.ts
+++ b/apps/frontend/src/util/color-detection/hook.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { captureException } from "@sentry/react";
 
-import type { Rect } from "./types";
+import type { MessageData, Rect } from "./types";
 
 /**
  * Detects colored areas in the image provided by the URL.
@@ -12,7 +12,7 @@ export function useColoredRects(input: { url: string }): null | Rect[] {
     const worker = new Worker(new URL("./worker.ts", import.meta.url), {
       type: "module",
     });
-    worker.addEventListener("message", (event) => {
+    worker.addEventListener("message", (event: MessageEvent<MessageData>) => {
       setRects(event.data);
     });
     worker.addEventListener("error", (event) => {

--- a/apps/frontend/src/util/color-detection/hook.ts
+++ b/apps/frontend/src/util/color-detection/hook.ts
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { captureException } from "@sentry/react";
 
 import type { MessageData, Rect } from "./types";
 
@@ -17,7 +16,6 @@ export function useColoredRects(input: { url: string }): null | Rect[] {
     });
     worker.addEventListener("error", (event) => {
       console.error(event.message);
-      captureException(`Worker error: ${event.message}`);
     });
     worker.postMessage({ url: input.url });
     return () => {

--- a/apps/frontend/src/util/color-detection/types.ts
+++ b/apps/frontend/src/util/color-detection/types.ts
@@ -7,3 +7,5 @@ export type Rect = {
   width: number;
   height: number;
 };
+
+export type MessageData = Rect[] | null;


### PR DESCRIPTION
ImageKit supports 100M pixels and our limit is 80M in the API so all images should be in jpg now and the problem is solved. It's a fix only for old builds.

Fix ARGOS-BROWSER-B8
