### PR TITLE
fix: handle npm registry failures in SDK latestVersion resolver

### DIFF
--- a/apps/backend/src/config/index.ts
+++ b/apps/backend/src/config/index.ts
@@ -37,6 +37,12 @@ export function createConfig() {
       doc: "The contact email",
       default: "contact@argos-ci.com",
     },
+    selfHosted: {
+      doc: "Whether the instance is self-hosted. Disables features that require external network access (e.g. npm registry lookups).",
+      format: Boolean,
+      default: false,
+      env: "SELF_HOSTED",
+    },
     server: {
       port: {
         doc: "The server port number",

--- a/apps/backend/src/graphql/definitions/Screenshot.ts
+++ b/apps/backend/src/graphql/definitions/Screenshot.ts
@@ -2,6 +2,8 @@ import { invariant } from "@argos/util/invariant";
 import gqlTag from "graphql-tag";
 import semver from "semver";
 
+import config from "@/config";
+import logger from "@/logger";
 import {
   checkIsTrustedNpmPackage,
   getLatestPackageVersion,
@@ -160,12 +162,23 @@ export const resolvers: IResolvers = {
   },
   ScreenshotMetadataSDK: {
     async latestVersion(sdk) {
+      if (config.get("selfHosted")) {
+        return null;
+      }
       if (!checkIsTrustedNpmPackage(sdk.name)) {
         return null;
       }
-      const latestVersion = await getLatestPackageVersion(sdk.name);
-      if (semver.gt(latestVersion, sdk.version)) {
-        return latestVersion;
+      try {
+        const latestVersion = await getLatestPackageVersion(sdk.name);
+        if (semver.gt(latestVersion, sdk.version)) {
+          return latestVersion;
+        }
+      } catch (error) {
+        logger.warn(
+          { sdkName: sdk.name, error },
+          "Failed to fetch latest SDK version from npm registry",
+        );
+        return null;
       }
       return null;
     },


### PR DESCRIPTION
## Problem

The `ScreenshotMetadataSDK.latestVersion` GraphQL resolver fetches from the npm registry to check if a newer Argos SDK version is available. When the npm registry is unreachable, the unhandled `fetch` error propagates as a GraphQL `INTERNAL_SERVER_ERROR`, which crashes the React error boundary and makes the entire build page unusable.

This affects:
- **Self-hosted deployments** where the server can't reach `registry.npmjs.org` (firewalls, air-gapped networks, HTTP proxy restrictions)
- **SaaS** during transient npm registry outages

## Solution

1. **Skip the npm check when `SELF_HOSTED=true`** — consistent with existing self-hosted checks (`Account.ts`, `saml.ts`, `util.ts`). Self-hosted instances don't need the "update available" badge.

2. **Add try/catch as defense-in-depth** — even on SaaS, a transient npm failure shouldn't crash the build view. The `latestVersion` field is purely cosmetic.

## Context

We're running a self-hosted Argos instance at Square (Block) for visual regression testing. The server runs behind a corporate proxy that doesn't tunnel HTTPS to `registry.npmjs.org`. Every build with screenshot metadata crashed with:

```
"message": "fetch failed",
"path": ["project", "build", "screenshotDiffs", "edges", 0, "compareScreenshot", "metadata", "sdk", "latestVersion"]
```

Nulling the `metadata` field confirmed `latestVersion` as the sole cause.