### PR TITLE
Cast githubPullRequestId to string

### DIFF
--- a/apps/backend/src/build/createBuild.ts
+++ b/apps/backend/src/build/createBuild.ts
@@ -191,7 +191,7 @@ export async function createBuild(params: {
           await BuildMergeQueueGhPullRequest.query(trx).insert(
             mergeQueuePullRequests.map((pullRequest) => ({
               buildId: build.id,
-              githubPullRequestId: pullRequest.id,
+              githubPullRequestId: String(pullRequest.id),
             })),
           );
         }


### PR DESCRIPTION
The database expects this to be a string. A few lines above, `pullRequest.id` is cast to a string but not here. This was causing validation failures from the CLI `upload` command when running inside a `merge_group` job.

Happy for you to just close this but thought it might be valuable to pass it along.

I have [Argos CI running in Cloud Run](https://github.com/argos-ci/argos/discussions/1811) and was having trouble with GitHub Actions in `merge_group` jobs being unable to upload to Argos despite including the token and even trying to pass it myself. It might be a configuration issue but I can't see how as it is being returned from Knex/postgres. 