### PR TITLE
perf: use debounce instead of lock

### DIFF
--- a/apps/backend/src/build/concludeBuild.e2e.test.ts
+++ b/apps/backend/src/build/concludeBuild.e2e.test.ts
@@ -1,0 +1,92 @@
+import { test as base, describe, expect } from "vitest";
+
+import type { Build } from "@/database/models/Build";
+import { Build as BuildModel } from "@/database/models/Build";
+import { factory } from "@/database/testing";
+import { setupDatabase } from "@/database/testing/util";
+import { getRedisClient } from "@/util/redis/client";
+
+import { concludeBuild } from "./concludeBuild";
+
+const test = base.extend<{
+  unfinishedBuild: Build;
+}>({
+  unfinishedBuild: async ({}, use) => {
+    await setupDatabase();
+    const build = await factory.Build.create({ conclusion: null });
+    await use(build);
+  },
+});
+
+describe("#concludeBuild", () => {
+  test("does not conclude when some diffs are still in progress", async ({
+    unfinishedBuild,
+  }) => {
+    await factory.ScreenshotDiff.create({
+      buildId: unfinishedBuild.id,
+      jobStatus: "complete",
+    });
+    await factory.ScreenshotDiff.create({
+      buildId: unfinishedBuild.id,
+      jobStatus: "progress",
+    });
+
+    await concludeBuild({ build: unfinishedBuild, notify: false });
+
+    const refreshed = await BuildModel.query()
+      .findById(unfinishedBuild.id)
+      .throwIfNotFound();
+    expect(refreshed.conclusion).toBeNull();
+  });
+
+  test("treats diffs in completedScreenshotDiffIds as complete", async ({
+    unfinishedBuild,
+  }) => {
+    const inProgressDiff = await factory.ScreenshotDiff.create({
+      buildId: unfinishedBuild.id,
+      jobStatus: "progress",
+    });
+    await factory.ScreenshotDiff.create({
+      buildId: unfinishedBuild.id,
+      jobStatus: "complete",
+    });
+
+    await concludeBuild({
+      build: unfinishedBuild,
+      notify: false,
+      completedScreenshotDiffIds: [inProgressDiff.id],
+    });
+
+    const refreshed = await BuildModel.query()
+      .findById(unfinishedBuild.id)
+      .throwIfNotFound();
+    expect(refreshed.conclusion).toBe("no-changes");
+  });
+
+  test("picks up completedScreenshotDiffIds pooled by previous callers", async ({
+    unfinishedBuild,
+  }) => {
+    // Simulates a coalesced burst: a previous caller's IDs were pooled
+    // in Redis before bailing. The current caller must see those pooled
+    // IDs and treat the corresponding diffs as complete — otherwise the
+    // build can stay unconcluded if the bailer's `complete` job hook
+    // hasn't fired yet.
+    const pooledDiff = await factory.ScreenshotDiff.create({
+      buildId: unfinishedBuild.id,
+      jobStatus: "progress",
+    });
+    const redis = await getRedisClient();
+    const poolKey = `conclude-build-completed-ids:${unfinishedBuild.id}`;
+    await redis.del(poolKey);
+    await redis.sAdd(poolKey, [pooledDiff.id]);
+
+    // No completedScreenshotDiffIds in the call — the pooled set must
+    // fill in.
+    await concludeBuild({ build: unfinishedBuild, notify: false });
+
+    const refreshed = await BuildModel.query()
+      .findById(unfinishedBuild.id)
+      .throwIfNotFound();
+    expect(refreshed.conclusion).toBe("no-changes");
+  });
+});

--- a/apps/backend/src/build/concludeBuild.ts
+++ b/apps/backend/src/build/concludeBuild.ts
@@ -39,13 +39,14 @@ export async function concludeBuild(input: {
       },
     },
     () =>
-      // Debounce instead of locking: coalesce a burst of completions
-      // (e.g. 100 screenshot diffs finishing in parallel) into a single
-      // execution. The first caller claims the window, waits briefly so
-      // concurrent callers can register their `complete` job handlers,
-      // then runs the conclude logic once. Other callers in the window
-      // bail immediately — they would only have been no-ops anyway.
-      redisLock.debounce(
+      // Coalesce a burst of completions (e.g. 100 screenshot diffs
+      // finishing in parallel) into a single execution. The first caller
+      // claims the window, waits briefly so concurrent callers can register
+      // their `complete` job handlers, then runs the conclude logic once.
+      // Other callers in the window bail immediately — they would only
+      // have been no-ops anyway. The rerun flag captures any caller that
+      // arrives during execution so its work isn't dropped.
+      redisLock.coalesce(
         ["conclude-build", buildId],
         async () => {
           const existingBuild = await Build.query()
@@ -105,7 +106,7 @@ export async function concludeBuild(input: {
               .patch(getBuildData({ conclusion, stats }));
           }
         },
-        { delay: 300 },
+        { delay: 30 },
       ),
   );
 }

--- a/apps/backend/src/build/concludeBuild.ts
+++ b/apps/backend/src/build/concludeBuild.ts
@@ -9,6 +9,17 @@ import { job as buildNotificationJob } from "@/build-notification/job";
 import { transaction } from "@/database";
 import { Build, BuildNotification } from "@/database/models";
 import { redisLock } from "@/util/redis";
