### PR TITLE
fix(build-review): keep submit pending until dialog closes

### DIFF
--- a/apps/frontend/src/pages/Build/BuildReviewDialog.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewDialog.tsx
@@ -129,6 +129,10 @@ function BuildReviewDialog(props: {
       event,
       body: hasEditorContent(data.body) ? data.body : undefined,
     });
+    // The dialog closes itself once the mutation completes (see `onCompleted`).
+    // Never resolve so the form stays pending through the closing animation,
+    // instead of flashing back to its idle state before the dialog disappears.
+    await new Promise(() => {});
   };
 
   const bodyError = form.formState.errors.body;


### PR DESCRIPTION
## Problem

In the build review dialog, clicking **Approve changes** showed the button in a pending state, then it flashed back to its idle state, and only then did the dialog close. The flicker was unpleasant from a UX standpoint.

## Cause

The `Form` wrapper sets the pending state, awaits `onSubmit`, then resets it in `finally`. On success the mutation's `onCompleted` fires `onClose()`, which starts the modal's 200ms exit animation — but `onSubmit` then resolves, flipping the button back to its idle state *while the dialog is still animating out*.

## Fix

Since the dialog closes itself via `onCompleted`, `onSubmit` never resolves after a successful submit. The form (button, editor, and menu, which all read the pending state) stays pending right through the close animation and unmount.

This is safe:
- The never-resolving promise is only reached after the mutation succeeds, and on success `onClose()` is guaranteed to fire and unmount the dialog.
- On failure, `createReview` throws before that line — the error propagates to the form's `catch`/`finally` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)