### PR TITLE
feat: auto-redirect to SSO on login for self-hosted instances

### DIFF
--- a/apps/backend/src/config/index.ts
+++ b/apps/backend/src/config/index.ts
@@ -43,6 +43,12 @@ export function createConfig() {
       default: false,
       env: "SELF_HOSTED",
     },
+    samlTeamSlug: {
+      doc: "For self-hosted instances: the team account slug to auto-redirect to on login. Enables SSO-only login flow.",
+      format: String,
+      default: "",
+      env: "SAML_TEAM_SLUG",
+    },
     server: {
       port: {
         doc: "The server port number",

--- a/apps/backend/src/web/app-router.ts
+++ b/apps/backend/src/web/app-router.ts
@@ -30,7 +30,10 @@ export const installAppRouter = async (app: express.Application) => {
 
   router.use(limiter);
 
+  const samlTeamSlugValue = config.get("samlTeamSlug");
   const clientConfig: ClientConfig = {
+    selfHosted: config.get("selfHosted"),
+    samlTeamSlug: samlTeamSlugValue || null,
     sentry: {
       environment: config.get("sentry.environment"),
       clientDsn: config.get("sentry.clientDsn"),

--- a/apps/backend/src/web/app-router.ts
+++ b/apps/backend/src/web/app-router.ts
@@ -30,10 +30,10 @@ export const installAppRouter = async (app: express.Application) => {
 
   router.use(limiter);
 
-  const samlTeamSlugValue = config.get("samlTeamSlug");
+  const selfHosted = config.get("selfHosted");
   const clientConfig: ClientConfig = {
-    selfHosted: config.get("selfHosted"),
-    samlTeamSlug: samlTeamSlugValue || null,
+    selfHosted,
+    samlTeamSlug: selfHosted ? config.get("samlTeamSlug") || null : null,
     sentry: {
       environment: config.get("sentry.environment"),
       clientDsn: config.get("sentry.clientDsn"),

--- a/apps/frontend/src/pages/Login.tsx
+++ b/apps/frontend/src/pages/Login.tsx
@@ -8,6 +8,7 @@ import { Alert, AlertText, AlertTitle } from "@/ui/Alert";
 import { BrandShield } from "@/ui/BrandShield";
 import { Container } from "@/ui/Container";
 import { Link } from "@/ui/Link";
+import { config } from "@/config";
 import { redirectToSAMLLogin } from "@/util/saml";
 
 export function Component() {
@@ -20,6 +21,12 @@ export function Component() {
 
   if (samlTeamSlug) {
     return <RedirectToSAMLLogin teamSlug={samlTeamSlug} redirect={redirect} />;
+  }
+
+  // Self-hosted: skip the login form and redirect straight to SSO.
+  // Uses the samlTeamSlug from server config so the operator controls which team.
+  if (config.selfHosted && config.samlTeamSlug && !error) {
+    return <RedirectToSAMLLogin teamSlug={config.samlTeamSlug} redirect={redirect} />;
   }
 
   if (loggedIn) {

--- a/apps/frontend/src/pages/Login.tsx
+++ b/apps/frontend/src/pages/Login.tsx
@@ -2,13 +2,13 @@ import { useEffect, useState } from "react";
 import { Helmet } from "react-helmet";
 import { Navigate, useSearchParams } from "react-router-dom";
 
+import { config } from "@/config";
 import { useIsLoggedIn } from "@/containers/Auth";
 import { LoginOptions } from "@/containers/LoginOptions";
 import { Alert, AlertText, AlertTitle } from "@/ui/Alert";
 import { BrandShield } from "@/ui/BrandShield";
 import { Container } from "@/ui/Container";
 import { Link } from "@/ui/Link";
-import { config } from "@/config";
 import { redirectToSAMLLogin } from "@/util/saml";
 
 export function Component() {
@@ -25,8 +25,10 @@ export function Component() {
 
   // Self-hosted: skip the login form and redirect straight to SSO.
   // Uses the samlTeamSlug from server config so the operator controls which team.
-  if (config.selfHosted && config.samlTeamSlug && !error) {
-    return <RedirectToSAMLLogin teamSlug={config.samlTeamSlug} redirect={redirect} />;
+  if (config.selfHosted && config.samlTeamSlug && !error && !loggedIn) {
+    return (
+      <RedirectToSAMLLogin teamSlug={config.samlTeamSlug} redirect={redirect} />
+    );
   }
 
   if (loggedIn) {

--- a/packages/config-types/types.d.ts
+++ b/packages/config-types/types.d.ts
@@ -2,6 +2,10 @@
  * Client config types shared between frontend and backend.
  */
 export interface ClientConfig {
+  /** Whether this is a self-hosted instance. */
+  selfHosted: boolean;
+  /** For self-hosted instances: auto-redirect login to this team's SSO. Null on cloud. */
+  samlTeamSlug: string | null;
   sentry: {
     environment: string;
     clientDsn: string;


### PR DESCRIPTION
## Problem

Self-hosted Argos instances typically have a single SSO provider (e.g. Okta SAML) and don't want users to see GitHub/Google/GitLab login options. Currently users must:
1. Know to scroll to the SAML section
2. Know the team slug to enter

## Solution

Add `SAML_TEAM_SLUG` env var. When set alongside `SELF_HOSTED=true`, the login page skips the form entirely and redirects straight to the SSO provider — no UI shown, no team slug to enter.

**New config:**
- `SAML_TEAM_SLUG` — the account slug to redirect to (e.g. `block`, `my-company`)
- Exposed to frontend via `ClientConfig.samlTeamSlug`

**Behavior:**
- `SELF_HOSTED=false` or `SAML_TEAM_SLUG` not set → normal login page (no change)
- `SELF_HOSTED=true` + `SAML_TEAM_SLUG=block` + no error → immediate redirect to `/auth/saml/block`
- Error present → show error on login page (so auth failures are visible)