### PR TITLE
feat: support arbitrary text-based snapshot types

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -52,3 +52,26 @@
 - Avoid large shared setups that slow down the suite or reduce concurrency.
 - Load dependencies independently whenever possible so tests can run in parallel without unnecessary bottlenecks.
 - Avoid mocking unless the behavior cannot be tested realistically.
+
+### Running tests
+
+From the repo root:
+
+```bash
+pnpm test:unit          # unit tests (no infra)
+pnpm test:integration   # e2e tests (require Postgres + Redis)
+```
+
+Before running e2e tests for the first time — and after pulling new migrations — reset the test database so its schema matches `db/structure.sql`:
+
+```bash
+NODE_ENV=test pnpm run --filter @argos/backend db:reset
+```
+
+If `db:reset` reports `database "test" is being accessed by other users`, terminate the open sessions first:
+
+```bash
+psql -h 127.0.0.1 -U postgres -d postgres -c \
+  "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+   WHERE datname = 'test' AND pid <> pg_backend_pid();"
+```

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -36,6 +36,7 @@
     "@aws-sdk/client-s3": "^3.1049.0",
     "@aws-sdk/lib-dynamodb": "^3.1049.0",
     "@aws-sdk/lib-storage": "^3.1049.0",
+    "@aws-sdk/s3-presigned-post": "^3.1054.0",
     "@aws-sdk/s3-request-presigner": "^3.1049.0",
     "@gitbeaker/rest": "^43.8.0",
     "@graphql-tools/schema": "^10.0.33",

--- a/apps/backend/src/api/README.md
+++ b/apps/backend/src/api/README.md
@@ -8,7 +8,7 @@ The server creates the build along signed S3 URLs to upload the screenshots.
 
 ## _Client requirement_
 
-Client must upload the screenshots using the signed URLs it got from the server before starting the se 2.
+Client must upload the screenshots using the signed URLs it got from the server before starting step 2. Legacy clients send `screenshotKeys` and receive `putUrl`; new clients send `screenshots` with `key` and `contentType` and receive `postUrl` with its `fields`.
 
 ## 2. Update / Finalize — PUT /builds/:buildId
 

--- a/apps/backend/src/api/handlers/createBuild.ts
+++ b/apps/backend/src/api/handlers/createBuild.ts
@@ -1,4 +1,5 @@
 import { invariant } from "@argos/util/invariant";
+import { createPresignedPost } from "@aws-sdk/s3-presigned-post";
 import { z } from "zod";
 import { ZodOpenApiOperationObject } from "zod-openapi";
 
@@ -10,7 +11,6 @@ import { Build } from "@/database/models/Build";
 import { Project } from "@/database/models/Project";
 import { getUnknownFileKeys } from "@/database/services/file";
 import { getS3Client } from "@/storage/s3";
-import { getSignedObjectUrl } from "@/storage/signed-url";
 import { boom } from "@/util/error";
 import { redisLock } from "@/util/redis";
 
@@ -28,6 +28,14 @@ import {
   unauthorized,
 } from "../schema/util/error";
 import { CreateAPIHandler } from "../util";
