### PR TITLE
perf: use a dedupe strategy for build notifications

### DIFF
--- a/apps/backend/src/build-notification/bin/queue-pending-build-notifications.ts
+++ b/apps/backend/src/build-notification/bin/queue-pending-build-notifications.ts
@@ -11,9 +11,11 @@ const main = callbackify(async () => {
     .where({ jobStatus: "error" })
     .whereRaw(`"createdAt" > now() - interval '2 hour'`)
     .orderBy("id", "desc");
-  const ids = nodes.map((node) => node.id);
-  await job.push(...ids);
-  logger.info(`${nodes.length} pushed in queue`);
+  const buildIds = [...new Set(nodes.map((node) => node.buildId))];
+  await job.push(...buildIds);
+  logger.info(
+    `${nodes.length} errored notifications across ${buildIds.length} builds pushed in queue`,
+  );
 });
 
 main((err) => {

--- a/apps/backend/src/build-notification/job.ts
+++ b/apps/backend/src/build-notification/job.ts
@@ -1,36 +1,53 @@
-import { invariant } from "@argos/util/invariant";
-
 import { BuildNotification } from "@/database/models";
-import { createModelJob } from "@/job-core";
-import { redisLock } from "@/util/redis";
+import { createJob } from "@/job-core";
 
 import { processBuildNotification } from "./notifications";
 
-export const job = createModelJob(
-  "buildNotification",
-  BuildNotification,
-  async (buildNotification) => {
-    await redisLock.coalesce(
-      ["build-notification-process", buildNotification.buildId],
-      async () => {
-        // Always process the latest notification for this build. Bailers'
-        // notifications are captured by this query, so a single execution
-        // covers the whole burst; the rerun loop catches any notification
-        // enqueued while the task is running.
-        const latestBuildNotification = await BuildNotification.query()
-          .where("buildId", buildNotification.buildId)
-          .orderBy("id", "desc")
-          .first();
+export const job = createJob<string>(
+  "build-notification",
+  {
+    perform: async (buildId) => {
+      // Always process the latest non-complete notification for this build.
+      // Pushes are deduped by `buildId`, so messages arriving while we work
+      // re-enqueue and trigger another pass; notifications inserted after
+      // our SELECT (id > latest.id) stay pending for that next pass.
+      const latest = await BuildNotification.query()
+        .where("buildId", buildId)
+        .whereNot("jobStatus", "complete")
+        .orderBy("id", "desc")
+        .first();
 
-        invariant(
-          latestBuildNotification,
-          "Latest build notification not found",
-        );
+      if (!latest) {
+        return;
+      }
 
-        await processBuildNotification(latestBuildNotification);
-      },
-      { timeout: 20_000 },
-    );
+      await BuildNotification.query()
+        .findById(latest.id)
+        .patch({ jobStatus: "progress" });
+
+      await processBuildNotification(latest);
+
+      await BuildNotification.query()
+        .where("buildId", buildId)
+        .where("id", "<=", latest.id)
+        .whereNot("jobStatus", "complete")
+        .patch({ jobStatus: "complete" });
+    },
+    error: async (buildId) => {
+      // Mark the latest pending notification as errored so it shows up in
+      // the retry sweep. Newer notifications stay pending — the next run
+      // will pick them up.
+      const latest = await BuildNotification.query()
+        .where("buildId", buildId)
+        .whereNot("jobStatus", "complete")
+        .orderBy("id", "desc")
+        .first();
+      if (latest) {
+        await BuildNotification.query()
+          .findById(latest.id)
+          .patch({ jobStatus: "error" });
+      }
+    },
   },
-  { timeout: 25_000 },
+  { timeout: 25_000, dedupe: true },
 );

--- a/apps/backend/src/build-notification/notifications.ts
+++ b/apps/backend/src/build-notification/notifications.ts
@@ -32,7 +32,7 @@ export async function pushBuildNotification({
     type,
     jobStatus: "pending",
   });
-  await buildNotificationJob.push(buildNotification.id);
+  await buildNotificationJob.push(buildId);
   return buildNotification;
 }
 

--- a/apps/backend/src/build/concludeBuild.ts
+++ b/apps/backend/src/build/concludeBuild.ts
@@ -108,24 +108,22 @@ export async function concludeBuild(input: {
             return;
           }
           if (notify) {
-            const [updatedBuild, buildNotification] = await transaction(
-              async (trx) => {
-                return Promise.all([
-                  Build.query(trx).patchAndFetchById(
-                    buildId,
-                    getBuildData({ conclusion, stats }),
-                  ),
-                  BuildNotification.query(trx).insert({
-                    buildId,
-                    type: getNotificationType(conclusion),
-                    jobStatus: "pending",
-                  }),
-                ]);
-              },
-            );
+            const [updatedBuild] = await transaction(async (trx) => {
+              return Promise.all([
+                Build.query(trx).patchAndFetchById(
+                  buildId,
+                  getBuildData({ conclusion, stats }),
+                ),
+                BuildNotification.query(trx).insert({
+                  buildId,
+                  type: getNotificationType(conclusion),
+                  jobStatus: "pending",
+                }),
+              ]);
+            });
 
             await Promise.all([
-              buildNotificationJob.push(buildNotification.id),
+              buildNotificationJob.push(buildId),
               triggerAndRunAutomation({
                 projectId: build.projectId,
                 message: {

--- a/apps/backend/src/job-core/createJob.ts
+++ b/apps/backend/src/job-core/createJob.ts
@@ -6,6 +6,7 @@ import config from "@/config";
 import parentLogger, { type Logger } from "@/logger";
 import { checkIsRetryable } from "@/util/error";
 import { redisLock } from "@/util/redis";
+import { getRedisClient } from "@/util/redis/client";
 
 import { connect } from "./amqp";
 
@@ -61,6 +62,26 @@ export interface JobParams {
    * @default 20000 (20 seconds)
    */
   timeout?: number;
+
+  /**
+   * Coalesce concurrent pushes for the same value into a single in-flight
+   * message. The value itself is the dedupe key.
+   *
+   * How it works: at push time we take a Redis claim keyed by the value
+   * (`SET NX EX`). If the claim is taken, we enqueue the AMQP message;
+   * otherwise we skip — a worker is already on the way. The worker clears
+   * the claim right after acquiring its per-value lock and *before*
+   * running `perform`, so any push that lands during `perform` re-claims
+   * and enqueues a fresh message. That message blocks on the per-value
+   * lock until the current run finishes, then triggers another pass.
+   *
+   * Requirement for `perform`: read the "latest" state from a source of
+   * truth (DB row, Redis key, …) instead of trusting the value to encode
+   * the work — the value is now a key into the work, not the work itself.
+   *
+   * @default false
+   */
+  dedupe?: boolean | { ttl?: number };
 }
 
 type JobContext = {
@@ -197,16 +218,47 @@ export const createJob = <TValue extends string | number>(
       ctx: JobContext,
     ) => void | Promise<void>;
   },
-  { prefetch = 1, timeout = 20_000 }: JobParams = {},
+  { prefetch = 1, timeout = 20_000, dedupe }: JobParams = {},
 ): Job<TValue> => {
   queue = config.get("amqp.queuePrefix") + queue;
   const logger = parentLogger.child({ module: "job", queue });
+
+  const dedupeEnabled = Boolean(dedupe);
+  // Claim TTL must outlive queue lag + worst-case processing. We default to
+  // 1h or twice the job timeout, whichever is larger.
+  const dedupeTtlMs =
+    dedupeEnabled && typeof dedupe === "object" && dedupe.ttl !== undefined
+      ? dedupe.ttl
+      : Math.max(timeout * 2, 3_600_000);
+  const dedupeClaimKey = (value: TValue) => `job-dedupe.${queue}.${value}`;
+
   return {
     queue,
     async push(...values) {
       const channel = await getSharedChannel("publisher");
       await ensureQueueAsserted(channel, queue);
       const valuesSet = new Set(values);
+
+      if (dedupeEnabled) {
+        const client = await getRedisClient();
+        for (const value of [...valuesSet]) {
+          const claimed = await client.set(dedupeClaimKey(value), "1", {
+            condition: "NX",
+            expiration: { type: "PX", value: dedupeTtlMs },
+          });
+          if (claimed !== "OK") {
+            // A worker is already in flight (or about to be) for this
+            // value. It will clear the claim before running `perform`, so
+            // any state our caller wrote before this push will be visible
+            // to that worker.
+            valuesSet.delete(value);
+          }
+        }
+        if (valuesSet.size === 0) {
+          return;
+        }
+      }
+
       const sendOne = (value: TValue) => {
         return channel.sendToQueue(
           queue,
@@ -245,6 +297,14 @@ export const createJob = <TValue extends string | number>(
             [queue, id],
             async () => {
               ctx.logger.info("Running");
+              if (dedupeEnabled) {
+                // Clear the dedupe claim *before* perform. Any push that
+                // lands while perform runs will re-claim and enqueue a
+                // new message; that message waits on this same lock and
+                // triggers another pass once we release.
+                const client = await getRedisClient();
+                await client.del(dedupeClaimKey(id));
+              }
               const performStart = performance.now();
               await consumer.perform(id, ctx);
               const performEnd = performance.now();

--- a/apps/backend/src/job-core/createJob.ts
+++ b/apps/backend/src/job-core/createJob.ts
@@ -79,6 +79,10 @@ export interface JobParams {
    * truth (DB row, Redis key, …) instead of trusting the value to encode
    * the work — the value is now a key into the work, not the work itself.
    *
+   * `ttl` (milliseconds) is the lifetime of the Redis claim. It must
+   * outlive worst-case queue lag + processing. Defaults to
+   * `max(timeout × 2, 1h)`.
+   *
    * @default false
    */
   dedupe?: boolean | { ttl?: number };
@@ -239,6 +243,7 @@ export const createJob = <TValue extends string | number>(
       await ensureQueueAsserted(channel, queue);
       const valuesSet = new Set(values);
 
+      const claimedValues: TValue[] = [];
       if (dedupeEnabled) {
         const client = await getRedisClient();
         for (const value of [...valuesSet]) {
@@ -246,7 +251,9 @@ export const createJob = <TValue extends string | number>(
             condition: "NX",
             expiration: { type: "PX", value: dedupeTtlMs },
           });
-          if (claimed !== "OK") {
+          if (claimed === "OK") {
+            claimedValues.push(value);
+          } else {
             // A worker is already in flight (or about to be) for this
             // value. It will clear the claim before running `perform`, so
             // any state our caller wrote before this push will be visible
@@ -259,6 +266,16 @@ export const createJob = <TValue extends string | number>(
         }
       }
 
+      const releaseClaims = async () => {
+        if (claimedValues.length === 0) {
+          return;
+        }
+        const client = await getRedisClient();
+        await Promise.all(
+          claimedValues.map((value) => client.del(dedupeClaimKey(value))),
+        );
+      };
+
       const sendOne = (value: TValue) => {
         return channel.sendToQueue(
           queue,
@@ -266,20 +283,32 @@ export const createJob = <TValue extends string | number>(
           { persistent: true },
         );
       };
-      return new Promise((resolve) => {
-        const sendAll = () => {
-          for (const value of valuesSet) {
-            const keepSending = sendOne(value);
-            valuesSet.delete(value);
-            if (!keepSending) {
-              channel.once("drain", sendAll);
-              return;
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const sendAll = () => {
+            try {
+              for (const value of valuesSet) {
+                const keepSending = sendOne(value);
+                valuesSet.delete(value);
+                if (!keepSending) {
+                  channel.once("drain", sendAll);
+                  return;
+                }
+              }
+              resolve();
+            } catch (error) {
+              reject(error);
             }
-          }
-          resolve();
-        };
-        sendAll();
-      });
+          };
+          sendAll();
+        });
+      } catch (error) {
+        // Publish failed — release the dedupe claims we took so the next
+        // push can re-enqueue. Without this, the claim would survive its
+        // un-published message and silently drop pushes until the TTL.
+        await releaseClaims().catch(() => undefined);
+        throw error;
+      }
     },
     async run(id: TValue, ctx: JobContext) {
       await Sentry.startSpan(
@@ -302,6 +331,13 @@ export const createJob = <TValue extends string | number>(
                 // lands while perform runs will re-claim and enqueue a
                 // new message; that message waits on this same lock and
                 // triggers another pass once we release.
+                //
+                // Best-effort: we DEL without a token check. If our
+                // message sat in the queue long enough for the claim to
+                // expire and a later push re-claimed, this DEL clears
+                // the newer claim. Worst case is one redundant message
+                // that acquires the lock, re-reads "latest" state, and
+                // exits — bounded, not a correctness issue.
                 const client = await getRedisClient();
                 await client.del(dedupeClaimKey(id));
               }


### PR DESCRIPTION
## Summary

Replaces the per-notification `redisLock.coalesce` machinery in the build-notification job with a generic `dedupe` option on `createJob`, and migrates build-notification to be the first user.

### Before

- Every `pushBuildNotification` inserted a `BuildNotification` row **and** enqueued an AMQP message keyed by the notification id.
- The job used `redisLock.coalesce` (Lua-scripted claim + rerun flag) to ensure only one worker per `buildId` ran at a time and to capture notifications that arrived mid-run.
- Result: N notifications in a burst → N queue messages, N DB rows, and a fairly intricate single-flight + rerun loop sitting under the job to collapse them down to one effective run.

### After

`createJob` gains a `dedupe: boolean | { ttl?: number }` option. When enabled:

1. **Push** — `SET NX PX` a Redis claim `job-dedupe.<queue>.<value>`. Only enqueue if the claim was taken; otherwise drop the push (a worker is already coming).
2. **Run** — right after acquiring the existing `[queue, id]` lock and **before** calling `perform`, `DEL` the claim.

That timing is the load-bearing detail and makes it equivalent to the old rerun loop:

- A push that lands *before* the worker clears the claim is dropped, but its DB write happens *before* `perform`'s read — the worker sees it.
- A push that lands *after* the worker clears the claim succeeds, enqueues a fresh message, and that message blocks on the per-value lock until the current run releases — triggering another pass.

Requirement on `perform`: read "latest" state from a source of truth (DB / Redis / …) rather than trusting the value to encode the work. The value is now a key into the work, not the work itself.

### Build-notification migration

- `job.ts` switches from `createModelJob(BuildNotification, …)` (keyed by `notificationId`) to `createJob<string>` keyed by `buildId` with `dedupe: true`.
- `perform` selects the latest non-complete notification for the build, processes it, then drains peers with `id <= latest.id`. Notifications inserted *after* the SELECT keep `id > latest.id` and stay pending — the next pass (triggered by the dedupe re-claim) picks them up.
- Custom `error` hook marks the latest pending row errored so the existing retry sweep in `queue-pending-build-notifications.ts` still finds them; that script now pushes deduped `buildId`s.
- `pushBuildNotification` and the `concludeBuild` notification path push `buildId` instead of `buildNotification.id`.

### Trade-offs

- One extra Redis round-trip per push.
- `BuildNotification.jobStatus` no longer tracks 1:1 with queue messages — some rows go straight from `pending` → `complete` via the drain UPDATE without ever being individually dequeued. Surfaces in admin UI / monitoring only.

## Test plan

- [ ] `pnpm run check-types` (passes locally)
- [ ] `pnpm run lint` (passes locally)
- [ ] `pnpm test:unit` (141/141 pass locally)
- [ ] e2e: trigger a burst of `pushBuildNotification` for the same build and verify a single effective send + correct final commit status
- [ ] e2e: simulate a notification arriving mid-`processBuildNotification` and verify a second pass runs
- [ ] verify `queue-pending-build-notifications` retry script still recovers errored notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)