### PR TITLE
feat(build): allow adding a comment on a build

### DIFF
--- a/apps/backend/src/comment/createBuildComment.ts
+++ b/apps/backend/src/comment/createBuildComment.ts
@@ -10,6 +10,7 @@ import { sendNotification } from "@/notification";
 import { boom } from "@/util/error";
 
 import { renderCommentHtml } from "./html";
+import { formatCommentId } from "./id";
 import { isCommentEmpty, validateCommentJson } from "./validate";
 
 /**
@@ -39,7 +40,7 @@ export async function createBuildComment(input: {
 
   await Promise.all([
     autoSubscribeUserToBuild({ buildId: build.id, userId }),
-    notifyBuildSubscribers({ build, userId, body }),
+    notifyBuildSubscribers({ build, comment, userId, body }),
   ]);
 
   return comment;
@@ -47,10 +48,11 @@ export async function createBuildComment(input: {
 
 async function notifyBuildSubscribers(input: {
   build: Build;
+  comment: Comment;
   userId: string;
   body: JSONContent;
 }): Promise<void> {
-  const { build, userId, body } = input;
+  const { build, comment, userId, body } = input;
   const subscribedUserIds = await getBuildSubscribedUserIds(build.id);
   const recipients = subscribedUserIds.filter((id) => id !== userId);
   if (recipients.length === 0) {
@@ -64,6 +66,7 @@ async function notifyBuildSubscribers(input: {
   invariant(project, "project not found");
   invariant(project.account, "project account not found");
   const authorName = author?.account?.displayName ?? null;
+  const commentUrl = `${buildUrl}#${formatCommentId(comment.id)}`;
   await sendNotification({
     type: "comment_added",
     data: {
@@ -71,7 +74,7 @@ async function notifyBuildSubscribers(input: {
       projectName: project.name,
       buildNumber: build.number,
       buildName: build.name,
-      buildUrl,
+      commentUrl,
       authorName,
       bodyHtml: renderCommentHtml(body),
     },

--- a/apps/backend/src/comment/createBuildComment.ts
+++ b/apps/backend/src/comment/createBuildComment.ts
@@ -1,0 +1,80 @@
+import { invariant } from "@argos/util/invariant";
+import type { JSONContent } from "@tiptap/core";
+
+import { Build, Comment, User } from "@/database/models";
+import {
+  autoSubscribeUserToBuild,
+  getBuildSubscribedUserIds,
+} from "@/database/services/build-notification-subscription";
+import { sendNotification } from "@/notification";
+import { boom } from "@/util/error";
+
+import { renderCommentHtml } from "./html";
+import { isCommentEmpty, validateCommentJson } from "./validate";
+
+/**
+ * Post a standalone comment on a build (one that is not attached to a review),
+ * auto-subscribe the author to the build and notify the other subscribers.
+ */
+export async function createBuildComment(input: {
+  build: Build;
+  userId: string;
+  body: JSONContent;
+}): Promise<Comment> {
+  const { build, userId, body } = input;
+
+  if (!validateCommentJson(body)) {
+    throw boom(400, "Invalid comment body");
+  }
+
+  if (isCommentEmpty(body)) {
+    throw boom(400, "Comment cannot be empty");
+  }
+
+  const comment = await Comment.query().insert({
+    userId,
+    buildId: build.id,
+    content: body,
+  });
+
+  await Promise.all([
+    autoSubscribeUserToBuild({ buildId: build.id, userId }),
+    notifyBuildSubscribers({ build, userId, body }),
+  ]);
+
+  return comment;
+}
+
+async function notifyBuildSubscribers(input: {
+  build: Build;
+  userId: string;
+  body: JSONContent;
+}): Promise<void> {
+  const { build, userId, body } = input;
+  const subscribedUserIds = await getBuildSubscribedUserIds(build.id);
+  const recipients = subscribedUserIds.filter((id) => id !== userId);
+  if (recipients.length === 0) {
+    return;
+  }
+  const [project, author, buildUrl] = await Promise.all([
+    build.$relatedQuery("project").withGraphFetched("account"),
+    User.query().findById(userId).withGraphFetched("account"),
+    build.getUrl(),
+  ]);
+  invariant(project, "project not found");
+  invariant(project.account, "project account not found");
+  const authorName = author?.account?.displayName ?? null;
+  await sendNotification({
+    type: "comment_added",
+    data: {
+      accountSlug: project.account.slug,
+      projectName: project.name,
+      buildNumber: build.number,
+      buildName: build.name,
+      buildUrl,
+      authorName,
+      bodyHtml: renderCommentHtml(body),
+    },
+    recipients,
+  });
+}

--- a/apps/backend/src/comment/id.test.ts
+++ b/apps/backend/src/comment/id.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCommentId, parseCommentId } from "./id";
+
+describe("comment ID helpers", () => {
+  it("formats a comment ID with the comment- prefix", () => {
+    expect(formatCommentId("123")).toMatch(/^comment-/);
+  });
+
+  it("round-trips a numberish comment ID", () => {
+    expect(parseCommentId(formatCommentId("123"))).toBe("123");
+  });
+
+  it("throws when parsing an ID without the comment- prefix", () => {
+    expect(() => parseCommentId("123")).toThrow("Invalid comment ID format");
+  });
+
+  it("throws when parsing an invalid sqids payload", () => {
+    expect(() => parseCommentId("comment-")).toThrow(
+      "Invalid comment ID format",
+    );
+  });
+});

--- a/apps/backend/src/comment/id.ts
+++ b/apps/backend/src/comment/id.ts
@@ -1,0 +1,28 @@
+import { sqids } from "@/util/sqids";
+
+const COMMENT_ID_PREFIX = "comment-";
+
+/**
+ * Encodes a comment model ID into the public identifier format
+ * (e.g. `comment-xf23d`), used as the GraphQL id and to build shareable links
+ * to a comment.
+ */
+export function formatCommentId(commentId: string | number): string {
+  return `${COMMENT_ID_PREFIX}${sqids.encode([Number(commentId)])}`;
+}
+
+/**
+ * Decodes a public comment identifier back to the underlying model ID.
+ */
+export function parseCommentId(input: string): string {
+  if (!input.startsWith(COMMENT_ID_PREFIX)) {
+    throw new Error("Invalid comment ID format");
+  }
+
+  const decoded = sqids.decode(input.slice(COMMENT_ID_PREFIX.length))[0];
+  if (decoded === undefined) {
+    throw new Error("Invalid comment ID format");
+  }
+
+  return String(decoded);
+}

--- a/apps/backend/src/comment/validate.ts
+++ b/apps/backend/src/comment/validate.ts
@@ -30,3 +30,17 @@ export function validateCommentJson(value: unknown): value is JSONContent {
     return false;
   }
 }
+
+/**
+ * Check whether a (structurally valid) comment document carries no meaningful
+ * content, i.e. it holds only whitespace. Used to reject empty comments
+ * submitted directly through the API.
+ */
+export function isCommentEmpty(value: JSONContent): boolean {
+  try {
+    const node = schema.nodeFromJSON(value);
+    return node.textContent.trim().length === 0;
+  } catch {
+    return true;
+  }
+}