+import { getRedisClient } from "@/util/redis/client";
+
+// Diff IDs published by each caller are pooled in this Redis set so the
+// single coalesced execution can treat all callers' diffs as completed,
+// not just the winner's. Bailed callers would otherwise drop their IDs
+// and the runner could see their diffs as still in progress (their
+// `complete` job hook hasn't fired yet — see computeScreenshotDiff).
+const COMPLETED_IDS_TTL_MS = 60_000;
+function getCompletedIdsKey(buildId: string) {
+  return `conclude-build-completed-ids:${buildId}`;
+}
 
 /**
  * Concludes the build by updating the conclusion and the stats.
@@ -28,6 +39,7 @@ export async function concludeBuild(input: {
 }) {
   const { build, completedScreenshotDiffIds, notify = true } = input;
   const buildId = build.id;
+  const completedIdsKey = getCompletedIdsKey(buildId);
   return Sentry.startSpan(
     {
       name: "concludeBuild",
@@ -38,7 +50,18 @@ export async function concludeBuild(input: {
           completedScreenshotDiffIds?.length ?? 0,
       },
     },
-    () =>
+    async () => {
+      // Pool this caller's completed diff IDs in Redis *before* entering
+      // coalesce. If we lose the claim and return null, our IDs are still
+      // available to the winning runner — otherwise the runner would only
+      // know about its own diff and could see ours as still in progress
+      // (the job framework hasn't fired our `complete` hook yet).
+      if (completedScreenshotDiffIds && completedScreenshotDiffIds.length) {
+        const redis = await getRedisClient();
+        await redis.sAdd(completedIdsKey, completedScreenshotDiffIds);
+        await redis.pExpire(completedIdsKey, COMPLETED_IDS_TTL_MS);
+      }
+
       // Coalesce a burst of completions (e.g. 100 screenshot diffs
       // finishing in parallel) into a single execution. The first caller
       // claims the window, waits briefly so concurrent callers can register
@@ -46,7 +69,7 @@ export async function concludeBuild(input: {
       // Other callers in the window bail immediately — they would only
       // have been no-ops anyway. The rerun flag captures any caller that
       // arrives during execution so its work isn't dropped.
-      redisLock.coalesce(
+      return redisLock.coalesce(
         ["conclude-build", buildId],
         async () => {
           const existingBuild = await Build.query()
@@ -57,8 +80,13 @@ export async function concludeBuild(input: {
             // If the build is already concluded, we don't want to update it.
             return;
           }
+          // Read the pooled IDs (winner + every bailer that contributed
+          // before us). Each rerun iteration re-reads so later bailers
+          // are included too.
+          const redis = await getRedisClient();
+          const pooledIds = await redis.sMembers(completedIdsKey);
           const [status] = await Build.getScreenshotDiffsStatuses([buildId], {
-            completedScreenshotDiffIds,
+            completedScreenshotDiffIds: pooledIds,
           });
           invariant(status !== undefined, "status should exist for build");
 
@@ -107,7 +135,8 @@ export async function concludeBuild(input: {
           }
         },
         { delay: 30 },
-      ),
+      );
+    },
   );
 }
 

--- a/apps/backend/src/build/concludeBuild.ts
+++ b/apps/backend/src/build/concludeBuild.ts
@@ -58,8 +58,14 @@ export async function concludeBuild(input: {
       // (the job framework hasn't fired our `complete` hook yet).
       if (completedScreenshotDiffIds && completedScreenshotDiffIds.length) {
         const redis = await getRedisClient();
-        await redis.sAdd(completedIdsKey, completedScreenshotDiffIds);
-        await redis.pExpire(completedIdsKey, COMPLETED_IDS_TTL_MS);
+        // Pool IDs and refresh TTL atomically so a crash between the two
+        // commands can never leave a set without an expiration (which
+        // would leak in Redis forever).
+        await redis
+          .multi()
+          .sAdd(completedIdsKey, completedScreenshotDiffIds)
+          .pExpire(completedIdsKey, COMPLETED_IDS_TTL_MS)
+          .exec();
       }
 
       // Coalesce a burst of completions (e.g. 100 screenshot diffs

--- a/apps/backend/src/build/concludeBuild.ts
+++ b/apps/backend/src/build/concludeBuild.ts
@@ -39,62 +39,74 @@ export async function concludeBuild(input: {
       },
     },
     () =>
-      redisLock.acquire(["conclude-build", buildId], async () => {
-        const existingBuild = await Build.query()
-          .findById(buildId)
-          .throwIfNotFound();
-
-        if (existingBuild.conclusion !== null) {
-          // If the build is already concluded, we don't want to update it.
-          return;
-        }
-        const [status] = await Build.getScreenshotDiffsStatuses([buildId], {
-          completedScreenshotDiffIds,
-        });
-        invariant(status !== undefined, "status should exist for build");
-
-        const [conclusion, [stats]] = await Promise.all([
-          status === "complete" ? Build.computeConclusion(existingBuild) : null,
-          Build.computeStats([buildId]),
-        ]);
-        invariant(stats !== undefined, "stats should exist for build");
-        // If the build is not yet concluded, we don't want to update it.
-        if (conclusion === null) {
-          return;
-        }
-        if (notify) {
-          const [updatedBuild, buildNotification] = await transaction(
-            async (trx) => {
-              return Promise.all([
-                Build.query(trx).patchAndFetchById(
-                  buildId,
-                  getBuildData({ conclusion, stats }),
-                ),
-                BuildNotification.query(trx).insert({
-                  buildId,
-                  type: getNotificationType(conclusion),
-                  jobStatus: "pending",
-                }),
-              ]);
-            },
-          );
-
-          await Promise.all([
-            buildNotificationJob.push(buildNotification.id),
-            triggerAndRunAutomation({
-              projectId: build.projectId,
-              message: {
-                event: AutomationEvents.BuildCompleted,
-                payload: { build: updatedBuild },
-              },
-            }),
-          ]);
-        } else {
-          await Build.query()
+      // Debounce instead of locking: coalesce a burst of completions
+      // (e.g. 100 screenshot diffs finishing in parallel) into a single
+      // execution. The first caller claims the window, waits briefly so
+      // concurrent callers can register their `complete` job handlers,
+      // then runs the conclude logic once. Other callers in the window
+      // bail immediately — they would only have been no-ops anyway.
+      redisLock.debounce(
+        ["conclude-build", buildId],
+        async () => {
+          const existingBuild = await Build.query()
             .findById(buildId)
-            .patch(getBuildData({ conclusion, stats }));
-        }
-      }),
+            .throwIfNotFound();
+
+          if (existingBuild.conclusion !== null) {
+            // If the build is already concluded, we don't want to update it.
+            return;
+          }
+          const [status] = await Build.getScreenshotDiffsStatuses([buildId], {
+            completedScreenshotDiffIds,
+          });
+          invariant(status !== undefined, "status should exist for build");
+
+          const [conclusion, [stats]] = await Promise.all([
+            status === "complete"
+              ? Build.computeConclusion(existingBuild)
+              : null,
+            Build.computeStats([buildId]),
+          ]);
+          invariant(stats !== undefined, "stats should exist for build");
+          // If the build is not yet concluded, we don't want to update it.
+          if (conclusion === null) {
+            return;
+          }
+          if (notify) {
+            const [updatedBuild, buildNotification] = await transaction(
+              async (trx) => {
+                return Promise.all([
+                  Build.query(trx).patchAndFetchById(
+                    buildId,
+                    getBuildData({ conclusion, stats }),
+                  ),
+                  BuildNotification.query(trx).insert({
+                    buildId,
+                    type: getNotificationType(conclusion),
+                    jobStatus: "pending",
+                  }),
+                ]);
+              },
+            );
+
+            await Promise.all([
+              buildNotificationJob.push(buildNotification.id),
+              triggerAndRunAutomation({
+                projectId: build.projectId,
+                message: {
+                  event: AutomationEvents.BuildCompleted,
+                  payload: { build: updatedBuild },
+                },
+              }),
+            ]);
+          } else {
+            await Build.query()
+              .findById(buildId)
+              .patch(getBuildData({ conclusion, stats }));
+          }
+        },
+        { delay: 300 },
+      ),
   );
 }
 

--- a/apps/backend/src/util/redis/lock.e2e.test.ts
+++ b/apps/backend/src/util/redis/lock.e2e.test.ts
@@ -158,6 +158,95 @@ describe("redis-lock", () => {
       });
       expect(r2).toBe("second");
     });
+
+    it("does not delete a successor's claim when the task throws", async () => {
+      // Simulates: our TTL expired, another caller acquired, then our task
+      // errored. The atomic compare-and-delete in the error path must NOT
+      // remove the successor's claim.
+      const lock = createRedisLockClient({
+        getRedisClient: async () => client,
+      });
+      await expect(() =>
+        lock.coalesce(["x"], async () => {
+          // Overwrite the claim with a foreign id before throwing.
+          await client.set("coalesce.x", "stranger");
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+      expect(await client.get("coalesce.x")).toBe("stranger");
+    });
+
+    it("refreshes the claim TTL on each rerun iteration", async () => {
+      // With a short timeout, a first task that consumes most of it would
+      // leave little or no TTL for the rerun. The script's PEXPIRE on
+      // "continue" must restore the full timeout before the next iteration.
+      const lock = createRedisLockClient({
+        getRedisClient: async () => client,
+      });
+      const timeout = 2000;
+      let callCount = 0;
+      let pttlBeforeRerun = 0;
+      let pttlAfterRerun = 0;
+      const task = vi.fn(async () => {
+        callCount++;
+        if (callCount === 1) {
+          // Burn most of the timeout.
+          await delay(timeout - 500);
+          pttlBeforeRerun = await client.pTTL("coalesce.x");
+          // Trigger a rerun.
+          await client.set("coalesce-rerun.x", "1");
+          return "first";
+        }
+        pttlAfterRerun = await client.pTTL("coalesce.x");
+        return "second";
+      });
+      const result = await lock.coalesce(["x"], task, { timeout });
+      expect(callCount).toBe(2);
+      expect(result).toBe("second");
+      // Before the rerun, TTL is close to expiring.
+      expect(pttlBeforeRerun).toBeLessThan(700);
+      // After the script's PEXPIRE, TTL is back near the full timeout.
+      expect(pttlAfterRerun).toBeGreaterThan(timeout - 200);
+    });
+
+    it("stops looping when claim ownership is lost", async () => {
+      // If the claim's TTL expires and another caller acquires it, the
+      // script returns "lost". The runner must exit without clobbering the
+      // new owner's keys.
+      const lock = createRedisLockClient({
+        getRedisClient: async () => client,
+      });
+      let callCount = 0;
+      const task = vi.fn(async () => {
+        callCount++;
+        // Take over the claim and signal a rerun. The script should detect
+        // the ownership loss first and refuse to clear rerun or delete the
+        // claim.
+        await client.set("coalesce.x", "stranger");
+        await client.set("coalesce-rerun.x", "1");
+        return "first";
+      });
+      const result = await lock.coalesce(["x"], task);
+      expect(callCount).toBe(1);
+      expect(result).toBe("first");
+      // The new owner's claim and the rerun signal are intact.
+      expect(await client.get("coalesce.x")).toBe("stranger");
+      expect(await client.get("coalesce-rerun.x")).toBe("1");
+    });
+  });
+
+  it("does not delete a successor's claim when acquire's task throws", async () => {
+    // Simulates: our lock TTL expired, another caller acquired, then our
+    // task errored. The atomic compare-and-delete in the finally must NOT
+    // remove the successor's claim.
+    const lock = createRedisLockClient({ getRedisClient: async () => client });
+    await expect(() =>
+      lock.acquire(["x"], async () => {
+        await client.set("lock.x", "stranger");
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(await client.get("lock.x")).toBe("stranger");
   });
 
   it("handles errors", async () => {

--- a/apps/backend/src/util/redis/lock.e2e.test.ts
+++ b/apps/backend/src/util/redis/lock.e2e.test.ts
@@ -15,6 +15,7 @@ describe("redis-lock", () => {
     await client.connect();
     await client.del("lock.x");
     await client.del("debounce.x");
+    await client.del("debounce-rerun.x");
   });
 
   afterEach(async () => {
@@ -91,6 +92,32 @@ describe("redis-lock", () => {
       expect(spy2).not.toHaveBeenCalled();
       p1.resolve("first");
       expect(await l1).toBe("first");
+    });
+
+    it("re-runs the task when a caller arrives during execution", async () => {
+      const lock = createRedisLockClient({
+        getRedisClient: async () => client,
+      });
+      const p1 = createResolvablePromise();
+      let callCount = 0;
+      const task = vi.fn(() => {
+        callCount++;
+        // First call blocks until p1 resolves; later calls return quickly.
+        return callCount === 1 ? p1 : Promise.resolve("rerun");
+      });
+      const l1 = lock.debounce(["x"], task, { delay: 10 });
+      // Wait until the task is running (past the delay).
+      await delay(30);
+      // Bailer arrives during the task — flags rerun and returns null.
+      const r2 = await lock.debounce(["x"], task, { delay: 10 });
+      expect(r2).toBeNull();
+      expect(task).toHaveBeenCalledOnce();
+      // Let the first task finish — runner should detect the rerun flag
+      // and run the task again.
+      p1.resolve("first");
+      const r1 = await l1;
+      expect(task).toHaveBeenCalledTimes(2);
+      expect(r1).toBe("rerun");
     });
 
     it("allows a new claim after the task completes", async () => {

--- a/apps/backend/src/util/redis/lock.e2e.test.ts
+++ b/apps/backend/src/util/redis/lock.e2e.test.ts
@@ -14,6 +14,7 @@ describe("redis-lock", () => {
     client = createClient({ url: config.get("redis.url") });
     await client.connect();
     await client.del("lock.x");
+    await client.del("debounce.x");
   });
 
   afterEach(async () => {
@@ -42,6 +43,86 @@ describe("redis-lock", () => {
     expect(spy2).toHaveBeenCalledExactlyOnceWith("second");
     await l1;
     await l2;
+  });
+
+  describe("debounce", () => {
+    it("runs the task after the delay and returns its result", async () => {
+      const lock = createRedisLockClient({
+        getRedisClient: async () => client,
+      });
+      const spy = vi.fn(async () => "value");
+      const start = Date.now();
+      const result = await lock.debounce(["x"], spy, { delay: 50 });
+      const elapsed = Date.now() - start;
+      expect(result).toBe("value");
+      expect(spy).toHaveBeenCalledOnce();
+      expect(elapsed).toBeGreaterThanOrEqual(50);
+    });
+
+    it("coalesces concurrent callers into a single execution", async () => {
+      const lock = createRedisLockClient({
+        getRedisClient: async () => client,
+      });
+      const spy = vi.fn(async () => "value");
+      const [r1, r2, r3] = await Promise.all([
+        lock.debounce(["x"], spy, { delay: 50 }),
+        lock.debounce(["x"], spy, { delay: 50 }),
+        lock.debounce(["x"], spy, { delay: 50 }),
+      ]);
+      expect(spy).toHaveBeenCalledOnce();
+      const results = [r1, r2, r3];
+      expect(results.filter((r) => r === "value")).toHaveLength(1);
+      expect(results.filter((r) => r === null)).toHaveLength(2);
+    });
+
+    it("returns null immediately for concurrent callers while task runs", async () => {
+      const lock = createRedisLockClient({
+        getRedisClient: async () => client,
+      });
+      const p1 = createResolvablePromise();
+      const spy1 = vi.fn(() => p1);
+      const spy2 = vi.fn(async () => "second");
+      const l1 = lock.debounce(["x"], spy1, { delay: 10 });
+      await delay(30);
+      // First caller is past the delay, now executing task. Second caller
+      // arrives — should return null without running.
+      const r2 = await lock.debounce(["x"], spy2, { delay: 10 });
+      expect(r2).toBeNull();
+      expect(spy2).not.toHaveBeenCalled();
+      p1.resolve("first");
+      expect(await l1).toBe("first");
+    });
+
+    it("allows a new claim after the task completes", async () => {
+      const lock = createRedisLockClient({
+        getRedisClient: async () => client,
+      });
+      const r1 = await lock.debounce(["x"], async () => "first", { delay: 10 });
+      const r2 = await lock.debounce(["x"], async () => "second", {
+        delay: 10,
+      });
+      expect(r1).toBe("first");
+      expect(r2).toBe("second");
+    });
+
+    it("releases the claim when the task throws", async () => {
+      const lock = createRedisLockClient({
+        getRedisClient: async () => client,
+      });
+      await expect(() =>
+        lock.debounce(
+          ["x"],
+          async () => {
+            throw new Error("boom");
+          },
+          { delay: 10 },
+        ),
+      ).rejects.toThrow("boom");
+      const r2 = await lock.debounce(["x"], async () => "second", {
+        delay: 10,
+      });
+      expect(r2).toBe("second");
+    });
   });
 
   it("handles errors", async () => {

--- a/apps/backend/src/util/redis/lock.e2e.test.ts
+++ b/apps/backend/src/util/redis/lock.e2e.test.ts
@@ -14,8 +14,8 @@ describe("redis-lock", () => {
     client = createClient({ url: config.get("redis.url") });
     await client.connect();
     await client.del("lock.x");
-    await client.del("debounce.x");
-    await client.del("debounce-rerun.x");
+    await client.del("coalesce.x");
+    await client.del("coalesce-rerun.x");
   });
 
   afterEach(async () => {
@@ -46,14 +46,22 @@ describe("redis-lock", () => {
     await l2;
   });
 
-  describe("debounce", () => {
+  describe("coalesce", () => {
+    it("runs the task without a delay by default", async () => {
+      const lock = createRedisLockClient({
+        getRedisClient: async () => client,
+      });
+      const result = await lock.coalesce(["x"], async () => "value");
+      expect(result).toBe("value");
+    });
+
     it("runs the task after the delay and returns its result", async () => {
       const lock = createRedisLockClient({
         getRedisClient: async () => client,
       });
       const spy = vi.fn(async () => "value");
       const start = Date.now();
-      const result = await lock.debounce(["x"], spy, { delay: 50 });
+      const result = await lock.coalesce(["x"], spy, { delay: 50 });
       const elapsed = Date.now() - start;
       expect(result).toBe("value");
       expect(spy).toHaveBeenCalledOnce();
@@ -66,9 +74,9 @@ describe("redis-lock", () => {
       });
       const spy = vi.fn(async () => "value");
       const [r1, r2, r3] = await Promise.all([
-        lock.debounce(["x"], spy, { delay: 50 }),
-        lock.debounce(["x"], spy, { delay: 50 }),
-        lock.debounce(["x"], spy, { delay: 50 }),
+        lock.coalesce(["x"], spy, { delay: 50 }),
+        lock.coalesce(["x"], spy, { delay: 50 }),
+        lock.coalesce(["x"], spy, { delay: 50 }),
       ]);
       expect(spy).toHaveBeenCalledOnce();
       const results = [r1, r2, r3];
@@ -83,11 +91,11 @@ describe("redis-lock", () => {
       const p1 = createResolvablePromise();
       const spy1 = vi.fn(() => p1);
       const spy2 = vi.fn(async () => "second");
-      const l1 = lock.debounce(["x"], spy1, { delay: 10 });
+      const l1 = lock.coalesce(["x"], spy1, { delay: 10 });
       await delay(30);
       // First caller is past the delay, now executing task. Second caller
       // arrives — should return null without running.
-      const r2 = await lock.debounce(["x"], spy2, { delay: 10 });
+      const r2 = await lock.coalesce(["x"], spy2, { delay: 10 });
       expect(r2).toBeNull();
       expect(spy2).not.toHaveBeenCalled();
       p1.resolve("first");
@@ -105,11 +113,11 @@ describe("redis-lock", () => {
         // First call blocks until p1 resolves; later calls return quickly.
         return callCount === 1 ? p1 : Promise.resolve("rerun");
       });
-      const l1 = lock.debounce(["x"], task, { delay: 10 });
+      const l1 = lock.coalesce(["x"], task, { delay: 10 });
       // Wait until the task is running (past the delay).
       await delay(30);
       // Bailer arrives during the task — flags rerun and returns null.
-      const r2 = await lock.debounce(["x"], task, { delay: 10 });
+      const r2 = await lock.coalesce(["x"], task, { delay: 10 });
       expect(r2).toBeNull();
       expect(task).toHaveBeenCalledOnce();
       // Let the first task finish — runner should detect the rerun flag
@@ -124,8 +132,8 @@ describe("redis-lock", () => {
       const lock = createRedisLockClient({
         getRedisClient: async () => client,
       });
-      const r1 = await lock.debounce(["x"], async () => "first", { delay: 10 });
-      const r2 = await lock.debounce(["x"], async () => "second", {
+      const r1 = await lock.coalesce(["x"], async () => "first", { delay: 10 });
+      const r2 = await lock.coalesce(["x"], async () => "second", {
         delay: 10,
       });
       expect(r1).toBe("first");
@@ -137,7 +145,7 @@ describe("redis-lock", () => {
         getRedisClient: async () => client,
       });
       await expect(() =>
-        lock.debounce(
+        lock.coalesce(
           ["x"],
           async () => {
             throw new Error("boom");
@@ -145,7 +153,7 @@ describe("redis-lock", () => {
           { delay: 10 },
         ),
       ).rejects.toThrow("boom");
-      const r2 = await lock.debounce(["x"], async () => "second", {
+      const r2 = await lock.coalesce(["x"], async () => "second", {
         delay: 10,
       });
       expect(r2).toBe("second");

--- a/apps/backend/src/util/redis/lock.ts
+++ b/apps/backend/src/util/redis/lock.ts
@@ -4,21 +4,40 @@ import type { RedisClientType } from "redis";
 import { hashCacheKey, type CacheKey } from "./cache-key";
 
 // Atomically decides whether the runner should loop again or release the
-// claim. If a "rerun" flag was set by a bailer, clear it and return
-// "continue". Otherwise release the claim (only if still owned by this
-// runner) and return "done". Atomicity closes the race between checking
-// the rerun flag and releasing the claim.
+// claim. First checks ownership: if the claim no longer belongs to this
+// runner (TTL expired and someone else took over), returns "lost" without
+// touching any keys. Otherwise: if a "rerun" flag was set by a bailer,
+// clear it, refresh the claim TTL for the next iteration, and return
+// "continue". Else release the claim and return "done".
+//
+// KEYS[1] = claim key, KEYS[2] = rerun key
+// ARGV[1] = runner id, ARGV[2] = TTL (ms) to apply on "continue"
 const RELEASE_OR_CONTINUE_SCRIPT = `
+local current = redis.call("GET", KEYS[1])
+if current ~= ARGV[1] then
+  return "lost"
+end
 local rerun = redis.call("GET", KEYS[2])
 if rerun then
   redis.call("DEL", KEYS[2])
+  redis.call("PEXPIRE", KEYS[1], ARGV[2])
   return "continue"
 end
-local current = redis.call("GET", KEYS[1])
-if current == ARGV[1] then
+redis.call("DEL", KEYS[1])
+return "done"
+`;
+
+// Atomically deletes the claim key only if it still belongs to the caller.
+// Used in error/cleanup paths where we want to ensure we don't accidentally
+// delete a claim that has since been taken over by another caller after our
+// TTL expired.
+//
+// KEYS[1] = claim key, ARGV[1] = runner id
+const ATOMIC_RELEASE_SCRIPT = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
   redis.call("DEL", KEYS[1])
 end
-return "done"
+return 1
 `;
 
 async function acquireLock({
@@ -196,7 +215,9 @@ export function createRedisLockClient(options: {
             let lastResult: T;
             // Atomically check rerun-or-release after each task. The Lua
             // script guarantees there is no window in which a bailer's
-            // signal can land between the check and the release.
+            // signal can land between the check and the release. It also
+            // refreshes the claim's TTL on each rerun so a long-running
+            // task cannot lose ownership mid-loop.
             let decision: unknown;
             do {
               // Clear rerun before running. Any bailer that arrives during
@@ -205,17 +226,21 @@ export function createRedisLockClient(options: {
               lastResult = await runTask();
               decision = await client.eval(RELEASE_OR_CONTINUE_SCRIPT, {
                 keys: [claimKey, rerunKey],
-                arguments: [id],
+                arguments: [id, String(timeout)],
               });
+              // "lost" means our claim's TTL expired and someone else
+              // acquired it. Stop iterating; the new owner will handle
+              // anything left in the rerun flag.
             } while (decision === "continue");
             return lastResult;
           } catch (err) {
-            // Task threw — release the claim explicitly. Any pending rerun
-            // signal is left in place so the next caller picks it up.
-            const value = await client.get(claimKey);
-            if (value === id) {
-              await client.del(claimKey);
-            }
+            // Task threw — release the claim atomically (only if still
+            // ours). Any pending rerun signal is left in place so the
+            // next caller picks it up.
+            await client.eval(ATOMIC_RELEASE_SCRIPT, {
+              keys: [claimKey],
+              arguments: [id],
+            });
             throw err;
           }
         },
@@ -278,10 +303,13 @@ export function createRedisLockClient(options: {
             if (timer) {
               clearTimeout(timer);
             }
-            const value = await client.get(fullName);
-            if (value === id) {
-              await client.del(fullName);
-            }
+            // Atomic compare-and-delete: avoid removing a claim that has
+            // since been taken over by another caller after our TTL
+            // expired.
+            await client.eval(ATOMIC_RELEASE_SCRIPT, {
+              keys: [fullName],
+              arguments: [id],
+            });
           }
         },
       );

--- a/apps/backend/src/util/redis/lock.ts
+++ b/apps/backend/src/util/redis/lock.ts
@@ -88,41 +88,47 @@ export function createRedisLockClient(options: {
 }) {
   return {
     /**
-     * Coalesce a burst of calls into single-flight executions with a delay.
+     * Coalesce a burst of calls into single-flight executions.
      *
-     * The first caller claims the window, waits `delay` ms, then runs the
-     * task. Concurrent callers return `null` immediately; if they arrive
-     * *during* the running task, they flag a "rerun" so the runner repeats
-     * the task once more after its current pass — this captures work that
-     * became visible only after the task's read started.
+     * The first caller claims the window and runs the task. Concurrent
+     * callers return `null` immediately; if they arrive *during* the
+     * running task, they flag a "rerun" so the runner repeats the task
+     * once more after its current pass — this captures work that became
+     * visible only after the task's read started.
      *
-     * The bailer always sets the rerun flag *before* trying to claim, and
-     * the runner uses a Lua script to atomically check-and-clear rerun or
-     * release the claim. Together these close the race where a bailer's
-     * signal could be lost between the runner's last check and its claim
-     * release.
+     * Optionally takes a `delay` (default 0): the runner sleeps `delay`
+     * ms before its first task run, giving concurrent callers a window to
+     * accumulate so their work is captured in a single task run instead
+     * of via the rerun loop. Useful when the task is expensive and the
+     * burst is expected to spread over a known interval.
+     *
+     * The bailer always sets the rerun flag *before* retrying the claim,
+     * and the runner uses a Lua script to atomically check-and-clear
+     * rerun or release the claim. Together these close the race where a
+     * bailer's signal could be lost between the runner's last check and
+     * its claim release.
      *
      * Trade-off: the runner may run the task one extra time (idempotent
      * pass) rather than miss a signal — we err toward "run too many" over
      * "skip a needed run".
      */
