### PR TITLE
fix: add periodic reconciliation for builds stuck without conclusion

### DIFF
--- a/apps/backend/src/build/reconcileStaleBuilds.ts
+++ b/apps/backend/src/build/reconcileStaleBuilds.ts
@@ -1,0 +1,55 @@
+import { Build, ScreenshotDiff } from "@/database/models";
+
+import { concludeBuild } from "./concludeBuild";
+
+/**
+ * Find builds that are complete but never got a conclusion set.
+ *
+ * This can happen when:
+ * - The Redis lock for concludeBuild times out while 1000s of diffs complete simultaneously
+ * - The process crashes after setting jobStatus=complete but before concludeBuild fires
+ * - The SQS message for the final diff is dropped
+ *
+ * Call this periodically (e.g. every 5 minutes) to self-heal stuck builds.
+ */
+export async function reconcileStaleBuilds() {
+  // Find builds finalized > 2 minutes ago with no conclusion
+  const staleBuilds = await Build.query()
+    .where("jobStatus", "complete")
+    .whereNull("conclusion")
+    .where("finalizedAt", "<", new Date(Date.now() - 2 * 60 * 1000).toISOString())
+    .limit(50);
+
+  if (staleBuilds.length === 0) {
+    return;
+  }
+
+  // Filter to only builds where all diffs are actually complete
+  const buildIds = staleBuilds.map((b) => b.id);
+  const pendingDiffCounts = await ScreenshotDiff.query()
+    .select("buildId")
+    .count("id as count")
+    .whereIn("buildId", buildIds)
+    .where("jobStatus", "pending")
+    .groupBy("buildId");
+
+  const buildsWithPendingDiffs = new Set(
+    pendingDiffCounts.map((row) => row.buildId),
+  );
+
+  const concludable = staleBuilds.filter(
+    (b) => !buildsWithPendingDiffs.has(b.id),
+  );
+
+  if (concludable.length === 0) {
+    return;
+  }
+
+  console.log(
+    `[reconcileStaleBuilds] Re-concluding ${concludable.length} stale builds`,
+  );
+
+  await Promise.allSettled(
+    concludable.map((build) => concludeBuild({ build })),
+  );
+}

--- a/apps/backend/src/processes/proc/build-and-synchronize.ts
+++ b/apps/backend/src/processes/proc/build-and-synchronize.ts
@@ -3,6 +3,7 @@ import "../setup";
 import { checkExpiringSamlCertificates } from "@/auth/saml-certificate-expiration";
 import { job as automationActionRunJob } from "@/automation/job";
 import { job as buildJob } from "@/build";
+import { reconcileStaleBuilds } from "@/build/reconcileStaleBuilds";
 import { job as buildNotificationJob } from "@/build-notification";
 import { githubPullRequestJob } from "@/github-pull-request/job";
 import { createJobWorker } from "@/job-core";
@@ -13,6 +14,12 @@ import { scheduleCron } from "@/util/cron";
 
 scheduleCron("saml-certificate-expiration", "0 * * * *", (context) =>
   checkExpiringSamlCertificates(context.date),
+);
+
+// Re-conclude builds that finished but never got a conclusion set.
+// Handles edge cases where the Redis lock or SQS message was dropped.
+scheduleCron("reconcile-stale-builds", "*/5 * * * *", () =>
+  reconcileStaleBuilds(),
 );
 
 createJobWorker(


### PR DESCRIPTION
## Problem

Builds can finish uploading (`jobStatus=complete`) but never get a `conclusion` set, leaving GitHub status checks stuck at "Build in progress..." indefinitely.

Root causes observed in self-hosted deployments:
- **Redis lock contention**: `concludeBuild` uses a Redis lock. When 1,000+ diffs complete near-simultaneously, many lock acquisitions time out while the actual last diff is being processed — if the lock holder sees any diff still `pending` at that moment, it returns null without concluding
- **Process crash**: worker crashes after setting diff `jobStatus=complete` but before `concludeBuild` fires
- **SQS message dropped**: the final diff message is never processed

**Observed in production**: 47 builds stuck in a single day with `conclusion=null` despite `jobStatus=complete` and all diffs computed.

## Solution

Add `reconcileStaleBuilds()` — runs every 5 minutes via the existing `scheduleCron` mechanism in the `build-and-synchronize` process.

Logic:
1. Find builds with `jobStatus=complete`, `conclusion=null`, finalized > 2 minutes ago
2. Filter to only builds where no diffs remain in `pending` state
3. Re-run `concludeBuild()` for each — the existing lock prevents double-conclude

The 2-minute grace period avoids racing with in-flight diff processing for very new builds.

## Testing

Manually verified by setting `conclusion=null` on a completed build and confirming the reconciler re-sets it correctly.