--- a/apps/backend/src/graphql/definitions/Comment.ts
+++ b/apps/backend/src/graphql/definitions/Comment.ts
@@ -3,6 +3,7 @@ import type { JSONContent } from "@tiptap/core";
 import gqlTag from "graphql-tag";
 
 import { createBuildComment } from "@/comment/createBuildComment";
+import { formatCommentId } from "@/comment/id";
 import { Build } from "@/database/models/Build";
 
 import type { IResolvers } from "../__generated__/resolver-types";
@@ -38,6 +39,7 @@ export const typeDefs = gql`
 
 export const resolvers: IResolvers = {
   Comment: {
+    id: (comment) => formatCommentId(comment.id),
     date: (comment) => {
       return new Date(comment.createdAt);
     },

--- a/apps/backend/src/graphql/definitions/Comment.ts
+++ b/apps/backend/src/graphql/definitions/Comment.ts
@@ -1,7 +1,12 @@
 import { invariant } from "@argos/util/invariant";
+import type { JSONContent } from "@tiptap/core";
 import gqlTag from "graphql-tag";
 
+import { createBuildComment } from "@/comment/createBuildComment";
+import { Build } from "@/database/models/Build";
+
 import type { IResolvers } from "../__generated__/resolver-types";
+import { forbidden, notFound, unauthenticated } from "../util";
 
 const { gql } = gqlTag;
 
@@ -17,6 +22,17 @@ export const typeDefs = gql`
     content: JSONObject!
     "Author of the comment"
     user: User
