### PR TITLE
Various fixes

### DIFF
--- a/apps/backend/src/build/job.e2e.test.ts
+++ b/apps/backend/src/build/job.e2e.test.ts
@@ -32,6 +32,7 @@ describe("build", () => {
         compareScreenshotBucketId: compareBucket.id,
         projectId: project.id,
         jobStatus: "progress",
+        conclusion: null,
       });
       const file = await factory.File.create({
         type: "screenshot",

--- a/apps/backend/src/graphql/tests/setValidationStatus.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/setValidationStatus.e2e.test.ts
@@ -41,6 +41,7 @@ describe("GraphQL", () => {
       });
       build = await factory.Build.create({
         projectId: project.id,
+        conclusion: null,
       });
       const screenshot1 = await factory.Screenshot.create({
         name: "email_deleted",

--- a/apps/backend/src/screenshot-diff/job.ts
+++ b/apps/backend/src/screenshot-diff/job.ts
@@ -14,5 +14,5 @@ export const job = createModelJob(
       bucket: config.get("s3.screenshotsBucket"),
     });
   },
-  { prefetch: 1 },
+  { timeout: 30_000 },
 );


### PR DESCRIPTION
- **refactor: run compute build in a lock**
- **refactor: allow to specify a custom timeout for a job**
- **refactor: set the screenshot diff job timeout to 30s**
- **perf: optimize computeScreenshotDiff for grouping**
- **fix(build): avoid being dependant on GitHub**
