### PR TITLE
add automation build filters

### DIFF
--- a/apps/backend/src/automation/actions/sendSlackMessage/index.ts
+++ b/apps/backend/src/automation/actions/sendSlackMessage/index.ts
@@ -61,7 +61,7 @@ export const automationAction = defineAutomationAction({
   process: async (input) => {
     const message: AutomationMessage = await (async () => {
       const actionRun = await input.ctx.automationActionRun.$fetchGraph(
-        "automationRun.[build,buildReview]",
+        "automationRun.[build.compareScreenshotBucket,buildReview]",
       );
 
       invariant(
@@ -83,15 +83,29 @@ export const automationAction = defineAutomationAction({
             "build relation not found",
             UnretryableError,
           );
+          invariant(
+            actionRun.automationRun.build.compareScreenshotBucket,
+            "compareScreenshotBucket relation not found",
+            UnretryableError,
+          );
           return {
             event: actionRun.automationRun.event,
-            payload: { build: actionRun.automationRun.build },
+            payload: {
+              build: actionRun.automationRun.build,
+              compareScreenshotBucket:
+                actionRun.automationRun.build.compareScreenshotBucket,
+            },
           };
         }
         case "build.reviewed": {
           invariant(
             actionRun.automationRun.build,
             "build relation not found",
+            UnretryableError,
+          );
+          invariant(
+            actionRun.automationRun.build.compareScreenshotBucket,
+            "compareScreenshotBucket relation not found",
             UnretryableError,
           );
           invariant(
@@ -103,6 +117,8 @@ export const automationAction = defineAutomationAction({
             event: actionRun.automationRun.event,
             payload: {
               build: actionRun.automationRun.build,
+              compareScreenshotBucket:
+                actionRun.automationRun.build.compareScreenshotBucket,
               buildReview: actionRun.automationRun.buildReview,
             },
           };

--- a/apps/backend/src/automation/actions/sendSlackMessage/message.e2e.test.ts
+++ b/apps/backend/src/automation/actions/sendSlackMessage/message.e2e.test.ts
@@ -38,7 +38,7 @@ describe("buildSlackMessage", () => {
         isTestMessage: false,
         message: {
           event: "build.completed",
-          payload: { build },
+          payload: { build, compareScreenshotBucket: bucket },
         },
       });
 
@@ -132,7 +132,7 @@ describe("buildSlackMessage", () => {
         isTestMessage: false,
         message: {
           event: "build.reviewed",
-          payload: { build, buildReview },
+          payload: { build, compareScreenshotBucket: bucket, buildReview },
         },
       });
 

--- a/apps/backend/src/automation/actions/sendSlackMessage/message.ts
+++ b/apps/backend/src/automation/actions/sendSlackMessage/message.ts
@@ -36,7 +36,6 @@ export async function buildSlackMessage(args: {
     build.getUrl(),
     build.$clone().$fetchGraph(`
     [
-      compareScreenshotBucket,
       project.[
         githubRepository.[
           githubAccount
@@ -79,7 +78,7 @@ export async function buildSlackMessage(args: {
     detailsBlock({
       build,
       project: richBuild.project,
-      compareScreenshotBucket: richBuild.compareScreenshotBucket ?? null,
+      compareScreenshotBucket: message.payload.compareScreenshotBucket,
       pullRequest: richBuild.pullRequest ?? null,
     }),
   );

--- a/apps/backend/src/automation/triggerAutomation.e2e.test.ts
+++ b/apps/backend/src/automation/triggerAutomation.e2e.test.ts
@@ -7,11 +7,38 @@ import {
   AutomationRun,
   Build,
   Project,
+  ScreenshotBucket,
   SlackChannel,
 } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
 
 import { triggerAutomation } from "./triggerAutomation";
+import type { AutomationMessage } from "./types/events";
+
+async function getCompareScreenshotBucket(
+  build: Build,
+): Promise<ScreenshotBucket> {
+  const compareScreenshotBucket = await build.$relatedQuery(
+    "compareScreenshotBucket",
+  );
+  invariant(
+    compareScreenshotBucket,
+    `Compare screenshot bucket not found for build: ${build.id}`,
+  );
+  return compareScreenshotBucket;
+}
+
+async function getBuildCompletedMessage(
+  build: Build,
+): Promise<AutomationMessage> {
+  return {
+    event: AutomationEvents.BuildCompleted,
+    payload: {
+      build,
+      compareScreenshotBucket: await getCompareScreenshotBucket(build),
+    },
+  };
+}
 
 describe("automation/triggerAutomation", () => {
   let project: Project;
@@ -43,10 +70,7 @@ describe("automation/triggerAutomation", () => {
 
       await triggerAutomation({
         projectId: project.id,
-        message: {
-          event: AutomationEvents.BuildCompleted,
-          payload: { build },
-        },
+        message: await getBuildCompletedMessage(build),
       });
 
       const automationRuns = await AutomationRun.query().where({
@@ -100,10 +124,321 @@ describe("automation/triggerAutomation", () => {
 
       await triggerAutomation({
         projectId: project.id,
-        message: {
-          event: AutomationEvents.BuildCompleted,
-          payload: { build },
+        message: await getBuildCompletedMessage(build),
+      });
+
+      const automationRuns = await AutomationRun.query().where({
+        automationRuleId: automationRule.id,
+        buildId: build.id,
+      });
+      expect(automationRuns).toHaveLength(1);
+    });
+
+    it("should trigger if build mode condition matches", async () => {
+      const build = await factory.Build.create({
+        projectId: project.id,
+        mode: "monitoring",
+      });
+
+      const automationRule = await factory.AutomationRule.create({
+        projectId: project.id,
+        on: ["build.completed"],
+        if: {
+          all: [
+            {
+              type: "build-mode",
+              value: "monitoring",
+            },
+          ],
         },
+        then: [
+          {
+            action: "sendSlackMessage",
+            actionPayload: {
+              type: "sendSlackMessage",
+              channelId: slackChannel.slackId,
+            },
+          },
+        ],
+      });
+
+      await triggerAutomation({
+        projectId: project.id,
+        message: await getBuildCompletedMessage(build),
+      });
+
+      const automationRuns = await AutomationRun.query().where({
+        automationRuleId: automationRule.id,
+        buildId: build.id,
+      });
+      expect(automationRuns).toHaveLength(1);
+    });
+
+    it("should trigger if build branch glob condition matches", async () => {
+      const screenshotBucket = await factory.ScreenshotBucket.create({
+        projectId: project.id,
+        branch: "release/2026-05",
+      });
+      const build = await factory.Build.create({
+        projectId: project.id,
+        compareScreenshotBucketId: screenshotBucket.id,
+      });
+
+      const automationRule = await factory.AutomationRule.create({
+        projectId: project.id,
+        on: ["build.completed"],
+        if: {
+          all: [
+            {
+              glob: {
+                type: "build-branch",
+                value: "release/*",
+              },
+            },
+          ],
+        },
+        then: [
+          {
+            action: "sendSlackMessage",
+            actionPayload: {
+              type: "sendSlackMessage",
+              channelId: slackChannel.slackId,
+            },
+          },
+        ],
+      });
+
+      await triggerAutomation({
+        projectId: project.id,
+        message: await getBuildCompletedMessage(build),
+      });
+
+      const automationRuns = await AutomationRun.query().where({
+        automationRuleId: automationRule.id,
+        buildId: build.id,
+      });
+      expect(automationRuns).toHaveLength(1);
+    });
+
+    it("should not trigger if build branch glob condition does not match", async () => {
+      const screenshotBucket = await factory.ScreenshotBucket.create({
+        projectId: project.id,
+        branch: "feature/login",
+      });
+      const build = await factory.Build.create({
+        projectId: project.id,
+        compareScreenshotBucketId: screenshotBucket.id,
+      });
+
+      const automationRule = await factory.AutomationRule.create({
+        projectId: project.id,
+        on: ["build.completed"],
+        if: {
+          all: [
+            {
+              glob: {
+                type: "build-branch",
+                value: "release/*",
+              },
+            },
+          ],
+        },
+        then: [
+          {
+            action: "sendSlackMessage",
+            actionPayload: {
+              type: "sendSlackMessage",
+              channelId: slackChannel.slackId,
+            },
+          },
+        ],
+      });
+
+      await triggerAutomation({
+        projectId: project.id,
+        message: await getBuildCompletedMessage(build),
+      });
+
+      const automationRuns = await AutomationRun.query().where({
+        automationRuleId: automationRule.id,
+        buildId: build.id,
+      });
+      expect(automationRuns).toHaveLength(0);
+    });
+
+    it("should trigger if build branch glob not condition matches", async () => {
+      const screenshotBucket = await factory.ScreenshotBucket.create({
+        projectId: project.id,
+        branch: "feature/login",
+      });
+      const build = await factory.Build.create({
+        projectId: project.id,
+        compareScreenshotBucketId: screenshotBucket.id,
+      });
+
+      const automationRule = await factory.AutomationRule.create({
+        projectId: project.id,
+        on: ["build.completed"],
+        if: {
+          all: [
+            {
+              not: {
+                glob: {
+                  type: "build-branch",
+                  value: "release/*",
+                },
+              },
+            },
+          ],
+        },
+        then: [
+          {
+            action: "sendSlackMessage",
+            actionPayload: {
+              type: "sendSlackMessage",
+              channelId: slackChannel.slackId,
+            },
+          },
+        ],
+      });
+
+      await triggerAutomation({
+        projectId: project.id,
+        message: await getBuildCompletedMessage(build),
+      });
+
+      const automationRuns = await AutomationRun.query().where({
+        automationRuleId: automationRule.id,
+        buildId: build.id,
+      });
+      expect(automationRuns).toHaveLength(1);
+    });
+
+    it("should trigger if build branch exact condition matches", async () => {
+      const screenshotBucket = await factory.ScreenshotBucket.create({
+        projectId: project.id,
+        branch: "release/2026-05",
+      });
+      const build = await factory.Build.create({
+        projectId: project.id,
+        compareScreenshotBucketId: screenshotBucket.id,
+      });
+
+      const automationRule = await factory.AutomationRule.create({
+        projectId: project.id,
+        on: ["build.completed"],
+        if: {
+          all: [
+            {
+              type: "build-branch",
+              value: "release/2026-05",
+            },
+          ],
+        },
+        then: [
+          {
+            action: "sendSlackMessage",
+            actionPayload: {
+              type: "sendSlackMessage",
+              channelId: slackChannel.slackId,
+            },
+          },
+        ],
+      });
+
+      await triggerAutomation({
+        projectId: project.id,
+        message: await getBuildCompletedMessage(build),
+      });
+
+      const automationRuns = await AutomationRun.query().where({
+        automationRuleId: automationRule.id,
+        buildId: build.id,
+      });
+      expect(automationRuns).toHaveLength(1);
+    });
+
+    it("should not trigger if build branch exact condition does not match", async () => {
+      const screenshotBucket = await factory.ScreenshotBucket.create({
+        projectId: project.id,
+        branch: "release/2026-05",
+      });
+      const build = await factory.Build.create({
+        projectId: project.id,
+        compareScreenshotBucketId: screenshotBucket.id,
+      });
+
+      const automationRule = await factory.AutomationRule.create({
+        projectId: project.id,
+        on: ["build.completed"],
+        if: {
+          all: [
+            {
+              type: "build-branch",
+              value: "release/*",
+            },
+          ],
+        },
+        then: [
+          {
+            action: "sendSlackMessage",
+            actionPayload: {
+              type: "sendSlackMessage",
+              channelId: slackChannel.slackId,
+            },
+          },
+        ],
+      });
+
+      await triggerAutomation({
+        projectId: project.id,
+        message: await getBuildCompletedMessage(build),
+      });
+
+      const automationRuns = await AutomationRun.query().where({
+        automationRuleId: automationRule.id,
+        buildId: build.id,
+      });
+      expect(automationRuns).toHaveLength(0);
+    });
+
+    it("should trigger if build branch exact not condition matches", async () => {
+      const screenshotBucket = await factory.ScreenshotBucket.create({
+        projectId: project.id,
+        branch: "feature/login",
+      });
+      const build = await factory.Build.create({
+        projectId: project.id,
+        compareScreenshotBucketId: screenshotBucket.id,
+      });
+
+      const automationRule = await factory.AutomationRule.create({
+        projectId: project.id,
+        on: ["build.completed"],
+        if: {
+          all: [
+            {
+              not: {
+                type: "build-branch",
+                value: "release/2026-05",
+              },
+            },
+          ],
+        },
+        then: [
+          {
+            action: "sendSlackMessage",
+            actionPayload: {
+              type: "sendSlackMessage",
+              channelId: slackChannel.slackId,
+            },
+          },
+        ],
+      });
+
+      await triggerAutomation({
+        projectId: project.id,
+        message: await getBuildCompletedMessage(build),
       });
 
       const automationRuns = await AutomationRun.query().where({
@@ -145,10 +480,7 @@ describe("automation/triggerAutomation", () => {
 
       await triggerAutomation({
         projectId: project.id,
-        message: {
-          event: AutomationEvents.BuildCompleted,
-          payload: { build },
-        },
+        message: await getBuildCompletedMessage(build),
       });
 
       const automationRuns = await AutomationRun.query().where({
@@ -190,10 +522,7 @@ describe("automation/triggerAutomation", () => {
 
       await triggerAutomation({
         projectId: project.id,
-        message: {
-          event: AutomationEvents.BuildCompleted,
-          payload: { build },
-        },
+        message: await getBuildCompletedMessage(build),
       });
 
       const automationRuns = await AutomationRun.query().where({
@@ -233,10 +562,7 @@ describe("automation/triggerAutomation", () => {
 
       await triggerAutomation({
         projectId: project.id,
-        message: {
-          event: AutomationEvents.BuildCompleted,
-          payload: { build },
-        },
+        message: await getBuildCompletedMessage(build),
       });
 
       const automationRuns = await AutomationRun.query().where({
@@ -269,10 +595,7 @@ describe("automation/triggerAutomation", () => {
 
       await triggerAutomation({
         projectId: project.id,
-        message: {
-          event: AutomationEvents.BuildCompleted,
-          payload: { build },
-        },
+        message: await getBuildCompletedMessage(build),
       });
 
       const automationRuns = await AutomationRun.query().where({

--- a/apps/backend/src/automation/triggerAutomation.ts
+++ b/apps/backend/src/automation/triggerAutomation.ts
@@ -1,27 +1,31 @@
 import {
   AutomationConditionSchema,
   type AllAutomationCondition,
+  type AutomationBuildCondition,
   type AutomationCondition,
+  type BuildBranchCondition,
   type BuildConclusionCondition,
+  type BuildModeCondition,
   type BuildNameCondition,
   type BuildTypeCondition,
 } from "@argos/schemas/automation-condition";
 import { AutomationEvents } from "@argos/schemas/automation-event";
 import { assertNever } from "@argos/util/assertNever";
 import { invariant } from "@argos/util/invariant";
+import { minimatch } from "minimatch";
 
 import { transaction } from "@/database";
 import {
   AutomationActionRun,
   AutomationRule,
   AutomationRun,
-  Build,
+  type ScreenshotBucket,
 } from "@/database/models";
 
 import { getAutomationAction } from "./actions";
 import type { AutomationMessage } from "./types/events";
 
-function getBuildFromPayload(message: AutomationMessage): Build {
+function getBuildFromPayload(message: AutomationMessage) {
   const { event, payload } = message;
   switch (event) {
     case AutomationEvents.BuildCompleted:
@@ -40,6 +44,12 @@ function getBuildFromPayload(message: AutomationMessage): Build {
         `[AutomationEngine] Unsupported event type for build extraction: ${event}`,
       );
   }
+}
+
+function getCompareScreenshotBucketFromPayload(
+  message: AutomationMessage,
+): ScreenshotBucket {
+  return message.payload.compareScreenshotBucket;
 }
 
 /**
@@ -65,6 +75,17 @@ function checkBuildConclusionCondition(
 }
 
 /**
+ * Checks if the build mode matches the condition.
+ */
+function checkBuildModeCondition(
+  condition: BuildModeCondition,
+  message: AutomationMessage,
+): boolean {
+  const build = getBuildFromPayload(message);
+  return build.mode === condition.value;
+}
+
+/**
  * Checks if the build name matches the condition.
  */
 function checkBuildNameCondition(
@@ -76,6 +97,36 @@ function checkBuildNameCondition(
 }
 
 /**
+ * Checks if the build branch matches the condition glob.
+ */
+function checkBuildBranchCondition(
+  condition: BuildBranchCondition,
+  message: AutomationMessage,
+  options: { glob: boolean },
+): boolean {
+  const compareScreenshotBucket =
+    getCompareScreenshotBucketFromPayload(message);
+  return options.glob
+    ? minimatch(compareScreenshotBucket.branch, condition.value)
+    : compareScreenshotBucket.branch === condition.value;
+}
+
+function unwrapCondition(condition: AutomationCondition): {
+  glob: boolean;
+  negative: boolean;
+  rawCondition: AutomationBuildCondition;
+} {
+  if ("not" in condition) {
+    const unwrapped = unwrapCondition(condition.not);
+    return { ...unwrapped, negative: !unwrapped.negative };
+  }
+  if ("glob" in condition) {
+    return { glob: true, negative: false, rawCondition: condition.glob };
+  }
+  return { glob: false, negative: false, rawCondition: condition };
+}
+
+/**
  * Evaluates a single automation condition.
  */
 function evaluateCondition(
@@ -83,23 +134,26 @@ function evaluateCondition(
   message: AutomationMessage,
 ): boolean {
   AutomationConditionSchema.parse(condition);
-  const { negative, rawCondition } = (() => {
-    if ("not" in condition) {
-      return { negative: true, rawCondition: condition.not };
-    }
-    return { negative: false, rawCondition: condition };
-  })();
+  const { glob, negative, rawCondition } = unwrapCondition(condition);
 
   const conditionType = rawCondition.type;
 
   const result = (() => {
     switch (conditionType) {
+      case "build-branch": {
+        return checkBuildBranchCondition(rawCondition, message, { glob });
+      }
+
       case "build-type": {
         return checkBuildTypeCondition(rawCondition, message);
       }
 
       case "build-conclusion": {
         return checkBuildConclusionCondition(rawCondition, message);
+      }
+
+      case "build-mode": {
+        return checkBuildModeCondition(rawCondition, message);
       }
 
       case "build-name": {
@@ -125,9 +179,13 @@ function evaluateAllCondition(
   if (!allCondition.all.length) {
     return true;
   }
-  return (allCondition.all ?? []).every((condition) =>
-    evaluateCondition(condition, message),
-  );
+  for (const condition of allCondition.all ?? []) {
+    const conditionMet = evaluateCondition(condition, message);
+    if (!conditionMet) {
+      return false;
+    }
+  }
+  return true;
 }
 
 export type TriggerAutomationProps = {
@@ -147,14 +205,17 @@ export async function triggerAutomation(
     .where("active", true)
     .whereRaw(`"on" @> ?::jsonb`, [JSON.stringify([message.event])]);
 
+  const matchingAutomationRules: AutomationRule[] = [];
+  for (const automationRule of automationRules) {
+    const conditionsMet = evaluateAllCondition(automationRule.if, message);
+    if (conditionsMet) {
+      matchingAutomationRules.push(automationRule);
+    }
+  }
+
   return transaction(async (trx) => {
     const automationActionRuns = await Promise.all(
-      automationRules.map(async (automationRule) => {
-        const conditionsMet = evaluateAllCondition(automationRule.if, message);
-        if (!conditionsMet) {
-          return [];
-        }
-
+      matchingAutomationRules.map(async (automationRule) => {
         const automationRun = await AutomationRun.query(trx).insertAndFetch({
           automationRuleId: automationRule.id,
           event: message.event,

--- a/apps/backend/src/automation/types/events.ts
+++ b/apps/backend/src/automation/types/events.ts
@@ -1,12 +1,16 @@
 import type { AutomationEvent } from "@argos/schemas/automation-event";
 
-import { Build, BuildReview } from "@/database/models";
+import type { Build, BuildReview, ScreenshotBucket } from "@/database/models";
 
 type AutomationEventPayload<Event extends AutomationEvent> =
   Event extends "build.completed"
-    ? { build: Build }
+    ? { build: Build; compareScreenshotBucket: ScreenshotBucket }
     : Event extends "build.reviewed"
-      ? { build: Build; buildReview: BuildReview }
+      ? {
+          build: Build;
+          compareScreenshotBucket: ScreenshotBucket;
+          buildReview: BuildReview;
+        }
       : never;
 
 export type AutomationMessage = {

--- a/apps/backend/src/build/concludeBuild.ts
+++ b/apps/backend/src/build/concludeBuild.ts
@@ -124,13 +124,21 @@ export async function concludeBuild(input: {
               },
             );
 
+            const compareScreenshotBucket = await updatedBuild.$relatedQuery(
+              "compareScreenshotBucket",
+            );
+            invariant(
+              compareScreenshotBucket,
+              `Compare screenshot bucket not found for build: ${updatedBuild.id}`,
+            );
+
             await Promise.all([
               buildNotificationJob.push(buildNotification.id),
               triggerAndRunAutomation({
                 projectId: build.projectId,
                 message: {
                   event: AutomationEvents.BuildCompleted,
-                  payload: { build: updatedBuild },
+                  payload: { build: updatedBuild, compareScreenshotBucket },
                 },
               }),
             ]);

--- a/apps/backend/src/build/createBuildReview.ts
+++ b/apps/backend/src/build/createBuildReview.ts
@@ -1,4 +1,5 @@
 import { AutomationEvents } from "@argos/schemas/automation-event";
+import { invariant } from "@argos/util/invariant";
 
 import { triggerAndRunAutomation } from "@/automation";
 import { pushBuildNotification } from "@/build-notification/notifications";
@@ -38,6 +39,14 @@ export async function createBuildReview(input: {
     return buildReview;
   });
 
+  const compareScreenshotBucket = await build.$relatedQuery(
+    "compareScreenshotBucket",
+  );
+  invariant(
+    compareScreenshotBucket,
+    `Compare screenshot bucket not found for build: ${build.id}`,
+  );
+
   await Promise.all([
     pushBuildNotification({
       buildId: build.id,
@@ -47,7 +56,7 @@ export async function createBuildReview(input: {
       projectId: build.projectId,
       message: {
         event: AutomationEvents.BuildReviewed,
-        payload: { build, buildReview },
+        payload: { build, compareScreenshotBucket, buildReview },
       },
     }),
   ]);

--- a/apps/backend/src/graphql/definitions/AutomationRule.ts
+++ b/apps/backend/src/graphql/definitions/AutomationRule.ts
@@ -557,6 +557,7 @@ export const resolvers: IResolvers = {
         case "build.completed": {
           const lastBuild = await project
             .$relatedQuery("builds")
+            .withGraphFetched("compareScreenshotBucket")
             .orderBy("id", "desc")
             .first();
 
@@ -565,6 +566,10 @@ export const resolvers: IResolvers = {
               "The project must have at least one build to test this automation.",
             );
           }
+          invariant(
+            lastBuild.compareScreenshotBucket,
+            "compareScreenshotBucket relation not found",
+          );
 
           await testAutomation({
             actions,
@@ -572,6 +577,7 @@ export const resolvers: IResolvers = {
               event: automationEvent,
               payload: {
                 build: lastBuild,
+                compareScreenshotBucket: lastBuild.compareScreenshotBucket,
               },
             },
           });
@@ -580,7 +586,7 @@ export const resolvers: IResolvers = {
         case "build.reviewed": {
           const lastBuildReview = await BuildReview.query()
             .joinRelated("build")
-            .withGraphFetched("build")
+            .withGraphFetched("build.compareScreenshotBucket")
             .where("build.projectId", project.id)
             .orderBy("build_reviews.createdAt", "desc")
             .first();
@@ -592,6 +598,10 @@ export const resolvers: IResolvers = {
           }
 
           invariant(lastBuildReview.build, "build relation not found");
+          invariant(
+            lastBuildReview.build.compareScreenshotBucket,
+            "compareScreenshotBucket relation not found",
+          );
 
           await testAutomation({
             actions,
@@ -599,6 +609,8 @@ export const resolvers: IResolvers = {
               event: automationEvent,
               payload: {
                 build: lastBuildReview.build,
+                compareScreenshotBucket:
+                  lastBuildReview.build.compareScreenshotBucket,
                 buildReview: lastBuildReview,
               },
             },

--- a/apps/frontend/src/pages/Automation/AutomationFormConditionsStep.tsx
+++ b/apps/frontend/src/pages/Automation/AutomationFormConditionsStep.tsx
@@ -1,16 +1,23 @@
-import { useId, useMemo } from "react";
+import { useEffect, useId, useMemo } from "react";
+import type { AutomationInputCondition } from "@argos/schemas/automation-condition";
 import { assertNever } from "@argos/util/assertNever";
 import { invariant } from "@argos/util/invariant";
+import { GitPullRequestIcon, TowerControlIcon } from "lucide-react";
 import { Text } from "react-aria-components";
 import { useFieldArray } from "react-hook-form";
 
-import { BuildStatus, BuildType } from "@/gql/graphql";
+import { BuildMode, BuildStatus, BuildType } from "@/gql/graphql";
 import { FieldError } from "@/ui/FieldError";
+import { FormTextInput } from "@/ui/FormTextInput";
 import { ListBox, ListBoxItem } from "@/ui/ListBox";
 import { MenuItemIcon } from "@/ui/Menu";
 import { Popover } from "@/ui/Popover";
 import { Select, SelectButton, SelectField, SelectValue } from "@/ui/Select";
-import { checkIsNotCondition, getBuildCondition } from "@/util/automation";
+import {
+  checkIsGlobCondition,
+  checkIsNotCondition,
+  getBuildCondition,
+} from "@/util/automation";
 import { buildStatusDescriptors, buildTypeDescriptors } from "@/util/build";
 import { lowTextColorClassNames } from "@/util/colors";
 
@@ -24,7 +31,9 @@ import {
 
 type ConditionValueName =
   | `conditions.${number}.value`
-  | `conditions.${number}.not.value`;
+  | `conditions.${number}.glob.value`
+  | `conditions.${number}.not.value`
+  | `conditions.${number}.not.glob.value`;
 
 function BuildConclusionCondition(props: {
   form: AutomationForm;
@@ -81,6 +90,36 @@ function BuildConclusionCondition(props: {
   );
 }
 
+function BuildBranchCondition(props: {
+  form: AutomationForm;
+  conditionName: `conditions.${number}`;
+  name: ConditionValueName;
+}) {
+  const { form, conditionName, name } = props;
+  const branchOperator = getBranchOperator(form.watch(conditionName));
+  const placeholder =
+    branchOperator === "glob" || branchOperator === "not-glob"
+      ? "release/*"
+      : "main";
+
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      <span>Branch</span>
+      <BranchOperatorSelector form={form} name={conditionName} />
+      <FormTextInput
+        control={form.control}
+        {...form.register(name)}
+        hiddenLabel
+        label="Branch"
+        placeholder={placeholder}
+        scale="sm"
+        className="min-w-0 flex-1"
+        orientation="horizontal"
+      />
+    </div>
+  );
+}
+
 function BuildNameCondition(props: {
   projectBuildNames: string[];
   form: AutomationForm;
@@ -124,6 +163,83 @@ function BuildNameCondition(props: {
                 className="text-sm"
               >
                 {name}
+              </ListBoxItem>
+            ))}
+          </ListBox>
+        </Popover>
+      </SelectField>
+    </div>
+  );
+}
+
+const buildModeOptions = [
+  {
+    mode: BuildMode.Ci,
+    label: "CI",
+    icon: GitPullRequestIcon,
+  },
+  {
+    mode: BuildMode.Monitoring,
+    label: "Monitoring",
+    icon: TowerControlIcon,
+  },
+];
+
+function BuildModeCondition(props: {
+  form: AutomationForm;
+  conditionName: `conditions.${number}`;
+  name: ConditionValueName;
+}) {
+  const { form, conditionName, name } = props;
+  const id = useId();
+  const condition = form.watch(conditionName);
+
+  useEffect(() => {
+    if (!checkIsNotCondition(condition)) {
+      return;
+    }
+    const buildCondition = getBuildCondition(condition);
+    invariant(buildCondition.type === "build-mode");
+    form.setValue(conditionName, {
+      type: "build-mode",
+      value:
+        buildCondition.value === BuildMode.Ci
+          ? BuildMode.Monitoring
+          : buildCondition.value === BuildMode.Monitoring
+            ? BuildMode.Ci
+            : null,
+    });
+  }, [condition, conditionName, form]);
+
+  return (
+    <div className="flex items-center gap-2">
+      <label htmlFor={id}>Build mode</label>
+      <span>is</span>
+      <SelectField
+        id={id}
+        control={form.control}
+        aria-label="Build Mode"
+        orientation="horizontal"
+        name={name}
+        placeholder="Select build mode…"
+      >
+        <SelectButton className="text-sm">
+          <SelectValue />
+        </SelectButton>
+        <FieldError />
+        <Popover>
+          <ListBox>
+            {buildModeOptions.map(({ mode, label, icon: Icon }) => (
+              <ListBoxItem
+                key={mode}
+                id={mode}
+                textValue={label}
+                className="text-sm"
+              >
+                <MenuItemIcon>
+                  <Icon />
+                </MenuItemIcon>
+                <Text slot="label">{label}</Text>
               </ListBoxItem>
             ))}
           </ListBox>
@@ -192,13 +308,25 @@ function ConditionDetail(props: {
   const { projectBuildNames, form, name } = props;
   const value = form.watch(name);
   const condition = getBuildCondition(value);
-  const valueName = checkIsNotCondition(value)
-    ? (`${name}.not.value` as const)
-    : (`${name}.value` as const);
+  const valueName = getConditionValueName(value, name);
 
   switch (condition.type) {
+    case "build-branch":
+      return (
+        <BuildBranchCondition
+          conditionName={name}
+          form={form}
+          name={valueName}
+        />
+      );
+
     case "build-conclusion":
       return <BuildConclusionCondition form={form} name={valueName} />;
+
+    case "build-mode":
+      return (
+        <BuildModeCondition conditionName={name} form={form} name={valueName} />
+      );
 
     case "build-name":
       return (
@@ -217,14 +345,29 @@ function ConditionDetail(props: {
   }
 }
 
+function getConditionValueName(
+  condition: AutomationInputCondition,
+  name: `conditions.${number}`,
+): ConditionValueName {
+  if (checkIsNotCondition(condition)) {
+    return checkIsGlobCondition(condition.not)
+      ? (`${name}.not.glob.value` as const)
+      : (`${name}.not.value` as const);
+  }
+  return checkIsGlobCondition(condition)
+    ? (`${name}.glob.value` as const)
+    : (`${name}.value` as const);
+}
+
 function OperatorSelector(props: {
   form: AutomationForm;
   name: ConditionValueName;
+  labels?: { eq: string; neq: string };
 }) {
-  const { name, form } = props;
+  const { name, form, labels = { eq: "is", neq: "is not" } } = props;
   const operator = name.endsWith(".not.value") ? "neq" : "eq";
   const conditionName = name.replace(
-    /(\.not)?\.value/,
+    /(\.not)?(\.glob)?\.value/,
     "",
   ) as `conditions.${number}`;
   return (
@@ -254,11 +397,89 @@ function OperatorSelector(props: {
       </SelectButton>
       <Popover>
         <ListBox>
+          <ListBoxItem id="eq" textValue={labels.eq}>
+            {labels.eq}
+          </ListBoxItem>
+          <ListBoxItem id="neq" textValue={labels.neq}>
+            {labels.neq}
+          </ListBoxItem>
+        </ListBox>
+      </Popover>
+    </Select>
+  );
+}
+
+type BranchOperator = "eq" | "neq" | "glob" | "not-glob";
+
+function getBranchOperator(
+  condition: AutomationInputCondition,
+): BranchOperator {
+  if (checkIsNotCondition(condition)) {
+    return checkIsGlobCondition(condition.not) ? "not-glob" : "neq";
+  }
+  return checkIsGlobCondition(condition) ? "glob" : "eq";
+}
+
+function BranchOperatorSelector(props: {
+  form: AutomationForm;
+  name: `conditions.${number}`;
+}) {
+  const { form, name } = props;
+  const condition = form.watch(name);
+  const operator = getBranchOperator(condition);
+
+  return (
+    <Select
+      aria-label="Operator"
+      value={operator}
+      onChange={(value) => {
+        const rawCondition = form.getValues(name);
+        const buildCondition = getBuildCondition(rawCondition);
+        invariant(buildCondition.type === "build-branch");
+        invariant(
+          value === "eq" ||
+            value === "neq" ||
+            value === "glob" ||
+            value === "not-glob",
+        );
+        switch (value) {
+          case "eq": {
+            form.setValue(name, buildCondition);
+            break;
+          }
+          case "neq": {
+            form.setValue(name, { not: buildCondition });
+            break;
+          }
+          case "glob": {
+            form.setValue(name, { glob: buildCondition });
+            break;
+          }
+          case "not-glob": {
+            form.setValue(name, { not: { glob: buildCondition } });
+            break;
+          }
+          default:
+            assertNever(value);
+        }
+      }}
+    >
+      <SelectButton>
+        <SelectValue />
+      </SelectButton>
+      <Popover>
+        <ListBox>
           <ListBoxItem id="eq" textValue="is">
             is
           </ListBoxItem>
           <ListBoxItem id="neq" textValue="is not">
             is not
+          </ListBoxItem>
+          <ListBoxItem id="glob" textValue="matches">
+            matches
+          </ListBoxItem>
+          <ListBoxItem id="not-glob" textValue="does not match">
+            does not match
           </ListBoxItem>
         </ListBox>
       </Popover>
@@ -272,7 +493,9 @@ const CONDITIONS = [
     label: "Build conclusion",
   },
   { type: "build-type" as const, label: "Build type" },
+  { type: "build-mode" as const, label: "Build mode" },
   { type: "build-name" as const, label: "Build name" },
+  { type: "build-branch" as const, label: "Build branch" },
 ];
 
 export function AutomationConditionsStep(props: {
@@ -319,10 +542,12 @@ export function AutomationConditionsStep(props: {
           onChange={(key) => {
             switch (key) {
               case "build-conclusion":
+              case "build-mode":
               case "build-type": {
                 append({ type: key, value: null });
                 return;
               }
+              case "build-branch":
               case "build-name": {
                 append({ type: key, value: "" });
                 return;

--- a/apps/frontend/src/util/automation.ts
+++ b/apps/frontend/src/util/automation.ts
@@ -2,6 +2,7 @@ import { AutomationSlackActionTypeSchema } from "@argos/schemas/automation-actio
 import {
   type AutomationInputBuildCondition,
   type AutomationInputCondition,
+  type AutomationInputGlobCondition,
   type AutomationInputNotCondition,
 } from "@argos/schemas/automation-condition";
 import { AutomationEvent } from "@argos/schemas/automation-event";
@@ -18,15 +19,27 @@ export function checkIsNotCondition(
 }
 
 /**
+ * Check if the condition is a "glob" one.
+ */
+export function checkIsGlobCondition(
+  condition: AutomationInputCondition | AutomationInputNotCondition["not"],
+): condition is AutomationInputGlobCondition {
+  return "glob" in condition && condition.glob !== undefined;
+}
+
+/**
  * Extract the build condition from an automation condition.
  * If the condition is a direct build condition, return it.
- * Otherwise, extract it from the `not` wrapper.
+ * Otherwise, extract it from the operator wrapper.
  */
 export function getBuildCondition(
   condition: AutomationInputCondition,
 ): AutomationInputBuildCondition {
   if (checkIsNotCondition(condition)) {
-    return condition.not;
+    return getBuildCondition(condition.not);
+  }
+  if (checkIsGlobCondition(condition)) {
+    return condition.glob;
   }
   return condition;
 }

--- a/packages/schemas/src/automation-condition.ts
+++ b/packages/schemas/src/automation-condition.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import { BuildConclusionSchema } from "./build-status.js";
 import { BuildTypeSchema } from "./build-type.js";
 
+const BuildModeSchema = z.enum(["ci", "monitoring"]);
+
 const BuildConclusionConditionSchema = z.object({
   type: z.literal("build-conclusion"),
   value: BuildConclusionSchema.nullable().refine((val) => val !== null, {
@@ -23,6 +25,24 @@ const BuildNameConditionSchema = z.object({
 
 export type BuildNameCondition = z.output<typeof BuildNameConditionSchema>;
 
+const BuildBranchConditionSchema = z.object({
+  type: z.literal("build-branch"),
+  value: z.string().nonempty({
+    error: "Required",
+  }),
+});
+
+export type BuildBranchCondition = z.output<typeof BuildBranchConditionSchema>;
+
+const BuildModeConditionSchema = z.object({
+  type: z.literal("build-mode"),
+  value: BuildModeSchema.nullable().refine((val) => val !== null, {
+    message: "Required",
+  }),
+});
+
+export type BuildModeCondition = z.output<typeof BuildModeConditionSchema>;
+
 const BuildTypeConditionSchema = z.object({
   type: z.literal("build-type"),
   value: BuildTypeSchema.nullable().refine((val) => val !== null, {
@@ -32,8 +52,10 @@ const BuildTypeConditionSchema = z.object({
 
 export type BuildTypeCondition = z.infer<typeof BuildTypeConditionSchema>;
 
-const AutomationBuildConditionSchema = z.discriminatedUnion("type", [
+export const AutomationBuildConditionSchema = z.discriminatedUnion("type", [
+  BuildBranchConditionSchema,
   BuildConclusionConditionSchema,
+  BuildModeConditionSchema,
   BuildNameConditionSchema,
   BuildTypeConditionSchema,
 ]);
@@ -45,8 +67,24 @@ export type AutomationInputBuildCondition = z.input<
   typeof AutomationBuildConditionSchema
 >;
 
+const AutomationGlobConditionSchema = z.object({
+  glob: BuildBranchConditionSchema,
+});
+
+export type AutomationGlobCondition = z.output<
+  typeof AutomationGlobConditionSchema
+>;
+export type AutomationInputGlobCondition = z.input<
+  typeof AutomationGlobConditionSchema
+>;
+
+const AutomationComparableConditionSchema = z.union([
+  AutomationBuildConditionSchema,
+  AutomationGlobConditionSchema,
+]);
+
 const AutomationNotConditionSchema = z.object({
-  not: AutomationBuildConditionSchema,
+  not: AutomationComparableConditionSchema,
 });
 
 export type AutomationInputNotCondition = z.input<
@@ -54,7 +92,7 @@ export type AutomationInputNotCondition = z.input<
 >;
 
 export const AutomationConditionSchema = z.union([
-  AutomationBuildConditionSchema,
+  AutomationComparableConditionSchema,
   AutomationNotConditionSchema,
 ]);
 

--- a/packages/schemas/src/automation-condition.ts
+++ b/packages/schemas/src/automation-condition.ts
@@ -8,7 +8,7 @@ const BuildModeSchema = z.enum(["ci", "monitoring"]);
 const BuildConclusionConditionSchema = z.object({
   type: z.literal("build-conclusion"),
   value: BuildConclusionSchema.nullable().refine((val) => val !== null, {
-    message: "Required",
+    error: "Required",
   }),
 });
 
@@ -37,7 +37,7 @@ export type BuildBranchCondition = z.output<typeof BuildBranchConditionSchema>;
 const BuildModeConditionSchema = z.object({
   type: z.literal("build-mode"),
   value: BuildModeSchema.nullable().refine((val) => val !== null, {
-    message: "Required",
+    error: "Required",
   }),
 });
 
@@ -46,7 +46,7 @@ export type BuildModeCondition = z.output<typeof BuildModeConditionSchema>;
 const BuildTypeConditionSchema = z.object({
   type: z.literal("build-type"),
   value: BuildTypeSchema.nullable().refine((val) => val !== null, {
-    message: "Required",
+    error: "Required",
   }),
 });
 


### PR DESCRIPTION
## Summary

Adds two new automation build filters:

- Build mode, with CI and Monitoring choices.
- Build branch, with exact operators and glob operators.

The branch filter supports exact `is` / `is not` matching and glob-based `matches` / `does not match` matching through a new `glob` condition wrapper. Automation build event payloads now pass `compareScreenshotBucket` as a direct typed payload property so condition evaluation stays synchronous.

## Impact

Project automations can now target CI versus Monitoring builds and branch patterns without overloading existing build-name/type/conclusion filters. Existing automation conditions continue to use the same JSON condition storage model.

## Validation

- `prettier` on modified files
- `pnpm --dir packages/schemas run check-types`
- `pnpm --dir apps/frontend run check-types`
- `pnpm --dir apps/backend run check-types`
- `eslint` on modified files
- `pnpm test apps/backend/src/automation/triggerAutomation.e2e.test.ts apps/backend/src/automation/actions/sendSlackMessage/message.e2e.test.ts apps/backend/src/automation/actions/sendSlackMessage/index.e2e.test.ts`