### PR TITLE
feat: aggregate test stats

### DIFF
--- a/apps/backend/db/migrations/20250602091017_test-stats.js
+++ b/apps/backend/db/migrations/20250602091017_test-stats.js
@@ -1,0 +1,27 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+export const up = async (knex) => {
+  await knex.schema.createTable("test_stats_changes", (table) => {
+    table.bigInteger("testId").notNullable().references("tests.id");
+    table.bigInteger("fileId").nullable().references("files.id");
+    table.dateTime("date").notNullable();
+    table.primary(["testId", "fileId", "date"]);
+    table.integer("value").notNullable();
+  });
+
+  await knex.schema.createTable("test_stats_builds", (table) => {
+    table.bigInteger("testId").notNullable().references("tests.id");
+    table.dateTime("date").notNullable();
+    table.primary(["testId", "date"]);
+    table.integer("value").notNullable();
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+export const down = async (knex) => {
+  await knex.schema.dropTable("test_stats_changes");
+  await knex.schema.dropTable("test_stats_builds");
+};

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -1366,6 +1366,33 @@ CREATE TABLE public.test_activities (
 ALTER TABLE public.test_activities OWNER TO postgres;
 
 --
+-- Name: test_stats_builds; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.test_stats_builds (
+    "testId" bigint NOT NULL,
+    date timestamp with time zone NOT NULL,
+    value integer NOT NULL
+);
+
+
+ALTER TABLE public.test_stats_builds OWNER TO postgres;
+
+--
+-- Name: test_stats_changes; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.test_stats_changes (
+    "testId" bigint NOT NULL,
+    "fileId" bigint NOT NULL,
+    date timestamp with time zone NOT NULL,
+    value integer NOT NULL
+);
+
+
+ALTER TABLE public.test_stats_changes OWNER TO postgres;
+
+--
 -- Name: tests; Type: TABLE; Schema: public; Owner: postgres
 --
 
@@ -2037,6 +2064,22 @@ ALTER TABLE ONLY public.team_users
 
 ALTER TABLE ONLY public.teams
     ADD CONSTRAINT teams_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: test_stats_builds test_stats_builds_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.test_stats_builds
+    ADD CONSTRAINT test_stats_builds_pkey PRIMARY KEY ("testId", date);
+
+
+--
+-- Name: test_stats_changes test_stats_changes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.test_stats_changes
+    ADD CONSTRAINT test_stats_changes_pkey PRIMARY KEY ("testId", "fileId", date);
 
 
 --
@@ -2895,6 +2938,30 @@ ALTER TABLE ONLY public.teams
 
 
 --
+-- Name: test_stats_builds test_stats_builds_testid_foreign; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.test_stats_builds
+    ADD CONSTRAINT test_stats_builds_testid_foreign FOREIGN KEY ("testId") REFERENCES public.tests(id);
+
+
+--
+-- Name: test_stats_changes test_stats_changes_fileid_foreign; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.test_stats_changes
+    ADD CONSTRAINT test_stats_changes_fileid_foreign FOREIGN KEY ("fileId") REFERENCES public.files(id);
+
+
+--
+-- Name: test_stats_changes test_stats_changes_testid_foreign; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.test_stats_changes
+    ADD CONSTRAINT test_stats_changes_testid_foreign FOREIGN KEY ("testId") REFERENCES public.tests(id);
+
+
+--
 -- Name: tests tests_projectid_foreign; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
@@ -3065,3 +3132,4 @@ INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('2025011
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20250202084159_cleanup-test-table.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20250505143128_proxy-github.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20250524183823_clean-stability-store.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20250602091017_test-stats.js', 1, NOW());

--- a/apps/backend/src/metrics/account.ts
+++ b/apps/backend/src/metrics/account.ts
@@ -15,7 +15,7 @@ export async function getAccountScreenshotMetrics(input: {
 }) {
   const interval = `1 ${input.groupBy}`;
   const query = `
-    WITH aggregated AS (
+  WITH aggregated AS (
     SELECT
       date_trunc(:groupBy, sb."createdAt") AS date,
       p.id AS "projectId",

--- a/apps/backend/src/metrics/test.e2e.test.ts
+++ b/apps/backend/src/metrics/test.e2e.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { knex } from "@/database";
+import type { File, Test } from "@/database/models/index.js";
+import { factory, setupDatabase } from "@/database/testing/index.js";
+
+import { upsertTestStats } from "./test.js";
+
+describe("upsertTestStats", () => {
+  let test: Test;
+  let file: File;
+
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  beforeEach(async () => {
+    [test, file] = await Promise.all([
+      factory.Test.create(),
+      factory.File.create({ type: "screenshotDiff" }),
+    ]);
+
+    const builds = await factory.Build.createMany(3, {
+      projectId: test.projectId,
+      type: "reference",
+    });
+
+    await factory.ScreenshotDiff.createMany(3, [
+      {
+        buildId: builds[0]!.id,
+        testId: test.id,
+        createdAt: "2025-06-02T09:12:00.000Z",
+        score: 0.5,
+        fileId: file.id,
+      },
+      {
+        buildId: builds[1]!.id,
+        testId: test.id,
+        createdAt: "2025-06-02T09:18:00.000Z",
+        score: 0,
+      },
+      {
+        buildId: builds[2]!.id,
+        testId: test.id,
+        createdAt: "2025-06-02T09:23:00.000Z",
+        score: 0.3,
+        fileId: file.id,
+      },
+    ]);
+  });
+
+  describe('without "fileId"', () => {
+    it("upsert stats into test_stats_builds", async () => {
+      await upsertTestStats({
+        testId: test.id,
+        date: new Date("2025-06-02T09:18:00.000Z"),
+        fileId: null,
+      });
+
+      const buildsStats = await knex("test_stats_builds");
+      expect(buildsStats).toHaveLength(1);
+      expect(buildsStats[0]).toEqual({
+        testId: test.id,
+        date: new Date("2025-06-02T09:00:00.000Z"),
+        value: 2,
+      });
+
+      // Change with a wrong value
+      await knex("test_stats_builds").update({ value: 0 });
+
+      // Validate that upsert is working
+      await upsertTestStats({
+        testId: test.id,
+        date: new Date("2025-06-02T09:18:00.000Z"),
+        fileId: null,
+      });
+
+      const newBuildsStats = await knex("test_stats_builds");
+      expect(newBuildsStats).toHaveLength(1);
+      expect(newBuildsStats[0]).toEqual({
+        testId: test.id,
+        date: new Date("2025-06-02T09:00:00.000Z"),
+        value: 2,
+      });
+    });
+  });
+
+  describe('with "fileId"', () => {
+    it("upsert stats into test_stats_changes and test_stats_builds", async () => {
+      await upsertTestStats({
+        testId: test.id,
+        date: new Date("2025-06-02T09:18:00.000Z"),
+        fileId: file.id,
+      });
+
+      const [buildsStats, changesStats] = await Promise.all([
+        knex("test_stats_builds"),
+        knex("test_stats_changes"),
+      ]);
+      expect(buildsStats).toHaveLength(1);
+      expect(buildsStats[0]).toEqual({
+        testId: test.id,
+        date: new Date("2025-06-02T09:00:00.000Z"),
+        value: 2,
+      });
+
+      expect(changesStats).toHaveLength(1);
+      expect(changesStats[0]).toEqual({
+        testId: test.id,
+        fileId: file.id,
+        date: new Date("2025-06-02T09:00:00.000Z"),
+        value: 1,
+      });
+    });
+  });
+});

--- a/apps/backend/src/util/date.test.ts
+++ b/apps/backend/src/util/date.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { get20MinutesSlot } from "./date";
+
+describe("get20MinutesSlot", () => {
+  it("returns the start of the slot (20 minutes)", () => {
+    expect(
+      get20MinutesSlot(new Date("2025-06-02T09:26:03.473Z")).toISOString(),
+    ).toBe("2025-06-02T09:20:00.000Z");
+    expect(
+      get20MinutesSlot(new Date("2025-06-02T09:12:03.473Z")).toISOString(),
+    ).toBe("2025-06-02T09:00:00.000Z");
+    expect(
+      get20MinutesSlot(new Date("2025-06-02T09:48:03.473Z")).toISOString(),
+    ).toBe("2025-06-02T09:40:00.000Z");
+  });
+});

--- a/apps/backend/src/util/date.ts
+++ b/apps/backend/src/util/date.ts
@@ -1,0 +1,11 @@
+import moment from "moment";
+
+/**
+ * Get the 20 minutes slot from the input date.
+ */
+export function get20MinutesSlot(date: Date) {
+  const result = moment(date).startOf("hour").toDate();
+  const minutes = Math.floor(date.getMinutes() / 20) * 20;
+  result.setMinutes(minutes);
+  return result;
+}


### PR DESCRIPTION
We aggregate test stats into two tables: "test_stats_builds" and "test_stats_changes".
We store the number of reference builds a test is present in and also
the number of changes by fileId a test has.
The computation will be done after each screenshot diff process (on a
reference build).
These two tables can be used to compute all stats without having to rely
on "screenshot_diffs" table.
It will allow us to create a test dashboard for a project.
