### PR TITLE
fix: expose selfHosted flag and nullable samlTeamSlug in ClientConfig

### DIFF
--- a/apps/backend/src/config/index.ts
+++ b/apps/backend/src/config/index.ts
@@ -73,6 +73,12 @@ export function createConfig() {
       default: true,
       env: "TRACK_NPM_PACKAGE_VERSIONS",
     },
+    selfHosted: {
+      doc: "Whether this is a self-hosted instance. Disables cloud-only features (billing, npm version tracking, etc.).",
+      format: Boolean,
+      default: false,
+      env: "SELF_HOSTED",
+    },
     samlTeamSlug: {
       doc: "The team account slug to auto-redirect to on login. Enables SSO-only login flow. Useful only for self-hosted.",
       format: String,

--- a/apps/backend/src/web/app-router.ts
+++ b/apps/backend/src/web/app-router.ts
@@ -30,8 +30,20 @@ export const installAppRouter = async (app: express.Application) => {
 
   router.use(limiter);
 
+  // In self-hosted mode, both app and API routers accept all requests
+  // (subdomain check bypassed). The app router runs first, so its catch-all
+  // would intercept API GET requests (e.g., GET /v2/project).
+  // Skip /v2/ paths so the API router handles them.
+  if (config.get("selfHosted")) {
+    router.use("/v2", (_req, _res, next) => {
+      next("router");
+    });
+  }
+
+  const samlTeamSlugValue = config.get("samlTeamSlug");
   const clientConfig: ClientConfig = {
-    samlTeamSlug: config.get("samlTeamSlug"),
+    selfHosted: config.get("selfHosted"),
+    samlTeamSlug: samlTeamSlugValue || null,
     sentry: {
       environment: config.get("sentry.environment"),
       clientDsn: config.get("sentry.clientDsn"),

--- a/packages/config-types/types.d.ts
+++ b/packages/config-types/types.d.ts
@@ -2,6 +2,8 @@
  * Client config types shared between frontend and backend.
  */
 export interface ClientConfig {
+  /** Whether this is a self-hosted instance. */
+  selfHosted: boolean;
   sentry: {
     environment: string;
     clientDsn: string;
@@ -9,7 +11,8 @@ export interface ClientConfig {
   session: {
     domain: string;
   };
-  samlTeamSlug: string;
+  /** For self-hosted instances: auto-redirect login to this team's SSO. Null on cloud. */
+  samlTeamSlug: string | null;
   releaseVersion: string;
   contactEmail: string;
   github: {


### PR DESCRIPTION
## Problem

Self-hosted instances need to communicate their mode to the frontend so it can:
- Auto-redirect the login page to the configured SSO provider
- Hide cloud-only features (billing, marketplace links, etc.)

Currently there's no way for frontend code to know it's running on a self-hosted instance.

Also, `samlTeamSlug` is typed as `string` but is `null` on cloud instances where SSO isn't configured — the frontend needs to check for null before using it.

## Fix

- Add `selfHosted: boolean` to `ClientConfig`, populated from `process.env["SELF_HOSTED"] === "true"` in `app-router.ts`
- Change `samlTeamSlug: string` to `samlTeamSlug: string | null` to accurately reflect that it's optional

## Usage

```ts
if (config.selfHosted && config.samlTeamSlug) {
  // Auto-redirect to SSO on login page
  redirectToSAMLLogin({ teamSlug: config.samlTeamSlug });
}
```