### PR TITLE
feat(comment): limit the size of a comment

### DIFF
--- a/apps/backend/src/api/handlers/createReview.ts
+++ b/apps/backend/src/api/handlers/createReview.ts
@@ -12,7 +12,7 @@ import {
   createBuildReview,
   ScreenshotDiffReviewState,
 } from "@/build/createBuildReview";
-import { validateCommentJson } from "@/comment/validate";
+import { isCommentTooLarge, validateCommentJson } from "@/comment/validate";
 import { Build } from "@/database/models/Build";
 import { boom } from "@/util/error";
 
@@ -55,6 +55,13 @@ const CreateReviewBodySchema = z.object({
       message:
         "Invalid comment body. Expected a valid rich-text JSON document.",
     })
+    .refine(
+      (value) =>
+        value === undefined ||
+        !validateCommentJson(value) ||
+        !isCommentTooLarge(value),
+      { message: "Comment is too large." },
+    )
     .meta({
       description:
         "Optional comment to attach to the review. Expected as the JSON representation of a rich-text document.",

--- a/apps/backend/src/build/createBuildReview.ts
+++ b/apps/backend/src/build/createBuildReview.ts
@@ -8,7 +8,7 @@ import type { JSONContent } from "@tiptap/core";
 import { triggerAndRunAutomation } from "@/automation";
 import { pushBuildNotification } from "@/build-notification/notifications";
 import { renderCommentHtml } from "@/comment/html";
-import { validateCommentJson } from "@/comment/validate";
+import { isCommentTooLarge, validateCommentJson } from "@/comment/validate";
 import type { BuildNotification } from "@/database/models";
 import {
   Build,
@@ -81,6 +81,10 @@ export async function createBuildReview(input: {
 
   if (body !== undefined && !validateCommentJson(body)) {
     throw boom(400, "Invalid comment body");
+  }
+
+  if (body !== undefined && isCommentTooLarge(body)) {
+    throw boom(400, "Comment is too large");
   }
 
   const state = getReviewStateFromEvent(event);

--- a/apps/backend/src/comment/createBuildComment.ts
+++ b/apps/backend/src/comment/createBuildComment.ts
@@ -11,7 +11,11 @@ import { boom } from "@/util/error";
 
 import { renderCommentHtml } from "./html";
 import { formatCommentId } from "./id";
-import { isCommentEmpty, validateCommentJson } from "./validate";
+import {
+  isCommentEmpty,
+  isCommentTooLarge,
+  validateCommentJson,
+} from "./validate";
 
 /**
  * Post a standalone comment on a build (one that is not attached to a review),
@@ -30,6 +34,10 @@ export async function createBuildComment(input: {
 
   if (isCommentEmpty(body)) {
     throw boom(400, "Comment cannot be empty");
+  }
+
+  if (isCommentTooLarge(body)) {
+    throw boom(400, "Comment is too large");
   }
 
   const comment = await Comment.query().insert({

--- a/apps/backend/src/comment/updateBuildComment.ts
+++ b/apps/backend/src/comment/updateBuildComment.ts
@@ -3,7 +3,11 @@ import type { JSONContent } from "@tiptap/core";
 import type { Comment } from "@/database/models";
 import { boom } from "@/util/error";
 
-import { isCommentEmpty, validateCommentJson } from "./validate";
+import {
+  isCommentEmpty,
+  isCommentTooLarge,
+  validateCommentJson,
+} from "./validate";
 
 /**
  * Update the content of an existing build comment and stamp its `editedAt`
@@ -21,6 +25,10 @@ export async function updateBuildComment(input: {
 
   if (isCommentEmpty(body)) {
     throw boom(400, "Comment cannot be empty");
+  }
+
+  if (isCommentTooLarge(body)) {
+    throw boom(400, "Comment is too large");
   }
 
   return comment.$query().patchAndFetch({

--- a/apps/backend/src/comment/validate.test.ts
+++ b/apps/backend/src/comment/validate.test.ts
@@ -1,6 +1,14 @@
+import type { JSONContent } from "@tiptap/core";
 import { describe, expect, it } from "vitest";
 
-import { validateCommentJson } from "./validate";
+import { isCommentTooLarge, validateCommentJson } from "./validate";
+
+function docWithText(text: string) {
+  return {
+    type: "doc",
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  };
+}
 
 describe("validateCommentJson", () => {
   describe("valid content", () => {
@@ -192,5 +200,60 @@ describe("validateCommentJson", () => {
         }),
       ).toBe(false);
     });
+  });
+});
+
+describe("isCommentTooLarge", () => {
+  it("accepts a small comment", () => {
+    expect(isCommentTooLarge(docWithText("Hello world!"))).toBe(false);
+  });
+
+  it("accepts a comment at the character limit", () => {
+    expect(isCommentTooLarge(docWithText("a".repeat(2_000)))).toBe(false);
+  });
+
+  it("rejects a comment over the character limit", () => {
+    expect(isCommentTooLarge(docWithText("a".repeat(2_001)))).toBe(true);
+  });
+
+  it("rejects a comment over the JSON byte limit", () => {
+    // Few nodes and few characters, but a giant attribute value (a long link
+    // href) blows the byte budget — only the byte check catches this.
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "x",
+              marks: [
+                {
+                  type: "link",
+                  attrs: { href: `https://example.com/${"a".repeat(25_000)}` },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(isCommentTooLarge(doc)).toBe(true);
+  });
+
+  it("rejects a comment with too many nodes", () => {
+    const content = Array.from({ length: 301 }, () => ({
+      type: "paragraph",
+    }));
+    expect(isCommentTooLarge({ type: "doc", content })).toBe(true);
+  });
+
+  it("rejects a deeply nested comment", () => {
+    let node: JSONContent = { type: "text", text: "deep" };
+    for (let i = 0; i < 13; i++) {
+      node = { type: "bulletList", content: [node] };
+    }
+    expect(isCommentTooLarge({ type: "doc", content: [node] })).toBe(true);
   });
 });

--- a/apps/backend/src/comment/validate.ts
+++ b/apps/backend/src/comment/validate.ts
@@ -44,3 +44,63 @@ export function isCommentEmpty(value: JSONContent): boolean {
     return true;
   }
 }
+
+/**
+ * Upper bounds on a comment's content. The client enforces a matching character
+ * limit for UX, but anyone can craft a request directly, so these guard the
+ * server independently:
+ * - characters protects against walls of text,
+ * - JSON bytes protects storage and bandwidth from abuse,
+ * - node count protects rendering from huge documents,
+ * - depth protects recursive rendering from pathological nesting.
+ */
+const MAX_COMMENT_CHARACTERS = 2_000;
+const MAX_COMMENT_JSON_BYTES = 20_000;
+const MAX_COMMENT_NODES = 300;
+const MAX_COMMENT_DEPTH = 12;
+
+type CommentContentStats = {
+  characters: number;
+  nodes: number;
+  maxDepth: number;
+};
+
+/**
+ * Check whether a (structurally valid) comment document exceeds any of the
+ * content limits. Returns `true` when the comment is too large and should be
+ * rejected. Schema/type validation is handled separately by
+ * {@link validateCommentJson}.
+ */
+export function isCommentTooLarge(value: JSONContent): boolean {
+  if (
+    Buffer.byteLength(JSON.stringify(value), "utf8") > MAX_COMMENT_JSON_BYTES
+  ) {
+    return true;
+  }
+
+  const stats: CommentContentStats = { characters: 0, nodes: 0, maxDepth: 0 };
+  visitCommentContent(value, 1, stats);
+
+  return (
+    stats.characters > MAX_COMMENT_CHARACTERS ||
+    stats.nodes > MAX_COMMENT_NODES ||
+    stats.maxDepth > MAX_COMMENT_DEPTH
+  );
+}
+
+function visitCommentContent(
+  content: JSONContent,
+  depth: number,
+  stats: CommentContentStats,
+): void {
+  stats.nodes += 1;
+  stats.maxDepth = Math.max(stats.maxDepth, depth);
+
+  if (typeof content.text === "string") {
+    stats.characters += content.text.length;
+  }
+
+  for (const child of content.content ?? []) {
+    visitCommentContent(child, depth + 1, stats);
+  }
+}

--- a/apps/frontend/src/ui/Editor/Editor.tsx
+++ b/apps/frontend/src/ui/Editor/Editor.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { Placeholder } from "@tiptap/extensions";
+import { CharacterCount, Placeholder } from "@tiptap/extensions";
 import { AllSelection, Plugin, TextSelection } from "@tiptap/pm/state";
 import {
   EditorContent,
@@ -93,6 +93,13 @@ export interface EditorProps {
   readOnly?: boolean;
 }
 
+/**
+ * Hard cap on the number of characters a comment can contain. This protects the
+ * UX (no pathologically large comments) and mirrors the server-side limit. It's
+ * enforced silently — there's no character-count UI.
+ */
+const MAX_COMMENT_CHARACTERS = 2_000;
+
 const EDITOR_CONTENT_CLASS = clsx(
   EDITOR_PROSE_CLASS,
   "outline-hidden",
@@ -143,6 +150,7 @@ export function Editor(props: EditorProps) {
           autolink: false,
         },
       }),
+      CharacterCount.configure({ limit: MAX_COMMENT_CHARACTERS }),
       CollapseAllSelectionDelete,
       CollapseSelectionOnEscape,
       LinkEditTrigger,


### PR DESCRIPTION
## What

Prevents users from posting very large comments by enforcing size limits on both the client and the server.

### Client character limit
- [Editor.tsx](apps/frontend/src/ui/Editor/Editor.tsx) loads TipTap's `CharacterCount` extension, capping input at **2,000 characters**. No UI — it just silently prevents typing past the cap.

### Server validation
- [validate.ts](apps/backend/src/comment/validate.ts) gains `isCommentTooLarge()`, which walks the document once and rejects it if it exceeds any of:

  | Limit | Value | Protects |
  |---|---|---|
  | characters | 2,000 | UX / walls of text |
  | JSON bytes | 20,000 | storage & bandwidth abuse |
  | nodes | 300 | rendering |
  | depth | 12 | recursive rendering / pathological nesting |

  The schema/node-mark whitelist was already enforced by `validateCommentJson`, so it isn't duplicated.

### Wired into all comment entry points
- `createBuildComment`, `updateBuildComment`, `createBuildReview` — `throw boom(400, "Comment is too large")`.
- `createReview` API handler — added a Zod `.refine` with a "Comment is too large." message.

## Notes
The client cap and server `MAX_COMMENT_CHARACTERS` are defined independently in the two packages (no shared constant) but kept in sync.

## Tests
Added 6 unit tests to [validate.test.ts](apps/backend/src/comment/validate.test.ts) covering each limit. All 21 unit tests pass; `tsc` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)