### PR TITLE
feat(oidc): bind short-lived project token to OIDC sha

### DIFF
--- a/apps/backend/src/api/auth/project.e2e.test.ts
+++ b/apps/backend/src/api/auth/project.e2e.test.ts
@@ -9,6 +9,7 @@ import { hashToken } from "@/database/services/crypto";
 import { factory, setupDatabase } from "@/database/testing";
 
 import {
+  assertAuthAttributes,
   assertProjectAccess,
   getAuthPayloadFromExpressReq,
   getAuthProjectPayloadFromExpressReq,
@@ -178,6 +179,59 @@ describe("api/auth/project", () => {
         }),
       );
 
+      expect(error).toMatchObject({ statusCode: 401 });
+    });
+  });
+
+  describe("assertAuthAttributes", () => {
+    const sha = "b6bf264029c03888b7fb7e6db7386f3b245b77b0";
+
+    test("no-op when attributes is undefined", () => {
+      const auth = {
+        type: "project",
+        project: { id: "p" },
+        sha,
+      } as AuthProjectPayload;
+      expect(() => assertAuthAttributes(auth, undefined)).not.toThrow();
+    });
+
+    test("no-op when token has no bound sha", () => {
+      const auth = {
+        type: "project",
+        project: { id: "p" },
+        sha: null,
+      } as AuthProjectPayload;
+      expect(() => assertAuthAttributes(auth, { sha })).not.toThrow();
+    });
+
+    test("no-op for non-project auth", () => {
+      const auth = {
+        type: "pat",
+        scope: [{ slug: "acme" }],
+      } as AuthPATPayload;
+      expect(() => assertAuthAttributes(auth, { sha })).not.toThrow();
+    });
+
+    test("passes when token sha matches", () => {
+      const auth = {
+        type: "project",
+        project: { id: "p" },
+        sha,
+      } as AuthProjectPayload;
+      expect(() => assertAuthAttributes(auth, { sha })).not.toThrow();
+    });
+
+    test("throws when token sha does not match", () => {
+      const auth = {
+        type: "project",
+        project: { id: "p" },
+        sha,
+      } as AuthProjectPayload;
+      const error = captureSyncError(() =>
+        assertAuthAttributes(auth, {
+          sha: "0000000000000000000000000000000000000000",
+        }),
+      );
       expect(error).toMatchObject({ statusCode: 401 });
     });
   });

--- a/apps/backend/src/api/auth/project.ts
+++ b/apps/backend/src/api/auth/project.ts
@@ -4,11 +4,47 @@ import {
   getAuthHeaderFromExpressReq,
   parseBearerFromHeader,
 } from "@/auth/auth-header";
-import type { AuthPATPayload, AuthProjectPayload } from "@/auth/payload";
+import type {
+  AuthJWTPayload,
+  AuthPATPayload,
+  AuthProjectPayload,
+} from "@/auth/payload";
 import { getAuthProjectPayloadFromBearerToken } from "@/auth/project";
 import { getAuthPayloadFromUserAccessToken } from "@/auth/user-access-token";
 import { Project, UserAccessToken } from "@/database/models";
 import { boom } from "@/util/error";
+
+/**
+ * Optional caller-asserted attributes that must match the token's bound
+ * attributes when the token carries them. Used to bind a short-lived OIDC
+ * token to the commit it was minted from so it cannot be reused on a
+ * different commit.
+ */
+export type AuthAttributes = {
+  sha?: string | null | undefined;
+};
+
+/**
+ * Validate that any attribute the token is bound to matches the caller's
+ * asserted attribute. No-op when either side is absent.
+ */
+export function assertAuthAttributes(
+  auth: AuthJWTPayload | AuthPATPayload | AuthProjectPayload,
+  attributes: AuthAttributes | undefined,
+): void {
+  if (!attributes) {
+    return;
+  }
+  if (auth.type !== "project") {
+    return;
+  }
+  if (attributes.sha && auth.sha && auth.sha !== attributes.sha) {
+    throw boom(
+      401,
+      "Token is bound to a different commit than the one provided.",
+    );
+  }
+}
 
 export function assertProjectAccess(
   auth: AuthPATPayload | AuthProjectPayload,
@@ -46,19 +82,28 @@ export function assertProjectAccess(
   }
 }
 
