### PR TITLE
fix: prevent project card overflow with long names

### DIFF
--- a/apps/frontend/src/containers/ProjectList.tsx
+++ b/apps/frontend/src/containers/ProjectList.tsx
@@ -60,7 +60,12 @@ function RepositoryChip(props: { repository: Project["repository"] }) {
   }
 
   return (
-    <Chip scale="sm" color="neutral" icon={<RepositoryIcon />}>
+    <Chip
+      scale="sm"
+      color="neutral"
+      icon={<RepositoryIcon />}
+      className="max-w-full"
+    >
       {props.repository.fullName}
     </Chip>
   );
@@ -78,7 +83,7 @@ function ProjectCard({ project }: { project: Project }) {
         className="absolute inset-0"
         href={`/${project.slug}`}
       />
-      <div className="min-w-0">
+      <div className="w-full min-w-0">
         <div className="truncate font-medium">{project.name}</div>
         {deploymentsFlag.isEnabled && (
           <div className="text-low mt-1 truncate text-sm">


### PR DESCRIPTION
## Summary
- constrain the project card title container to the full card width
- cap the repository chip width so long repository names truncate inside the card
- fix the overflow case reported in ARG-371

## Validation
- pnpm exec prettier --write apps/frontend/src/containers/ProjectList.tsx
- pnpm exec eslint apps/frontend/src/containers/ProjectList.tsx
- pnpm exec tsc --noEmit --project apps/frontend/tsconfig.json