### PR TITLE
feat(project): require connected GitHub repo for CI authentication

### DIFF
--- a/apps/frontend/src/containers/Project/ConnectedRepository.tsx
+++ b/apps/frontend/src/containers/Project/ConnectedRepository.tsx
@@ -1,0 +1,99 @@
+import { invariant } from "@argos/util/invariant";
+import clsx from "clsx";
+
+import { DocumentType, graphql } from "@/gql";
+import { getProjectURL, useProjectParams } from "@/pages/Project/ProjectParams";
+import { LinkButton } from "@/ui/Button";
+import { Link } from "@/ui/Link";
+
+import { RepositoryIcons } from "../Repository";
+
+const _ProjectFragment = graphql(`
+  fragment ConnectedRepository_Project on Project {
+    id
+    repository {
+      __typename
+      id
+      fullName
+      url
+    }
+  }
+`);
+
+type Project = DocumentType<typeof _ProjectFragment>;
+
+/**
+ * Whether the project is connected to a GitHub repository.
+ *
+ * GitHub Actions authentication (tokenless & OIDC) only works for projects
+ * connected to a GitHub repository, so a GitLab project is not eligible.
+ */
+export function isGithubRepositoryConnected(project: Project): boolean {
+  return project.repository?.__typename === "GithubRepository";
+}
+
+/**
+ * Displays the GitHub repository this feature applies to, or explains why the
+ * project is not eligible when no GitHub repository is connected.
+ */
+export function ConnectedRepository(props: {
+  project: Project;
+  className?: string;
+}) {
+  const { project, className } = props;
+  const { repository } = project;
+
+  if (repository?.__typename === "GithubRepository") {
+    const RepoIcon = RepositoryIcons[repository.__typename];
+    return (
+      <div className={clsx("flex flex-col gap-1.5", className)}>
+        <div className="text-low text-sm font-medium">
+          Applies to GitHub Actions runs from this repository:
+        </div>
+        <div className="flex items-center gap-2 rounded-sm border p-4">
+          <RepoIcon className="size-6 shrink-0" />
+          <Link
+            className="font-semibold"
+            href={repository.url}
+            target="_blank"
+            variant="neutral"
+          >
+            {repository.fullName}
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={clsx(
+        "text-low rounded-sm border border-dashed p-4 text-sm",
+        className,
+      )}
+    >
+      {repository
+        ? "This authentication is only available for projects connected to a GitHub repository, but this project is connected to a GitLab repository."
+        : "No GitHub repository is connected to this project. Connect one to use this authentication for your GitHub Actions runs."}
+    </div>
+  );
+}
+
+/**
+ * Secondary button linking to the Git settings, used to connect (or change) the
+ * project's repository when it is not eligible for GitHub Actions authentication.
+ */
+export function ConnectRepositoryButton(props: { project: Project }) {
+  const params = useProjectParams();
+  invariant(params);
+  return (
+    <LinkButton
+      variant="secondary"
+      href={`${getProjectURL(params)}/settings/git`}
+    >
+      {props.project.repository
+        ? "Manage Git repository"
+        : "Connect a Git repository"}
+    </LinkButton>
+  );
+}

--- a/apps/frontend/src/containers/Project/GitHubActionsOIDC.tsx
+++ b/apps/frontend/src/containers/Project/GitHubActionsOIDC.tsx
@@ -2,16 +2,29 @@ import { useApolloClient } from "@apollo/client/react";
 import { SubmitHandler, useForm } from "react-hook-form";
 
 import { DocumentType, graphql } from "@/gql";
-import { Card, CardBody, CardParagraph, CardTitle } from "@/ui/Card";
+import {
+  Card,
+  CardBody,
+  CardFooter,
+  CardParagraph,
+  CardTitle,
+} from "@/ui/Card";
 import { Form } from "@/ui/Form";
 import { FormCardFooter } from "@/ui/FormCardFooter";
 import { FormSwitch } from "@/ui/FormSwitch";
 import { Link } from "@/ui/Link";
 
+import {
+  ConnectedRepository,
+  ConnectRepositoryButton,
+  isGithubRepositoryConnected,
+} from "./ConnectedRepository";
+
 const _ProjectFragment = graphql(`
   fragment ProjectGitHubActionsOIDC_Project on Project {
     id
     githubActionsOidcEnabled
+    ...ConnectedRepository_Project
   }
 `);
 
@@ -41,6 +54,7 @@ export function ProjectGitHubActionsOIDC(props: {
 }) {
   const { project } = props;
   const client = useApolloClient();
+  const eligible = isGithubRepositoryConnected(project);
   const form = useForm<Inputs>({
     defaultValues: {
       githubActionsOidcEnabled: project.githubActionsOidcEnabled,
@@ -58,31 +72,56 @@ export function ProjectGitHubActionsOIDC(props: {
     form.reset(data);
   };
 
+  const title = <CardTitle>GitHub Actions OIDC</CardTitle>;
+  const description = (
+    <CardParagraph>
+      Allow GitHub Actions workflows to authenticate with Argos using
+      short-lived OpenID Connect tokens instead of the project token.
+    </CardParagraph>
+  );
+  const learnMore = (
+    <>
+      Learn more about{" "}
+      <Link
+        href="https://argos-ci.com/docs/learn/integrations/github-oidc-authentication"
+        target="_blank"
+      >
+        GitHub Actions OIDC
+      </Link>
+      .
+    </>
+  );
+
+  if (!eligible) {
+    return (
+      <Card>
+        <CardBody>
+          {title}
+          {description}
+          <ConnectedRepository project={project} />
+        </CardBody>
+        <CardFooter className="flex items-center justify-between gap-4">
+          <div>{learnMore}</div>
+          <ConnectRepositoryButton project={project} />
+        </CardFooter>
+      </Card>
+    );
+  }
+
   return (
     <Card>
       <Form form={form} onSubmit={onSubmit}>
         <CardBody>
-          <CardTitle>GitHub Actions OIDC</CardTitle>
-          <CardParagraph>
-            Allow GitHub Actions workflows to authenticate with Argos using
-            short-lived OpenID Connect tokens instead of the project token.
-          </CardParagraph>
+          {title}
+          {description}
+          <ConnectedRepository project={project} className="mb-4" />
           <FormSwitch
             control={form.control}
             name="githubActionsOidcEnabled"
-            label="Enable GitHub Actions OIDC for this project"
+            label="Enable GitHub Actions OIDC"
           />
         </CardBody>
-        <FormCardFooter control={form.control}>
-          Learn more about{" "}
-          <Link
-            href="https://argos-ci.com/docs/learn/integrations/github-oidc-authentication"
-            target="_blank"
-          >
-            GitHub Actions OIDC
-          </Link>
-          .
-        </FormCardFooter>
+        <FormCardFooter control={form.control}>{learnMore}</FormCardFooter>
       </Form>
     </Card>
   );

--- a/apps/frontend/src/containers/Project/TokenlessAuth.tsx
+++ b/apps/frontend/src/containers/Project/TokenlessAuth.tsx
@@ -2,15 +2,29 @@ import { useApolloClient } from "@apollo/client/react";
 import { SubmitHandler, useForm } from "react-hook-form";
 
 import { DocumentType, graphql } from "@/gql";
-import { Card, CardBody, CardParagraph, CardTitle } from "@/ui/Card";
+import {
+  Card,
+  CardBody,
+  CardFooter,
+  CardParagraph,
+  CardTitle,
+} from "@/ui/Card";
 import { Form } from "@/ui/Form";
 import { FormCardFooter } from "@/ui/FormCardFooter";
 import { FormSwitch } from "@/ui/FormSwitch";
+import { Link } from "@/ui/Link";
+
+import {
+  ConnectedRepository,
+  ConnectRepositoryButton,
+  isGithubRepositoryConnected,
+} from "./ConnectedRepository";
 
 const _ProjectFragment = graphql(`
   fragment ProjectTokenlessAuth_Project on Project {
     id
     tokenlessAuthEnabled
+    ...ConnectedRepository_Project
   }
 `);
 
@@ -37,6 +51,7 @@ export function ProjectTokenlessAuth(props: {
 }) {
   const { project } = props;
   const client = useApolloClient();
+  const eligible = isGithubRepositoryConnected(project);
   const form = useForm<Inputs>({
     defaultValues: {
       tokenlessAuthEnabled: project.tokenlessAuthEnabled,
@@ -54,23 +69,57 @@ export function ProjectTokenlessAuth(props: {
     form.reset(data);
   };
 
+  const title = <CardTitle>Tokenless authentication</CardTitle>;
+  const description = (
+    <CardParagraph>
+      Allow GitHub Actions workflows to authenticate without an{" "}
+      <code>ARGOS_TOKEN</code> environment variable. Disable this if you want to
+      require every CI run to set a project token explicitly.
+    </CardParagraph>
+  );
+  const learnMore = (
+    <>
+      Learn more about{" "}
+      <Link
+        href="https://argos-ci.com/docs/learn/integrations/github-tokenless-authentication"
+        target="_blank"
+      >
+        tokenless authentication
+      </Link>
+      .
+    </>
+  );
+
+  if (!eligible) {
+    return (
+      <Card>
+        <CardBody>
+          {title}
+          {description}
+          <ConnectedRepository project={project} />
+        </CardBody>
+        <CardFooter className="flex items-center justify-between gap-4">
+          <div>{learnMore}</div>
+          <ConnectRepositoryButton project={project} />
+        </CardFooter>
+      </Card>
+    );
+  }
+
   return (
     <Card>
       <Form form={form} onSubmit={onSubmit}>
         <CardBody>
-          <CardTitle>Tokenless authentication</CardTitle>
-          <CardParagraph>
-            Allow GitHub Actions workflows to authenticate without an{" "}
-            <code>ARGOS_TOKEN</code> environment variable. Disable this if you
-            want to require every CI run to set a project token explicitly.
-          </CardParagraph>
+          {title}
+          {description}
+          <ConnectedRepository project={project} className="mb-4" />
           <FormSwitch
             control={form.control}
             name="tokenlessAuthEnabled"
-            label="Enable tokenless authentication for this project"
+            label="Enable tokenless authentication"
           />
         </CardBody>
-        <FormCardFooter control={form.control} />
+        <FormCardFooter control={form.control}>{learnMore}</FormCardFooter>
       </Form>
     </Card>
   );


### PR DESCRIPTION
## Summary

Tokenless authentication and GitHub Actions OIDC only work for projects connected to a **GitHub** repository. This makes that requirement explicit in the project authentication settings.

- New shared `ConnectedRepository` container that:
  - displays the connected GitHub repository the feature applies to (icon + link), with an "Applies to GitHub Actions runs from this repository" label;
  - explains why the project is **not** eligible when no repository is connected, or when the connected repository is a GitLab project.
- `isGithubRepositoryConnected()` helper gates eligibility strictly on `GithubRepository` (a GitLab project is not eligible).
- When not eligible, the enable switch is hidden and a secondary button ("Connect a Git repository" / "Manage Git repository") is shown in the footer, linking to the project's Git settings.
- Added a docs link for tokenless authentication in its card footer (matching the OIDC card).

Applies to both `ProjectTokenlessAuth` and `ProjectGitHubActionsOIDC`.

## Screenshots

### With a GitHub repository linked to the project

<img width="1834" height="1548" alt="with-a-github-repo" src="https://github.com/user-attachments/assets/f592170a-7005-42c7-8ab0-af7403792d6e" />

### Without a GitHub repository linked to the project

<img width="1854" height="1148" alt="without-a-github-repo" src="https://github.com/user-attachments/assets/4498ac97-731d-4f81-802b-4511efffcb0d" />


## Test plan

- [x] `tsc --noEmit`
- [x] ESLint (`--max-warnings 0`)
- [x] Prettier
- [ ] Manual: project with no repo → switch hidden, "Connect a Git repository" button
- [ ] Manual: project with GitLab repo → switch hidden, explanatory message, "Manage Git repository" button
- [ ] Manual: project with GitHub repo → repo shown, switch + Save work

🤖 Generated with [Claude Code](https://claude.com/claude-code)