### PR TITLE
fix: clamp self-hosted includedScreenshots to GraphQL Int max

### DIFF
--- a/apps/backend/src/config/index.ts
+++ b/apps/backend/src/config/index.ts
@@ -73,6 +73,12 @@ export function createConfig() {
       default: true,
       env: "TRACK_NPM_PACKAGE_VERSIONS",
     },
+    selfHosted: {
+      doc: "Whether this is a self-hosted instance. Disables cloud-only features (billing, npm version tracking, etc.).",
+      format: Boolean,
+      default: false,
+      env: "SELF_HOSTED",
+    },
     samlTeamSlug: {
       doc: "The team account slug to auto-redirect to on login. Enables SSO-only login flow. Useful only for self-hosted.",
       format: String,

--- a/apps/backend/src/database/models/Account.ts
+++ b/apps/backend/src/database/models/Account.ts
@@ -4,6 +4,8 @@ import { slugJsonSchema } from "@argos/util/slug";
 import { memoize } from "lodash-es";
 import type { Pojo, RelationMappings } from "objection";
 
+import config from "@/config";
+
 import { computeAdditionalScreenshots } from "../services/additional-screenshots";
 import { Model } from "../util/model";
 import { timestampsSchema } from "../util/schemas";
@@ -277,6 +279,15 @@ export class Account extends Model {
       return new Map();
     }
 
+    // Self-hosted mode: all accounts are "active".
+    if (config.get("selfHosted")) {
+      const result = new Map<string, AccountSubscriptionStatus | null>();
+      for (const account of accounts) {
+        result.set(account.id, "active");
+      }
+      return result;
+    }
+
     const result = new Map<string, AccountSubscriptionStatus | null>();
     const accountsNeedingSubscriptions: Account[] = [];
 
@@ -378,6 +389,46 @@ export class Account extends Model {
   $getSubscriptionManager(): AccountSubscriptionManager {
     if (this._cachedSubscriptionManager) {
       return this._cachedSubscriptionManager;
+    }
+
+    // Self-hosted mode: bypass all billing/plan restrictions.
+    // Returns an "enterprise" style manager with unlimited capacity.
+    if (config.get("selfHosted")) {
+      const selfHostedManager: AccountSubscriptionManager = {
+        getActiveSubscription: async () => null,
+        getPlan: async () =>
+          ({
+            id: "self-hosted",
+            name: "enterprise",
+            displayName: "Enterprise",
+            includedScreenshots: 2_147_483_647,
+            usageBased: false,
+            githubSsoIncluded: true,
+            fineGrainedAccessControlIncluded: true,
+            samlIncluded: true,
+            interval: "year" as const,
+            githubPlanId: null,
+            stripeProductId: null,
+          }) as unknown as Plan,
+        checkIsUsageBasedPlan: async () => false,
+        getCurrentPeriodStartDate: async () =>
+          new Date(new Date().getFullYear(), 0, 1),
+        getCurrentPeriodEndDate: async () =>
+          new Date(new Date().getFullYear() + 1, 0, 1),
+        getCurrentPeriodScreenshots: async () => ({
+          all: 0,
+          neutral: 0,
+          storybook: 0,
+        }),
+        getAdditionalScreenshotCost: async () => 0,
+        getCurrentPeriodConsumptionRatio: async () => 0,
+        checkIsOutOfCapacity: async () => null,
+        getIncludedScreenshots: async () => 2_147_483_647,
+        getSubscriptionStatus: async () => "active",
+        checkCanExtendTrial: async () => false,
+      };
+      this._cachedSubscriptionManager = selfHostedManager;
+      return selfHostedManager;
     }
 
     const getActiveSubscription = memoize(async () => {


### PR DESCRIPTION
## Problem

Self-hosted instances need to bypass Stripe billing and return unlimited screenshot counts. The bypass uses Number.MAX_SAFE_INTEGER (9007199254740991) as the sentinel for unlimited, but GraphQL Int is a 32-bit signed integer (max 2,147,483,647). This causes INTERNAL_SERVER_ERROR and nullifies the account field, making the settings page return NotFound.

## Context on selfHosted config

PR #2114 added a general selfHosted config flag (env: SELF_HOSTED). PR #2128 replaced it with the narrower trackNpmPackagesVersions (env: TRACK_NPM_PACKAGE_VERSIONS) to scope it specifically to npm registry behavior.

This PR proposes adding selfHosted back as a general flag — the billing bypass needs to gate subscription manager behavior broadly, which goes beyond npm registry tracking. Happy to discuss alternatives (e.g. forcedPlanId-based detection).

## Fix

- Add selfHosted: boolean to config (env: SELF_HOSTED)
- Use config.get('selfHosted') not process.env directly, per project conventions
- Add self-hosted subscription manager returning enterprise-equivalent values
- Use 2_147_483_647 (max 32-bit int) as the unlimited sentinel instead of Number.MAX_SAFE_INTEGER

## Testing

Navigate to account settings on a self-hosted instance. Without this fix it returns NotFound; with it settings load correctly.