+  }
+
+  input AddBuildCommentInput {
+    buildId: ID!
+    "Rich-text JSON content of the comment"
+    body: JSONObject!
+  }
+
+  extend type Mutation {
+    "Post a comment on a build"
+    addBuildComment(input: AddBuildCommentInput!): Build!
   }
 `;
 
@@ -37,6 +53,40 @@ export const resolvers: IResolvers = {
       });
       invariant(account, "Account not found");
       return account;
+    },
+  },
+  Mutation: {
+    addBuildComment: async (_root, args, ctx) => {
+      const { auth } = ctx;
+      if (!auth) {
+        throw unauthenticated();
+      }
+
+      const { input } = args;
+
+      const build = await Build.query()
+        .findById(input.buildId)
+        .withGraphFetched("project.account");
+
+      if (!build) {
+        throw notFound("Build not found");
+      }
+
+      invariant(build.project?.account);
+
+      const permissions = await build.project.$getPermissions(auth.user);
+
+      if (!permissions.includes("review")) {
+        throw forbidden("You cannot comment on this build");
+      }
+
+      await createBuildComment({
+        build,
+        userId: auth.user.id,
+        body: input.body as JSONContent,
+      });
+
+      return build;
     },
   },
 };

--- a/apps/backend/src/graphql/tests/addBuildComment.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/addBuildComment.e2e.test.ts
@@ -1,0 +1,224 @@
+import request from "supertest";
+import { test as base, beforeEach, describe, expect, vi } from "vitest";
+
+import {
+  Account,
+  Build,
+  BuildNotificationSubscription,
+  Comment,
+  Project,
+} from "@/database/models";
+import { subscribeUserToBuild } from "@/database/services/build-notification-subscription";
+import { factory, setupDatabase } from "@/database/testing";
+import { sendNotification } from "@/notification";
+
+import { apolloServer, createApolloMiddleware } from "../apollo";
+import { expectNoGraphQLError } from "../testing";
+import { createApolloServerApp } from "./util";
+
+vi.mock("@/notification", () => ({
+  sendNotification: vi.fn(),
+}));
+
+const mockSendNotification = vi.mocked(sendNotification);
+
+const MUTATION = `
+  mutation AddBuildComment($input: AddBuildCommentInput!) {
+    addBuildComment(input: $input) {
+      id
+      comments {
+        id
+        content
+        user {
+          id
+        }
+      }
+    }
+  }
+`;
+
+function commentBody(text: string) {
+  return {
+    type: "doc",
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  };
+}
+
+type Fixtures = {
+  fixture: {
+    userAccount: Account;
+    teamAccount: Account;
+    project: Project;
+    build: Build;
+  };
+};
+
+const test = base.extend<Fixtures>({
+  fixture: async ({}, use) => {
+    await setupDatabase();
+    const [userAccount, teamAccount] = await Promise.all([
+      factory.UserAccount.create(),
+      factory.TeamAccount.create(),
+    ]);
+    const [project] = await Promise.all([
+      factory.Project.create({ accountId: teamAccount.id }),
+      factory.TeamUser.create({
+        teamId: teamAccount.teamId!,
+        userId: userAccount.userId!,
+        userLevel: "owner",
+      }),
+      userAccount.$fetchGraph("user"),
+      teamAccount.$fetchGraph("team"),
+    ]);
+    const build = await factory.Build.create({ projectId: project.id });
+    await use({ build, userAccount, teamAccount, project });
+  },
+});
+
+describe("GraphQL addBuildComment mutation", () => {
+  beforeEach(() => {
+    mockSendNotification.mockReset();
+  });
+
+  test("posts a comment on a build", async ({ fixture }) => {
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user: fixture.userAccount.user!, account: fixture.userAccount },
+    );
+    const body = commentBody("Looks great to me!");
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: MUTATION,
+        variables: { input: { buildId: fixture.build.id, body } },
+      });
+
+    expectNoGraphQLError(res);
+    expect(res.status).toBe(200);
+
+    const comments = res.body.data.addBuildComment.comments;
+    expect(comments).toHaveLength(1);
+    expect(comments[0].content).toEqual(body);
+    expect(comments[0].user.id).toBe(fixture.userAccount.id);
+
+    const stored = await Comment.query().where({ buildId: fixture.build.id });
+    expect(stored).toHaveLength(1);
+    expect(stored[0]!.buildReviewId).toBeNull();
+    expect(stored[0]!.userId).toBe(fixture.userAccount.userId);
+
+    // The author is auto-subscribed to the build.
+    const subscription = await BuildNotificationSubscription.query().findOne({
+      buildId: fixture.build.id,
+      userId: fixture.userAccount.userId!,
+    });
+    expect(subscription?.isSubscribed()).toBe(true);
+  });
+
+  test("notifies the build subscribers", async ({ fixture }) => {
+    const subscriberAccount = await factory.UserAccount.create();
+    await subscriberAccount.$fetchGraph("user");
+    await subscribeUserToBuild({
+      buildId: fixture.build.id,
+      userId: subscriberAccount.userId!,
+    });
+
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user: fixture.userAccount.user!, account: fixture.userAccount },
+    );
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: MUTATION,
+        variables: {
+          input: {
+            buildId: fixture.build.id,
+            body: commentBody("Please take another look."),
+          },
+        },
+      });
+
+    expectNoGraphQLError(res);
+    expect(mockSendNotification).toHaveBeenCalledTimes(1);
+    const call = mockSendNotification.mock.calls[0]![0];
+    expect(call.type).toBe("comment_added");
+    // The author is excluded, the subscriber is notified.
+    expect(call.recipients).toEqual([subscriberAccount.userId]);
+  });
+
+  test("rejects an invalid comment body", async ({ fixture }) => {
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user: fixture.userAccount.user!, account: fixture.userAccount },
+    );
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: MUTATION,
+        variables: {
+          input: {
+            buildId: fixture.build.id,
+            body: { type: "doc", content: [{ type: "unknownNode" }] },
+          },
+        },
+      });
+
+    expect(res.body.errors).toBeDefined();
+    expect(res.body.errors[0].message).toBe("Invalid comment body");
+    const comments = await Comment.query().where({ buildId: fixture.build.id });
+    expect(comments).toHaveLength(0);
+  });
+
+  test("rejects an empty comment", async ({ fixture }) => {
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user: fixture.userAccount.user!, account: fixture.userAccount },
+    );
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: MUTATION,
+        variables: {
+          input: {
+            buildId: fixture.build.id,
+            body: { type: "doc", content: [{ type: "paragraph" }] },
+          },
+        },
+      });
+
+    expect(res.body.errors).toBeDefined();
+    expect(res.body.errors[0].message).toBe("Comment cannot be empty");
+    const comments = await Comment.query().where({ buildId: fixture.build.id });
+    expect(comments).toHaveLength(0);
+  });
+
+  test("returns an error if the user cannot review", async ({ fixture }) => {
+    const outsiderAccount = await factory.UserAccount.create();
+    await outsiderAccount.$fetchGraph("user");
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user: outsiderAccount.user!, account: outsiderAccount },
+    );
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: MUTATION,
+        variables: {
+          input: {
+            buildId: fixture.build.id,
+            body: commentBody("Hello"),
+          },
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.errors[0].message).toBe("You cannot comment on this build");
+    const comments = await Comment.query().where({ buildId: fixture.build.id });
+    expect(comments).toHaveLength(0);
+  });
+});

--- a/apps/backend/src/notification/handlers/comment_added.tsx
+++ b/apps/backend/src/notification/handlers/comment_added.tsx
@@ -11,7 +11,7 @@ export const handler = defineNotificationHandler({
     projectName: z.string(),
     buildNumber: z.number(),
     buildName: z.string().nullish(),
-    buildUrl: z.url(),
+    commentUrl: z.url(),
     authorName: z.string().nullish(),
     bodyHtml: z.string(),
   }),
@@ -20,7 +20,8 @@ export const handler = defineNotificationHandler({
     projectName: "my-project",
     buildNumber: 42,
     buildName: "default",
-    buildUrl: "https://app.argos-ci.com/argos/my-project/builds/42",
+    commentUrl:
+      "https://app.argos-ci.com/argos/my-project/builds/42#comment-xf23d",
     authorName: "Jane Doe",
     bodyHtml: "<p>Could you double-check the header spacing?</p>",
   },
@@ -30,7 +31,7 @@ export const handler = defineNotificationHandler({
       projectName,
       buildNumber,
       buildName,
-      buildUrl,
+      commentUrl,
       authorName,
       bodyHtml,
       ctx,
@@ -50,7 +51,7 @@ export const handler = defineNotificationHandler({
           <Hi name={ctx.user.name} />
           <Paragraph>
             <strong>{author}</strong> commented on build{" "}
-            <Link href={buildUrl}>
+            <Link href={commentUrl}>
               {accountSlug}/{projectName} {buildLabel}
             </Link>
             .
@@ -60,7 +61,7 @@ export const handler = defineNotificationHandler({
             dangerouslySetInnerHTML={{ __html: bodyHtml }}
           />
           <Paragraph>
-            <Link href={buildUrl}>View the build on Argos →</Link>
+            <Link href={commentUrl}>View the comment on Argos →</Link>
           </Paragraph>
         </EmailLayout>
       ),

--- a/apps/backend/src/notification/handlers/comment_added.tsx
+++ b/apps/backend/src/notification/handlers/comment_added.tsx
@@ -1,0 +1,69 @@
+import { z } from "zod";
+
+import { EmailLayout, H1, Hi, Link, Paragraph } from "../../email/components";
+import { defineNotificationHandler } from "../workflow-types";
+
+export const handler = defineNotificationHandler({
+  type: "comment_added",
+  category: "review",
+  schema: z.object({
+    accountSlug: z.string(),
+    projectName: z.string(),
+    buildNumber: z.number(),
+    buildName: z.string().nullish(),
+    buildUrl: z.url(),
+    authorName: z.string().nullish(),
+    bodyHtml: z.string(),
+  }),
+  previewData: {
+    accountSlug: "argos",
+    projectName: "my-project",
+    buildNumber: 42,
+    buildName: "default",
+    buildUrl: "https://app.argos-ci.com/argos/my-project/builds/42",
+    authorName: "Jane Doe",
+    bodyHtml: "<p>Could you double-check the header spacing?</p>",
+  },
+  email: (props) => {
+    const {
+      accountSlug,
+      projectName,
+      buildNumber,
+      buildName,
+      buildUrl,
+      authorName,
+      bodyHtml,
+      ctx,
+    } = props;
+    const buildLabel = buildName
+      ? `${buildName} #${buildNumber}`
+      : `#${buildNumber}`;
+    const author = authorName || "Someone";
+    return {
+      subject: `[${accountSlug}/${projectName}] New comment on build ${buildLabel}`,
+      body: (
+        <EmailLayout
+          preview={`${author} commented on build ${buildLabel} in ${accountSlug}/${projectName}.`}
+          preferencesUrl={ctx.preferencesUrl}
+        >
+          <H1>New comment</H1>
+          <Hi name={ctx.user.name} />
+          <Paragraph>
+            <strong>{author}</strong> commented on build{" "}
+            <Link href={buildUrl}>
+              {accountSlug}/{projectName} {buildLabel}
+            </Link>
+            .
+          </Paragraph>
+          <div
+            className="my-4 rounded bg-[#f6f6f6] p-4 text-sm text-gray-950"
+            dangerouslySetInnerHTML={{ __html: bodyHtml }}
+          />
+          <Paragraph>
+            <Link href={buildUrl}>View the build on Argos →</Link>
+          </Paragraph>
+        </EmailLayout>
+      ),
+    };
+  },
+});

--- a/apps/backend/src/notification/handlers/index.ts
+++ b/apps/backend/src/notification/handlers/index.ts
@@ -1,4 +1,5 @@
 import type { NotificationHandler } from "../workflow-types";
+import * as comment_added from "./comment_added";
 import * as email_added from "./email_added";
 import * as email_removed from "./email_removed";
 import * as invalid_gitlab_token from "./invalid_gitlab_token";
