### PR TITLE
fix: skip app router catch-all for /v2 in single-domain self-hosted mode

### DIFF
--- a/apps/backend/src/config/index.ts
+++ b/apps/backend/src/config/index.ts
@@ -73,6 +73,12 @@ export function createConfig() {
       default: true,
       env: "TRACK_NPM_PACKAGE_VERSIONS",
     },
+    selfHosted: {
+      doc: "Whether this is a self-hosted instance. Disables cloud-only features (billing, npm version tracking, etc.).",
+      format: Boolean,
+      default: false,
+      env: "SELF_HOSTED",
+    },
     samlTeamSlug: {
       doc: "The team account slug to auto-redirect to on login. Enables SSO-only login flow. Useful only for self-hosted.",
       format: String,

--- a/apps/backend/src/web/app-router.ts
+++ b/apps/backend/src/web/app-router.ts
@@ -30,6 +30,16 @@ export const installAppRouter = async (app: express.Application) => {
 
   router.use(limiter);
 
+  // In self-hosted mode, both app and API routers accept all requests
+  // (subdomain check bypassed). The app router runs first, so its catch-all
+  // would intercept API GET requests (e.g., GET /v2/project).
+  // Skip /v2/ paths so the API router handles them.
+  if (config.get("selfHosted")) {
+    router.use("/v2", (_req, _res, next) => {
+      next("router");
+    });
+  }
+
   const clientConfig: ClientConfig = {
     samlTeamSlug: config.get("samlTeamSlug"),
     sentry: {


### PR DESCRIPTION
## Problem

In single-domain self-hosted deployments (using `WILDCARD_DOMAINS` from #2128), all requests are routed to the app router. The app router has a catch-all `/{*splat}` that serves `index.html` for any unmatched path.

This means `GET /v2/project`, `POST /v2/builds`, etc. all return `index.html` instead of API responses, completely breaking CI integrations on self-hosted instances.

## Fix

Add a `/v2` handler early in the app router that calls `next('router')` when `SELF_HOSTED=true`. This skips the app router and passes the request to the API router registered next in `app.ts`.

## Context

This pairs with `wildcardDomains` support added in #2128. Without this fix, single-domain self-hosted instances cannot accept any API calls from CI.