### PR TITLE
feat(comment): allow the author to edit a comment

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -1,5 +1,53 @@
 # Argos project
 
+## Database
+
+The schema lives in `db/` and is managed with **Knex** + **Objection** models.
+
+### Changing the schema (migration + model)
+
+To add/change a column or table:
+
+1. **Create a new migration** using `pnpm run --filter backend db:migrate:make short-description`, it will add a file in `db/migrations/`. Overwrite the content of this file to use `async / wait` for `up` and `down` functions and write the migration:
+
+   ```js
+   export async function up(knex) {
+     await knex.schema.alterTable("comments", (table) => {
+       table.dateTime("editedAt").nullable();
+     });
+   }
+   export async function down(knex) {
+     await knex.schema.alterTable("comments", (table) => {
+       table.dropColumn("editedAt");
+     });
+   }
+   ```
+
+   For raw constraint changes (e.g. CHECK constraints) use `knex.raw(...)` and
+   add `export const config = { transaction: false }` when needed.
+
+2. **Apply it and regenerate `db/structure.sql`** (the committed schema dump) in
+   one step:
+
+   ```bash
+   pnpm --filter @argos/backend run db:dump
+   ```
+
+   This runs `db:migrate:latest` then dumps `structure.sql`. Commit both the
+   migration and the updated `structure.sql`.
+
+3. **Update the Objection model** in `src/database/models/`:
+   - Add the column to `jsonSchema.properties` (nullable columns use
+     `{ type: ["string", "null"] }`; dates are stored as ISO strings).
+   - Add the typed class field (e.g. `editedAt!: string | null;`).
+   - `createdAt`/`updatedAt` are handled by the base `Model`.
+
+4. **Reset the test DB** before running e2e tests after a new migration:
+
+   ```bash
+   NODE_ENV=test pnpm run --filter @argos/backend db:reset
+   ```
+
 ## GraphQL
 
 - Keep the schema as the **source of truth**.
@@ -9,6 +57,34 @@
 
 - Add the relevant mapper in `/codegen.ts` when needed.
 - Prefer explicit mappers to avoid hidden inconsistencies.
+- After editing any `typeDefs` (in `src/graphql/definitions/`), regenerate types
+  from the repo root:
+
+  ```bash
+  pnpm run codegen
+  ```
+
+  This writes the backend resolver types
+  (`src/graphql/__generated__/resolver-types.ts`, `schema.gql`) and the frontend
+  types (`apps/frontend/src/gql/`). Import generated enums/types (e.g.
+  `ICommentPermission`) from `../__generated__/resolver-types` and cast service
+  return values to them rather than using `any`.
+
+### Exposing a model field
+
+To surface a model column in the API: add it to the relevant `type` in the
+`typeDefs`, add a resolver in the matching `definitions/*.ts` (map DB
+representation → GraphQL, e.g. ISO string → `DateTime` via `new Date(...)`,
+returning `null` when absent), run `pnpm run codegen`, then consume it in the
+frontend fragment.
+
+### Permissions
+
+Expose per-object permissions as an enum field
+(`permissions: [XxxPermission!]!`) computed from `ctx.auth?.user`. Put the logic
+in a small pure helper (see `src/comment/permissions.ts`) so the same function
+backs both the `permissions` resolver and the authorization guard inside the
+mutation. Always enforce the check in the mutation — never trust the client.
 
 ### Resolvers
 

