### PR TITLE
fix: fix support for `URL.canParse` not available

### DIFF
--- a/apps/frontend/src/pages/Build/BuildDetailToolbar.tsx
+++ b/apps/frontend/src/pages/Build/BuildDetailToolbar.tsx
@@ -7,6 +7,7 @@ import { generatePath, useMatch } from "react-router-dom";
 import { BuildType, ScreenshotDiffStatus } from "@/gql/graphql";
 import { ButtonGroup } from "@/ui/ButtonGroup";
 import { Separator } from "@/ui/Separator";
+import { canParseURL } from "@/util/url";
 
 import { checkCanBeReviewed, Diff } from "./BuildDiffState";
 import { AutomationLibraryIndicator } from "./metadata/automationLibrary/AutomationLibraryIndicator";
@@ -239,7 +240,7 @@ export const BuildDetailToolbar = memo(function BuildDetailToolbar({
             {mediaType && (
               <MediaTypeIndicator mediaType={mediaType} className="size-4" />
             )}
-            {url && checkIsValidURL(url) ? (
+            {url && canParseURL(url) ? (
               <UrlIndicator
                 url={url}
                 previewUrl={previewUrl}
@@ -366,25 +367,6 @@ function hashViewport(viewport: MetadataViewport): string {
  */
 function hashBrowser(browser: MetadataBrowser): string {
   return `${browser.name} ${browser.version}`;
-}
-
-/**
- * Check if a URL can be parsed.
- */
-function checkIsValidURL(url: string) {
-  // If browser does not support URL, return false.
-  if (typeof URL !== "function") {
-    return false;
-  }
-  // If browser does not support URL.canParse, try to parse the URL.
-  if (typeof URL.canParse !== "function") {
-    try {
-      new URL(url);
-    } catch {
-      return false;
-    }
-  }
-  return URL.canParse(url);
 }
 
 function resolveDiffMetadata(diff: Diff) {

--- a/apps/frontend/src/util/url.ts
+++ b/apps/frontend/src/util/url.ts
@@ -1,0 +1,22 @@
+/**
+ * Check if a URL can be parsed.
+ */
+export function canParseURL(url: string) {
+  // If browser does not support URL, return false.
+  if (typeof URL !== "function") {
+    return false;
+  }
+
+  // If browser supports URL.canParse, use it.
+  if (typeof URL.canParse === "function") {
+    return URL.canParse(url);
+  }
+
+  // Otherwise, try to parse the URL and return true if it succeeds.
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Fix ARGOS-BROWSER-BD
