### PR TITLE
perf(build-notif): fix n+1 query

### DIFF
--- a/apps/backend/src/git-platform/comment.ts
+++ b/apps/backend/src/git-platform/comment.ts
@@ -125,7 +125,7 @@ export async function getCommentBody(props: {
     Build.query()
       .distinctOn("builds.name", "builds.projectId")
       .joinRelated("compareScreenshotBucket")
-      .withGraphFetched("project")
+      .withGraphFetched("project.account")
       .where("compareScreenshotBucket.commit", props.commit)
       .orderBy([
         { column: "builds.name", order: "desc" },


### PR DESCRIPTION
A customer has lot of builds and the `build.getUrl()` triggers a n+1 that slows down everything.