--- a/apps/backend/db/migrations/20260530120000_comment-edited-at.js
+++ b/apps/backend/db/migrations/20260530120000_comment-edited-at.js
@@ -1,0 +1,17 @@
+/**
+ * @param { import("knex").Knex } knex
+ */
+export async function up(knex) {
+  await knex.schema.alterTable("comments", (table) => {
+    table.dateTime("editedAt").nullable();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+export async function down(knex) {
+  await knex.schema.alterTable("comments", (table) => {
+    table.dropColumn("editedAt");
+  });
+}

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -573,7 +573,8 @@ CREATE TABLE public.comments (
     "buildId" bigint NOT NULL,
     "buildReviewId" bigint,
     "threadId" bigint,
-    content jsonb NOT NULL
+    content jsonb NOT NULL,
+    "editedAt" timestamp with time zone
 );
 
 
@@ -4808,3 +4809,4 @@ INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('2026052
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260526104543_build-review-dismissed-together.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260526120000_build-shards-nonce.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260528120000_user-notification-preferences.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260530120000_comment-edited-at.js', 1, NOW());

--- a/apps/backend/src/comment/permissions.test.ts
+++ b/apps/backend/src/comment/permissions.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import type { Comment, User } from "@/database/models";
+
+import { getCommentPermissions } from "./permissions";
+
+const comment = { userId: "1" } as Comment;
+
+describe("getCommentPermissions", () => {
+  it("grants edit to the author", () => {
+    const user = { id: "1" } as User;
+    expect(getCommentPermissions(comment, user)).toEqual(["edit"]);
+  });
+
+  it("grants nothing to another user", () => {
+    const user = { id: "2" } as User;
+    expect(getCommentPermissions(comment, user)).toEqual([]);
+  });
+
+  it("grants nothing to an anonymous user", () => {
+    expect(getCommentPermissions(comment, null)).toEqual([]);
+  });
+});

--- a/apps/backend/src/comment/permissions.ts
+++ b/apps/backend/src/comment/permissions.ts
@@ -1,0 +1,18 @@
+import type { Comment, User } from "@/database/models";
+
+export type CommentPermission = "edit";
+
+/**
+ * Compute the permissions a user has on a given comment.
+ * Only the author of a comment can edit it.
+ */
+export function getCommentPermissions(
+  comment: Comment,
+  user: User | null,
+): CommentPermission[] {
+  const permissions: CommentPermission[] = [];
+  if (user && comment.userId === user.id) {
+    permissions.push("edit");
+  }
+  return permissions;
+}

--- a/apps/backend/src/comment/updateBuildComment.e2e.test.ts
+++ b/apps/backend/src/comment/updateBuildComment.e2e.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import type { Comment } from "@/database/models";
+import { factory, setupDatabase } from "@/database/testing";
+
+import { updateBuildComment } from "./updateBuildComment";
+
+const body = {
+  type: "doc",
+  content: [
+    { type: "paragraph", content: [{ type: "text", text: "Updated" }] },
+  ],
+};
+
+const it = test.extend<{ comment: Comment }>({
+  comment: async ({}, use) => {
+    const comment = await factory.Comment.create({
+      content: {
+        type: "doc",
+        content: [
+          { type: "paragraph", content: [{ type: "text", text: "Original" }] },
+        ],
+      },
+    });
+    await use(comment);
+  },
+});
+
+describe("updateBuildComment", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  it("updates the content and stamps editedAt", async ({ comment }) => {
+    expect(comment.editedAt).toBeNull();
+
+    const updated = await updateBuildComment({ comment, body });
+
+    expect(updated.content).toEqual(body);
+    expect(updated.editedAt).not.toBeNull();
+  });
+
+  it("rejects an empty comment", async ({ comment }) => {
+    await expect(
+      updateBuildComment({
+        comment,
+        body: { type: "doc", content: [{ type: "paragraph" }] },
+      }),
+    ).rejects.toThrow("Comment cannot be empty");
+  });
+
+  it("rejects an invalid comment body", async ({ comment }) => {
+    await expect(
+      updateBuildComment({
+        comment,
+        body: { type: "not-a-doc" },
+      }),
+    ).rejects.toThrow("Invalid comment body");
+  });
+});

--- a/apps/backend/src/comment/updateBuildComment.ts
+++ b/apps/backend/src/comment/updateBuildComment.ts
@@ -1,0 +1,30 @@
+import type { JSONContent } from "@tiptap/core";
+
+import type { Comment } from "@/database/models";
+import { boom } from "@/util/error";
+
+import { isCommentEmpty, validateCommentJson } from "./validate";
+
+/**
+ * Update the content of an existing build comment and stamp its `editedAt`
+ * date so consumers can tell it has been edited.
+ */
+export async function updateBuildComment(input: {
+  comment: Comment;
+  body: JSONContent;
+}): Promise<Comment> {
+  const { comment, body } = input;
+
+  if (!validateCommentJson(body)) {
+    throw boom(400, "Invalid comment body");
+  }
+
+  if (isCommentEmpty(body)) {
+    throw boom(400, "Comment cannot be empty");
+  }
+
+  return comment.$query().patchAndFetch({
+    content: body,
+    editedAt: new Date().toISOString(),
+  });
+}

--- a/apps/backend/src/database/models/Comment.ts
+++ b/apps/backend/src/database/models/Comment.ts
@@ -25,6 +25,7 @@ export class Comment extends Model {
           buildId: { type: "string" },
           buildReviewId: { type: ["string", "null"] },
           threadId: { type: ["string", "null"] },
+          editedAt: { type: ["string", "null"] },
           content: {
             anyOf: [
               { type: "array" },
@@ -44,6 +45,7 @@ export class Comment extends Model {
   buildId!: string;
   buildReviewId!: string | null;
   threadId!: string | null;
+  editedAt!: string | null;
   content!: unknown;
 
   static override get relationMappings(): RelationMappings {

--- a/apps/backend/src/graphql/definitions/Comment.ts
+++ b/apps/backend/src/graphql/definitions/Comment.ts
@@ -3,15 +3,25 @@ import type { JSONContent } from "@tiptap/core";
 import gqlTag from "graphql-tag";
 
 import { createBuildComment } from "@/comment/createBuildComment";
-import { formatCommentId } from "@/comment/id";
+import { formatCommentId, parseCommentId } from "@/comment/id";
+import { getCommentPermissions } from "@/comment/permissions";
+import { updateBuildComment } from "@/comment/updateBuildComment";
 import { Build } from "@/database/models/Build";
+import { Comment } from "@/database/models/Comment";
 
-import type { IResolvers } from "../__generated__/resolver-types";
+import type {
+  ICommentPermission,
+  IResolvers,
+} from "../__generated__/resolver-types";
 import { forbidden, notFound, unauthenticated } from "../util";
 
 const { gql } = gqlTag;
 
 export const typeDefs = gql`
+  enum CommentPermission {
+    edit
+  }
+
   """
   A comment posted on a build.
   """
@@ -19,10 +29,14 @@ export const typeDefs = gql`
     id: ID!
     "Date the comment was posted"
     date: DateTime!
+    "Date the comment was last edited, null if never edited"
+    editedAt: DateTime
     "Rich-text JSON content of the comment"
     content: JSONObject!
     "Author of the comment"
     user: User
+    "Permissions of the current user on this comment"
+    permissions: [CommentPermission!]!
   }
 
   input AddBuildCommentInput {
@@ -31,9 +45,17 @@ export const typeDefs = gql`
     body: JSONObject!
   }
 
+  input UpdateCommentInput {
+    id: ID!
+    "Rich-text JSON content of the comment"
+    body: JSONObject!
+  }
+
   extend type Mutation {
     "Post a comment on a build"
     addBuildComment(input: AddBuildCommentInput!): Build!
+    "Update an existing comment"
+    updateComment(input: UpdateCommentInput!): Comment!
   }
 `;
 
@@ -42,6 +64,9 @@ export const resolvers: IResolvers = {
     id: (comment) => formatCommentId(comment.id),
     date: (comment) => {
       return new Date(comment.createdAt);
+    },
+    editedAt: (comment) => {
+      return comment.editedAt ? new Date(comment.editedAt) : null;
     },
     content: (comment) => {
       return comment.content as Record<string, unknown>;
@@ -55,6 +80,12 @@ export const resolvers: IResolvers = {
       });
       invariant(account, "Account not found");
       return account;
+    },
+    permissions: (comment, _args, ctx) => {
+      return getCommentPermissions(
+        comment,
+        ctx.auth?.user ?? null,
+      ) as ICommentPermission[];
     },
   },
   Mutation: {
@@ -89,6 +120,31 @@ export const resolvers: IResolvers = {
       });
 
       return build;
+    },
+    updateComment: async (_root, args, ctx) => {
+      const { auth } = ctx;
+      if (!auth) {
+        throw unauthenticated();
+      }
+
+      const { input } = args;
+
+      const comment = await Comment.query().findById(parseCommentId(input.id));
+
+      if (!comment) {
+        throw notFound("Comment not found");
+      }
+
+      const permissions = getCommentPermissions(comment, auth.user);
+
+      if (!permissions.includes("edit")) {
+        throw forbidden("You cannot edit this comment");
+      }
+
+      return updateBuildComment({
+        comment,
+        body: input.body as JSONContent,
+      });
     },
   },
 };

--- a/apps/backend/src/graphql/definitions/Comment.ts
+++ b/apps/backend/src/graphql/definitions/Comment.ts
@@ -17,6 +17,25 @@ import { forbidden, notFound, unauthenticated } from "../util";
 
 const { gql } = gqlTag;
 
+/**
+ * Resolve a comment from its public GraphQL ID. Malformed IDs and missing
+ * comments both surface as a clean "not found" error rather than an untyped
+ * 500.
+ */
+async function getCommentByGraphqlId(id: string): Promise<Comment> {
+  let commentId: string;
+  try {
+    commentId = parseCommentId(id);
+  } catch {
+    throw notFound("Comment not found");
+  }
+  const comment = await Comment.query().findById(commentId);
+  if (!comment) {
+    throw notFound("Comment not found");
+  }
+  return comment;
+}
+
 export const typeDefs = gql`
   enum CommentPermission {
     edit
@@ -129,11 +148,7 @@ export const resolvers: IResolvers = {
 
       const { input } = args;
 
-      const comment = await Comment.query().findById(parseCommentId(input.id));
-
-      if (!comment) {
-        throw notFound("Comment not found");
-      }
+      const comment = await getCommentByGraphqlId(input.id);
 
       const permissions = getCommentPermissions(comment, auth.user);
 

--- a/apps/backend/src/graphql/tests/updateComment.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/updateComment.e2e.test.ts
@@ -133,3 +133,25 @@ test("requires authentication", async ({ fixture }) => {
   const stored = await Comment.query().findById(fixture.comment.id);
   expect(stored!.editedAt).toBeNull();
 });
+
+test("returns a clean error for a malformed comment ID", async ({
+  fixture,
+}) => {
+  const app = await createApolloServerApp(
+    apolloServer,
+    createApolloMiddleware,
+    {
+      user: fixture.authorAccount.user!,
+      account: fixture.authorAccount,
+    },
+  );
+  const res = await request(app)
+    .post("/graphql")
+    .send({
+      query: MUTATION,
+      variables: { input: { id: "not-a-comment-id", body: commentBody("x") } },
+    });
+
+  expect(res.status).toBe(200);
+  expect(res.body.errors[0].message).toBe("Comment not found");
+});

--- a/apps/backend/src/graphql/tests/updateComment.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/updateComment.e2e.test.ts
@@ -1,0 +1,135 @@
+import request from "supertest";
+import { test as base, expect } from "vitest";
+
+import { formatCommentId } from "@/comment/id";
+import { Comment, type Account, type Build } from "@/database/models";
+import { factory, setupDatabase } from "@/database/testing";
+
+import { apolloServer, createApolloMiddleware } from "../apollo";
+import { expectNoGraphQLError } from "../testing";
+import { createApolloServerApp } from "./util";
+
+const MUTATION = `
+  mutation UpdateComment($input: UpdateCommentInput!) {
+    updateComment(input: $input) {
+      id
+      content
+      editedAt
+      permissions
+    }
+  }
+`;
+
+function commentBody(text: string) {
+  return {
+    type: "doc",
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  };
+}
+
+type Fixtures = {
+  fixture: {
+    authorAccount: Account;
+    build: Build;
+    comment: Comment;
+  };
+};
+
+const test = base.extend<Fixtures>({
+  fixture: async ({}, use) => {
+    await setupDatabase();
+    const authorAccount = await factory.UserAccount.create();
+    await authorAccount.$fetchGraph("user");
+    const build = await factory.Build.create();
+    const comment = await factory.Comment.create({
+      buildId: build.id,
+      userId: authorAccount.userId!,
+      content: commentBody("Original"),
+    });
+    await use({ authorAccount, build, comment });
+  },
+});
+
+test("lets the author edit the comment", async ({ fixture }) => {
+  const app = await createApolloServerApp(
+    apolloServer,
+    createApolloMiddleware,
+    {
+      user: fixture.authorAccount.user!,
+      account: fixture.authorAccount,
+    },
+  );
+  const body = commentBody("Edited content");
+  const res = await request(app)
+    .post("/graphql")
+    .send({
+      query: MUTATION,
+      variables: { input: { id: formatCommentId(fixture.comment.id), body } },
+    });
+
+  expectNoGraphQLError(res);
+  expect(res.status).toBe(200);
+
+  const updated = res.body.data.updateComment;
+  expect(updated.content).toEqual(body);
+  expect(updated.editedAt).not.toBeNull();
+  expect(updated.permissions).toEqual(["edit"]);
+
+  const stored = await Comment.query().findById(fixture.comment.id);
+  expect(stored!.content).toEqual(body);
+  expect(stored!.editedAt).not.toBeNull();
+});
+
+test("forbids a non-author from editing the comment", async ({ fixture }) => {
+  const outsiderAccount = await factory.UserAccount.create();
+  await outsiderAccount.$fetchGraph("user");
+  const app = await createApolloServerApp(
+    apolloServer,
+    createApolloMiddleware,
+    {
+      user: outsiderAccount.user!,
+      account: outsiderAccount,
+    },
+  );
+  const res = await request(app)
+    .post("/graphql")
+    .send({
+      query: MUTATION,
+      variables: {
+        input: {
+          id: formatCommentId(fixture.comment.id),
+          body: commentBody("Hacked"),
+        },
+      },
+    });
+
+  expect(res.status).toBe(200);
+  expect(res.body.errors[0].message).toBe("You cannot edit this comment");
+
+  const stored = await Comment.query().findById(fixture.comment.id);
+  expect(stored!.content).toEqual(commentBody("Original"));
+  expect(stored!.editedAt).toBeNull();
+});
+
+test("requires authentication", async ({ fixture }) => {
+  const app = await createApolloServerApp(
+    apolloServer,
+    createApolloMiddleware,
+    null,
+  );
+  const res = await request(app)
+    .post("/graphql")
+    .send({
+      query: MUTATION,
+      variables: {
+        input: {
+          id: formatCommentId(fixture.comment.id),
+          body: commentBody("Anon"),
+        },
+      },
+    });
+
+  expect(res.body.errors).toBeDefined();
+  const stored = await Comment.query().findById(fixture.comment.id);
+  expect(stored!.editedAt).toBeNull();
+});

--- a/apps/frontend/src/pages/Build/sidebar/CommentActionsMenu.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentActionsMenu.tsx
@@ -1,0 +1,43 @@
+import { LinkIcon, MoreHorizontalIcon, PencilIcon } from "lucide-react";
+
+import { IconButton } from "@/ui/IconButton";
+import { Menu, MenuItem, MenuItemIcon, MenuTrigger } from "@/ui/Menu";
+import { Popover } from "@/ui/Popover";
+
+export function CommentActionsMenu(props: {
+  onCopyLink: () => void;
+  /** When provided, an "Edit comment" action is shown. */
+  onEdit?: () => void;
+}) {
+  const { onCopyLink, onEdit } = props;
+  return (
+    <MenuTrigger>
+      <IconButton
+        rounded
+        size="small"
+        aria-label="Comment actions"
+        className="ml-auto"
+      >
+        <MoreHorizontalIcon />
+      </IconButton>
+      <Popover placement="bottom end">
+        <Menu aria-label="Comment actions">
+          {onEdit ? (
+            <MenuItem onAction={onEdit}>
+              <MenuItemIcon>
+                <PencilIcon />
+              </MenuItemIcon>
+              Edit comment
+            </MenuItem>
+          ) : null}
+          <MenuItem onAction={onCopyLink}>
+            <MenuItemIcon>
+              <LinkIcon />
+            </MenuItemIcon>
+            Copy link to comment
+          </MenuItem>
+        </Menu>
+      </Popover>
+    </MenuTrigger>
+  );
+}

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -1,26 +1,36 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useMutation } from "@apollo/client/react";
 import { clsx } from "clsx";
-import { LinkIcon, MoreHorizontalIcon } from "lucide-react";
+import moment from "moment";
 import { Button } from "react-aria-components";
 import { toast } from "sonner";
 import { useClipboard } from "use-clipboard-copy";
 
 import { AccountAvatar } from "@/containers/AccountAvatar";
 import { DocumentType, graphql } from "@/gql";
+import { CommentPermission } from "@/gql/graphql";
+import { type EditorValue } from "@/ui/Editor/Editor";
 import { ReadOnlyEditor } from "@/ui/Editor/ReadOnlyEditor";
-import { IconButton } from "@/ui/IconButton";
-import { Menu, MenuItem, MenuItemIcon, MenuTrigger } from "@/ui/Menu";
-import { Popover } from "@/ui/Popover";
+import { StandaloneEditor } from "@/ui/Editor/StandaloneEditor";
 import { Time } from "@/ui/Time";
+import { Tooltip } from "@/ui/Tooltip";
+import { getErrorMessage } from "@/util/error";
+
+import { CommentActionsMenu } from "./CommentActionsMenu";
 
 // Shared id so copying a comment link reuses a single toast instead of stacking.
 const COPY_TOAST_ID = "comment-link-copied";
+
+// Detailed date format used in the date tooltip, e.g. "Thu May 21, 2026, 15:47:43".
+const DETAILED_DATE_FORMAT = "ddd MMM D, YYYY, HH:mm:ss";
 
 const _CommentFragment = graphql(`
   fragment CommentCard_Comment on Comment {
     id
     date
+    editedAt
     content
+    permissions
     user {
       id
       name
@@ -32,6 +42,15 @@ const _CommentFragment = graphql(`
   }
 `);
 
+const UpdateCommentMutation = graphql(`
+  mutation CommentCard_updateComment($input: UpdateCommentInput!) {
+    updateComment(input: $input) {
+      id
+      ...CommentCard_Comment
+    }
+  }
+`);
+
 export function CommentCard(props: {
   comment: DocumentType<typeof _CommentFragment>;
   highlighted?: boolean;
@@ -39,6 +58,8 @@ export function CommentCard(props: {
   const { comment, highlighted = false } = props;
   const ref = useRef<HTMLDivElement>(null);
   const clipboard = useClipboard();
+  const [isEditing, setIsEditing] = useState(false);
+  const [updateComment] = useMutation(UpdateCommentMutation);
 
   useEffect(() => {
     if (highlighted && ref.current) {
@@ -56,6 +77,22 @@ export function CommentCard(props: {
     });
   };
 
+  const handleEditSubmit = async (body: EditorValue) => {
+    try {
+      await updateComment({
+        variables: { input: { id: comment.id, body } },
+      });
+      setIsEditing(false);
+    } catch (error) {
+      toast.error(getErrorMessage(error));
+      // Rethrow so the editor keeps the content and the user can retry.
+      throw error;
+    }
+  };
+
+  const canEdit = comment.permissions.includes(CommentPermission.Edit);
+  const isEdited = Boolean(comment.editedAt);
+
   return (
     <div
       ref={ref}
@@ -65,7 +102,7 @@ export function CommentCard(props: {
         highlighted ? "ring-2" : "ring-0",
       )}
     >
-      <div className="flex items-center gap-2 px-3 py-2">
+      <div className="flex items-center gap-2 py-2 pr-2 pl-3">
         {comment.user ? (
           <AccountAvatar
             avatar={comment.user.avatar}
@@ -75,43 +112,55 @@ export function CommentCard(props: {
         <span className="text-default text-xs font-medium">
           {comment.user?.name || comment.user?.slug || "Unknown user"}
         </span>
-        <Button
-          onPress={copyLink}
-          aria-label="Copy link to comment"
-          className="text-low hover:text-default text-xs transition"
+        <Tooltip
+          content={
+            <div className="flex flex-col">
+              <span>
+                Created: {moment(comment.date).format(DETAILED_DATE_FORMAT)}
+              </span>
+              {comment.editedAt ? (
+                <span>
+                  Edited:{" "}
+                  {moment(comment.editedAt).format(DETAILED_DATE_FORMAT)}
+                </span>
+              ) : null}
+            </div>
+          }
         >
-          <Time date={comment.date} />
-        </Button>
-        <CommentActionsMenu onCopyLink={copyLink} />
+          <Button
+            onPress={copyLink}
+            aria-label="Copy link to comment"
+            className="text-low hover:text-default text-xs transition"
+          >
+            <Time date={comment.date} tooltip="none" />
+            {isEdited ? " (edited)" : null}
+          </Button>
+        </Tooltip>
+        <CommentActionsMenu
+          onCopyLink={copyLink}
+          onEdit={canEdit ? () => setIsEditing(true) : undefined}
+        />
       </div>
-      <div className="text-default px-3 pb-2 text-sm">
-        <ReadOnlyEditor content={comment.content} />
+      <div className="text-default px-2 pb-2 text-sm">
+        {isEditing ? (
+          <StandaloneEditor
+            variant="plain"
+            defaultValue={comment.content}
+            onSubmit={handleEditSubmit}
+            onCancel={() => setIsEditing(false)}
+            submitLabel="Save"
+            emptyMessage={{
+              title: "Comment required",
+              description: "Please add a comment before saving.",
+            }}
+            autoFocus
+            aria-label="Edit comment"
+            contentClassName="px-1"
+          />
+        ) : (
+          <ReadOnlyEditor content={comment.content} className="px-1" />
+        )}
       </div>
     </div>
-  );
-}
-
-function CommentActionsMenu(props: { onCopyLink: () => void }) {
-  return (
-    <MenuTrigger>
-      <IconButton
-        rounded
-        size="small"
-        aria-label="Comment actions"
-        className="ml-auto"
-      >
-        <MoreHorizontalIcon />
-      </IconButton>
-      <Popover placement="bottom end">
-        <Menu aria-label="Comment actions">
-          <MenuItem onAction={props.onCopyLink}>
-            <MenuItemIcon>
-              <LinkIcon />
-            </MenuItemIcon>
-            Copy link to comment
-          </MenuItem>
-        </Menu>
-      </Popover>
-    </MenuTrigger>
   );
 }

--- a/apps/frontend/src/ui/Button.stories.tsx
+++ b/apps/frontend/src/ui/Button.stories.tsx
@@ -19,6 +19,7 @@ export const Default: Story = {
       <div className="flex flex-wrap items-center gap-4">
         <Button variant="primary">Primary</Button>
         <Button variant="secondary">Secondary</Button>
+        <Button variant="ghost">Ghost</Button>
         <Button variant="destructive">Destructive</Button>
         <Button variant="github">GitHub</Button>
         <Button variant="gitlab">GitLab</Button>
@@ -30,6 +31,25 @@ export const Default: Story = {
         <Button size="small">Small</Button>
         <Button size="medium">Medium</Button>
         <Button size="large">Large</Button>
+      </div>
+
+      <StoryTitle>Rounded</StoryTitle>
+      <div className="flex flex-wrap items-center gap-4">
+        <Button rounded size="small">
+          Small
+        </Button>
+        <Button rounded size="medium">
+          Medium
+        </Button>
+        <Button rounded size="large">
+          Large
+        </Button>
+        <Button rounded variant="primary">
+          <ButtonIcon>
+            <DownloadIcon />
+          </ButtonIcon>
+          Download
+        </Button>
       </div>
 
       <StoryTitle>With Icon</StoryTitle>

--- a/apps/frontend/src/ui/Button.tsx
+++ b/apps/frontend/src/ui/Button.tsx
@@ -15,6 +15,7 @@ import { Loader } from "./Loader";
 type ButtonVariant =
   | "primary"
   | "secondary"
+  | "ghost"
   | "destructive"
   | "github"
   | "gitlab"
@@ -30,6 +31,8 @@ type ButtonOptions = {
    * (do not wrap it in `ButtonIcon`).
    */
   iconOnly?: boolean;
+  /** Fully round the edges (pill shape) instead of the default rounded corners. */
+  rounded?: boolean;
 };
 
 const variantClassNames: Record<ButtonVariant, string> = {
@@ -37,6 +40,8 @@ const variantClassNames: Record<ButtonVariant, string> = {
     "data-focus-visible:ring-primary text-white border-transparent bg-primary-solid data-hovered:bg-primary-solid-hover data-pressed:bg-primary-solid-active aria-expanded:bg-primary-solid-active group-[*]/button-group:not-first:border-l-white/20",
   secondary:
     "data-focus-visible:ring-default text-default border bg-transparent data-hovered:bg-hover data-hovered:border-hover data-pressed:bg-active",
+  ghost:
+    "data-focus-visible:ring-default text-default border-transparent bg-transparent data-hovered:bg-hover data-pressed:bg-active aria-expanded:bg-active",
   destructive:
     "data-focus-visible:ring-danger text-white border-transparent bg-danger-solid data-hovered:bg-danger-solid-hover data-pressed:bg-danger-solid-active aria-expanded:bg-danger-solid-active group-[*]/button-group:not-first:border-l-white/20",
   github:
@@ -48,25 +53,33 @@ const variantClassNames: Record<ButtonVariant, string> = {
 };
 
 const sizeClassNames: Record<ButtonSize, string> = {
-  small: "rounded-sm py-1 px-2 text-xs",
-  medium: "rounded-lg py-[calc(0.375rem-1px)] px-3 text-sm",
-  large: "rounded-xl py-3 px-8 text-base",
+  small: "py-1 px-2 text-xs",
+  medium: "py-[calc(0.375rem-1px)] px-3 text-sm",
+  large: "py-3 px-8 text-base",
 };
 
 // Keep the same vertical padding as the regular sizes so an iconOnly button
 // matches the height of a text button (e.g. when placed in a ButtonGroup).
 const iconOnlySizeClassNames: Record<ButtonSize, string> = {
-  small: "rounded-sm py-1 px-1.5 text-xs",
-  medium: "rounded-lg py-[calc(0.375rem-1px)] px-2 text-sm",
-  large: "rounded-xl py-3 px-4 text-base",
+  small: "py-1 px-1.5 text-xs",
+  medium: "py-[calc(0.375rem-1px)] px-2 text-sm",
+  large: "py-3 px-4 text-base",
+};
+
+// Default corner rounding per size (overridden by `rounded` for a pill shape).
+const roundingClassNames: Record<ButtonSize, string> = {
+  small: "rounded-sm",
+  medium: "rounded-lg",
+  large: "rounded-xl",
 };
 
 function getButtonClassName(options: {
   variant: ButtonVariant;
   size: ButtonSize;
   iconOnly: boolean;
+  rounded: boolean;
 }) {
-  const { variant, size, iconOnly } = options;
+  const { variant, size, iconOnly, rounded } = options;
   const variantClassName = variantClassNames[variant];
   const sizeClassName = (iconOnly ? iconOnlySizeClassNames : sizeClassNames)[
     size
@@ -75,6 +88,7 @@ function getButtonClassName(options: {
     "group/button",
     variantClassName,
     sizeClassName,
+    rounded ? "rounded-full" : roundingClassNames[size],
     // ButtonGroup integration: drop the inner rounded corners and overlap
     // adjacent borders so each variant's `border-l-*` acts as the separator.
     "group-[*]/button-group:not-first:rounded-l-none",
@@ -89,9 +103,14 @@ function getButtonClassName(options: {
 }
 
 function getButtonProps(options: ButtonOptions) {
-  const { variant = "primary", size = "medium", iconOnly = false } = options;
+  const {
+    variant = "primary",
+    size = "medium",
+    iconOnly = false,
+    rounded = false,
+  } = options;
   return {
-    className: getButtonClassName({ variant, size, iconOnly }),
+    className: getButtonClassName({ variant, size, iconOnly, rounded }),
     "data-size": size ?? "medium",
     "data-icon-only": iconOnly ? "true" : undefined,
   };
@@ -123,12 +142,13 @@ export function Button({
   variant,
   size,
   iconOnly,
+  rounded,
   children,
   onAction,
   onPress,
   ...props
 }: ButtonProps) {
-  const buttonProps = getButtonProps({ variant, size, iconOnly });
+  const buttonProps = getButtonProps({ variant, size, iconOnly, rounded });
   const [isPending, setIsPending] = useState(false);
   return (
     <RACButton
@@ -182,9 +202,10 @@ export function LinkButton({
   variant,
   size,
   iconOnly,
+  rounded,
   ...props
 }: LinkButtonProps) {
-  const buttonProps = getButtonProps({ variant, size, iconOnly });
+  const buttonProps = getButtonProps({ variant, size, iconOnly, rounded });
   return (
     <RACLink
       ref={ref}

--- a/apps/frontend/src/ui/Editor/Editor.tsx
+++ b/apps/frontend/src/ui/Editor/Editor.tsx
@@ -62,9 +62,18 @@ const CollapseSelectionOnEscape = Extension.create({
 
 export type EditorValue = JSONContent | null;
 
+/**
+ * - `boxed`: the editor is wrapped in a bordered box with a formatting toolbar
+ *   (used for composing a new comment).
+ * - `plain`: no border, no toolbar and no built-in padding — only the rich-text
+ *   content. Renders identically whether read-only or editable, so toggling
+ *   between the two causes no layout shift.
+ */
+export type EditorVariant = "boxed" | "plain";
+
 export interface EditorProps {
   defaultValue?: EditorValue;
-  onChange: (value: EditorValue) => void;
+  onChange?: (value: EditorValue) => void;
   onBlur?: () => void;
   /** Called when the user presses Cmd/Ctrl+Enter. */
   onSubmit?: () => void;
@@ -78,14 +87,21 @@ export interface EditorProps {
   autoFocus?: boolean;
   "aria-label"?: string;
   disabled?: boolean;
+  /** Visual style of the editor. Defaults to `boxed`. */
+  variant?: EditorVariant;
+  /** Render the content without allowing edits. */
+  readOnly?: boolean;
 }
 
 const EDITOR_CONTENT_CLASS = clsx(
   EDITOR_PROSE_CLASS,
-  "px-3 py-2 outline-hidden",
+  "outline-hidden",
   // Placeholder
   "[&_p.is-editor-empty:first-child]:before:content-[attr(data-placeholder)] [&_p.is-editor-empty:first-child]:before:text-low [&_p.is-editor-empty:first-child]:before:pointer-events-none [&_p.is-editor-empty:first-child]:before:float-left [&_p.is-editor-empty:first-child]:before:h-0",
 );
+
+// Internal padding of the editable area, only applied in the `boxed` variant.
+const BOXED_CONTENT_PADDING_CLASS = "px-3 py-2";
 
 const DEFAULT_CONTENT_HEIGHT_CLASS = "min-h-20";
 
@@ -102,7 +118,12 @@ export function Editor(props: EditorProps) {
     placeholder,
     autoFocus,
     disabled,
+    variant = "boxed",
+    readOnly = false,
   } = props;
+
+  const isBoxed = variant === "boxed";
+  const editable = !disabled && !readOnly;
 
   const onChangeRef = useRef(onChange);
   const onBlurRef = useRef(onBlur);
@@ -127,14 +148,17 @@ export function Editor(props: EditorProps) {
       LinkEditTrigger,
       ...(placeholder ? [Placeholder.configure({ placeholder })] : []),
     ],
-    editable: !disabled,
+    editable,
     content: defaultValue,
     autofocus: autoFocus ? "end" : false,
     editorProps: {
       attributes: {
         class: clsx(
           EDITOR_CONTENT_CLASS,
-          contentClassName ?? DEFAULT_CONTENT_HEIGHT_CLASS,
+          isBoxed && BOXED_CONTENT_PADDING_CLASS,
+          isBoxed
+            ? (contentClassName ?? DEFAULT_CONTENT_HEIGHT_CLASS)
+            : contentClassName,
         ),
         ...(props["aria-label"] ? { "aria-label": props["aria-label"] } : {}),
       },
@@ -152,7 +176,7 @@ export function Editor(props: EditorProps) {
       },
     },
     onUpdate: ({ editor }) => {
-      onChangeRef.current(editor.getJSON());
+      onChangeRef.current?.(editor.getJSON());
     },
     onBlur: () => {
       onBlurRef.current?.();
@@ -160,8 +184,8 @@ export function Editor(props: EditorProps) {
   });
 
   useEffect(() => {
-    editor?.setEditable(!disabled);
-  }, [editor, disabled]);
+    editor?.setEditable(editable);
+  }, [editor, editable]);
 
   useEffect(() => {
     if (!editor || !ref) {
@@ -184,7 +208,7 @@ export function Editor(props: EditorProps) {
   const handleContainerMouseDown = (
     event: React.MouseEvent<HTMLDivElement>,
   ) => {
-    if (!editor || disabled) {
+    if (!editor || !editable) {
       return;
     }
     // Only handle primary-button clicks (avoid interfering with context menus).
@@ -216,15 +240,17 @@ export function Editor(props: EditorProps) {
     <div
       data-hotkeys-disabled
       data-disabled={disabled ? "" : undefined}
-      onMouseDown={handleContainerMouseDown}
+      onMouseDown={isBoxed ? handleContainerMouseDown : undefined}
       className={clsx(
-        "bg-app focus-within:border-active rounded-md border text-sm",
-        "data-disabled:opacity-disabled",
-        !disabled && "cursor-text",
+        isBoxed && [
+          "bg-app focus-within:border-active rounded-md border text-sm",
+          "data-disabled:opacity-disabled",
+          editable && "cursor-text",
+        ],
         className,
       )}
     >
-      <EditorToolbar editor={editor} />
+      {isBoxed ? <EditorToolbar editor={editor} /> : null}
       <EditorContent editor={editor} />
       {footer}
     </div>

--- a/apps/frontend/src/ui/Editor/Editor.tsx
+++ b/apps/frontend/src/ui/Editor/Editor.tsx
@@ -238,7 +238,9 @@ export function Editor(props: EditorProps) {
 
   return (
     <div
-      data-hotkeys-disabled
+      // Only swallow build hotkeys while the editor is interactive. Read-only
+      // content (e.g. rendered comments) must not disable page shortcuts.
+      data-hotkeys-disabled={readOnly ? undefined : ""}
       data-disabled={disabled ? "" : undefined}
       onMouseDown={isBoxed ? handleContainerMouseDown : undefined}
       className={clsx(

--- a/apps/frontend/src/ui/Editor/ReadOnlyEditor.tsx
+++ b/apps/frontend/src/ui/Editor/ReadOnlyEditor.tsx
@@ -1,129 +1,30 @@
-import { Fragment, memo } from "react";
-import { clsx } from "clsx";
+import { memo } from "react";
 
-import { EDITOR_PROSE_CLASS } from "./EditorContent.css";
-
-type MarkType =
-  | "bold"
-  | "italic"
-  | "strike"
-  | "underline"
-  | "code"
-  | "link"
-  | string;
-
-type Mark = {
-  type: MarkType;
-  attrs?: { href?: string; target?: string };
-};
-
-type Node = {
-  type: string;
-  attrs?: { level?: number };
-  content?: Node[];
-  text?: string;
-  marks?: Mark[];
-};
-
-type ReadOnlyEditorContent = Node | null | undefined;
+import { Editor, type EditorValue } from "./Editor";
 
 export interface ReadOnlyEditorProps {
-  content: ReadOnlyEditorContent;
+  content: EditorValue;
   className?: string;
 }
 
+/**
+ * Renders rich-text content using the same {@link Editor} as the editable one,
+ * in plain read-only mode. Sharing the component guarantees the rendering is
+ * pixel-identical to the editable state (no layout shift when toggling).
+ */
 export const ReadOnlyEditor = memo(function ReadOnlyEditor(
   props: ReadOnlyEditorProps,
 ) {
   const { content, className } = props;
-  if (!content || !content.content) {
+  if (!content) {
     return null;
   }
   return (
-    <div className={clsx(EDITOR_PROSE_CLASS, className)}>
-      {content.content.map((node, index) => renderNode(node, index))}
-    </div>
+    <Editor
+      variant="plain"
+      readOnly
+      defaultValue={content}
+      className={className}
+    />
   );
 });
-
-const HEADING_TAGS = ["h1", "h2", "h3", "h4", "h5", "h6"] as const;
-
-function renderNode(node: Node, key: number): React.ReactNode {
-  const children = node.content?.map((child, index) =>
-    renderNode(child, index),
-  );
-  switch (node.type) {
-    case "paragraph":
-      return <p key={key}>{children}</p>;
-    case "heading": {
-      const level = node.attrs?.level;
-      const Tag: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" =
-        typeof level === "number" && level >= 1 && level <= 6
-          ? HEADING_TAGS[level - 1]!
-          : "h1";
-      return <Tag key={key}>{children}</Tag>;
-    }
-    case "bulletList":
-      return <ul key={key}>{children}</ul>;
-    case "orderedList":
-      return <ol key={key}>{children}</ol>;
-    case "listItem":
-      return <li key={key}>{children}</li>;
-    case "blockquote":
-      return <blockquote key={key}>{children}</blockquote>;
-    case "codeBlock":
-      return (
-        <pre key={key}>
-          <code>{children}</code>
-        </pre>
-      );
-    case "horizontalRule":
-      return <hr key={key} />;
-    case "hardBreak":
-      return <br key={key} />;
-    case "text":
-      return renderText(node, key);
-    default:
-      return null;
-  }
-}
-
-function renderText(node: Node, key: number): React.ReactNode {
-  let element: React.ReactNode = node.text ?? "";
-  const marks = node.marks;
-  if (marks) {
-    for (const mark of marks) {
-      switch (mark.type) {
-        case "bold":
-          element = <strong>{element}</strong>;
-          break;
-        case "italic":
-          element = <em>{element}</em>;
-          break;
-        case "strike":
-          element = <s>{element}</s>;
-          break;
-        case "underline":
-          element = <u>{element}</u>;
-          break;
-        case "code":
-          element = <code>{element}</code>;
-          break;
-        case "link": {
-          const href = mark.attrs?.href;
-          if (href) {
-            element = (
-              <a href={href} target="_blank" rel="noreferrer noopener">
-                {element}
-              </a>
-            );
-          }
-          break;
-        }
-        default:
-          break;
-      }
-    }
-  }
-  return <Fragment key={key}>{element}</Fragment>;
-}

--- a/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
+++ b/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
@@ -1,10 +1,12 @@
 import { useId, useState } from "react";
+import clsx from "clsx";
 import { ArrowUpIcon } from "lucide-react";
 import { toast } from "sonner";
 
+import { Button } from "../Button";
 import { HotkeyTooltip } from "../HotkeyTooltip";
 import { IconButton } from "../IconButton";
-import { Editor, type EditorValue } from "./Editor";
+import { Editor, type EditorValue, type EditorVariant } from "./Editor";
 import { MOD } from "./EditorToolbar.shortcuts";
 import { hasEditorContent } from "./util";
 
@@ -22,6 +24,16 @@ export interface StandaloneEditorProps {
    * so the user can retry.
    */
   onSubmit: (value: EditorValue) => void | Promise<void>;
+  /**
+   * Initial content of the editor. Defaults to empty. Pass existing content to
+   * use the editor in "edit" mode.
+   */
+  defaultValue?: EditorValue;
+  /**
+   * When provided, a cancel button is shown next to the send button. Useful when
+   * editing existing content.
+   */
+  onCancel?: () => void;
   placeholder?: string;
   /** Accessible label and tooltip text for the send button. */
   submitLabel?: string;
@@ -31,6 +43,13 @@ export interface StandaloneEditorProps {
   autoFocus?: boolean;
   className?: string;
   "aria-label"?: string;
+  /**
+   * Visual style, forwarded to the {@link Editor}. `boxed` (default) shows the
+   * bordered box with a toolbar; `plain` renders only the content with the
+   * action buttons below (used to edit in place without any layout shift).
+   */
+  variant?: EditorVariant;
+  contentClassName?: string;
 }
 
 /**
@@ -43,6 +62,8 @@ export interface StandaloneEditorProps {
 export function StandaloneEditor(props: StandaloneEditorProps) {
   const {
     onSubmit,
+    defaultValue = null,
+    onCancel,
     placeholder,
     submitLabel = "Send",
     emptyMessage = DEFAULT_EMPTY_MESSAGE,
@@ -50,8 +71,10 @@ export function StandaloneEditor(props: StandaloneEditorProps) {
     autoFocus,
     className,
     "aria-label": ariaLabel,
+    variant = "boxed",
+    contentClassName,
   } = props;
-  const [value, setValue] = useState<EditorValue>(null);
+  const [value, setValue] = useState<EditorValue>(defaultValue);
   // Remounts the editor after a successful submit to clear its content.
   const [editorKey, setEditorKey] = useState(0);
   const [isPending, setIsPending] = useState(false);
@@ -89,7 +112,7 @@ export function StandaloneEditor(props: StandaloneEditorProps) {
   return (
     <Editor
       key={editorKey}
-      defaultValue={null}
+      defaultValue={defaultValue}
       onChange={setValue}
       onSubmit={submit}
       placeholder={placeholder}
@@ -97,31 +120,62 @@ export function StandaloneEditor(props: StandaloneEditorProps) {
       autoFocus={autoFocus}
       aria-label={ariaLabel}
       className={className}
-      contentClassName="min-h-9"
+      variant={variant}
+      contentClassName={clsx(
+        variant === "boxed" ? "min-h-9" : undefined,
+        contentClassName,
+      )}
       footer={
-        <div className="flex justify-end p-1.5">
-          <HotkeyTooltip
-            description={submitLabel}
-            keys={[MOD, "Enter"]}
-            placement="top"
-          >
-            <IconButton
-              variant="contained"
+        onCancel ? (
+          <div className="flex justify-end gap-1.5 p-1 pt-2">
+            <Button
+              variant="secondary"
               size="small"
-              rounded
-              aria-label={submitLabel}
-              // Truly disabled (not focusable/clickable) while submitting or when
-              // disabled by the parent. When the editor is merely empty it only
-              // *looks* disabled but stays clickable, so the press can surface the
-              // "empty" toast.
-              isDisabled={disabled || isPending}
-              aria-disabled={isEmpty}
-              onPress={submit}
+              onPress={onCancel}
+              isDisabled={isPending}
             >
-              <ArrowUpIcon />
-            </IconButton>
-          </HotkeyTooltip>
-        </div>
+              Cancel
+            </Button>
+            <HotkeyTooltip
+              description={submitLabel}
+              keys={[MOD, "Enter"]}
+              placement="top"
+            >
+              <Button
+                variant="secondary"
+                size="small"
+                onPress={submit}
+                isDisabled={disabled || isPending}
+              >
+                {submitLabel}
+              </Button>
+            </HotkeyTooltip>
+          </div>
+        ) : (
+          <div className="flex justify-end p-1.5">
+            <HotkeyTooltip
+              description={submitLabel}
+              keys={[MOD, "Enter"]}
+              placement="top"
+            >
+              <IconButton
+                variant="contained"
+                size="small"
+                rounded
+                aria-label={submitLabel}
+                // Truly disabled (not focusable/clickable) while submitting or when
+                // disabled by the parent. When the editor is merely empty it only
+                // *looks* disabled but stays clickable, so the press can surface the
+                // "empty" toast.
+                isDisabled={disabled || isPending}
+                aria-disabled={isEmpty}
+                onPress={submit}
+              >
+                <ArrowUpIcon />
+              </IconButton>
+            </HotkeyTooltip>
+          </div>
+        )
       }
     />
   );

--- a/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
+++ b/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
@@ -129,7 +129,8 @@ export function StandaloneEditor(props: StandaloneEditorProps) {
         onCancel ? (
           <div className="flex justify-end gap-1.5 p-1 pt-2">
             <Button
-              variant="secondary"
+              variant="ghost"
+              rounded
               size="small"
               onPress={onCancel}
               isDisabled={isPending}
@@ -143,6 +144,7 @@ export function StandaloneEditor(props: StandaloneEditorProps) {
             >
               <Button
                 variant="secondary"
+                rounded
                 size="small"
                 onPress={submit}
                 isDisabled={disabled || isPending}

--- a/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
+++ b/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
@@ -147,7 +147,12 @@ export function StandaloneEditor(props: StandaloneEditorProps) {
                 rounded
                 size="small"
                 onPress={submit}
+                // Truly disabled (not focusable/clickable) while submitting or
+                // when disabled by the parent. When the editor is merely empty
+                // it only *looks* disabled but stays clickable, so the press can
+                // surface the "empty" toast.
                 isDisabled={disabled || isPending}
+                aria-disabled={isEmpty}
               >
                 {submitLabel}
               </Button>


### PR DESCRIPTION
## Summary

Adds the ability for a comment author to edit their own comment, end to end.

### Backend
- New nullable `editedAt` column on `comments` (migration + Objection model) used to flag edited comments.
- Exposes `editedAt` and `permissions: [CommentPermission!]!` on the `Comment` GraphQL type.
- New `updateComment` mutation backed by an `updateBuildComment` service. A shared `getCommentPermissions` helper is the single source of truth and is enforced in the mutation — only the author gets `edit`.
- Tests for the service, the permissions helper, and the mutation (author edits / non-author forbidden / unauthenticated).
- Documented the schema-change → codegen → permissions workflow in `apps/backend/AGENTS.md`.

### Frontend
- Extracted `CommentActionsMenu` into its own file and added an **Edit** action gated on the comment `edit` permission.
- Edit in place using a **plain** (borderless, toolbar-less) editor so there is **no layout shift**. `ReadOnlyEditor` now reuses the `Editor` in read-only mode for pixel-identical rendering.
- Shows **(edited)** next to the date with a two-line Created/Edited tooltip.

### UI Button
- New `ghost` variant (no border, hover-only background) and `rounded` (pill) option, used for the edit Save/Cancel actions and showcased in the Button story.

## Test plan
- [x] `pnpm test:unit` (permissions helper)
- [x] `pnpm test:integration` (service + mutation e2e)
- [x] `check-types` + `eslint` on frontend & backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)