-export async function getAuthPayloadFromExpressReq(request: Request) {
+export async function getAuthPayloadFromExpressReq(
+  request: Request,
+  attributes?: AuthAttributes,
+) {
   const authHeader = getAuthHeaderFromExpressReq(request);
   const bearer = parseBearerFromHeader(authHeader);
-  if (UserAccessToken.isValidUserAccessToken(bearer)) {
-    return getAuthPayloadFromUserAccessToken(bearer);
-  }
-  return getAuthProjectPayloadFromBearerToken(bearer);
+  const auth = UserAccessToken.isValidUserAccessToken(bearer)
+    ? await getAuthPayloadFromUserAccessToken(bearer)
+    : await getAuthProjectPayloadFromBearerToken(bearer);
+  assertAuthAttributes(auth, attributes);
+  return auth;
 }
 
-export async function getAuthProjectPayloadFromExpressReq(request: Request) {
+export async function getAuthProjectPayloadFromExpressReq(
+  request: Request,
+  attributes?: AuthAttributes,
+) {
   const authHeader = getAuthHeaderFromExpressReq(request);
   const bearer = parseBearerFromHeader(authHeader);
-  return getAuthProjectPayloadFromBearerToken(bearer);
+  const auth = await getAuthProjectPayloadFromBearerToken(bearer);
+  assertAuthAttributes(auth, attributes);
+  return auth;
 }
 
 export async function getProjectFromReqAndParams(

--- a/apps/backend/src/api/handlers/createBuild.ts
+++ b/apps/backend/src/api/handlers/createBuild.ts
@@ -211,7 +211,9 @@ export const createBuildOperation = {
 
 export const createBuild: CreateAPIHandler = ({ post }) => {
   return post("/builds", async (req, res) => {
-    const auth = await getAuthProjectPayloadFromExpressReq(req);
+    const auth = await getAuthProjectPayloadFromExpressReq(req, {
+      sha: req.ctx.body.commit,
+    });
 
     const ctx = {
       body: req.ctx.body,

--- a/apps/backend/src/api/handlers/createDeployment.ts
+++ b/apps/backend/src/api/handlers/createDeployment.ts
@@ -219,12 +219,15 @@ async function writeDeploymentFiles(
 
 export const createDeployment: CreateAPIHandler = ({ post }) => {
   return post("/deployments", async (req, res) => {
-    const auth = await getAuthProjectPayloadFromExpressReq(req);
     const body = req.ctx.body;
 
     if (!body) {
       throw boom(400, "Request body is required");
     }
+
+    const auth = await getAuthProjectPayloadFromExpressReq(req, {
+      sha: body.commit,
+    });
 
     const project = auth.project;
 

--- a/apps/backend/src/api/handlers/exchangeGitHubActionsOidcToken.e2e.test.ts
+++ b/apps/backend/src/api/handlers/exchangeGitHubActionsOidcToken.e2e.test.ts
@@ -86,7 +86,6 @@ describe("exchangeGitHubActionsOidcToken", () => {
         oidcToken: signGitHubActionsToken(),
         repository: "argos-ci/argos",
         commit: sha,
-        branch: "main",
       })
       .expect(200);
 
@@ -98,6 +97,7 @@ describe("exchangeGitHubActionsOidcToken", () => {
 
     const auth = await getAuthProjectPayloadFromBearerToken(res.body.token);
     expect(auth.project.id).toBe(linkedProject.project.id);
+    expect(auth.sha).toBe(sha);
   });
 
   test("rejects when GitHub Actions OIDC is disabled on the project", async ({

--- a/apps/backend/src/api/handlers/exchangeGitHubActionsOidcToken.ts
+++ b/apps/backend/src/api/handlers/exchangeGitHubActionsOidcToken.ts
@@ -26,12 +26,6 @@ const GitHubActionsOidcExchangeRequestSchema = z.object({
   commit: Sha1HashSchema.optional().meta({
     description: "Expected commit SHA",
   }),
-  branch: z.string().min(1).optional().meta({
-    description: "Expected branch name",
-  }),
-  pullRequestNumber: z.number().int().min(1).optional().meta({
-    description: "Expected pull request number",
-  }),
 });
 
 const GitHubActionsOidcExchangeResponseSchema = z.object({

--- a/apps/backend/src/api/handlers/finalizeBuilds.ts
+++ b/apps/backend/src/api/handlers/finalizeBuilds.ts
@@ -7,7 +7,10 @@ import { finalizeBuild as finalizeBuildService } from "@/build/finalizeBuild";
 import { Build } from "@/database/models";
 import { transaction } from "@/database/transaction";
 
-import { getAuthProjectPayloadFromExpressReq } from "../auth/project";
+import {
+  assertAuthAttributes,
+  getAuthProjectPayloadFromExpressReq,
+} from "../auth/project";
 import { BuildSchema, serializeBuilds } from "../schema/primitives/build";
 import {
   conflict,
@@ -61,6 +64,12 @@ export const finalizeBuilds: CreateAPIHandler = ({ post }) => {
       .where("builds.projectId", auth.project.id)
       .where("builds.externalId", parallelNonce)
       .where("builds.totalBatch", -1);
+
+    for (const build of builds) {
+      assertAuthAttributes(auth, {
+        sha: build.compareScreenshotBucket?.commit,
+      });
+    }
 
     const finalized = await transaction(async (trx) => {
       return Promise.all(

--- a/apps/backend/src/api/handlers/finalizeDeployment.ts
+++ b/apps/backend/src/api/handlers/finalizeDeployment.ts
@@ -15,7 +15,10 @@ import { invalidateDeploymentCache } from "@/deployment/invalidate";
 import { getDynamoDBClient, getTableName } from "@/storage/dynamodb";
 import { boom } from "@/util/error";
 
-import { getAuthProjectPayloadFromExpressReq } from "../auth/project";
+import {
+  assertAuthAttributes,
+  getAuthProjectPayloadFromExpressReq,
+} from "../auth/project";
 import {
   DeploymentSchema,
   serializeDeployment,
@@ -212,6 +215,8 @@ export const finalizeDeployment: CreateAPIHandler = ({ post }) => {
     if (deployment.projectId !== auth.project.id) {
       throw boom(401, "Unauthorized");
     }
+
+    assertAuthAttributes(auth, { sha: deployment.commitSha });
 
     if (deployment.status !== "pending") {
       throw boom(400, "Deployment is not in pending status");

--- a/apps/backend/src/api/handlers/updateBuild.ts
+++ b/apps/backend/src/api/handlers/updateBuild.ts
@@ -10,7 +10,10 @@ import { insertFilesAndScreenshots } from "@/database/services/screenshots";
 import { boom } from "@/util/error";
 import { redisLock } from "@/util/redis";
 
-import { getAuthProjectPayloadFromExpressReq } from "../auth/project";
+import {
+  assertAuthAttributes,
+  getAuthProjectPayloadFromExpressReq,
+} from "../auth/project";
 import {
   BuildIdSchema,
   BuildSchema,
@@ -94,6 +97,10 @@ export const updateBuild: CreateAPIHandler = ({ put }) => {
     if (!build.compareScreenshotBucket) {
       throw boom(500, "Could not find compareScreenshotBucket for build");
     }
+
+    assertAuthAttributes(auth, {
+      sha: build.compareScreenshotBucket.commit,
+    });
 
     if (build.compareScreenshotBucket.complete) {
       const duplicateParallelRequest =

--- a/apps/backend/src/auth/github-actions-oidc-exchange.ts
+++ b/apps/backend/src/auth/github-actions-oidc-exchange.ts
@@ -10,8 +10,6 @@ type GitHubActionsOidcExchangeInput = {
   oidcToken: string;
   repository?: string | undefined;
   commit?: string | undefined;
-  branch?: string | undefined;
-  pullRequestNumber?: number | undefined;
 };
 
 function parseGitHubRepositoryId(repositoryId: string) {
@@ -22,16 +20,6 @@ function parseGitHubRepositoryId(repositoryId: string) {
   }
 
   return parsed;
-}
-
-function getBranchFromRef(ref: string | undefined) {
-  const prefix = "refs/heads/";
-
-  if (!ref?.startsWith(prefix)) {
-    return null;
-  }
-
-  return ref.slice(prefix.length);
 }
 
 function assertOptionalClaimsMatchInput(
@@ -47,27 +35,6 @@ function assertOptionalClaimsMatchInput(
 
   if (input.commit && claims.sha !== input.commit) {
     throw boom(401, "GitHub Actions OIDC token does not match commit.");
-  }
-
-  if (input.branch) {
-    const refBranch = getBranchFromRef(claims.ref);
-    const matchesBranch =
-      refBranch === input.branch || claims.head_ref === input.branch;
-
-    if (!matchesBranch) {
-      throw boom(401, "GitHub Actions OIDC token does not match branch.");
-    }
-  }
-
-  if (input.pullRequestNumber) {
-    const refs = [
-      `refs/pull/${input.pullRequestNumber}/merge`,
-      `refs/pull/${input.pullRequestNumber}/head`,
-    ];
-
-    if (!claims.ref || !refs.includes(claims.ref)) {
-      throw boom(401, "GitHub Actions OIDC token does not match pull request.");
-    }
   }
 }
 
@@ -111,5 +78,6 @@ export async function exchangeGitHubActionsOidcToken(
   return createShortLivedProjectToken({
     projectId: project.id,
     source: "github-actions-oidc",
+    sha: claims.sha ?? null,
   });
 }

--- a/apps/backend/src/auth/payload.ts
+++ b/apps/backend/src/auth/payload.ts
@@ -3,6 +3,13 @@ import type { Account, Project, User } from "@/database/models";
 export type AuthProjectPayload = {
   type: "project";
   project: Project;
+  /**
+   * Commit SHA the bearer is bound to. Populated when the bearer is a
+   * short-lived token minted from a GitHub Actions OIDC claim that carried
+   * a `sha`. `null` for project tokens, tokenless bearers, and short-lived
+   * tokens minted without a sha claim.
+   */
+  sha: string | null;
 };
 
 export type AuthJWTPayload = {

--- a/apps/backend/src/auth/project.ts
+++ b/apps/backend/src/auth/project.ts
@@ -21,15 +21,16 @@ export async function getAuthProjectPayloadFromBearerToken(bearer: string) {
   }
 
   if (isShortLivedProjectToken(bearer)) {
-    const project = await getProjectFromShortLivedProjectToken(bearer);
+    const resolved = await getProjectFromShortLivedProjectToken(bearer);
 
-    if (!project) {
+    if (!resolved) {
       throw boom(401, "Short-lived project token has expired or is invalid.");
     }
 
     return {
       type: "project",
-      project,
+      project: resolved.project,
+      sha: resolved.sha,
     } satisfies AuthProjectPayload;
   }
 
@@ -57,6 +58,7 @@ export async function getAuthProjectPayloadFromBearerToken(bearer: string) {
   const authPayload: AuthProjectPayload = {
     type: "project",
     project,
+    sha: null,
   };
   return authPayload;
 }

--- a/apps/backend/src/auth/short-lived-project-token.e2e.test.ts
+++ b/apps/backend/src/auth/short-lived-project-token.e2e.test.ts
@@ -37,10 +37,22 @@ describe("short-lived project token", () => {
     expect(isShortLivedProjectToken(result.token)).toBe(true);
     expect(Date.parse(result.expiresAt)).toBeGreaterThan(Date.now());
 
-    const resolvedProject = await getProjectFromShortLivedProjectToken(
-      result.token,
-    );
-    expect(resolvedProject?.id).toBe(project.id);
+    const resolved = await getProjectFromShortLivedProjectToken(result.token);
+    expect(resolved?.project.id).toBe(project.id);
+    expect(resolved?.sha).toBeNull();
+  });
+
+  test("preserves the sha bound at creation time", async ({ project }) => {
+    const sha = "b6bf264029c03888b7fb7e6db7386f3b245b77b0";
+    const { token } = await createShortLivedProjectToken({
+      projectId: project.id,
+      source: "github-actions-oidc",
+      sha,
+    });
+
+    const resolved = await getProjectFromShortLivedProjectToken(token);
+    expect(resolved?.project.id).toBe(project.id);
+    expect(resolved?.sha).toBe(sha);
   });
 
   test("returns null for a non-temporary token", async ({ project }) => {
@@ -80,8 +92,8 @@ describe("short-lived project token", () => {
       source: "github-actions-tokenless",
     });
 
-    const resolvedProject = await getProjectFromShortLivedProjectToken(token);
-    expect(resolvedProject?.id).toBe(project.id);
+    const resolved = await getProjectFromShortLivedProjectToken(token);
+    expect(resolved?.project.id).toBe(project.id);
   });
 
   test("returns null when tokenless auth is disabled after token creation", async ({

--- a/apps/backend/src/auth/short-lived-project-token.ts
+++ b/apps/backend/src/auth/short-lived-project-token.ts
@@ -11,6 +11,7 @@ const SHORT_LIVED_PROJECT_TOKEN_TTL_MS = 10 * 60 * 1000;
 const ShortLivedProjectTokenPayloadSchema = z.object({
   projectId: z.string(),
   source: z.enum(["github-actions-oidc", "github-actions-tokenless"]),
+  sha: z.string().nullable().optional(),
 });
 
 type ShortLivedProjectTokenPayload = z.infer<
@@ -54,12 +55,17 @@ export async function createShortLivedProjectToken(
   return { token, expiresAt };
 }
 
+export type ResolvedShortLivedProjectToken = {
+  project: Project;
+  sha: string | null;
+};
+
 /**
  * Get a project from a short lived project token.
  */
 export async function getProjectFromShortLivedProjectToken(
   token: string,
-): Promise<Project | null> {
+): Promise<ResolvedShortLivedProjectToken | null> {
   if (!isShortLivedProjectToken(token)) {
     return null;
   }
@@ -91,11 +97,13 @@ export async function getProjectFromShortLivedProjectToken(
     return null;
   }
 
+  const sha = result.data.sha ?? null;
+
   switch (result.data.source) {
     case "github-actions-oidc":
-      return project.githubActionsOidcEnabled ? project : null;
+      return project.githubActionsOidcEnabled ? { project, sha } : null;
     case "github-actions-tokenless":
-      return project.tokenlessAuthEnabled ? project : null;
+      return project.tokenlessAuthEnabled ? { project, sha } : null;
     default:
       assertNever(result.data.source);
   }


### PR DESCRIPTION
## Summary

- Drop `branch` / `pullRequestNumber` validation from the GitHub Actions OIDC exchange. Both are derivable from the signed `sha` claim, so they were redundant defense-in-depth that complicated the API surface without strengthening trust.
- Bind the short-lived project token to the OIDC `sha` claim. The token payload now carries the commit it was minted for; `AuthProjectPayload` exposes it as `sha: string | null`.
- Add an optional `attributes` second argument to `getAuthPayloadFromExpressReq` and `getAuthProjectPayloadFromExpressReq`, plus an exported `assertAuthAttributes(auth, attributes)` helper. When the token is bound to a sha and the caller passes `attributes.sha`, the two must match — otherwise 401.
- Wire `{ sha: body.commit }` into `createBuild` and `createDeployment` at auth time. For `updateBuild`, `finalizeBuilds`, and `finalizeDeployment`, validate after loading the resource (commit is only known then).

### Why

The previous design returned a short-lived project token tied only to `projectId`, so any workflow that could mint an OIDC token (including a fork-PR contributor in a public repo with `id-token: write`) could exchange it and then upload builds for any commit/branch on the project. With the binding, the token can only be used to operate on the commit it was minted from.

## Test plan

- [ ] CI typecheck + lint pass
- [ ] Existing OIDC exchange e2e tests still pass (commit mismatch still rejected; branch/PR fields silently ignored if older SDKs send them)
- [ ] New tests: short-lived token round-trips the bound sha; `assertAuthAttributes` covers no-op cases (undefined attributes, project token without bound sha, PAT auth) and the mismatch case
- [ ] Manual: exchange OIDC → use short-lived token to `createBuild` with matching `commit` (200), mismatched `commit` (401)
- [ ] Manual: legacy project token still works against `createBuild` (no sha binding, no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)