-    async debounce<T>(
+    async coalesce<T>(
       key: CacheKey,
       task: () => Promise<T>,
-      { delay, timeout = 20000 }: { delay: number; timeout?: number },
+      { delay = 0, timeout = 20000 }: { delay?: number; timeout?: number } = {},
     ): Promise<T | null> {
       const hash = hashCacheKey(key);
-      const claimKey = `debounce.${hash}`;
-      const rerunKey = `debounce-rerun.${hash}`;
+      const claimKey = `coalesce.${hash}`;
+      const rerunKey = `coalesce-rerun.${hash}`;
       const keyTtl = delay + timeout;
       return Sentry.startSpan(
         {
-          name: "redis.debounce",
+          name: "redis.coalesce",
           attributes: {
-            "argos.debounce.name": claimKey,
-            "argos.debounce.hash": hash,
-            "argos.debounce.delay_ms": delay,
-            "argos.debounce.timeout_ms": timeout,
+            "argos.coalesce.name": claimKey,
+            "argos.coalesce.hash": hash,
+            "argos.coalesce.delay_ms": delay,
+            "argos.coalesce.timeout_ms": timeout,
           },
         },
         async () => {
@@ -154,11 +160,11 @@ export function createRedisLockClient(options: {
             let timer: NodeJS.Timeout | null = null;
             return Sentry.startSpan(
               {
-                name: "redis.debounce.task",
+                name: "redis.coalesce.task",
                 attributes: {
-                  "argos.debounce.name": claimKey,
-                  "argos.debounce.hash": hash,
-                  "argos.debounce.timeout_ms": timeout,
+                  "argos.coalesce.name": claimKey,
+                  "argos.coalesce.hash": hash,
+                  "argos.coalesce.timeout_ms": timeout,
                 },
               },
               () =>
@@ -168,7 +174,7 @@ export function createRedisLockClient(options: {
                     timer = setTimeout(() => {
                       reject(
                         new Error(
-                          `Debounce timeout "${hash}" after ${timeout}ms`,
+                          `Coalesce timeout "${hash}" after ${timeout}ms`,
                         ),
                       );
                     }, timeout);
@@ -182,9 +188,11 @@ export function createRedisLockClient(options: {
           };
 
           try {
-            await new Promise<void>((resolve) => {
-              setTimeout(resolve, delay);
-            });
+            if (delay > 0) {
+              await new Promise<void>((resolve) => {
+                setTimeout(resolve, delay);
+              });
+            }
             let lastResult: T;
             // Atomically check rerun-or-release after each task. The Lua
             // script guarantees there is no window in which a bailer's

--- a/apps/backend/src/util/redis/lock.ts
+++ b/apps/backend/src/util/redis/lock.ts
@@ -70,6 +70,86 @@ export function createRedisLockClient(options: {
 }) {
   return {
     /**
+     * Coalesce a burst of calls into a single delayed execution.
+     *
+     * The first caller in the debounce window claims it, waits `delay` ms,
+     * then runs the task. Concurrent callers that arrive while the window is
+     * held return `null` immediately without running the task.
+     *
+     * Useful when many workers might trigger the same downstream action and
+     * only one execution is needed (e.g. concluding a build after a burst
+     * of screenshot diffs complete).
+     */
+    async debounce<T>(
+      key: CacheKey,
+      task: () => Promise<T>,
+      { delay, timeout = 20000 }: { delay: number; timeout?: number },
+    ): Promise<T | null> {
+      const hash = hashCacheKey(key);
+      const fullName = `debounce.${hash}`;
+      return Sentry.startSpan(
+        {
+          name: "redis.debounce",
+          attributes: {
+            "argos.debounce.name": fullName,
+            "argos.debounce.hash": hash,
+            "argos.debounce.delay_ms": delay,
+            "argos.debounce.timeout_ms": timeout,
+          },
+        },
+        async () => {
+          const client = await options.getRedisClient();
+          const id = crypto.randomUUID();
+          const result = await client.set(fullName, id, {
+            expiration: { type: "PX", value: delay + timeout },
+            condition: "NX",
+          });
+          if (result !== "OK") {
+            return null;
+          }
+          let timer: NodeJS.Timeout | null = null;
+          try {
+            await new Promise<void>((resolve) => {
+              setTimeout(resolve, delay);
+            });
+            const result = (await Sentry.startSpan(
+              {
+                name: "redis.debounce.task",
+                attributes: {
+                  "argos.debounce.name": fullName,
+                  "argos.debounce.hash": hash,
+                  "argos.debounce.timeout_ms": timeout,
+                },
+              },
+              () =>
+                Promise.race([
+                  task(),
+                  new Promise((_resolve, reject) => {
+                    timer = setTimeout(() => {
+                      reject(
+                        new Error(
+                          `Debounce timeout "${hash}" after ${timeout}ms`,
+                        ),
+                      );
+                    }, timeout);
+                  }),
+                ]),
+            )) as T;
+            return result;
+          } finally {
+            if (timer) {
+              clearTimeout(timer);
+            }
+            const value = await client.get(fullName);
+            if (value === id) {
+              await client.del(fullName);
+            }
+          }
+        },
+      );
+    },
+
+    /**
      * Acquire the lock in Redis.
      */
     async acquire<T>(

--- a/apps/backend/src/util/redis/lock.ts
+++ b/apps/backend/src/util/redis/lock.ts
@@ -3,6 +3,24 @@ import type { RedisClientType } from "redis";
 
 import { hashCacheKey, type CacheKey } from "./cache-key";
 
+// Atomically decides whether the runner should loop again or release the
+// claim. If a "rerun" flag was set by a bailer, clear it and return
+// "continue". Otherwise release the claim (only if still owned by this
+// runner) and return "done". Atomicity closes the race between checking
+// the rerun flag and releasing the claim.
+const RELEASE_OR_CONTINUE_SCRIPT = `
+local rerun = redis.call("GET", KEYS[2])
+if rerun then
+  redis.call("DEL", KEYS[2])
+  return "continue"
+end
+local current = redis.call("GET", KEYS[1])
+if current == ARGV[1] then
+  redis.call("DEL", KEYS[1])
+end
+return "done"
+`;
+
 async function acquireLock({
   client,
   name,
@@ -70,15 +88,23 @@ export function createRedisLockClient(options: {
 }) {
   return {
     /**
-     * Coalesce a burst of calls into a single delayed execution.
+     * Coalesce a burst of calls into single-flight executions with a delay.
      *
-     * The first caller in the debounce window claims it, waits `delay` ms,
-     * then runs the task. Concurrent callers that arrive while the window is
-     * held return `null` immediately without running the task.
+     * The first caller claims the window, waits `delay` ms, then runs the
+     * task. Concurrent callers return `null` immediately; if they arrive
+     * *during* the running task, they flag a "rerun" so the runner repeats
+     * the task once more after its current pass — this captures work that
+     * became visible only after the task's read started.
      *
-     * Useful when many workers might trigger the same downstream action and
-     * only one execution is needed (e.g. concluding a build after a burst
-     * of screenshot diffs complete).
+     * The bailer always sets the rerun flag *before* trying to claim, and
+     * the runner uses a Lua script to atomically check-and-clear rerun or
+     * release the claim. Together these close the race where a bailer's
+     * signal could be lost between the runner's last check and its claim
+     * release.
+     *
+     * Trade-off: the runner may run the task one extra time (idempotent
+     * pass) rather than miss a signal — we err toward "run too many" over
+     * "skip a needed run".
      */
     async debounce<T>(
       key: CacheKey,
@@ -86,12 +112,14 @@ export function createRedisLockClient(options: {
       { delay, timeout = 20000 }: { delay: number; timeout?: number },
     ): Promise<T | null> {
       const hash = hashCacheKey(key);
-      const fullName = `debounce.${hash}`;
+      const claimKey = `debounce.${hash}`;
+      const rerunKey = `debounce-rerun.${hash}`;
+      const keyTtl = delay + timeout;
       return Sentry.startSpan(
         {
           name: "redis.debounce",
           attributes: {
-            "argos.debounce.name": fullName,
+            "argos.debounce.name": claimKey,
             "argos.debounce.hash": hash,
             "argos.debounce.delay_ms": delay,
             "argos.debounce.timeout_ms": timeout,
@@ -100,23 +128,35 @@ export function createRedisLockClient(options: {
         async () => {
           const client = await options.getRedisClient();
           const id = crypto.randomUUID();
-          const result = await client.set(fullName, id, {
-            expiration: { type: "PX", value: delay + timeout },
-            condition: "NX",
-          });
-          if (result !== "OK") {
-            return null;
-          }
-          let timer: NodeJS.Timeout | null = null;
-          try {
-            await new Promise<void>((resolve) => {
-              setTimeout(resolve, delay);
+
+          const tryClaim = () =>
+            client.set(claimKey, id, {
+              expiration: { type: "PX", value: keyTtl },
+              condition: "NX",
             });
-            const result = (await Sentry.startSpan(
+
+          let claimed = await tryClaim();
+          if (claimed !== "OK") {
+            // Set rerun *before* retrying the claim. This ordering closes
+            // the race: if the active runner is about to release, our
+            // retry will succeed and we become the new runner; otherwise
+            // the runner will see our rerun flag.
+            await client.set(rerunKey, "1", {
+              expiration: { type: "PX", value: keyTtl },
+            });
+            claimed = await tryClaim();
+            if (claimed !== "OK") {
+              return null;
+            }
+          }
+
+          const runTask = (): Promise<T> => {
+            let timer: NodeJS.Timeout | null = null;
+            return Sentry.startSpan(
               {
                 name: "redis.debounce.task",
                 attributes: {
-                  "argos.debounce.name": fullName,
+                  "argos.debounce.name": claimKey,
                   "argos.debounce.hash": hash,
                   "argos.debounce.timeout_ms": timeout,
                 },
@@ -124,7 +164,7 @@ export function createRedisLockClient(options: {
               () =>
                 Promise.race([
                   task(),
-                  new Promise((_resolve, reject) => {
+                  new Promise<never>((_resolve, reject) => {
                     timer = setTimeout(() => {
                       reject(
                         new Error(
@@ -133,17 +173,42 @@ export function createRedisLockClient(options: {
                       );
                     }, timeout);
                   }),
-                ]),
-            )) as T;
-            return result;
-          } finally {
-            if (timer) {
-              clearTimeout(timer);
-            }
-            const value = await client.get(fullName);
+                ]).finally(() => {
+                  if (timer) {
+                    clearTimeout(timer);
+                  }
+                }),
+            );
+          };
+
+          try {
+            await new Promise<void>((resolve) => {
+              setTimeout(resolve, delay);
+            });
+            let lastResult: T;
+            // Atomically check rerun-or-release after each task. The Lua
+            // script guarantees there is no window in which a bailer's
+            // signal can land between the check and the release.
+            let decision: unknown;
+            do {
+              // Clear rerun before running. Any bailer that arrives during
+              // the task will SET it again and trigger another iteration.
+              await client.del(rerunKey);
+              lastResult = await runTask();
+              decision = await client.eval(RELEASE_OR_CONTINUE_SCRIPT, {
+                keys: [claimKey, rerunKey],
+                arguments: [id],
+              });
+            } while (decision === "continue");
+            return lastResult;
+          } catch (err) {
+            // Task threw — release the claim explicitly. Any pending rerun
+            // signal is left in place so the next caller picks it up.
+            const value = await client.get(claimKey);
             if (value === id) {
-              await client.del(fullName);
+              await client.del(claimKey);
             }
+            throw err;
           }
         },
       );


### PR DESCRIPTION
When we are processing lot of diffs, there is a concurrency issue making
the lock struggling. We change the strategy, we now do a debounce to
avoid this effect.
