### PR TITLE
fix: use configured S3 region instead of hardcoded eu-west-1

### DIFF
--- a/apps/backend/src/config/index.ts
+++ b/apps/backend/src/config/index.ts
@@ -149,6 +149,12 @@ export function createConfig() {
         default: "argos-ci-development",
         env: "AWS_SCREENSHOTS_BUCKET",
       },
+      region: {
+        doc: "AWS region for the S3 screenshots bucket",
+        format: String,
+        default: "eu-west-1",
+        env: "S3_REGION",
+      },
       publicImageBaseUrl: {
         doc: "Public URL for screenshots",
         format: String,

--- a/apps/backend/src/storage/s3.ts
+++ b/apps/backend/src/storage/s3.ts
@@ -1,11 +1,11 @@
 import { S3Client } from "@aws-sdk/client-s3";
 import { memoize } from "lodash-es";
 
+import config from "@/config";
+
 export type { S3Client } from "@aws-sdk/client-s3";
 
-type S3Region = "eu-west-1" | "us-east-1";
-
-function getS3ClientBase(region: S3Region = "eu-west-1") {
+function getS3ClientBase(region: string = config.get("s3.region")) {
   return new S3Client({ region });
 }
 

--- a/apps/backend/src/web/app-router.ts
+++ b/apps/backend/src/web/app-router.ts
@@ -195,7 +195,7 @@ export const installAppRouter = async (app: express.Application) => {
             // ImageKit images
             "https://files.argos-ci.com",
             // S3 images
-            `https://${config.get("s3.screenshotsBucket")}.s3.eu-west-1.amazonaws.com`,
+            `https://${config.get("s3.screenshotsBucket")}.s3.${config.get("s3.region")}.amazonaws.com`,
             // GitHub and GitLab avatars
             "https://github.com",
             "https://avatars.githubusercontent.com",


### PR DESCRIPTION
## Problem

The S3 region is hardcoded to `eu-west-1` in several places:

1. **CSP `img-src` directive** (`app-router.ts`) — the Content-Security-Policy allows images only from `*.s3.eu-west-1.amazonaws.com`, blocking screenshots stored in other regions
2. **S3 client** (`s3.ts`) — the region type is restricted to `"eu-west-1" | "us-east-1"` and defaults to `eu-west-1`

This is a problem for self-hosted deployments that use a different AWS region (e.g. `us-west-2`).

## Solution

- Add `s3.region` config option (env: `S3_REGION`, default: `eu-west-1` for backward compatibility)
- Use the configured region in the CSP `img-src` directive
- Use the configured region as the S3 client default (removing the hardcoded type restriction)

No breaking changes — existing deployments that don't set `S3_REGION` continue using `eu-west-1`.

## Context

We're running a self-hosted Argos instance on AWS `us-east-1` and hit CSP violations when loading screenshots because the CSP only allowed `eu-west-1` S3 URLs.