@@ -11,6 +12,7 @@ import * as spend_limit from "./spend_limit";
 import * as welcome from "./welcome";
 
 export const notificationHandlers = [
+  comment_added.handler,
   email_added.handler,
   email_removed.handler,
   invalid_gitlab_token.handler,

--- a/apps/frontend/src/containers/BuildReviewersStatusList.tsx
+++ b/apps/frontend/src/containers/BuildReviewersStatusList.tsx
@@ -73,7 +73,9 @@ export function BuildReviewersStatusList<
               {review.user?.name || review.user?.slug}
             </strong>
             <Tooltip content={descriptor.label}>
-              <Icon className={clsx("size-4 shrink-0", descriptor.textColor)} />
+              <Icon
+                className={clsx("size-3.5 shrink-0", descriptor.textColor)}
+              />
             </Tooltip>
             {props.renderAction?.(review)}
           </li>

--- a/apps/frontend/src/pages/Build/RightSidebar.tsx
+++ b/apps/frontend/src/pages/Build/RightSidebar.tsx
@@ -152,7 +152,7 @@ function SidebarTabPanel(props: TabPanelProps) {
     <TabPanel
       {...props}
       className={clsx(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto pr-2 pb-4 empty:hidden",
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto pr-2 pb-6 empty:hidden",
         props.className,
       )}
     />

--- a/apps/frontend/src/pages/Build/RightSidebar.tsx
+++ b/apps/frontend/src/pages/Build/RightSidebar.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import clsx from "clsx";
 import { useAtom, useAtomValue } from "jotai";
 import { atomWithStorage } from "jotai/utils";
@@ -10,6 +11,7 @@ import {
   Tabs,
   type TabPanelProps,
 } from "react-aria-components";
+import { useLocation } from "react-router-dom";
 
 import { useBuildHotkey } from "@/containers/Build/BuildHotkeys";
 import { DocumentType, graphql } from "@/gql";
@@ -90,6 +92,13 @@ export function RightSidebar(
   const [tab, setTab] = useAtom(rightSidebarTabAtom);
   const { activeDiff, siblingDiffs } = useBuildDiffState();
   const { build, ...context } = props;
+  const { hash } = useLocation();
+  // Open the Review tab when arriving on a link to a specific comment.
+  useEffect(() => {
+    if (hash.startsWith("#comment-")) {
+      setTab("review");
+    }
+  }, [hash, setTab]);
   if (!open || !activeDiff) {
     return null;
   }

--- a/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
@@ -16,6 +16,7 @@ const AddBuildCommentMutation = graphql(`
   mutation AddCommentForm_addBuildComment($input: AddBuildCommentInput!) {
     addBuildComment(input: $input) {
       id
+      subscribed
       comments {
         ...CommentCard_Comment
       }

--- a/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
@@ -1,0 +1,54 @@
+import { useMutation } from "@apollo/client/react";
+import { toast } from "sonner";
+
+import { DocumentType, graphql } from "@/gql";
+import { type EditorValue } from "@/ui/Editor/Editor";
+import { StandaloneEditor } from "@/ui/Editor/StandaloneEditor";
+import { getErrorMessage } from "@/util/error";
+
+const _BuildFragment = graphql(`
+  fragment AddCommentForm_Build on Build {
+    id
+  }
+`);
+
+const AddBuildCommentMutation = graphql(`
+  mutation AddCommentForm_addBuildComment($input: AddBuildCommentInput!) {
+    addBuildComment(input: $input) {
+      id
+      comments {
+        ...CommentCard_Comment
+      }
+    }
+  }
+`);
+
+export function AddCommentForm(props: {
+  build: DocumentType<typeof _BuildFragment>;
+}) {
+  const { build } = props;
+  const [addBuildComment] = useMutation(AddBuildCommentMutation);
+  const handleSubmit = async (body: EditorValue) => {
+    try {
+      await addBuildComment({
+        variables: { input: { buildId: build.id, body } },
+      });
+    } catch (error) {
+      toast.error(getErrorMessage(error));
+      // Rethrow so the editor keeps the content and the user can retry.
+      throw error;
+    }
+  };
+  return (
+    <StandaloneEditor
+      onSubmit={handleSubmit}
+      placeholder="Leave a comment…"
+      submitLabel="Submit the comment"
+      emptyMessage={{
+        title: "Comment required",
+        description: "Please add a comment before submitting.",
+      }}
+      aria-label="Add a comment"
+    />
+  );
+}

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -77,6 +77,7 @@ export function CommentCard(props: {
         </span>
         <Button
           onPress={copyLink}
+          aria-label="Copy link to comment"
           className="text-low hover:text-default text-xs transition"
         >
           <Time date={comment.date} />

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -1,7 +1,19 @@
+import { useEffect, useRef } from "react";
+import { clsx } from "clsx";
+import { LinkIcon, MoreHorizontalIcon } from "lucide-react";
+import { toast } from "sonner";
+import { useClipboard } from "use-clipboard-copy";
+
 import { AccountAvatar } from "@/containers/AccountAvatar";
 import { DocumentType, graphql } from "@/gql";
 import { ReadOnlyEditor } from "@/ui/Editor/ReadOnlyEditor";
+import { IconButton } from "@/ui/IconButton";
+import { Menu, MenuItem, MenuItemIcon, MenuTrigger } from "@/ui/Menu";
+import { Popover } from "@/ui/Popover";
 import { Time } from "@/ui/Time";
+
+// Shared id so copying a comment link reuses a single toast instead of stacking.
+const COPY_TOAST_ID = "comment-link-copied";
 
 const _CommentFragment = graphql(`
   fragment CommentCard_Comment on Comment {
@@ -21,10 +33,37 @@ const _CommentFragment = graphql(`
 
 export function CommentCard(props: {
   comment: DocumentType<typeof _CommentFragment>;
+  highlighted?: boolean;
 }) {
-  const { comment } = props;
+  const { comment, highlighted = false } = props;
+  const ref = useRef<HTMLDivElement>(null);
+  const clipboard = useClipboard();
+
+  useEffect(() => {
+    if (highlighted && ref.current) {
+      ref.current.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [highlighted]);
+
+  const copyLink = () => {
+    const url = new URL(window.location.href);
+    url.hash = comment.id;
+    clipboard.copy(url.toString());
+    toast.success("Link copied", {
+      id: COPY_TOAST_ID,
+      description: "The link to this comment was copied to your clipboard.",
+    });
+  };
+
   return (
-    <div className="border-thin bg-app -mx-1 rounded-md">
+    <div
+      ref={ref}
+      id={comment.id}
+      className={clsx(
+        "border-thin bg-app ring-primary -mx-1 rounded-md transition",
+        highlighted ? "ring-2" : "ring-0",
+      )}
+    >
       <div className="flex items-center gap-2 px-3 py-2">
         {comment.user ? (
           <AccountAvatar
@@ -35,11 +74,43 @@ export function CommentCard(props: {
         <span className="text-default text-xs font-medium">
           {comment.user?.name || comment.user?.slug || "Unknown user"}
         </span>
-        <Time date={comment.date} className="text-low text-xs" />
+        <button
+          type="button"
+          onClick={copyLink}
+          className="text-low hover:text-default cursor-pointer text-xs transition"
+        >
+          <Time date={comment.date} tooltip="title" />
+        </button>
+        <CommentActionsMenu onCopyLink={copyLink} />
       </div>
       <div className="text-default px-3 pb-2 text-sm">
         <ReadOnlyEditor content={comment.content} />
       </div>
     </div>
+  );
+}
+
+function CommentActionsMenu(props: { onCopyLink: () => void }) {
+  return (
+    <MenuTrigger>
+      <IconButton
+        rounded
+        size="small"
+        aria-label="Comment actions"
+        className="ml-auto"
+      >
+        <MoreHorizontalIcon />
+      </IconButton>
+      <Popover placement="bottom end">
+        <Menu aria-label="Comment actions">
+          <MenuItem onAction={props.onCopyLink}>
+            <MenuItemIcon>
+              <LinkIcon />
+            </MenuItemIcon>
+            Copy link to comment
+          </MenuItem>
+        </Menu>
+      </Popover>
+    </MenuTrigger>
   );
 }

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -1,0 +1,45 @@
+import { AccountAvatar } from "@/containers/AccountAvatar";
+import { DocumentType, graphql } from "@/gql";
+import { ReadOnlyEditor } from "@/ui/Editor/ReadOnlyEditor";
+import { Time } from "@/ui/Time";
+
+const _CommentFragment = graphql(`
+  fragment CommentCard_Comment on Comment {
+    id
+    date
+    content
+    user {
+      id
+      name
+      slug
+      avatar {
+        ...AccountAvatarFragment
+      }
+    }
+  }
+`);
+
+export function CommentCard(props: {
+  comment: DocumentType<typeof _CommentFragment>;
+}) {
+  const { comment } = props;
+  return (
+    <div className="border-thin bg-app -mx-1 rounded-md">
+      <div className="flex items-center gap-2 px-3 py-2">
+        {comment.user ? (
+          <AccountAvatar
+            avatar={comment.user.avatar}
+            className="size-5 border"
+          />
+        ) : null}
+        <span className="text-default text-xs font-medium">
+          {comment.user?.name || comment.user?.slug || "Unknown user"}
+        </span>
+        <Time date={comment.date} className="text-low text-xs" />
+      </div>
+      <div className="text-default px-3 pb-2 text-sm">
+        <ReadOnlyEditor content={comment.content} />
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { clsx } from "clsx";
 import { LinkIcon, MoreHorizontalIcon } from "lucide-react";
+import { Button } from "react-aria-components";
 import { toast } from "sonner";
 import { useClipboard } from "use-clipboard-copy";
 
@@ -74,13 +75,12 @@ export function CommentCard(props: {
         <span className="text-default text-xs font-medium">
           {comment.user?.name || comment.user?.slug || "Unknown user"}
         </span>
-        <button
-          type="button"
-          onClick={copyLink}
-          className="text-low hover:text-default cursor-pointer text-xs transition"
+        <Button
+          onPress={copyLink}
+          className="text-low hover:text-default text-xs transition"
         >
-          <Time date={comment.date} tooltip="title" />
-        </button>
+          <Time date={comment.date} />
+        </Button>
         <CommentActionsMenu onCopyLink={copyLink} />
       </div>
       <div className="text-default px-3 pb-2 text-sm">

--- a/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
@@ -191,7 +191,7 @@ function SubscribeToggleButton(props: { build: Build }) {
   };
   return (
     <Tooltip content={label}>
-      <IconButton size="small" aria-label={label} onPress={handlePress}>
+      <IconButton rounded size="small" aria-label={label} onPress={handlePress}>
         {subscribed ? <BellIcon /> : <BellOffIcon />}
       </IconButton>
     </Tooltip>

--- a/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import { useMutation } from "@apollo/client/react";
 import clsx from "clsx";
 import {
@@ -8,6 +8,7 @@ import {
   FileUpIcon,
   MailCheckIcon,
 } from "lucide-react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 
 import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
@@ -18,6 +19,7 @@ import { IconButton } from "@/ui/IconButton";
 import { SidebarHeader, SidebarHeading, SidebarSection } from "@/ui/Sidebar";
 import { Time } from "@/ui/Time";
 import { Tooltip } from "@/ui/Tooltip";
+import { useLiveRef } from "@/ui/useLiveRef";
 import { buildReviewDescriptors } from "@/util/build-review";
 import { getErrorMessage } from "@/util/error";
 import { useNonNullable } from "@/util/useNonNullable";
@@ -124,21 +126,36 @@ function getActivityEntries(build: Build): ActivityEntry[] {
  * next click anywhere.
  */
 function useHighlightedCommentId(commentIds: string[]): string | null {
-  const [hashId, setHashId] = useState<string | null>(() => {
-    const hash = window.location.hash.slice(1);
-    return hash || null;
-  });
+  const { hash } = useLocation();
+  const navigate = useNavigate();
+  const hashId = hash.slice(1);
   const matchedId = hashId && commentIds.includes(hashId) ? hashId : null;
+  const matchedIdRef = useLiveRef(matchedId);
+  const clear = useCallback(() => {
+    if (matchedIdRef.current) {
+      navigate({ hash: "" }, { replace: true });
+    }
+  }, [navigate, matchedIdRef]);
+  // Clear when we click outside.
   useEffect(() => {
     if (!matchedId) {
       return;
     }
-    const clear = () => setHashId(null);
     document.addEventListener("click", clear, { once: true, capture: true });
     return () => {
       document.removeEventListener("click", clear, { capture: true });
     };
-  }, [matchedId]);
+  }, [matchedId, clear]);
+  // Clear after 3s.
+  useEffect(() => {
+    if (!matchedId) {
+      return;
+    }
+    const id = window.setTimeout(clear, 3000);
+    return () => window.clearTimeout(id);
+  }, [matchedId, clear]);
+  // Clear at unmount.
+  useEffect(() => clear, [clear]);
   return matchedId;
 }
 
@@ -234,7 +251,7 @@ function ActivityEntryRow(props: {
   entry: ActivityEntry;
   highlightedCommentId: string | null;
 }) {
-  const { entry } = props;
+  const { entry, highlightedCommentId } = props;
   switch (entry.kind) {
     case "created":
       return (
@@ -300,7 +317,7 @@ function ActivityEntryRow(props: {
       return (
         <CommentCard
           comment={entry.comment}
-          highlighted={entry.comment.id === props.highlightedCommentId}
+          highlighted={entry.comment.id === highlightedCommentId}
         />
       );
   }

--- a/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { useMutation } from "@apollo/client/react";
 import clsx from "clsx";
 import {
@@ -117,11 +118,38 @@ function getActivityEntries(build: Build): ActivityEntry[] {
   );
 }
 
+/**
+ * Reads a `#comment-…` hash from the URL and, when it matches a loaded comment,
+ * returns its id so the comment can be highlighted. The highlight clears on the
+ * next click anywhere.
+ */
+function useHighlightedCommentId(commentIds: string[]): string | null {
+  const [hashId, setHashId] = useState<string | null>(() => {
+    const hash = window.location.hash.slice(1);
+    return hash || null;
+  });
+  const matchedId = hashId && commentIds.includes(hashId) ? hashId : null;
+  useEffect(() => {
+    if (!matchedId) {
+      return;
+    }
+    const clear = () => setHashId(null);
+    document.addEventListener("click", clear, { once: true, capture: true });
+    return () => {
+      document.removeEventListener("click", clear, { capture: true });
+    };
+  }, [matchedId]);
+  return matchedId;
+}
+
 export function ReviewActivitySection(props: { build: Build }) {
   const { build } = props;
   const permissions = useNonNullable(ProjectPermissionsContext);
   const canComment = permissions.includes(ProjectPermission.Review);
   const entries = getActivityEntries(build);
+  const highlightedCommentId = useHighlightedCommentId(
+    build.comments.map((comment) => comment.id),
+  );
   return (
     <SidebarSection>
       <SidebarHeader>
@@ -131,7 +159,11 @@ export function ReviewActivitySection(props: { build: Build }) {
       <div className="px-3">
         <Activity>
           {entries.map((entry, index) => (
-            <ActivityEntryRow key={index} entry={entry} />
+            <ActivityEntryRow
+              key={index}
+              entry={entry}
+              highlightedCommentId={highlightedCommentId}
+            />
           ))}
         </Activity>
         {canComment ? (
@@ -198,7 +230,10 @@ function SubscribeToggleButton(props: { build: Build }) {
   );
 }
 
-function ActivityEntryRow(props: { entry: ActivityEntry }) {
+function ActivityEntryRow(props: {
+  entry: ActivityEntry;
+  highlightedCommentId: string | null;
+}) {
   const { entry } = props;
   switch (entry.kind) {
     case "created":
@@ -262,6 +297,11 @@ function ActivityEntryRow(props: { entry: ActivityEntry }) {
       );
     }
     case "comment":
-      return <CommentCard comment={entry.comment} />;
+      return (
+        <CommentCard
+          comment={entry.comment}
+          highlighted={entry.comment.id === props.highlightedCommentId}
+        />
+      );
   }
 }

--- a/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
@@ -123,7 +123,7 @@ function getActivityEntries(build: Build): ActivityEntry[] {
 /**
  * Reads a `#comment-…` hash from the URL and, when it matches a loaded comment,
  * returns its id so the comment can be highlighted. The highlight clears on the
- * next click anywhere.
+ * next click anywhere, after 3 seconds, or when the component unmounts.
  */
 function useHighlightedCommentId(commentIds: string[]): string | null {
   const { hash } = useLocation();

--- a/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
@@ -9,16 +9,20 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 
-import { AccountAvatar } from "@/containers/AccountAvatar";
+import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
 import { DocumentType, graphql } from "@/gql";
+import { ProjectPermission } from "@/gql/graphql";
 import { Activity, ActivityItem } from "@/ui/Activity";
-import { ReadOnlyEditor } from "@/ui/Editor/ReadOnlyEditor";
 import { IconButton } from "@/ui/IconButton";
 import { SidebarHeader, SidebarHeading, SidebarSection } from "@/ui/Sidebar";
 import { Time } from "@/ui/Time";
 import { Tooltip } from "@/ui/Tooltip";
 import { buildReviewDescriptors } from "@/util/build-review";
 import { getErrorMessage } from "@/util/error";
+import { useNonNullable } from "@/util/useNonNullable";
+
+import { AddCommentForm } from "./AddCommentForm";
+import { CommentCard } from "./CommentCard";
 
 const _BuildFragment = graphql(`
   fragment ReviewActivitySection_Build on Build {
@@ -26,6 +30,7 @@ const _BuildFragment = graphql(`
     createdAt
     concludedAt
     subscribed
+    ...AddCommentForm_Build
     reviews {
       id
       date
@@ -49,17 +54,7 @@ const _BuildFragment = graphql(`
       }
     }
     comments {
-      id
-      date
-      content
-      user {
-        id
-        name
-        slug
-        avatar {
-          ...AccountAvatarFragment
-        }
-      }
+      ...CommentCard_Comment
     }
   }
 `);
@@ -124,6 +119,8 @@ function getActivityEntries(build: Build): ActivityEntry[] {
 
 export function ReviewActivitySection(props: { build: Build }) {
   const { build } = props;
+  const permissions = useNonNullable(ProjectPermissionsContext);
+  const canComment = permissions.includes(ProjectPermission.Review);
   const entries = getActivityEntries(build);
   return (
     <SidebarSection>
@@ -137,6 +134,11 @@ export function ReviewActivitySection(props: { build: Build }) {
             <ActivityEntryRow key={index} entry={entry} />
           ))}
         </Activity>
+        {canComment ? (
+          <div className="mt-3">
+            <AddCommentForm build={build} />
+          </div>
+        ) : null}
       </div>
     </SidebarSection>
   );
@@ -262,27 +264,4 @@ function ActivityEntryRow(props: { entry: ActivityEntry }) {
     case "comment":
       return <CommentCard comment={entry.comment} />;
   }
-}
-
-function CommentCard(props: { comment: Build["comments"][number] }) {
-  const { comment } = props;
-  return (
-    <div className="border-thin bg-app -mx-1 rounded-md">
-      <div className="flex items-center gap-2 px-3 py-2">
-        {comment.user ? (
-          <AccountAvatar
-            avatar={comment.user.avatar}
-            className="size-5 border"
-          />
-        ) : null}
-        <span className="text-default text-xs font-medium">
-          {comment.user?.name || comment.user?.slug || "Unknown user"}
-        </span>
-        <Time date={comment.date} className="text-low text-xs" />
-      </div>
-      <div className="text-default px-3 pb-2 text-sm">
-        <ReadOnlyEditor content={comment.content} />
-      </div>
-    </div>
-  );
 }

--- a/apps/frontend/src/pages/Build/sidebar/ReviewersSection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewersSection.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useMutation } from "@apollo/client/react";
 import clsx from "clsx";
-import { BanIcon, MoreVerticalIcon } from "lucide-react";
+import { BanIcon, MoreHorizontalIcon } from "lucide-react";
 
 import { BuildReviewersStatusList } from "@/containers/BuildReviewersStatusList";
 import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
@@ -176,7 +176,7 @@ function ReviewActionsMenu(props: { review: Review; onDismiss: () => void }) {
         size="small"
         aria-label="Review actions"
       >
-        <MoreVerticalIcon />
+        <MoreHorizontalIcon />
       </IconButton>
       <Popover placement="bottom end">
         <Menu aria-label="Review actions">

--- a/apps/frontend/src/pages/Build/sidebar/ReviewersSection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewersSection.tsx
@@ -170,7 +170,12 @@ function ReviewActionsMenu(props: { review: Review; onDismiss: () => void }) {
 
   return (
     <MenuTrigger>
-      <IconButton data-actions-menu="" size="small" aria-label="Review actions">
+      <IconButton
+        rounded
+        data-actions-menu=""
+        size="small"
+        aria-label="Review actions"
+      >
         <MoreVerticalIcon />
       </IconButton>
       <Popover placement="bottom end">

--- a/apps/frontend/src/ui/Editor/Editor.tsx
+++ b/apps/frontend/src/ui/Editor/Editor.tsx
@@ -187,7 +187,16 @@ export function Editor(props: EditorProps) {
     if (!editor || disabled) {
       return;
     }
-    const target = event.target as HTMLElement;
+    // Only handle primary-button clicks (avoid interfering with context menus).
+    if (event.button !== 0 || event.ctrlKey) {
+      return;
+    }
+
+    if (!(event.target instanceof HTMLElement)) {
+      return;
+    }
+
+    const target = event.target;
     // Let ProseMirror place the cursor for clicks inside the editable content,
     // and let interactive controls (toolbar, footer button, links) behave
     // normally.

--- a/apps/frontend/src/ui/Editor/Editor.tsx
+++ b/apps/frontend/src/ui/Editor/Editor.tsx
@@ -66,8 +66,14 @@ export interface EditorProps {
   defaultValue?: EditorValue;
   onChange: (value: EditorValue) => void;
   onBlur?: () => void;
+  /** Called when the user presses Cmd/Ctrl+Enter. */
+  onSubmit?: () => void;
+  /** Content rendered inside the editor box, below the text area. */
+  footer?: React.ReactNode;
   ref?: React.Ref<HTMLElement>;
   className?: string;
+  /** Class applied to the editable text area (e.g. to override its height). */
+  contentClassName?: string;
   placeholder?: string;
   autoFocus?: boolean;
   "aria-label"?: string;
@@ -76,18 +82,23 @@ export interface EditorProps {
 
 const EDITOR_CONTENT_CLASS = clsx(
   EDITOR_PROSE_CLASS,
-  "min-h-20 px-3 py-2 outline-hidden",
+  "px-3 py-2 outline-hidden",
   // Placeholder
   "[&_p.is-editor-empty:first-child]:before:content-[attr(data-placeholder)] [&_p.is-editor-empty:first-child]:before:text-low [&_p.is-editor-empty:first-child]:before:pointer-events-none [&_p.is-editor-empty:first-child]:before:float-left [&_p.is-editor-empty:first-child]:before:h-0",
 );
+
+const DEFAULT_CONTENT_HEIGHT_CLASS = "min-h-20";
 
 export function Editor(props: EditorProps) {
   const {
     defaultValue,
     onChange,
     onBlur,
+    onSubmit,
+    footer,
     ref,
     className,
+    contentClassName,
     placeholder,
     autoFocus,
     disabled,
@@ -95,9 +106,11 @@ export function Editor(props: EditorProps) {
 
   const onChangeRef = useRef(onChange);
   const onBlurRef = useRef(onBlur);
+  const onSubmitRef = useRef(onSubmit);
   useEffect(() => {
     onChangeRef.current = onChange;
     onBlurRef.current = onBlur;
+    onSubmitRef.current = onSubmit;
   });
 
   const editor = useEditor({
@@ -119,8 +132,23 @@ export function Editor(props: EditorProps) {
     autofocus: autoFocus ? "end" : false,
     editorProps: {
       attributes: {
-        class: EDITOR_CONTENT_CLASS,
+        class: clsx(
+          EDITOR_CONTENT_CLASS,
+          contentClassName ?? DEFAULT_CONTENT_HEIGHT_CLASS,
+        ),
         ...(props["aria-label"] ? { "aria-label": props["aria-label"] } : {}),
+      },
+      handleKeyDown: (_view, event) => {
+        if (
+          (event.metaKey || event.ctrlKey) &&
+          event.key === "Enter" &&
+          onSubmitRef.current
+        ) {
+          event.preventDefault();
+          onSubmitRef.current();
+          return true;
+        }
+        return false;
       },
     },
     onUpdate: ({ editor }) => {
@@ -130,6 +158,10 @@ export function Editor(props: EditorProps) {
       onBlurRef.current?.();
     },
   });
+
+  useEffect(() => {
+    editor?.setEditable(!disabled);
+  }, [editor, disabled]);
 
   useEffect(() => {
     if (!editor || !ref) {
@@ -161,6 +193,7 @@ export function Editor(props: EditorProps) {
     >
       <EditorToolbar editor={editor} />
       <EditorContent editor={editor} />
+      {footer}
     </div>
   );
 }

--- a/apps/frontend/src/ui/Editor/Editor.tsx
+++ b/apps/frontend/src/ui/Editor/Editor.tsx
@@ -181,13 +181,37 @@ export function Editor(props: EditorProps) {
     };
   }, [editor, ref]);
 
+  const handleContainerMouseDown = (
+    event: React.MouseEvent<HTMLDivElement>,
+  ) => {
+    if (!editor || disabled) {
+      return;
+    }
+    const target = event.target as HTMLElement;
+    // Let ProseMirror place the cursor for clicks inside the editable content,
+    // and let interactive controls (toolbar, footer button, links) behave
+    // normally.
+    if (
+      editor.view.dom.contains(target) ||
+      target.closest("button, a, input, textarea")
+    ) {
+      return;
+    }
+    // Clicking the surrounding chrome (padding, footer) focuses the field
+    // instead of blurring it.
+    event.preventDefault();
+    editor.commands.focus("end");
+  };
+
   return (
     <div
       data-hotkeys-disabled
       data-disabled={disabled ? "" : undefined}
+      onMouseDown={handleContainerMouseDown}
       className={clsx(
         "bg-app focus-within:border-active rounded-md border text-sm",
         "data-disabled:opacity-disabled",
+        !disabled && "cursor-text",
         className,
       )}
     >

--- a/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
+++ b/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
@@ -109,8 +109,11 @@ export function StandaloneEditor(props: StandaloneEditorProps) {
               size="small"
               rounded
               aria-label={submitLabel}
-              // Looks disabled when empty, but stays clickable so the press can
-              // surface the "empty" toast.
+              // Truly disabled (not focusable/clickable) while submitting or when
+              // disabled by the parent. When the editor is merely empty it only
+              // *looks* disabled but stays clickable, so the press can surface the
+              // "empty" toast.
+              isDisabled={disabled || isPending}
               aria-disabled={isEmpty}
               onPress={submit}
             >

--- a/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
+++ b/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
@@ -1,0 +1,124 @@
+import { useId, useState } from "react";
+import { ArrowUpIcon } from "lucide-react";
+import { toast } from "sonner";
+
+import { HotkeyTooltip } from "../HotkeyTooltip";
+import { IconButton } from "../IconButton";
+import { Editor, type EditorValue } from "./Editor";
+import { MOD } from "./EditorToolbar.shortcuts";
+import { hasEditorContent } from "./util";
+
+type EmptyMessage = { title: string; description?: string };
+
+const DEFAULT_EMPTY_MESSAGE: EmptyMessage = {
+  title: "Nothing to submit",
+  description: "Write something before submitting.",
+};
+
+export interface StandaloneEditorProps {
+  /**
+   * Called when the content is submitted (send button or Cmd/Ctrl+Enter). The
+   * editor clears once the returned promise resolves; throw to keep the content
+   * so the user can retry.
+   */
+  onSubmit: (value: EditorValue) => void | Promise<void>;
+  placeholder?: string;
+  /** Accessible label and tooltip text for the send button. */
+  submitLabel?: string;
+  /** Toast shown when the user submits while the editor is empty. */
+  emptyMessage?: EmptyMessage;
+  disabled?: boolean;
+  autoFocus?: boolean;
+  className?: string;
+  "aria-label"?: string;
+}
+
+/**
+ * A self-contained rich-text comment box: the {@link Editor} with a send button
+ * integrated into the box. It owns its content, clears it on a successful
+ * submit and keeps it on failure. The send button is never disabled — an empty
+ * submit surfaces a toast instead.
+ */
+export function StandaloneEditor(props: StandaloneEditorProps) {
+  const {
+    onSubmit,
+    placeholder,
+    submitLabel = "Send",
+    emptyMessage = DEFAULT_EMPTY_MESSAGE,
+    disabled,
+    autoFocus,
+    className,
+    "aria-label": ariaLabel,
+  } = props;
+  const [value, setValue] = useState<EditorValue>(null);
+  // Remounts the editor after a successful submit to clear its content.
+  const [editorKey, setEditorKey] = useState(0);
+  const [isPending, setIsPending] = useState(false);
+  // Stable id so repeated empty submits reuse the same toast instead of stacking.
+  const emptyToastId = useId();
+  const isEmpty = !hasEditorContent(value);
+
+  const performSubmit = async () => {
+    setIsPending(true);
+    try {
+      await onSubmit(value);
+      setValue(null);
+      setEditorKey((key) => key + 1);
+    } catch {
+      // Keep the content so the user can retry.
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  const submit = () => {
+    if (disabled || isPending) {
+      return;
+    }
+    if (isEmpty) {
+      toast.warning(emptyMessage.title, {
+        id: emptyToastId,
+        description: emptyMessage.description,
+      });
+      return;
+    }
+    void performSubmit();
+  };
+
+  return (
+    <Editor
+      key={editorKey}
+      defaultValue={null}
+      onChange={setValue}
+      onSubmit={submit}
+      placeholder={placeholder}
+      disabled={disabled || isPending}
+      autoFocus={autoFocus}
+      aria-label={ariaLabel}
+      className={className}
+      contentClassName="min-h-9"
+      footer={
+        <div className="flex justify-end p-1.5">
+          <HotkeyTooltip
+            description={submitLabel}
+            keys={[MOD, "Enter"]}
+            placement="top"
+          >
+            <IconButton
+              variant="contained"
+              size="small"
+              rounded
+              aria-label={submitLabel}
+              // Looks disabled when empty, but stays clickable so the press can
+              // surface the "empty" toast.
+              aria-disabled={isEmpty}
+              onPress={submit}
+            >
+              <ArrowUpIcon />
+            </IconButton>
+          </HotkeyTooltip>
+        </div>
+      }
+    />
+  );
+}

--- a/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
+++ b/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
@@ -36,8 +36,9 @@ export interface StandaloneEditorProps {
 /**
  * A self-contained rich-text comment box: the {@link Editor} with a send button
  * integrated into the box. It owns its content, clears it on a successful
- * submit and keeps it on failure. The send button is never disabled — an empty
- * submit surfaces a toast instead.
+ * submit and keeps it on failure. The send button is disabled while a submit is
+ * pending or when disabled by the parent; when the editor is merely empty it
+ * stays clickable so the press can surface a toast.
  */
 export function StandaloneEditor(props: StandaloneEditorProps) {
   const {

--- a/apps/frontend/src/ui/IconButton.tsx
+++ b/apps/frontend/src/ui/IconButton.tsx
@@ -50,7 +50,7 @@ function getIconButtonClassName(options: IconButtonOptions) {
     "group-[*]/button-group:rounded-none group-[*]/button-group:first:rounded-l-lg group-[*]/button-group:last:rounded-r-lg text-xs font-medium",
     /* Size */
     {
-      small: "p-[calc(0.25rem-1px)] *:size-4 leading-4 text-sm",
+      small: "p-[calc(0.3125rem-1px)] *:size-3.5 leading-4 text-sm",
       medium: "p-[calc(0.5rem-1px)] *:size-4 leading-4 text-sm",
     }[size],
     /* Shape */

--- a/apps/frontend/src/ui/IconButton.tsx
+++ b/apps/frontend/src/ui/IconButton.tsx
@@ -12,6 +12,8 @@ type IconButtonOptions = {
   variant?: IconButtonVariant;
   color?: IconButtonColor;
   size?: IconButtonSize;
+  /** Render as a circle instead of the default rounded square. */
+  rounded?: boolean;
 };
 
 const colorClassNames: Record<
@@ -35,7 +37,12 @@ const colorClassNames: Record<
 };
 
 function getIconButtonClassName(options: IconButtonOptions) {
-  const { variant = "outline", color = "neutral", size = "medium" } = options;
+  const {
+    variant = "outline",
+    color = "neutral",
+    size = "medium",
+    rounded = false,
+  } = options;
   const variantClassName = colorClassNames[variant][color];
   return clsx(
     variantClassName,
@@ -43,11 +50,17 @@ function getIconButtonClassName(options: IconButtonOptions) {
     "group-[*]/button-group:rounded-none group-[*]/button-group:first:rounded-l-lg group-[*]/button-group:last:rounded-r-lg text-xs font-medium",
     /* Size */
     {
-      small: "p-[calc(0.25rem-1px)] *:size-4 rounded-md leading-4 text-sm",
-      medium: "p-[calc(0.5rem-1px)] *:size-4 rounded-lg leading-4 text-sm",
+      small: "p-[calc(0.25rem-1px)] *:size-4 leading-4 text-sm",
+      medium: "p-[calc(0.5rem-1px)] *:size-4 leading-4 text-sm",
     }[size],
+    /* Shape */
+    rounded
+      ? "rounded-full"
+      : { small: "rounded-md", medium: "rounded-lg" }[size],
     /* Base */
-    "data-disabled:opacity-disabled flex cursor-default border border-transparent text-sm",
+    "flex cursor-default border border-transparent text-sm",
+    /* Disabled, including the not-really-disabled `aria-disabled` style */
+    "data-disabled:opacity-disabled aria-disabled:opacity-disabled aria-disabled:cursor-not-allowed",
     /* Focus */
     "focus:outline-hidden data-focus-visible:ring-4",
   );
@@ -62,13 +75,14 @@ export function IconButton({
   color,
   variant,
   size,
+  rounded,
   ...props
 }: IconButtonProps) {
   return (
     <RACButton
       {...props}
       className={clsx(
-        getIconButtonClassName({ color, variant, size }),
+        getIconButtonClassName({ color, variant, size, rounded }),
         props.className,
       )}
     />


### PR DESCRIPTION
## ARG-366

Lets reviewers post a **standalone comment** on a build from the bottom of the Activity flow, and notifies the build's subscribers when one is added.

The `Comment` model already supported standalone comments (nullable `buildReviewId`) and the Activity flow already rendered them — this adds the missing mutation, notification, and UI to create one.

Also fix ARG-360

### Backend
- `createBuildComment` service: inserts a standalone comment, auto-subscribes the author, and notifies the other subscribers (excludes the author), mirroring `createBuildReview`.
- `addBuildComment` GraphQL mutation, gated on the **`review`** permission (same gate as approving/rejecting — avoids letting any logged-in user comment on public projects).
- New `comment_added` email handler in the **review** category (respects notification preferences).
- Rejects empty (`isCommentEmpty`) and structurally invalid comment bodies.
- e2e tests: posts/auto-subscribe, notifies subscribers, invalid body, empty body, forbidden.

### Frontend
- New reusable **`StandaloneEditor`** UI: a self-contained comment box with an integrated rounded send button, `Cmd/Ctrl+Enter` to submit, a shortcut tooltip, and a single reused "Comment required" toast on empty submit. Clears on success, keeps content on failure.
- Made `Editor` reusable: added a `footer` slot, `onSubmit` (Cmd/Ctrl+Enter), `contentClassName`, and dynamic editability.
- `IconButton` gains a `rounded` prop and `aria-disabled` styling (looks disabled but stays clickable).
- Extracted `CommentCard` and `AddCommentForm` into their own files; slimmed down `ReviewActivitySection`.

### Validation
Type-check (all packages), ESLint, and Prettier pass. New backend e2e tests pass and the full e2e suite stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)