### PR TITLE
fix: add explicit root route handler for Express 5

### DIFF
--- a/apps/backend/src/web/app-router.ts
+++ b/apps/backend/src/web/app-router.ts
@@ -230,6 +230,13 @@ export const installAppRouter = async (app: express.Application) => {
     res.sendFile(join(distDir, "index.html"));
   });
 
+  // Express 5 {*splat} requires at least one path segment, so "/" does not
+  // match the catch-all above. Add an explicit root handler so that "/"
+  // serves the SPA shell (needed for single-domain deployments).
+  router.get("/", (_req, res) => {
+    res.sendFile(join(distDir, "index.html"));
+  });
+
   app.use(subdomain(router, "app"));
 };
 


### PR DESCRIPTION
## Problem

Express 5's `{*splat}` pattern requires at least one path segment, so the catch-all route `/{*splat}` does **not** match `/`. This means navigating to the root URL returns a 404 instead of serving the SPA shell.

This is a regression from Express 4, where `*` matched zero or more segments including the empty path.

## Solution

Add an explicit `GET /` handler after the `/{*splat}` catch-all so that `/` correctly serves `index.html`.

## Who is affected

This primarily affects single-domain deployments (e.g. self-hosted) where there is no subdomain-based routing to redirect `/` elsewhere. In the default multi-subdomain setup (`app.argos-ci.com`), the root is typically not hit directly.