+
+/**
+ * Maximum size (in bytes) accepted for an uploaded snapshot or trace file. The
+ * limit is enforced by S3 itself: each presigned upload URL is signed with a
+ * `content-length-range` condition that S3 verifies on receipt, so an oversized
+ * file is rejected at upload time and never reaches the bucket.
+ */
+const MAX_UPLOAD_FILE_BYTES = 25 * 1024 * 1024;
 
 const RequestBodySchema = z.object({
   commit: Sha1HashSchema.meta({
@@ -108,7 +116,8 @@ type RequestBody = z.infer<typeof RequestBodySchema>;
 
 const UploadSchema = z.object({
   key: z.string(),
-  putUrl: z.url(),
+  url: z.url(),
+  fields: z.record(z.string(), z.string()),
 });
 
 type Upload = z.infer<typeof UploadSchema>;
@@ -175,28 +184,27 @@ type BuildContext = {
 };
 
 /**
- * Get signed URLs for unknown file keys.
+ * Get presigned POST policies for unknown file keys.
+ *
+ * Each policy is signed with a `content-length-range` condition so that S3
+ * itself rejects oversized uploads (the body must be within
+ * `[1, MAX_UPLOAD_FILE_BYTES]`).
  */
 async function getUploads(keys: string[]): Promise<Upload[]> {
   const unknownKeys = await getUnknownFileKeys(keys);
   const s3 = getS3Client();
   const screenshotsBucket = config.get("s3.screenshotsBucket");
-  const putUrls = await Promise.all(
-    unknownKeys.map((key) =>
-      getSignedObjectUrl({
-        s3,
-        Key: key,
+  return Promise.all(
+    unknownKeys.map(async (key) => {
+      const { url, fields } = await createPresignedPost(s3, {
         Bucket: screenshotsBucket,
-        expiresIn: 1800, // 30 minutes
-        method: "PUT",
-      }),
-    ),
+        Key: key,
+        Expires: 1800, // 30 minutes
+        Conditions: [["content-length-range", 1, MAX_UPLOAD_FILE_BYTES]],
+      });
+      return { key, url, fields };
+    }),
   );
-  return unknownKeys.map((key, index) => {
-    const putUrl = putUrls[index];
-    invariant(putUrl, "`putUrl` is undefined");
-    return { key, putUrl };
-  });
 }
 
 /**

--- a/apps/backend/src/api/handlers/createBuild.ts
+++ b/apps/backend/src/api/handlers/createBuild.ts
@@ -12,6 +12,7 @@ import { Build } from "@/database/models/Build";
 import { Project } from "@/database/models/Project";
 import { getUnknownFileKeys } from "@/database/services/file";
 import { getS3Client } from "@/storage/s3";
+import { getSignedObjectUrl } from "@/storage/signed-url";
 import { boom } from "@/util/error";
 import { redisLock } from "@/util/redis";
 
@@ -33,9 +34,9 @@ import { CreateAPIHandler } from "../util";
 
 /**
  * Maximum size (in bytes) accepted for an uploaded snapshot or trace file. The
- * limit is enforced by S3 itself: each presigned upload URL is signed with a
- * `content-length-range` condition that S3 verifies on receipt, so an oversized
- * file is rejected at upload time and never reaches the bucket.
+ * limit is enforced by S3 itself for the secure POST upload path. The legacy
+ * PUT upload path is kept for backward compatibility and does not enforce this
+ * policy.
  */
 const MAX_UPLOAD_FILE_BYTES = 25 * 1024 * 1024;
 
@@ -45,34 +46,12 @@ const MAX_UPLOAD_FILE_BYTES = 25 * 1024 * 1024;
  */
 const PLAYWRIGHT_TRACE_CONTENT_TYPE = "application/zip";
 
-const ScreenshotUploadRequestSchema = z
-  .object({
-    key: Sha256HashSchema,
-    contentType: SnapshotContentTypeSchema,
-  })
-  .meta({
-    description: "Screenshot file to upload",
-    id: "ScreenshotUploadRequest",
-  });
-
-type ScreenshotUploadRequest = z.infer<typeof ScreenshotUploadRequestSchema>;
-
-const UniqueScreenshotUploadsSchema = z
-  .array(ScreenshotUploadRequestSchema)
-  .refine(
-    (items) => new Set(items.map((item) => item.key)).size === items.length,
-    { message: "Must be an array of uploads with unique keys" },
-  );
-
-const RequestBodySchema = z.object({
+const CommonRequestBodySchema = z.object({
   commit: Sha1HashSchema.meta({
     description: "The commit the build is running on",
   }),
   branch: GitBranchSchema.meta({
     description: "The branch the build is running on",
-  }),
-  screenshots: UniqueScreenshotUploadsSchema.meta({
-    description: "Screenshot files to upload",
   }),
   pwTraceKeys: UniqueSha256HashArraySchema.optional().meta({
     description: "Keys of Playwright trace files",
@@ -139,14 +118,64 @@ const RequestBodySchema = z.object({
     }),
 });
 
+const ScreenshotUploadRequestSchema = z
+  .object({
+    key: Sha256HashSchema,
+    contentType: SnapshotContentTypeSchema,
+  })
+  .meta({
+    description: "Screenshot file to upload",
+    id: "ScreenshotUploadRequest",
+  });
+
+type ScreenshotUploadRequest = z.infer<typeof ScreenshotUploadRequestSchema>;
+
+const UniqueScreenshotUploadsSchema = z
+  .array(ScreenshotUploadRequestSchema)
+  .refine(
+    (items) => new Set(items.map((item) => item.key)).size === items.length,
+    { message: "Must be an array of uploads with unique keys" },
+  );
+
+const LegacyUploadRequestSchema = z.object({
+  screenshotKeys: UniqueSha256HashArraySchema.meta({
+    deprecated: true,
+    description: "Keys of screenshot files",
+  }),
+  screenshots: z.undefined().optional(),
+});
+
+const SecureUploadRequestSchema = z.object({
+  screenshots: UniqueScreenshotUploadsSchema.meta({
+    description: "Screenshot files to upload",
+  }),
+  screenshotKeys: z.undefined().optional(),
+});
+
+const RequestBodySchema = CommonRequestBodySchema.and(
+  z.union([LegacyUploadRequestSchema, SecureUploadRequestSchema]),
+);
+
 type RequestBody = z.infer<typeof RequestBodySchema>;
 
-const UploadSchema = z.object({
+const LegacyUploadSchema = z.object({
   key: z.string(),
-  url: z.url(),
+  putUrl: z.url().meta({
+    deprecated: true,
+    description: "Deprecated. Use postUrl and fields instead.",
+  }),
+});
+
+const SecureUploadSchema = z.object({
+  key: z.string(),
+  postUrl: z.url(),
   fields: z.record(z.string(), z.string()),
 });
 
+const UploadSchema = z.union([LegacyUploadSchema, SecureUploadSchema]);
+
+type LegacyUpload = z.infer<typeof LegacyUploadSchema>;
+type SecureUpload = z.infer<typeof SecureUploadSchema>;
 type Upload = z.infer<typeof UploadSchema>;
 
 const ResponseSchema = z.object({
@@ -185,7 +214,7 @@ export const createBuild: CreateAPIHandler = ({ post }) => {
     const auth = await getAuthProjectPayloadFromExpressReq(req);
 
     const ctx = {
-      body: req.body,
+      body: req.ctx.body,
       project: auth.project,
     } satisfies BuildContext;
 
@@ -211,7 +240,28 @@ type BuildContext = {
 };
 
 /**
- * Get presigned POST policies for the given items.
+ * Get legacy signed PUT URLs for unknown file keys.
+ */
+async function getLegacyUploads(keys: string[]): Promise<LegacyUpload[]> {
+  const unknownKeys = await getUnknownFileKeys(keys);
+  const s3 = getS3Client();
+  const screenshotsBucket = config.get("s3.screenshotsBucket");
+  return Promise.all(
+    unknownKeys.map(async (key) => {
+      const putUrl = await getSignedObjectUrl({
+        s3,
+        Key: key,
+        Bucket: screenshotsBucket,
+        expiresIn: 1800, // 30 minutes
+        method: "PUT",
+      });
+      return { key, putUrl };
+    }),
+  );
+}
+
+/**
+ * Get secure presigned POST policies for unknown file keys.
  *
  * Each policy is signed with two conditions enforced by S3 on upload:
  *   - `content-length-range`: the body size must be within
@@ -219,9 +269,12 @@ type BuildContext = {
  *   - `eq $Content-Type <contentType>`: the client must upload with exactly the
  *     content type declared at `createBuild` time.
  */
-async function getUploads(
-  items: { key: string; contentType: string }[],
-): Promise<Upload[]> {
+async function getSecureUploads(
+  items: {
+    key: string;
+    contentType: string;
+  }[],
+): Promise<SecureUpload[]> {
   const unknownKeys = new Set(
     await getUnknownFileKeys(items.map((item) => item.key)),
   );
@@ -234,33 +287,48 @@ async function getUploads(
         Bucket: screenshotsBucket,
         Key: item.key,
         Expires: 1800, // 30 minutes
+        Fields: { "Content-Type": item.contentType },
         Conditions: [
           ["content-length-range", 1, MAX_UPLOAD_FILE_BYTES],
           ["eq", "$Content-Type", item.contentType],
         ],
       });
-      return { key: item.key, url, fields };
+      return { key: item.key, postUrl: url, fields };
     }),
   );
+}
+
+function isSecureBuildRequest(
+  body: RequestBody,
+): body is RequestBody & { screenshots: ScreenshotUploadRequest[] } {
+  return "screenshots" in body && Array.isArray(body.screenshots);
 }
 
 /**
  * Get screenshots and pw traces from the request body.
  */
-async function getScreenshotAndPwTraces(params: {
-  screenshots: ScreenshotUploadRequest[];
-  pwTraceKeys?: string[] | undefined;
-}): Promise<{ screenshots: Upload[]; pwTraces: Upload[] }> {
-  const screenshotKeys = new Set(params.screenshots.map((s) => s.key));
-  const pwTraceItems = (params.pwTraceKeys ?? []).map((key) => ({
-    key,
-    contentType: PLAYWRIGHT_TRACE_CONTENT_TYPE,
-  }));
-  const uploads = await getUploads([...params.screenshots, ...pwTraceItems]);
-  return {
-    screenshots: uploads.filter((upload) => screenshotKeys.has(upload.key)),
-    pwTraces: uploads.filter((upload) => !screenshotKeys.has(upload.key)),
-  };
+async function getScreenshotAndPwTraces(body: RequestBody): Promise<{
+  screenshots: Upload[];
+  pwTraces: Upload[];
+}> {
+  if (isSecureBuildRequest(body)) {
+    const [screenshots, pwTraces] = await Promise.all([
+      getSecureUploads(body.screenshots),
+      getSecureUploads(
+        (body.pwTraceKeys ?? []).map((key) => ({
+          key,
+          contentType: PLAYWRIGHT_TRACE_CONTENT_TYPE,
+        })),
+      ),
+    ]);
+    return { screenshots, pwTraces };
+  }
+
+  const [screenshots, pwTraces] = await Promise.all([
+    getLegacyUploads(body.screenshotKeys),
+    getLegacyUploads(body.pwTraceKeys ?? []),
+  ]);
+  return { screenshots, pwTraces };
 }
 
 /**

--- a/apps/backend/src/api/handlers/createBuild.ts
+++ b/apps/backend/src/api/handlers/createBuild.ts
@@ -1,3 +1,4 @@
+import { SnapshotContentTypeSchema } from "@argos/schemas/content-type";
 import { invariant } from "@argos/util/invariant";
 import { createPresignedPost } from "@aws-sdk/s3-presigned-post";
 import { z } from "zod";
@@ -19,6 +20,7 @@ import { BuildSchema, serializeBuild } from "../schema/primitives/build";
 import { GitBranchSchema, GitPRNumberSchema } from "../schema/primitives/git";
 import {
   Sha1HashSchema,
+  Sha256HashSchema,
   UniqueSha256HashArraySchema,
 } from "../schema/primitives/sha";
 import {
@@ -37,6 +39,31 @@ import { CreateAPIHandler } from "../util";
  */
 const MAX_UPLOAD_FILE_BYTES = 25 * 1024 * 1024;
 
+/**
+ * Content type of Playwright trace files. Hard-coded because the SDK always
+ * uploads traces as ZIP archives.
+ */
+const PLAYWRIGHT_TRACE_CONTENT_TYPE = "application/zip";
+
+const ScreenshotUploadRequestSchema = z
+  .object({
+    key: Sha256HashSchema,
+    contentType: SnapshotContentTypeSchema,
+  })
+  .meta({
+    description: "Screenshot file to upload",
+    id: "ScreenshotUploadRequest",
+  });
+
+type ScreenshotUploadRequest = z.infer<typeof ScreenshotUploadRequestSchema>;
+
+const UniqueScreenshotUploadsSchema = z
+  .array(ScreenshotUploadRequestSchema)
+  .refine(
+    (items) => new Set(items.map((item) => item.key)).size === items.length,
+    { message: "Must be an array of uploads with unique keys" },
+  );
+
 const RequestBodySchema = z.object({
   commit: Sha1HashSchema.meta({
     description: "The commit the build is running on",
@@ -44,8 +71,8 @@ const RequestBodySchema = z.object({
   branch: GitBranchSchema.meta({
     description: "The branch the build is running on",
   }),
-  screenshotKeys: UniqueSha256HashArraySchema.meta({
-    description: "Keys of screenshot files",
+  screenshots: UniqueScreenshotUploadsSchema.meta({
+    description: "Screenshot files to upload",
   }),
   pwTraceKeys: UniqueSha256HashArraySchema.optional().meta({
     description: "Keys of Playwright trace files",
@@ -184,25 +211,35 @@ type BuildContext = {
 };
 
 /**
- * Get presigned POST policies for unknown file keys.
+ * Get presigned POST policies for the given items.
  *
- * Each policy is signed with a `content-length-range` condition so that S3
- * itself rejects oversized uploads (the body must be within
- * `[1, MAX_UPLOAD_FILE_BYTES]`).
+ * Each policy is signed with two conditions enforced by S3 on upload:
+ *   - `content-length-range`: the body size must be within
+ *     `[1, MAX_UPLOAD_FILE_BYTES]`.
+ *   - `eq $Content-Type <contentType>`: the client must upload with exactly the
+ *     content type declared at `createBuild` time.
  */
-async function getUploads(keys: string[]): Promise<Upload[]> {
-  const unknownKeys = await getUnknownFileKeys(keys);
+async function getUploads(
+  items: { key: string; contentType: string }[],
+): Promise<Upload[]> {
+  const unknownKeys = new Set(
+    await getUnknownFileKeys(items.map((item) => item.key)),
+  );
+  const unknownItems = items.filter((item) => unknownKeys.has(item.key));
   const s3 = getS3Client();
   const screenshotsBucket = config.get("s3.screenshotsBucket");
   return Promise.all(
-    unknownKeys.map(async (key) => {
+    unknownItems.map(async (item) => {
       const { url, fields } = await createPresignedPost(s3, {
         Bucket: screenshotsBucket,
-        Key: key,
+        Key: item.key,
         Expires: 1800, // 30 minutes
-        Conditions: [["content-length-range", 1, MAX_UPLOAD_FILE_BYTES]],
+        Conditions: [
+          ["content-length-range", 1, MAX_UPLOAD_FILE_BYTES],
+          ["eq", "$Content-Type", item.contentType],
+        ],
       });
-      return { key, url, fields };
+      return { key: item.key, url, fields };
     }),
   );
 }
@@ -211,18 +248,18 @@ async function getUploads(keys: string[]): Promise<Upload[]> {
  * Get screenshots and pw traces from the request body.
  */
 async function getScreenshotAndPwTraces(params: {
-  screenshotKeys: string[];
+  screenshots: ScreenshotUploadRequest[];
   pwTraceKeys?: string[] | undefined;
 }): Promise<{ screenshots: Upload[]; pwTraces: Upload[] }> {
-  const screenshotKeys = params.screenshotKeys;
-  const pwTraceKeys = params.pwTraceKeys ?? [];
-  const fileKeys = [...params.screenshotKeys, ...pwTraceKeys];
-  const uploads = await getUploads(fileKeys);
+  const screenshotKeys = new Set(params.screenshots.map((s) => s.key));
+  const pwTraceItems = (params.pwTraceKeys ?? []).map((key) => ({
+    key,
+    contentType: PLAYWRIGHT_TRACE_CONTENT_TYPE,
+  }));
+  const uploads = await getUploads([...params.screenshots, ...pwTraceItems]);
   return {
-    screenshots: uploads.filter((upload) =>
-      screenshotKeys.includes(upload.key),
-    ),
-    pwTraces: uploads.filter((upload) => pwTraceKeys.includes(upload.key)),
+    screenshots: uploads.filter((upload) => screenshotKeys.has(upload.key)),
+    pwTraces: uploads.filter((upload) => !screenshotKeys.has(upload.key)),
   };
 }
 

--- a/apps/backend/src/api/schema/primitives/screenshot.test.ts
+++ b/apps/backend/src/api/schema/primitives/screenshot.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { ScreenshotInputSchema } from "./screenshot";
+
+const base = { key: "a".repeat(64), name: "home.png" };
+
+describe("ScreenshotInputSchema", () => {
+  it("defaults contentType to image/png", () => {
+    expect(ScreenshotInputSchema.parse(base).contentType).toBe("image/png");
+  });
+
+  it("accepts supported image and text content types", () => {
+    const supported = [
+      "image/png",
+      "image/jpeg",
+      "image/webp",
+      "text/plain",
+      "application/json",
+      "application/yaml",
+      "text/yaml",
+      "application/xml",
+      "text/xml",
+      "text/html",
+      "text/markdown",
+    ];
+    for (const contentType of supported) {
+      expect(
+        ScreenshotInputSchema.parse({ ...base, contentType }).contentType,
+      ).toBe(contentType);
+    }
+  });
+
+  it("normalizes the content type (lowercase and strips parameters)", () => {
+    expect(
+      ScreenshotInputSchema.parse({
+        ...base,
+        contentType: "TEXT/HTML; charset=utf-8",
+      }).contentType,
+    ).toBe("text/html");
+  });
+
+  it("rejects unsupported and unsafe content types", () => {
+    const rejected = [
+      "image/svg+xml",
+      "application/x-msdownload",
+      "text/x-evil",
+      "video/mp4",
+      "",
+    ];
+    for (const contentType of rejected) {
+      expect(() =>
+        ScreenshotInputSchema.parse({ ...base, contentType }),
+      ).toThrow();
+    }
+  });
+});

--- a/apps/backend/src/api/schema/primitives/screenshot.ts
+++ b/apps/backend/src/api/schema/primitives/screenshot.ts
@@ -1,3 +1,4 @@
+import { SnapshotContentTypeSchema } from "@argos/schemas/content-type";
 import { ScreenshotMetadataSchema } from "@argos/schemas/screenshot-metadata";
 import { z } from "zod";
 
@@ -12,7 +13,7 @@ export const ScreenshotInputSchema = z
     metadata: ScreenshotMetadataSchema.nullish(),
     pwTraceKey: z.string().regex(SHA256_REGEX).nullish(),
     threshold: z.number().min(0).max(1).nullish(),
-    contentType: z.string().optional().default("image/png"),
+    contentType: SnapshotContentTypeSchema.default("image/png"),
   })
   .meta({
     description: "Screenshot input",

--- a/apps/backend/src/api/schema/primitives/snapshot-diff.ts
+++ b/apps/backend/src/api/schema/primitives/snapshot-diff.ts
@@ -7,7 +7,7 @@ import {
   ScreenshotDiff,
   type File as FileModel,
 } from "@/database/models";
-import { getPublicImageFileUrl, getPublicUrl, getTwicPicsUrl } from "@/storage";
+import { getPublicFileUrl, getPublicUrl, getTwicPicsUrl } from "@/storage";
 
 const SnapshotDiffStatusSchema = z
   .enum([
@@ -89,8 +89,8 @@ async function serializeSnapshot(
   }
 
   const file = screenshot.file as FileModel | null | undefined;
-  const imageUrl = file
-    ? await getPublicImageFileUrl(file)
+  const url = file
+    ? await getPublicFileUrl(file)
     : await getPublicUrl(screenshot.s3Id);
 
   return {
@@ -99,7 +99,7 @@ async function serializeSnapshot(
     metadata: screenshot.metadata,
     width: file?.width ?? null,
     height: file?.height ?? null,
-    url: imageUrl,
+    url,
     contentType: file?.contentType ?? "image/png",
   };
 }
@@ -107,7 +107,7 @@ async function serializeSnapshot(
 async function getSnapshotDiffUrl(diff: ScreenshotDiff) {
   const file = diff.file as FileModel | null | undefined;
   if (file) {
-    return getPublicImageFileUrl(file);
+    return getPublicFileUrl(file);
   }
   if (diff.s3Id) {
     return getTwicPicsUrl(diff.s3Id);

--- a/apps/backend/src/graphql/definitions/Screenshot.ts
+++ b/apps/backend/src/graphql/definitions/Screenshot.ts
@@ -8,7 +8,7 @@ import {
   checkIsTrustedNpmPackage,
   getLatestPackageVersion,
 } from "@/npm/version";
-import { getPublicImageFileUrl, getPublicUrl } from "@/storage";
+import { getPublicFileUrl, getPublicUrl } from "@/storage";
 
 import type { IResolvers } from "../__generated__/resolver-types";
 
@@ -112,7 +112,7 @@ export const resolvers: IResolvers = {
       }
       const file = await ctx.loaders.File.load(screenshot.fileId);
       invariant(file, "File not found");
-      return getPublicImageFileUrl(file);
+      return getPublicFileUrl(file);
     },
     originalUrl: async (screenshot, _args, ctx) => {
       if (!screenshot.fileId) {
@@ -120,7 +120,9 @@ export const resolvers: IResolvers = {
       }
       const file = await ctx.loaders.File.load(screenshot.fileId);
       invariant(file, "File not found");
-      return getPublicUrl(file.key);
+      return file.isImage()
+        ? getPublicUrl(file.key)
+        : getPublicUrl(file.key, { download: true });
     },
     width: async (screenshot, _args, ctx) => {
       if (!screenshot.fileId) {

--- a/apps/backend/src/graphql/definitions/ScreenshotDiff.ts
+++ b/apps/backend/src/graphql/definitions/ScreenshotDiff.ts
@@ -2,7 +2,7 @@ import { invariant } from "@argos/util/invariant";
 import gqlTag from "graphql-tag";
 
 import { getStartDateFromPeriod } from "@/metrics/test";
-import { getPublicImageFileUrl, getTwicPicsUrl } from "@/storage";
+import { getPublicFileUrl, getTwicPicsUrl } from "@/storage";
 
 import {
   IResolvers,
@@ -139,7 +139,7 @@ export const resolvers: IResolvers = {
       }
       const file = await ctx.loaders.File.load(screenshotDiff.fileId);
       invariant(file, "File not found");
-      return getPublicImageFileUrl(file);
+      return getPublicFileUrl(file);
     },
     contentType: async (screenshotDiff, _args, ctx) => {
       if (!screenshotDiff.fileId) {

--- a/apps/backend/src/slack/unfurl.ts
+++ b/apps/backend/src/slack/unfurl.ts
@@ -6,7 +6,7 @@ import { match } from "path-to-regexp";
 import { getBuildLabel } from "@/build/label";
 import { getStatsMessage } from "@/build/stats";
 import { Build, ScreenshotDiff } from "@/database/models";
-import { getPublicImageFileUrl, getTwicPicsUrl } from "@/storage";
+import { getPublicFileUrl, getTwicPicsUrl } from "@/storage";
 
 type BuildMatchParams = {
   accountSlug: string;
@@ -61,7 +61,7 @@ export async function unfurlBuild(
     if (!screenshot.file) {
       return getTwicPicsUrl(screenshot.s3Id);
     }
-    return getPublicImageFileUrl(screenshot.file);
+    return getPublicFileUrl(screenshot.file);
   })();
 
   const attachment: Bolt.types.MessageAttachment = {

--- a/apps/backend/src/storage/FileHandle.ts
+++ b/apps/backend/src/storage/FileHandle.ts
@@ -57,12 +57,10 @@ export class S3FileHandle implements FileHandle {
         Key: this.#key,
       });
       invariant(result.ContentType, "missing content type");
-      const ext = mime.getExtension(result.ContentType);
-      if (!ext) {
-        throw new Error(
-          `Unable to determine file extension for ${result.ContentType}`,
-        );
-      }
+      // The extension is only used to name the temporary file. Fall back to a
+      // generic one for content types `mime` doesn't know about (e.g.
+      // `application/yaml`).
+      const ext = mime.getExtension(result.ContentType) ?? "bin";
       const outputPath = await tmpName({ postfix: `.${ext}` });
       await s3Download(result, outputPath);
       this.#filepath = outputPath;

--- a/apps/backend/src/storage/public-url.ts
+++ b/apps/backend/src/storage/public-url.ts
@@ -4,7 +4,17 @@ import { File as FileModel } from "@/database/models/File";
 import { getS3Client } from "./s3";
 import { getSignedObjectUrl } from "./signed-url";
 
-export async function getPublicUrl(key: string) {
+export async function getPublicUrl(
+  key: string,
+  options?: {
+    /**
+     * Serve the file as a neutralized download: forces a `text/plain` content
+     * type and an `attachment` disposition so attacker-controlled content
+     * (e.g. HTML) cannot be rendered as active content on the storage origin.
+     */
+    download?: boolean;
+  },
+) {
   const s3 = getS3Client();
   const url = await getSignedObjectUrl({
     s3,
@@ -12,6 +22,12 @@ export async function getPublicUrl(key: string) {
     Key: key,
     expiresIn: 3600,
     method: "GET",
+    ...(options?.download
+      ? {
+          responseContentType: "text/plain; charset=utf-8",
+          responseContentDisposition: "attachment",
+        }
+      : {}),
   });
   return url;
 }
@@ -38,4 +54,19 @@ export async function getPublicImageFileUrl(file: FileModel) {
   }
 
   return getPublicUrl(file.key);
+}
+
+/**
+ * Get the public URL used to serve a file to a browser.
+ *
+ * Images are served inline (optionally through the image CDN). Non-image files
+ * (e.g. text snapshots) are served as neutralized downloads so that
+ * attacker-controlled content cannot be rendered as active content on the
+ * storage origin.
+ */
+export async function getPublicFileUrl(file: FileModel) {
+  if (file.isImage()) {
+    return getPublicImageFileUrl(file);
+  }
+  return getPublicUrl(file.key, { download: true });
 }

--- a/apps/backend/src/storage/signed-url.test.ts
+++ b/apps/backend/src/storage/signed-url.test.ts
@@ -43,3 +43,41 @@ describe("#getSignedObjectUrl", () => {
     expect(axiosResponse.status).toBe(200);
   });
 });
+
+describe("#getSignedObjectUrl response overrides", () => {
+  // Static credentials keep presigning fully offline and deterministic.
+  const s3 = new S3Client({
+    region: "eu-west-1",
+    credentials: { accessKeyId: "test", secretAccessKey: "test" },
+  });
+
+  it("serves a file as a neutralized attachment when requested", async () => {
+    const url = await getSignedObjectUrl({
+      s3,
+      Bucket: config.get("s3.screenshotsBucket"),
+      Key: "snapshot.html",
+      expiresIn: 60,
+      method: "GET",
+      responseContentType: "text/plain; charset=utf-8",
+      responseContentDisposition: "attachment",
+    });
+    const { searchParams } = new URL(url);
+    expect(searchParams.get("response-content-disposition")).toBe("attachment");
+    expect(searchParams.get("response-content-type")).toBe(
+      "text/plain; charset=utf-8",
+    );
+  });
+
+  it("does not add response overrides by default", async () => {
+    const url = await getSignedObjectUrl({
+      s3,
+      Bucket: config.get("s3.screenshotsBucket"),
+      Key: "screenshot.png",
+      expiresIn: 60,
+      method: "GET",
+    });
+    const { searchParams } = new URL(url);
+    expect(searchParams.get("response-content-disposition")).toBeNull();
+    expect(searchParams.get("response-content-type")).toBeNull();
+  });
+});

--- a/apps/backend/src/storage/signed-url.ts
+++ b/apps/backend/src/storage/signed-url.ts
@@ -5,6 +5,11 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 /**
  * Get a signed URL for S3.
+ *
+ * On GET, `responseContentType` and `responseContentDisposition` override the
+ * headers S3 returns when the object is fetched (via the `response-content-*`
+ * presigned query parameters). This is used to serve non-image files as
+ * neutralized downloads regardless of the content type stored on the object.
  */
 export async function getSignedObjectUrl(args: {
   s3: S3Client;
@@ -12,12 +17,19 @@ export async function getSignedObjectUrl(args: {
   Key: string;
   expiresIn: number;
   method: "GET" | "PUT";
+  responseContentType?: string;
+  responseContentDisposition?: string;
 }) {
   const { s3, Bucket, Key, expiresIn } = args;
   const command = (() => {
     switch (args.method) {
       case "GET":
-        return new GetObjectCommand({ Bucket, Key });
+        return new GetObjectCommand({
+          Bucket,
+          Key,
+          ResponseContentType: args.responseContentType,
+          ResponseContentDisposition: args.responseContentDisposition,
+        });
       case "PUT":
         return new PutObjectCommand({ Bucket, Key });
       default:

--- a/apps/backend/src/web/app.api-v2.e2e.test.ts
+++ b/apps/backend/src/web/app.api-v2.e2e.test.ts
@@ -37,9 +37,9 @@ async function uploadFile(
   for (const [name, value] of Object.entries(upload.fields)) {
     formData.append(name, value);
   }
-  // The `file` field must come after every policy field and must be the last
-  // entry in the form. We don't set a `Content-Type` form field because the
-  // policy doesn't condition it (S3 would 403 on any unconditioned field).
+  // The policy conditions Content-Type via `eq`, so the form must include a
+  // matching `Content-Type` field. The `file` field must come last.
+  formData.append("Content-Type", contentType);
   formData.append(
     "file",
     new Blob([new Uint8Array(file)], { type: contentType }),
@@ -78,9 +78,15 @@ describe("api v2", () => {
           .set("Authorization", "Bearer nop")
           .send({
             commit: "b6bf264029c03888b7fb7e6db7386f3b245b77b0",
-            screenshotKeys: [
-              "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
-              "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589",
+            screenshots: [
+              {
+                key: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+                contentType: "image/jpeg",
+              },
+              {
+                key: "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589",
+                contentType: "image/jpeg",
+              },
             ],
             branch: "main",
             name: "current",
@@ -118,9 +124,15 @@ describe("api v2", () => {
           .set("Authorization", "Bearer awesome-token")
           .send({
             commit: "b6bf264029c03888b7fb7e6db7386f3b245b77b0",
-            screenshotKeys: [
-              "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
-              "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589",
+            screenshots: [
+              {
+                key: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+                contentType: "image/jpeg",
+              },
+              {
+                key: "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589",
+                contentType: "image/jpeg",
+              },
             ],
             branch: "main",
             name: "current",
@@ -233,9 +245,9 @@ describe("api v2", () => {
           .set("Authorization", "Bearer awesome-token")
           .send({
             commit: "b6bf264029c03888b7fb7e6db7386f3b245b77b0",
-            screenshotKeys: Array.from(
+            screenshots: Array.from(
               new Set(screenshots.map((screenshot) => screenshot.key)),
-            ),
+            ).map((key) => ({ key, contentType: "image/jpeg" })),
             branch: "main",
             name: "current",
           })
@@ -360,9 +372,9 @@ describe("api v2", () => {
           .set("Authorization", "Bearer awesome-token")
           .send({
             commit: "b6bf264029c03888b7fb7e6db7386f3b245b77b0",
-            screenshotKeys: Array.from(
+            screenshots: Array.from(
               new Set(screenshots.map((screenshot) => screenshot.key)),
-            ),
+            ).map((key) => ({ key, contentType: "image/jpeg" })),
             branch: "main",
             name: "current",
             mode: "monitoring",
@@ -492,7 +504,10 @@ describe("api v2", () => {
               .set("Authorization", "Bearer awesome-token")
               .send({
                 commit: "b6bf264029c03888b7fb7e6db7386f3b245b77b0",
-                screenshotKeys: screenshots.map((screenshot) => screenshot.key),
+                screenshots: screenshots.map((screenshot) => ({
+                  key: screenshot.key,
+                  contentType: "image/jpeg",
+                })),
                 branch: "main",
                 name: "current",
                 parallel: true,
@@ -603,9 +618,10 @@ describe("api v2", () => {
           .set("Authorization", "Bearer awesome-token")
           .send({
             commit: "b6bf264029c03888b7fb7e6db7386f3b245b77b0",
-            screenshotKeys: screenshotGroups[0]!.map(
-              (screenshot) => screenshot.key,
-            ),
+            screenshots: screenshotGroups[0]!.map((screenshot) => ({
+              key: screenshot.key,
+              contentType: "image/jpeg",
+            })),
             branch: "main",
             name: "current",
             parallel: true,
@@ -667,9 +683,10 @@ describe("api v2", () => {
           .set("Authorization", "Bearer awesome-token")
           .send({
             commit: "b6bf264029c03888b7fb7e6db7386f3b245b77b0",
-            screenshotKeys: screenshotGroups[1]!.map(
-              (screenshot) => screenshot.key,
-            ),
+            screenshots: screenshotGroups[1]!.map((screenshot) => ({
+              key: screenshot.key,
+              contentType: "image/jpeg",
+            })),
             branch: "main",
             name: "current",
             parallel: true,
@@ -743,7 +760,10 @@ describe("api v2", () => {
               .set("Authorization", "Bearer awesome-token")
               .send({
                 commit: "b6bf264029c03888b7fb7e6db7386f3b245b77b0",
-                screenshotKeys: screenshots.map((screenshot) => screenshot.key),
+                screenshots: screenshots.map((screenshot) => ({
+                  key: screenshot.key,
+                  contentType: "image/jpeg",
+                })),
                 branch: "main",
                 name: "current",
                 parallel: true,

--- a/apps/backend/src/web/app.api-v2.e2e.test.ts
+++ b/apps/backend/src/web/app.api-v2.e2e.test.ts
@@ -16,11 +16,22 @@ import { createApp } from "./app";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
-type UploadEntry = {
+type LegacyUploadEntry = {
   key: string;
-  url: string;
+  putUrl: string;
+};
+
+type SecureUploadEntry = {
+  key: string;
+  postUrl: string;
   fields: Record<string, string>;
 };
+
+type UploadEntry = LegacyUploadEntry | SecureUploadEntry;
+
+function isSecureUpload(upload: UploadEntry): upload is SecureUploadEntry {
+  return "postUrl" in upload;
+}
 
 /**
  * Upload a file using the presigned POST policy returned by createBuild.
@@ -28,8 +39,8 @@ type UploadEntry = {
  * S3 enforces the size limit baked into the policy's `content-length-range`
  * condition; oversized uploads are rejected by S3 itself, not by Argos.
  */
-async function uploadFile(
-  upload: UploadEntry,
+async function uploadFileWithPostUrl(
+  upload: SecureUploadEntry,
   file: Buffer,
   contentType: string,
 ): Promise<void> {
@@ -37,18 +48,41 @@ async function uploadFile(
   for (const [name, value] of Object.entries(upload.fields)) {
     formData.append(name, value);
   }
-  // The policy conditions Content-Type via `eq`, so the form must include a
-  // matching `Content-Type` field. The `file` field must come last.
-  formData.append("Content-Type", contentType);
+  // The `file` field must come last.
   formData.append(
     "file",
     new Blob([new Uint8Array(file)], { type: contentType }),
   );
-  const response = await fetch(upload.url, {
+  const response = await fetch(upload.postUrl, {
     method: "POST",
     body: formData,
   });
   expect(response.status).toBe(204);
+}
+
+async function uploadFileWithPutUrl(
+  upload: LegacyUploadEntry,
+  file: Buffer,
+  contentType: string,
+): Promise<void> {
+  const response = await fetch(upload.putUrl, {
+    method: "PUT",
+    headers: { "Content-Type": contentType },
+    body: new Uint8Array(file),
+  });
+  expect(response.status).toBe(200);
+}
+
+async function uploadFile(
+  upload: UploadEntry,
+  file: Buffer,
+  contentType: string,
+): Promise<void> {
+  if (isSecureUpload(upload)) {
+    await uploadFileWithPostUrl(upload, file, contentType);
+    return;
+  }
+  await uploadFileWithPutUrl(upload, file, contentType);
 }
 
 describe("api v2", () => {
@@ -78,15 +112,9 @@ describe("api v2", () => {
           .set("Authorization", "Bearer nop")
           .send({
             commit: "b6bf264029c03888b7fb7e6db7386f3b245b77b0",
-            screenshots: [
-              {
-                key: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
-                contentType: "image/jpeg",
-              },
-              {
-                key: "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589",
-                contentType: "image/jpeg",
-              },
+            screenshotKeys: [
+              "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+              "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589",
             ],
             branch: "main",
             name: "current",
@@ -117,22 +145,16 @@ describe("api v2", () => {
         });
       });
 
-      it("creates build and upload urls", async () => {
+      it("creates build and legacy upload urls", async () => {
         const res = await request(app)
           .post("/v2/builds")
           .set("Host", "api.argos-ci.dev")
           .set("Authorization", "Bearer awesome-token")
           .send({
             commit: "b6bf264029c03888b7fb7e6db7386f3b245b77b0",
-            screenshots: [
-              {
-                key: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
-                contentType: "image/jpeg",
-              },
-              {
-                key: "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589",
-                contentType: "image/jpeg",
-              },
+            screenshotKeys: [
+              "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+              "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589",
             ],
             branch: "main",
             name: "current",
@@ -177,19 +199,141 @@ describe("api v2", () => {
               gitlab: { state: "pending" },
             },
           },
-          screenshots: [
-            {
-              key: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
-              url: expect.any(String),
-              fields: expect.any(Object),
-            },
-            {
-              key: "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589",
-              url: expect.any(String),
-              fields: expect.any(Object),
-            },
-          ],
         });
+        expect(res.body.screenshots).toEqual([
+          {
+            key: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            putUrl: expect.any(String),
+          },
+          {
+            key: "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589",
+            putUrl: expect.any(String),
+          },
+        ]);
+
+        const [firstUpload, secondUpload] = res.body
+          .screenshots as UploadEntry[];
+        if (
+          !firstUpload ||
+          !secondUpload ||
+          isSecureUpload(firstUpload) ||
+          isSecureUpload(secondUpload)
+        ) {
+          throw new Error("Expected two upload targets");
+        }
+        await uploadFileWithPutUrl(
+          firstUpload,
+          Buffer.from("legacy upload"),
+          "image/jpeg",
+        );
+        await uploadFileWithPutUrl(
+          secondUpload,
+          Buffer.from("legacy upload"),
+          "image/jpeg",
+        );
+      });
+
+      it("creates build and secure upload fields", async () => {
+        const res = await request(app)
+          .post("/v2/builds")
+          .set("Host", "api.argos-ci.dev")
+          .set("Authorization", "Bearer awesome-token")
+          .send({
+            commit: "b6bf264029c03888b7fb7e6db7386f3b245b77b0",
+            screenshots: [
+              {
+                key: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+                contentType: "image/jpeg",
+              },
+              {
+                key: "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589",
+                contentType: "application/json",
+              },
+            ],
+            branch: "main",
+            name: "current",
+            prNumber: 12,
+            mode: null,
+          })
+          .expect(201);
+
+        expect(res.body.screenshots).toEqual([
+          {
+            key: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            postUrl: expect.any(String),
+            fields: expect.objectContaining({
+              "Content-Type": "image/jpeg",
+            }),
+          },
+          {
+            key: "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589",
+            postUrl: expect.any(String),
+            fields: expect.objectContaining({
+              "Content-Type": "application/json",
+            }),
+          },
+        ]);
+
+        const [imageUpload, jsonUpload] = res.body.screenshots as UploadEntry[];
+        if (
+          !imageUpload ||
+          !jsonUpload ||
+          !isSecureUpload(imageUpload) ||
+          !isSecureUpload(jsonUpload)
+        ) {
+          throw new Error("Expected two secure upload targets");
+        }
+        await uploadFileWithPostUrl(
+          imageUpload,
+          Buffer.from("secure upload"),
+          "image/jpeg",
+        );
+        await uploadFileWithPostUrl(
+          jsonUpload,
+          Buffer.from('{"ok":true}'),
+          "application/json",
+        );
+      });
+
+      it("rejects requests with both legacy and secure screenshot inputs", async () => {
+        await request(app)
+          .post("/v2/builds")
+          .set("Host", "api.argos-ci.dev")
+          .set("Authorization", "Bearer awesome-token")
+          .send({
+            commit: "b6bf264029c03888b7fb7e6db7386f3b245b77b0",
+            screenshotKeys: [
+              "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            ],
+            screenshots: [
+              {
+                key: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+                contentType: "image/jpeg",
+              },
+            ],
+            branch: "main",
+            name: "current",
+          })
+          .expect((res) => {
+            expect(res.body.error).toBe("Invalid request");
+          })
+          .expect(400);
+      });
+
+      it("rejects requests without screenshot inputs", async () => {
+        await request(app)
+          .post("/v2/builds")
+          .set("Host", "api.argos-ci.dev")
+          .set("Authorization", "Bearer awesome-token")
+          .send({
+            commit: "b6bf264029c03888b7fb7e6db7386f3b245b77b0",
+            branch: "main",
+            name: "current",
+          })
+          .expect((res) => {
+            expect(res.body.error).toBe("Invalid request");
+          })
+          .expect(400);
       });
     });
 
@@ -245,9 +389,9 @@ describe("api v2", () => {
           .set("Authorization", "Bearer awesome-token")
           .send({
             commit: "b6bf264029c03888b7fb7e6db7386f3b245b77b0",
-            screenshots: Array.from(
+            screenshotKeys: Array.from(
               new Set(screenshots.map((screenshot) => screenshot.key)),
-            ).map((key) => ({ key, contentType: "image/jpeg" })),
+            ),
             branch: "main",
             name: "current",
           })
@@ -372,9 +516,9 @@ describe("api v2", () => {
           .set("Authorization", "Bearer awesome-token")
           .send({
             commit: "b6bf264029c03888b7fb7e6db7386f3b245b77b0",
-            screenshots: Array.from(
+            screenshotKeys: Array.from(
               new Set(screenshots.map((screenshot) => screenshot.key)),
-            ).map((key) => ({ key, contentType: "image/jpeg" })),
+            ),
             branch: "main",
             name: "current",
             mode: "monitoring",
@@ -504,10 +648,7 @@ describe("api v2", () => {
               .set("Authorization", "Bearer awesome-token")
               .send({
                 commit: "b6bf264029c03888b7fb7e6db7386f3b245b77b0",
-                screenshots: screenshots.map((screenshot) => ({
-                  key: screenshot.key,
-                  contentType: "image/jpeg",
-                })),
+                screenshotKeys: screenshots.map((screenshot) => screenshot.key),
                 branch: "main",
                 name: "current",
                 parallel: true,
@@ -618,10 +759,9 @@ describe("api v2", () => {
           .set("Authorization", "Bearer awesome-token")
           .send({
             commit: "b6bf264029c03888b7fb7e6db7386f3b245b77b0",
-            screenshots: screenshotGroups[0]!.map((screenshot) => ({
-              key: screenshot.key,
-              contentType: "image/jpeg",
-            })),
+            screenshotKeys: screenshotGroups[0]!.map(
+              (screenshot) => screenshot.key,
+            ),
             branch: "main",
             name: "current",
             parallel: true,
@@ -683,10 +823,9 @@ describe("api v2", () => {
           .set("Authorization", "Bearer awesome-token")
           .send({
             commit: "b6bf264029c03888b7fb7e6db7386f3b245b77b0",
-            screenshots: screenshotGroups[1]!.map((screenshot) => ({
-              key: screenshot.key,
-              contentType: "image/jpeg",
-            })),
+            screenshotKeys: screenshotGroups[1]!.map(
+              (screenshot) => screenshot.key,
+            ),
             branch: "main",
             name: "current",
             parallel: true,
@@ -760,10 +899,7 @@ describe("api v2", () => {
               .set("Authorization", "Bearer awesome-token")
               .send({
                 commit: "b6bf264029c03888b7fb7e6db7386f3b245b77b0",
-                screenshots: screenshots.map((screenshot) => ({
-                  key: screenshot.key,
-                  contentType: "image/jpeg",
-                })),
+                screenshotKeys: screenshots.map((screenshot) => screenshot.key),
                 branch: "main",
                 name: "current",
                 parallel: true,

--- a/apps/backend/src/web/app.api-v2.e2e.test.ts
+++ b/apps/backend/src/web/app.api-v2.e2e.test.ts
@@ -1,7 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import axios from "axios";
 import type { Express } from "express";
 import request from "supertest";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -16,6 +15,41 @@ import { setupRedis } from "@/util/redis/testing";
 import { createApp } from "./app";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
+type UploadEntry = {
+  key: string;
+  url: string;
+  fields: Record<string, string>;
+};
+
+/**
+ * Upload a file using the presigned POST policy returned by createBuild.
+ *
+ * S3 enforces the size limit baked into the policy's `content-length-range`
+ * condition; oversized uploads are rejected by S3 itself, not by Argos.
+ */
+async function uploadFile(
+  upload: UploadEntry,
+  file: Buffer,
+  contentType: string,
+): Promise<void> {
+  const formData = new FormData();
+  for (const [name, value] of Object.entries(upload.fields)) {
+    formData.append(name, value);
+  }
+  // The `file` field must come after every policy field and must be the last
+  // entry in the form. We don't set a `Content-Type` form field because the
+  // policy doesn't condition it (S3 would 403 on any unconditioned field).
+  formData.append(
+    "file",
+    new Blob([new Uint8Array(file)], { type: contentType }),
+  );
+  const response = await fetch(upload.url, {
+    method: "POST",
+    body: formData,
+  });
+  expect(response.status).toBe(204);
+}
 
 describe("api v2", () => {
   let app: Express;
@@ -134,11 +168,13 @@ describe("api v2", () => {
           screenshots: [
             {
               key: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
-              putUrl: expect.any(String),
+              url: expect.any(String),
+              fields: expect.any(Object),
             },
             {
               key: "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589",
-              putUrl: expect.any(String),
+              url: expect.any(String),
+              fields: expect.any(Object),
             },
           ],
         });
@@ -208,22 +244,13 @@ describe("api v2", () => {
         // Upload screenshots
         await Promise.all(
           createResult.body.screenshots.map(
-            async (resScreenshot: { key: string; putUrl: string }) => {
+            async (resScreenshot: UploadEntry) => {
               const path = screenshots.find(
                 (s) => s.key === resScreenshot.key,
               )!.path;
               const file = await readFile(path);
 
-              const axiosResponse = await axios({
-                method: "PUT",
-                url: resScreenshot.putUrl,
-                data: file,
-                headers: {
-                  "Content-Type": "image/jpeg",
-                },
-              });
-
-              expect(axiosResponse.status).toBe(200);
+              await uploadFile(resScreenshot, file, "image/jpeg");
             },
           ),
         );
@@ -345,22 +372,13 @@ describe("api v2", () => {
         // Upload screenshots
         await Promise.all(
           createResult.body.screenshots.map(
-            async (resScreenshot: { key: string; putUrl: string }) => {
+            async (resScreenshot: UploadEntry) => {
               const path = screenshots.find(
                 (s) => s.key === resScreenshot.key,
               )!.path;
               const file = await readFile(path);
 
-              const axiosResponse = await axios({
-                method: "PUT",
-                url: resScreenshot.putUrl,
-                data: file,
-                headers: {
-                  "Content-Type": "image/jpeg",
-                },
-              });
-
-              expect(axiosResponse.status).toBe(200);
+              await uploadFile(resScreenshot, file, "image/jpeg");
             },
           ),
         );
@@ -485,22 +503,13 @@ describe("api v2", () => {
             // Upload screenshots
             await Promise.all(
               createResult.body.screenshots.map(
-                async (resScreenshot: { key: string; putUrl: string }) => {
+                async (resScreenshot: UploadEntry) => {
                   const path = screenshots.find(
                     (s) => s.key === resScreenshot.key,
                   )!.path;
                   const file = await readFile(path);
 
-                  const axiosResponse = await axios({
-                    method: "PUT",
-                    url: resScreenshot.putUrl,
-                    data: file,
-                    headers: {
-                      "Content-Type": "image/jpeg",
-                    },
-                  });
-
-                  expect(axiosResponse.status).toBe(200);
+                  await uploadFile(resScreenshot, file, "image/jpeg");
                 },
               ),
             );
@@ -604,24 +613,14 @@ describe("api v2", () => {
           })
           .expect(201);
 
-        for (const resScreenshot of createFirstShard.body.screenshots as {
-          key: string;
-          putUrl: string;
-        }[]) {
+        for (const resScreenshot of createFirstShard.body
+          .screenshots as UploadEntry[]) {
           const screenshot = screenshotGroups[0]!.find(
             (candidate) => candidate.key === resScreenshot.key,
           );
           expect(screenshot).toBeDefined();
           const file = await readFile(screenshot!.path);
-          const axiosResponse = await axios({
-            method: "PUT",
-            url: resScreenshot.putUrl,
-            data: file,
-            headers: {
-              "Content-Type": "image/jpeg",
-            },
-          });
-          expect(axiosResponse.status).toBe(200);
+          await uploadFile(resScreenshot, file, "image/jpeg");
         }
 
         await request(app)
@@ -678,24 +677,14 @@ describe("api v2", () => {
           })
           .expect(201);
 
-        for (const resScreenshot of createSecondShard.body.screenshots as {
-          key: string;
-          putUrl: string;
-        }[]) {
+        for (const resScreenshot of createSecondShard.body
+          .screenshots as UploadEntry[]) {
           const screenshot = screenshotGroups[1]!.find(
             (candidate) => candidate.key === resScreenshot.key,
           );
           expect(screenshot).toBeDefined();
           const file = await readFile(screenshot!.path);
-          const axiosResponse = await axios({
-            method: "PUT",
-            url: resScreenshot.putUrl,
-            data: file,
-            headers: {
-              "Content-Type": "image/jpeg",
-            },
-          });
-          expect(axiosResponse.status).toBe(200);
+          await uploadFile(resScreenshot, file, "image/jpeg");
         }
 
         await request(app)
@@ -765,22 +754,13 @@ describe("api v2", () => {
             // Upload screenshots
             await Promise.all(
               createResult.body.screenshots.map(
-                async (resScreenshot: { key: string; putUrl: string }) => {
+                async (resScreenshot: UploadEntry) => {
                   const path = screenshots.find(
                     (s) => s.key === resScreenshot.key,
                   )!.path;
                   const file = await readFile(path);
 
-                  const axiosResponse = await axios({
-                    method: "PUT",
-                    url: resScreenshot.putUrl,
-                    data: file,
-                    headers: {
-                      "Content-Type": "image/jpeg",
-                    },
-                  });
-
-                  expect(axiosResponse.status).toBe(200);
+                  await uploadFile(resScreenshot, file, "image/jpeg");
                 },
               ),
             );

--- a/apps/frontend/src/containers/Build/DiffEditor.tsx
+++ b/apps/frontend/src/containers/Build/DiffEditor.tsx
@@ -64,7 +64,9 @@ export function Editor(props: Pick<EditorProps, "value" | "language">) {
 }
 
 export function getLanguageFromContentType(contentType: string) {
-  switch (contentType) {
+  // Normalize: drop any parameters (e.g. "; charset=utf-8") and lowercase.
+  const normalized = (contentType.split(";")[0] ?? "").trim().toLowerCase();
+  switch (normalized) {
     case "application/json":
       return "json";
     case "application/javascript":
@@ -77,6 +79,7 @@ export function getLanguageFromContentType(contentType: string) {
       return "html";
     case "text/css":
       return "css";
+    case "application/xml":
     case "text/xml":
       return "xml";
     case "text/markdown":

--- a/packages/schemas/src/content-type.ts
+++ b/packages/schemas/src/content-type.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+
+/**
+ * Image content types supported for snapshots.
+ *
+ * These are raster formats that are safe to serve inline to a browser (they
+ * cannot execute scripts). Vector formats such as `image/svg+xml` are
+ * intentionally excluded because they can carry active content.
+ */
+export const IMAGE_SNAPSHOT_CONTENT_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/avif",
+  "image/gif",
+] as const;
+
+/**
+ * Text content types supported for snapshots.
+ *
+ * These are compared as text and rendered as source code. They are never
+ * served as active content (see the storage layer, which serves them as
+ * neutralized downloads).
+ */
+export const TEXT_SNAPSHOT_CONTENT_TYPES = [
+  "text/plain",
+  "application/json",
+  "application/yaml",
+  "text/yaml",
+  "application/xml",
+  "text/xml",
+  "text/html",
+  "text/markdown",
+  "text/css",
+  "application/javascript",
+  "text/javascript",
+] as const;
+
+/**
+ * All content types supported for snapshots.
+ */
+export const SNAPSHOT_CONTENT_TYPES = [
+  ...IMAGE_SNAPSHOT_CONTENT_TYPES,
+  ...TEXT_SNAPSHOT_CONTENT_TYPES,
+] as const;
+
+export type SnapshotContentType = (typeof SNAPSHOT_CONTENT_TYPES)[number];
+
+/**
+ * Normalize a content type: lowercase, trimmed and stripped of any parameters
+ * (e.g. `text/html; charset=utf-8` becomes `text/html`).
+ */
+export function normalizeContentType(contentType: string): string {
+  return (contentType.split(";")[0] ?? "").trim().toLowerCase();
+}
+
+/**
+ * Check if a (normalized) content type is an image.
+ */
+export function isImageContentType(contentType: string): boolean {
+  return normalizeContentType(contentType).startsWith("image/");
+}
+
+/**
+ * Check if a content type is a supported snapshot content type.
+ */
+export function isSnapshotContentType(
+  contentType: string,
+): contentType is SnapshotContentType {
+  return (SNAPSHOT_CONTENT_TYPES as readonly string[]).includes(
+    normalizeContentType(contentType),
+  );
+}
+
+/**
+ * Zod schema for a snapshot content type.
+ *
+ * The value is normalized (lowercased, parameters stripped) and validated
+ * against the list of supported content types.
+ */
+export const SnapshotContentTypeSchema = z
+  .string()
+  .transform(normalizeContentType)
+  .refine(isSnapshotContentType, {
+    message: `Unsupported content type. Supported content types are: ${SNAPSHOT_CONTENT_TYPES.join(
+      ", ",
+    )}.`,
+  })
+  .meta({
+    description: "Content type of the snapshot file",
+    examples: ["image/png", "application/json", "text/plain"],
+  });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       '@aws-sdk/lib-storage':
         specifier: ^3.1049.0
         version: 3.1049.0(@aws-sdk/client-s3@3.1049.0)
+      '@aws-sdk/s3-presigned-post':
+        specifier: ^3.1054.0
+        version: 3.1054.0
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.1049.0
         version: 3.1049.0
@@ -1025,44 +1028,88 @@ packages:
     resolution: {integrity: sha512-e5ToFwYeHSfkKDPs/G0yhO7vxvfVOF6DhmlvI2xFi4m12NvjxPhaA2Y35QMaYLrw/oGPXmu9McfKnBm/oXYXbg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-s3@3.1054.0':
+    resolution: {integrity: sha512-2ue7uVqaHYX4rytkcrLySYU/m/ZlRbL8KojWefbR24B0/TcFkqN2IovpBFrnmla/dtZAn9eVSlhHeEddOghZ5w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/core@3.974.12':
     resolution: {integrity: sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.14':
+    resolution: {integrity: sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/crc64-nvme@3.972.8':
     resolution: {integrity: sha512-fVfUCL/Xh2zINYMPZvj+iBn6XWouQf0DAnjaWCI9MkmqXzL2Iy5FoQB8O7syFe6gN6AH1ecDDU58T51Ou0kFkA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/crc64-nvme@3.972.9':
+    resolution: {integrity: sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.38':
     resolution: {integrity: sha512-m3WjZEgPtioMhPmwqUt+DhlTJ2i9ufR6DhfkyXojb9puEvfR+ur2U5shavu5/Cc9WHHsDCvALi6UFHgcqjhQ5w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.40':
+    resolution: {integrity: sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.40':
     resolution: {integrity: sha512-D78L/m2Dr6cJnnSvWoAudPhQmCwmJ7j6APXsPYmFpPaKfQTfCSu0rdm8j14Np+VmXF9z8Aj8HE3xFpsrwtfgeg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.972.42':
+    resolution: {integrity: sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.972.42':
     resolution: {integrity: sha512-Mu5ESvFXeinafVM8jTIvRqcvK2Ehj4kz3auT39yUcHwu1Vfxo6xRlmUafdKLW4tusjAJukQwK09sCSMgOm7OKg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.44':
+    resolution: {integrity: sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.42':
     resolution: {integrity: sha512-O6WkZga3kf0yqyJYd1dbeJqVhEgJx/x1UaLgtbR+XuL/YP+K5y6QTxQKL7ka9z3jnQASESKGAPnRyt4D5hQrxA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-login@3.972.44':
+    resolution: {integrity: sha512-QqEGHfQeZgUDqh7zpqHufrZ8T644ELEWvB+4gUdewLyRw4IRF+6CJqeQuRWqucZdQzoQeMh7fNAD9BWxFAdNig==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.43':
     resolution: {integrity: sha512-D/DJmbrWRP5BXEO3FH+ar4el+2n6OlGofiud7dQun2jES+AQEJjczenp1jBb4MBN7CpGpS8nsWGQLtuzc9tQbA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.45':
+    resolution: {integrity: sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.38':
     resolution: {integrity: sha512-EnbYVajGgbkb24s0K1eo4VNAPV5mHIET7LSvirTaFCwkfrfaOJxtSE+wY/tJdKDS21cEYkZs2ruCaAm+W4iblg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-process@3.972.40':
+    resolution: {integrity: sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.972.42':
     resolution: {integrity: sha512-RVV/9NbFwI8ZHEH5dn39lGyFmSbSVj1+orZdr6QsOe1mW9DCglmlen0cFaNZmCcqkqc7erNRHNBduxbeZuHAnw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.44':
+    resolution: {integrity: sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.42':
     resolution: {integrity: sha512-/67fXX0ddllD4u2Nujc5PvT4byHgpMUfz6+RxIKi/0nFIckeorm7JvXgzBuDyVKw0s58EbofmETDWUf9vTEuHQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.44':
+    resolution: {integrity: sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/dynamodb-codec@3.973.12':
@@ -1089,6 +1136,10 @@ packages:
     resolution: {integrity: sha512-Aaj0d+xbo1jJquBWJP0/9V/XZRYukO3LWIRp3dOLHmoFrYKb4YZ0aLefgVHfGcNOVBS2ZTq7L/n5JcrE7DaC+Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-bucket-endpoint@3.972.16':
+    resolution: {integrity: sha512-FhasMTBDBmMN7EEa1hUeHwo5p5Mv3Dm8w0VEbdXX/6ola/uyhRuJt8zGkH09mLTmab20USTzEpPqyqEoe1MqNg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-endpoint-discovery@3.972.13':
     resolution: {integrity: sha512-1r6EkFdSQ4quTP3pW8yWIcYuyDwdwdBxGr+kfuPFYE3DqR+1gBc6NyJneAyoIs+wc/cUfnyJ4ZYC0T2SQTxP9A==}
     engines: {node: '>=20.0.0'}
@@ -1097,24 +1148,52 @@ packages:
     resolution: {integrity: sha512-dA5pKTom/Ls9mgeyeaRBNQrRIVOLVjv4AmKOB0/e4yaiXEUy0gSz2d3liP8JHtYoCAEWySU1jWnyzwLOREN+4g==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-expect-continue@3.972.13':
+    resolution: {integrity: sha512-sHiqIFg8o2ipT7t40B89Vj0ubSUtY6OSt/+Ee/OXhHch5K4+81zP2+QX8Lkc/nJ2QSmCySxOke7TEbmX69fe2g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-flexible-checksums@3.974.20':
     resolution: {integrity: sha512-NdnMVQCR1YjIcqFAiNLdBiOwr2DyQDB2IiXQrBhzolKOv32ae4d4Ll7IzLMi04eMHiq/o/Y/GjFuVjF9HuG0QA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.22':
+    resolution: {integrity: sha512-ot1kZ1JGHUxcXPOARhej/n/+Odfx9VPt60pNrUq8Lf/U2blIF3+uj5v56gw76VD70dZvrfeLNo9jKz6pQJfOlA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-location-constraint@3.972.10':
     resolution: {integrity: sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-location-constraint@3.972.11':
+    resolution: {integrity: sha512-hkfspNUP4criAH6ton6BGKgnm5dZx+7bUOy1YqlTfejDeUPAM23D81q/IX+hdlS3KUsfwGz5ADTqZWKBEUpf4A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-sdk-s3@3.972.41':
     resolution: {integrity: sha512-M4T2I2WPuH5WQpU8Tsp+u2bcO29zGRkU14ATzuqb9I4xh8tzsLqtp4hzaJM5aO2dhMZnHDzyQwSFVgc3XbnoGg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.43':
+    resolution: {integrity: sha512-CBmixMY36JdAdt9ALgm7yVlvOXGUCHt9Z2kn5p9XVO5StO6HCH+cayV7YYV1CDLsXvVyebaXgBmif9wHoxCeNA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-ssec@3.972.10':
     resolution: {integrity: sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-ssec@3.972.11':
+    resolution: {integrity: sha512-7PQvGNhtveKlvVqNahqWx5yrwxP7ecwAoB1dYBf8eKwfo2tzzCbNnW+q2nO3N066ktQaB4iBQbDRWtizm+amoQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/nested-clients@3.997.10':
     resolution: {integrity: sha512-FtQ/Bt327peZJuyo4WZSOLVUTw9ujRxntepiC7L65FxA2P82Xlq0g14T22BuqBUeMjDoxa9nvwiMHjLIfP3eUg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.12':
+    resolution: {integrity: sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/s3-presigned-post@3.1054.0':
+    resolution: {integrity: sha512-CmsTyCz0+jUOMCxAgAVlqOyicuU7vO6cR05a4nVrjp1/amenXnI8JlBwWJQt2U5dkMW5tbX4ChN5btboLsecjg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/s3-request-presigner@3.1049.0':
@@ -1125,12 +1204,24 @@ packages:
     resolution: {integrity: sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.29':
+    resolution: {integrity: sha512-Few9FoQqOt/0KSvZYP+qdW0dfOhfQ9N+gl2UUDvCPW6mkPKHli9LMbKxWj+wZ5zKPaOoqxuR3Hhy3OTpndkfSw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1049.0':
     resolution: {integrity: sha512-r7+d0lQMTHKypkmaF5jRTBYLYHCUHzt3gaVoN9SidLhQeWhCmHk3AKrboDTpPF5b7Pt7vKu3+oeMjznM2Eu1ow==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1054.0':
+    resolution: {integrity: sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.973.8':
     resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.9':
+    resolution: {integrity: sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-dynamodb@3.996.2':
@@ -1145,6 +1236,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.24':
     resolution: {integrity: sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.26':
+    resolution: {integrity: sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -8925,10 +9020,42 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/client-s3@3.1054.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/credential-provider-node': 3.972.45
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.16
+      '@aws-sdk/middleware-expect-continue': 3.972.13
+      '@aws-sdk/middleware-flexible-checksums': 3.974.22
+      '@aws-sdk/middleware-location-constraint': 3.972.11
+      '@aws-sdk/middleware-sdk-s3': 3.972.43
+      '@aws-sdk/middleware-ssec': 3.972.11
+      '@aws-sdk/signature-v4-multi-region': 3.996.29
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.974.12':
     dependencies:
       '@aws-sdk/types': 3.973.8
       '@aws-sdk/xml-builder': 3.972.24
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.3
+      '@smithy/signature-v4': 5.4.3
+      '@smithy/types': 4.14.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.14':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/xml-builder': 3.972.26
       '@aws/lambda-invoke-store': 0.2.4
       '@smithy/core': 3.24.3
       '@smithy/signature-v4': 5.4.3
@@ -8941,6 +9068,11 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/crc64-nvme@3.972.9':
+    dependencies:
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.38':
     dependencies:
       '@aws-sdk/core': 3.974.12
@@ -8949,10 +9081,28 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.40':
     dependencies:
       '@aws-sdk/core': 3.974.12
       '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.3
       '@smithy/fetch-http-handler': 5.4.3
       '@smithy/node-http-handler': 4.7.3
@@ -8975,11 +9125,36 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/credential-provider-env': 3.972.40
+      '@aws-sdk/credential-provider-http': 3.972.42
+      '@aws-sdk/credential-provider-login': 3.972.44
+      '@aws-sdk/credential-provider-process': 3.972.40
+      '@aws-sdk/credential-provider-sso': 3.972.44
+      '@aws-sdk/credential-provider-web-identity': 3.972.44
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.3
+      '@smithy/credential-provider-imds': 4.3.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.42':
     dependencies:
       '@aws-sdk/core': 3.974.12
       '@aws-sdk/nested-clients': 3.997.10
       '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.3
       '@smithy/types': 4.14.2
       tslib: 2.8.1
@@ -8998,10 +9173,32 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.45':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.40
+      '@aws-sdk/credential-provider-http': 3.972.42
+      '@aws-sdk/credential-provider-ini': 3.972.44
+      '@aws-sdk/credential-provider-process': 3.972.40
+      '@aws-sdk/credential-provider-sso': 3.972.44
+      '@aws-sdk/credential-provider-web-identity': 3.972.44
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.3
+      '@smithy/credential-provider-imds': 4.3.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.38':
     dependencies:
       '@aws-sdk/core': 3.974.12
       '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.3
       '@smithy/types': 4.14.2
       tslib: 2.8.1
@@ -9016,11 +9213,30 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/token-providers': 3.1054.0
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.42':
     dependencies:
       '@aws-sdk/core': 3.974.12
       '@aws-sdk/nested-clients': 3.997.10
       '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.3
       '@smithy/types': 4.14.2
       tslib: 2.8.1
@@ -9064,6 +9280,14 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-bucket-endpoint@3.972.16':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-endpoint-discovery@3.972.13':
     dependencies:
       '@aws-sdk/endpoint-cache': 3.972.5
@@ -9075,6 +9299,13 @@ snapshots:
   '@aws-sdk/middleware-expect-continue@3.972.12':
     dependencies:
       '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-expect-continue@3.972.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.3
       '@smithy/types': 4.14.2
       tslib: 2.8.1
@@ -9091,9 +9322,27 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-flexible-checksums@3.974.22':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/crc64-nvme': 3.972.9
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-location-constraint@3.972.10':
     dependencies:
       '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-location-constraint@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -9107,9 +9356,24 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-sdk-s3@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/signature-v4-multi-region': 3.996.29
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-ssec@3.972.10':
     dependencies:
       '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-ssec@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -9123,6 +9387,29 @@ snapshots:
       '@smithy/core': 3.24.3
       '@smithy/fetch-http-handler': 5.4.3
       '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.12':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/signature-v4-multi-region': 3.996.29
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/s3-presigned-post@3.1054.0':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1054.0
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.3
+      '@smithy/signature-v4': 5.4.3
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -9143,6 +9430,13 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.29':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/signature-v4': 5.4.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1049.0':
     dependencies:
       '@aws-sdk/core': 3.974.12
@@ -9152,7 +9446,21 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/token-providers@3.1054.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.9':
     dependencies:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
@@ -9169,6 +9477,12 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.24':
     dependencies:
       '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.2
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.26':
+    dependencies:
       '@smithy/types': 4.14.2
       fast-xml-parser: 5.7.3
       tslib: 2.8.1


### PR DESCRIPTION
## Summary
- Add support for text-based snapshots (JSON, YAML, XML, HTML, markdown, plain text, …) alongside the existing image and ARIA snapshots, gated by a shared content-type allowlist in `@argos/schemas/content-type`. Server-side, the input content type is validated against the allowlist and normalized (lowercased, parameters stripped).
- Harden non-image file serving: override the presigned GET with `Content-Disposition: attachment` + `Content-Type: text/plain; charset=utf-8` so attacker-controlled content (e.g. HTML, SVG) cannot be rendered as active content on the storage origin. In-app rendering of text snapshots is unchanged (Monaco source view).
- Move the upload size limit into the signed URL itself: switch `createBuild` from presigned PUT to `createPresignedPost` with a `["content-length-range", 1, 25 MB]` condition. S3 itself rejects oversized uploads before they hit the bucket — no server-side HEAD or post-hoc validation needed.
- Frontend Monaco language map gains `application/xml` and normalizes the content type (handles `; charset=…` etc.). The diff downloader falls back to a generic extension when `mime` cannot resolve one (e.g. `application/yaml`).
- Documents how to run backend tests in `apps/backend/AGENTS.md`.

## Breaking change (API + SDK)
The `createBuild` response changed from `{ key, putUrl }` to `{ key, url, fields }` (S3 POST policy). The Argos SDK upload now needs to send a multipart `POST` to `url` with `fields` merged into the form and the file part appended last. **The SDK update lands in a follow-up PR in the SDK repo** — this PR is API + UI only.

## Test plan
- [x] Unit — `ScreenshotInputSchema`: defaults, allowlist acceptance, normalization, rejection of unsupported / unsafe content types (incl. `image/svg+xml`).
- [x] Unit — `getSignedObjectUrl`: response-content-disposition / response-content-type query params for downloads, absent by default.
- [x] e2e — `snapshot-diff` serialization still returns correct image URLs.
- [x] e2e — `api-v2` full create-build → multipart POST upload → update-build flow against real S3 (7/7).
- [x] Backend / frontend / schemas typecheck, lint, prettier.
- [x] SDK update: https://github.com/argos-ci/argos-javascript/pull/313

🤖 Generated with [Claude Code](https://claude.com/claude-code)