### PR TITLE
feat(comment): allow the author to delete a comment

### DIFF
--- a/apps/backend/db/migrations/20260530130000_comment-deleted-at.js
+++ b/apps/backend/db/migrations/20260530130000_comment-deleted-at.js
@@ -1,0 +1,30 @@
+/**
+ * @param { import("knex").Knex } knex
+ */
+export async function up(knex) {
+  await knex.schema.alterTable("comments", (table) => {
+    table.dateTime("deletedAt").nullable();
+  });
+  // Comments are listed per build, ordered by creation date, and deleted
+  // comments are filtered out. A partial index on the non-deleted rows keeps
+  // that query fast without indexing soft-deleted comments.
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS comments_buildid_createdat_active_index
+    ON comments ("buildId", "createdAt")
+    WHERE "deletedAt" IS NULL
+  `);
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+export async function down(knex) {
+  await knex.raw(
+    `DROP INDEX CONCURRENTLY IF EXISTS comments_buildid_createdat_active_index`,
+  );
+  await knex.schema.alterTable("comments", (table) => {
+    table.dropColumn("deletedAt");
+  });
+}
+
+export const config = { transaction: false };

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -574,7 +574,8 @@ CREATE TABLE public.comments (
     "buildReviewId" bigint,
     "threadId" bigint,
     content jsonb NOT NULL,
-    "editedAt" timestamp with time zone
+    "editedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
 );
 
 
@@ -3453,6 +3454,13 @@ CREATE INDEX builds_runid_index ON public.builds USING btree ("runId");
 
 
 --
+-- Name: comments_buildid_createdat_active_index; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX comments_buildid_createdat_active_index ON public.comments USING btree ("buildId", "createdAt") WHERE ("deletedAt" IS NULL);
+
+
+--
 -- Name: comments_buildid_createdat_index; Type: INDEX; Schema: public; Owner: postgres
 --
 
@@ -4810,3 +4818,4 @@ INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('2026052
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260526120000_build-shards-nonce.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260528120000_user-notification-preferences.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260530120000_comment-edited-at.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260530130000_comment-deleted-at.js', 1, NOW());

--- a/apps/backend/src/comment/deleteBuildComment.ts
+++ b/apps/backend/src/comment/deleteBuildComment.ts
@@ -1,0 +1,20 @@
+import type { Comment } from "@/database/models";
+
+/**
+ * Soft-delete a build comment by stamping its `deletedAt` date. The operation
+ * is idempotent: deleting an already-deleted comment is a no-op and returns the
+ * comment unchanged.
+ */
+export async function deleteBuildComment(input: {
+  comment: Comment;
+}): Promise<Comment> {
+  const { comment } = input;
+
+  if (comment.deletedAt) {
+    return comment;
+  }
+
+  return comment.$query().patchAndFetch({
+    deletedAt: new Date().toISOString(),
+  });
+}

--- a/apps/backend/src/comment/permissions.test.ts
+++ b/apps/backend/src/comment/permissions.test.ts
@@ -7,9 +7,9 @@ import { getCommentPermissions } from "./permissions";
 const comment = { userId: "1" } as Comment;
 
 describe("getCommentPermissions", () => {
-  it("grants edit to the author", () => {
+  it("grants edit and delete to the author", () => {
     const user = { id: "1" } as User;
-    expect(getCommentPermissions(comment, user)).toEqual(["edit"]);
+    expect(getCommentPermissions(comment, user)).toEqual(["edit", "delete"]);
   });
 
   it("grants nothing to another user", () => {

--- a/apps/backend/src/comment/permissions.ts
+++ b/apps/backend/src/comment/permissions.ts
@@ -1,10 +1,10 @@
 import type { Comment, User } from "@/database/models";
 
-export type CommentPermission = "edit";
+export type CommentPermission = "edit" | "delete";
 
 /**
  * Compute the permissions a user has on a given comment.
- * Only the author of a comment can edit it.
+ * Only the author of a comment can edit or delete it.
  */
 export function getCommentPermissions(
   comment: Comment,
@@ -12,7 +12,7 @@ export function getCommentPermissions(
 ): CommentPermission[] {
   const permissions: CommentPermission[] = [];
   if (user && comment.userId === user.id) {
-    permissions.push("edit");
+    permissions.push("edit", "delete");
   }
   return permissions;
 }

--- a/apps/backend/src/database/models/Comment.ts
+++ b/apps/backend/src/database/models/Comment.ts
@@ -26,6 +26,7 @@ export class Comment extends Model {
           buildReviewId: { type: ["string", "null"] },
           threadId: { type: ["string", "null"] },
           editedAt: { type: ["string", "null"] },
+          deletedAt: { type: ["string", "null"] },
           content: {
             anyOf: [
               { type: "array" },
@@ -46,6 +47,7 @@ export class Comment extends Model {
   buildReviewId!: string | null;
   threadId!: string | null;
   editedAt!: string | null;
+  deletedAt!: string | null;
   content!: unknown;
 
   static override get relationMappings(): RelationMappings {

--- a/apps/backend/src/graphql/definitions/Comment.ts
+++ b/apps/backend/src/graphql/definitions/Comment.ts
@@ -3,6 +3,7 @@ import type { JSONContent } from "@tiptap/core";
 import gqlTag from "graphql-tag";
 
 import { createBuildComment } from "@/comment/createBuildComment";
+import { deleteBuildComment } from "@/comment/deleteBuildComment";
 import { formatCommentId, parseCommentId } from "@/comment/id";
 import { getCommentPermissions } from "@/comment/permissions";
 import { updateBuildComment } from "@/comment/updateBuildComment";
@@ -39,6 +40,7 @@ async function getCommentByGraphqlId(id: string): Promise<Comment> {
 export const typeDefs = gql`
   enum CommentPermission {
     edit
+    delete
   }
 
   """
@@ -70,11 +72,17 @@ export const typeDefs = gql`
     body: JSONObject!
   }
 
+  input DeleteCommentInput {
+    id: ID!
+  }
+
   extend type Mutation {
     "Post a comment on a build"
     addBuildComment(input: AddBuildCommentInput!): Build!
     "Update an existing comment"
     updateComment(input: UpdateCommentInput!): Comment!
+    "Delete an existing comment"
+    deleteComment(input: DeleteCommentInput!): Comment!
   }
 `;
 
@@ -160,6 +168,24 @@ export const resolvers: IResolvers = {
         comment,
         body: input.body as JSONContent,
       });
+    },
+    deleteComment: async (_root, args, ctx) => {
+      const { auth } = ctx;
+      if (!auth) {
+        throw unauthenticated();
+      }
+
+      const { input } = args;
+
+      const comment = await getCommentByGraphqlId(input.id);
+
+      const permissions = getCommentPermissions(comment, auth.user);
+
+      if (!permissions.includes("delete")) {
+        throw forbidden("You cannot delete this comment");
+      }
+
+      return deleteBuildComment({ comment });
     },
   },
 };

--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -628,6 +628,7 @@ function createBuildPublishedCommentsLoader() {
   return new DataLoader<string, Comment[]>(async (inputs) => {
     const comments = await Comment.query()
       .whereIn("buildId", inputs as string[])
+      .whereNull("deletedAt")
       .where((qb) => {
         qb.whereNull("buildReviewId").orWhereExists(
           BuildReview.query()

--- a/apps/backend/src/graphql/tests/deleteComment.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/deleteComment.e2e.test.ts
@@ -10,12 +10,9 @@ import { expectNoGraphQLError } from "../testing";
 import { createApolloServerApp } from "./util";
 
 const MUTATION = `
-  mutation UpdateComment($input: UpdateCommentInput!) {
-    updateComment(input: $input) {
+  mutation DeleteComment($input: DeleteCommentInput!) {
+    deleteComment(input: $input) {
       id
-      content
-      editedAt
-      permissions
     }
   }
 `;
@@ -50,7 +47,7 @@ const test = base.extend<Fixtures>({
   },
 });
 
-test("lets the author edit the comment", async ({ fixture }) => {
+test("lets the author delete the comment", async ({ fixture }) => {
   const app = await createApolloServerApp(
     apolloServer,
     createApolloMiddleware,
@@ -59,28 +56,52 @@ test("lets the author edit the comment", async ({ fixture }) => {
       account: fixture.authorAccount,
     },
   );
-  const body = commentBody("Edited content");
   const res = await request(app)
     .post("/graphql")
     .send({
       query: MUTATION,
-      variables: { input: { id: formatCommentId(fixture.comment.id), body } },
+      variables: { input: { id: formatCommentId(fixture.comment.id) } },
     });
 
   expectNoGraphQLError(res);
   expect(res.status).toBe(200);
 
-  const updated = res.body.data.updateComment;
-  expect(updated.content).toEqual(body);
-  expect(updated.editedAt).not.toBeNull();
-  expect(updated.permissions).toEqual(["edit", "delete"]);
-
   const stored = await Comment.query().findById(fixture.comment.id);
-  expect(stored!.content).toEqual(body);
-  expect(stored!.editedAt).not.toBeNull();
+  expect(stored!.deletedAt).not.toBeNull();
 });
 
-test("forbids a non-author from editing the comment", async ({ fixture }) => {
+test("is idempotent when the comment is already deleted", async ({
+  fixture,
+}) => {
+  await fixture.comment.$query().patch({ deletedAt: new Date().toISOString() });
+  const deletedAt = new Date(
+    (await Comment.query().findById(fixture.comment.id))!.deletedAt!,
+  ).toISOString();
+
+  const app = await createApolloServerApp(
+    apolloServer,
+    createApolloMiddleware,
+    {
+      user: fixture.authorAccount.user!,
+      account: fixture.authorAccount,
+    },
+  );
+  const res = await request(app)
+    .post("/graphql")
+    .send({
+      query: MUTATION,
+      variables: { input: { id: formatCommentId(fixture.comment.id) } },
+    });
+
+  expectNoGraphQLError(res);
+  expect(res.status).toBe(200);
+
+  // The original deletedAt is preserved (no error, no overwrite).
+  const stored = await Comment.query().findById(fixture.comment.id);
+  expect(new Date(stored!.deletedAt!).toISOString()).toBe(deletedAt);
+});
+
+test("forbids a non-author from deleting the comment", async ({ fixture }) => {
   const outsiderAccount = await factory.UserAccount.create();
   await outsiderAccount.$fetchGraph("user");
   const app = await createApolloServerApp(
@@ -95,20 +116,14 @@ test("forbids a non-author from editing the comment", async ({ fixture }) => {
     .post("/graphql")
     .send({
       query: MUTATION,
-      variables: {
-        input: {
-          id: formatCommentId(fixture.comment.id),
-          body: commentBody("Hacked"),
-        },
-      },
+      variables: { input: { id: formatCommentId(fixture.comment.id) } },
     });
 
   expect(res.status).toBe(200);
-  expect(res.body.errors[0].message).toBe("You cannot edit this comment");
+  expect(res.body.errors[0].message).toBe("You cannot delete this comment");
 
   const stored = await Comment.query().findById(fixture.comment.id);
-  expect(stored!.content).toEqual(commentBody("Original"));
-  expect(stored!.editedAt).toBeNull();
+  expect(stored!.deletedAt).toBeNull();
 });
 
 test("requires authentication", async ({ fixture }) => {
@@ -121,17 +136,12 @@ test("requires authentication", async ({ fixture }) => {
     .post("/graphql")
     .send({
       query: MUTATION,
-      variables: {
-        input: {
-          id: formatCommentId(fixture.comment.id),
-          body: commentBody("Anon"),
-        },
-      },
+      variables: { input: { id: formatCommentId(fixture.comment.id) } },
     });
 
   expect(res.body.errors).toBeDefined();
   const stored = await Comment.query().findById(fixture.comment.id);
-  expect(stored!.editedAt).toBeNull();
+  expect(stored!.deletedAt).toBeNull();
 });
 
 test("returns a clean error for a malformed comment ID", async ({
@@ -149,7 +159,7 @@ test("returns a clean error for a malformed comment ID", async ({
     .post("/graphql")
     .send({
       query: MUTATION,
-      variables: { input: { id: "not-a-comment-id", body: commentBody("x") } },
+      variables: { input: { id: "not-a-comment-id" } },
     });
 
   expect(res.status).toBe(200);

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -74,6 +74,7 @@
     "lucide-react": "^1.16.0",
     "memoize": "^11.0.0",
     "moment": "^2.30.1",
+    "motion": "^12.40.0",
     "nuqs": "^2.8.9",
     "p-retry": "^8.0.0",
     "react": "catalog:",

--- a/apps/frontend/src/pages/Build/sidebar/CommentActionsMenu.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentActionsMenu.tsx
@@ -1,15 +1,28 @@
-import { LinkIcon, MoreHorizontalIcon, PencilIcon } from "lucide-react";
+import {
+  LinkIcon,
+  MoreHorizontalIcon,
+  PencilIcon,
+  Trash2Icon,
+} from "lucide-react";
 
 import { IconButton } from "@/ui/IconButton";
-import { Menu, MenuItem, MenuItemIcon, MenuTrigger } from "@/ui/Menu";
+import {
+  Menu,
+  MenuItem,
+  MenuItemIcon,
+  MenuSeparator,
+  MenuTrigger,
+} from "@/ui/Menu";
 import { Popover } from "@/ui/Popover";
 
 export function CommentActionsMenu(props: {
   onCopyLink: () => void;
   /** When provided, an "Edit comment" action is shown. */
   onEdit?: () => void;
+  /** When provided, a "Delete comment" action is shown. */
+  onDelete?: () => void;
 }) {
-  const { onCopyLink, onEdit } = props;
+  const { onCopyLink, onEdit, onDelete } = props;
   return (
     <MenuTrigger>
       <IconButton
@@ -36,6 +49,17 @@ export function CommentActionsMenu(props: {
             </MenuItemIcon>
             Copy link to comment
           </MenuItem>
+          {onDelete ? (
+            <>
+              <MenuSeparator />
+              <MenuItem variant="danger" onAction={onDelete}>
+                <MenuItemIcon>
+                  <Trash2Icon />
+                </MenuItemIcon>
+                Delete comment
+              </MenuItem>
+            </>
+          ) : null}
         </Menu>
       </Popover>
     </MenuTrigger>

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -12,11 +12,13 @@ import { CommentPermission } from "@/gql/graphql";
 import { type EditorValue } from "@/ui/Editor/Editor";
 import { ReadOnlyEditor } from "@/ui/Editor/ReadOnlyEditor";
 import { StandaloneEditor } from "@/ui/Editor/StandaloneEditor";
+import { Modal } from "@/ui/Modal";
 import { Time } from "@/ui/Time";
 import { Tooltip } from "@/ui/Tooltip";
 import { getErrorMessage } from "@/util/error";
 
 import { CommentActionsMenu } from "./CommentActionsMenu";
+import { DeleteCommentDialog } from "./DeleteCommentDialog";
 
 // Shared id so copying a comment link reuses a single toast instead of stacking.
 const COPY_TOAST_ID = "comment-link-copied";
@@ -59,6 +61,7 @@ export function CommentCard(props: {
   const ref = useRef<HTMLDivElement>(null);
   const clipboard = useClipboard();
   const [isEditing, setIsEditing] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [updateComment] = useMutation(UpdateCommentMutation);
 
   useEffect(() => {
@@ -91,76 +94,83 @@ export function CommentCard(props: {
   };
 
   const canEdit = comment.permissions.includes(CommentPermission.Edit);
+  const canDelete = comment.permissions.includes(CommentPermission.Delete);
   const isEdited = Boolean(comment.editedAt);
 
   return (
-    <div
-      ref={ref}
-      id={comment.id}
-      className={clsx(
-        "border-thin bg-app ring-primary -mx-1 rounded-md transition",
-        highlighted ? "ring-2" : "ring-0",
-      )}
-    >
-      <div className="flex items-center gap-2 py-2 pr-2 pl-3">
-        {comment.user ? (
-          <AccountAvatar
-            avatar={comment.user.avatar}
-            className="size-5 border"
-          />
-        ) : null}
-        <span className="text-default text-xs font-medium">
-          {comment.user?.name || comment.user?.slug || "Unknown user"}
-        </span>
-        <Tooltip
-          content={
-            <div className="flex flex-col">
-              <span>
-                Created: {moment(comment.date).format(DETAILED_DATE_FORMAT)}
-              </span>
-              {comment.editedAt ? (
-                <span>
-                  Edited:{" "}
-                  {moment(comment.editedAt).format(DETAILED_DATE_FORMAT)}
-                </span>
-              ) : null}
-            </div>
-          }
-        >
-          <Button
-            onPress={copyLink}
-            aria-label="Copy link to comment"
-            className="text-low hover:text-default text-xs transition"
-          >
-            <Time date={comment.date} tooltip="none" />
-            {isEdited ? " (edited)" : null}
-          </Button>
-        </Tooltip>
-        <CommentActionsMenu
-          onCopyLink={copyLink}
-          onEdit={canEdit ? () => setIsEditing(true) : undefined}
-        />
-      </div>
-      <div className="text-default px-2 pb-2 text-sm">
-        {isEditing ? (
-          <StandaloneEditor
-            variant="plain"
-            defaultValue={comment.content}
-            onSubmit={handleEditSubmit}
-            onCancel={() => setIsEditing(false)}
-            submitLabel="Save"
-            emptyMessage={{
-              title: "Comment required",
-              description: "Please add a comment before saving.",
-            }}
-            autoFocus
-            aria-label="Edit comment"
-            contentClassName="px-1"
-          />
-        ) : (
-          <ReadOnlyEditor content={comment.content} className="px-1" />
+    <>
+      <div
+        ref={ref}
+        id={comment.id}
+        className={clsx(
+          "border-thin bg-app ring-primary -mx-2.5 rounded-md transition",
+          highlighted ? "ring-2" : "ring-0",
         )}
+      >
+        <div className="flex items-center gap-2 px-2 py-1.5 pr-1.5">
+          {comment.user ? (
+            <AccountAvatar
+              avatar={comment.user.avatar}
+              className="size-5 border"
+            />
+          ) : null}
+          <span className="text-default text-xs font-medium">
+            {comment.user?.name || comment.user?.slug || "Unknown user"}
+          </span>
+          <Tooltip
+            content={
+              <div className="flex flex-col">
+                <span>
+                  Created: {moment(comment.date).format(DETAILED_DATE_FORMAT)}
+                </span>
+                {comment.editedAt ? (
+                  <span>
+                    Edited:{" "}
+                    {moment(comment.editedAt).format(DETAILED_DATE_FORMAT)}
+                  </span>
+                ) : null}
+              </div>
+            }
+          >
+            <Button
+              onPress={copyLink}
+              aria-label="Copy link to comment"
+              className="text-low hover:text-default text-xs transition"
+            >
+              <Time date={comment.date} tooltip="none" />
+              {isEdited ? " (edited)" : null}
+            </Button>
+          </Tooltip>
+          <CommentActionsMenu
+            onCopyLink={copyLink}
+            onEdit={canEdit ? () => setIsEditing(true) : undefined}
+            onDelete={canDelete ? () => setIsDeleteDialogOpen(true) : undefined}
+          />
+        </div>
+        <div className="text-default px-1 pb-2 text-sm">
+          {isEditing ? (
+            <StandaloneEditor
+              variant="plain"
+              defaultValue={comment.content}
+              onSubmit={handleEditSubmit}
+              onCancel={() => setIsEditing(false)}
+              submitLabel="Save"
+              emptyMessage={{
+                title: "Comment required",
+                description: "Please add a comment before saving.",
+              }}
+              autoFocus
+              aria-label="Edit comment"
+              contentClassName="px-1"
+            />
+          ) : (
+            <ReadOnlyEditor content={comment.content} className="px-1" />
+          )}
+        </div>
       </div>
-    </div>
+      <Modal isOpen={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+        <DeleteCommentDialog commentId={comment.id} />
+      </Modal>
+    </>
   );
 }

--- a/apps/frontend/src/pages/Build/sidebar/DeleteCommentDialog.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/DeleteCommentDialog.tsx
@@ -1,0 +1,75 @@
+import { useMutation } from "@apollo/client/react";
+
+import { graphql } from "@/gql";
+import { Button } from "@/ui/Button";
+import {
+  Dialog,
+  DialogBody,
+  DialogDismiss,
+  DialogFooter,
+  DialogText,
+  DialogTitle,
+  useOverlayTriggerState,
+} from "@/ui/Dialog";
+import { ErrorMessage } from "@/ui/ErrorMessage";
+import { getErrorMessage } from "@/util/error";
+
+const DeleteCommentMutation = graphql(`
+  mutation DeleteCommentDialog_deleteComment($input: DeleteCommentInput!) {
+    deleteComment(input: $input) {
+      id
+    }
+  }
+`);
+
+export function DeleteCommentDialog(props: { commentId: string }) {
+  const state = useOverlayTriggerState();
+  const [deleteComment, { loading, error }] = useMutation(
+    DeleteCommentMutation,
+    {
+      variables: { input: { id: props.commentId } },
+      // Drop the comment from the cache so it leaves the list. `AnimatePresence`
+      // in ReviewActivitySection plays its exit animation as it is removed.
+      update: (cache) => {
+        const cacheId = cache.identify({
+          __typename: "Comment",
+          id: props.commentId,
+        });
+        if (cacheId) {
+          cache.evict({ id: cacheId });
+          cache.gc();
+        }
+      },
+      onCompleted: () => {
+        state.close();
+      },
+    },
+  );
+  return (
+    <Dialog size="medium" role="alertdialog">
+      <DialogBody>
+        <DialogTitle>Delete this comment?</DialogTitle>
+        <DialogText>You cannot undo this action.</DialogText>
+      </DialogBody>
+      <DialogFooter>
+        {error && (
+          <ErrorMessage className="flex-1">
+            {getErrorMessage(error)}
+          </ErrorMessage>
+        )}
+        <DialogDismiss isDisabled={loading}>Cancel</DialogDismiss>
+        <Button
+          variant="destructive"
+          isPending={loading}
+          onPress={() => {
+            deleteComment().catch(() => {
+              // Error is surfaced through the `error` state above.
+            });
+          }}
+        >
+          Delete
+        </Button>
+      </DialogFooter>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
@@ -8,6 +8,7 @@ import {
   FileUpIcon,
   MailCheckIcon,
 } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 
@@ -121,6 +122,25 @@ function getActivityEntries(build: Build): ActivityEntry[] {
 }
 
 /**
+ * Stable key per activity entry so React keeps each row's component instance
+ * tied to its data. Index keys would let a removed comment's state (e.g. its
+ * delete animation) bleed onto the next row.
+ */
+function getActivityEntryKey(entry: ActivityEntry): string {
+  switch (entry.kind) {
+    case "created":
+    case "ready":
+      return entry.kind;
+    case "review":
+      return `review-${entry.review.id}`;
+    case "review-dismissed":
+      return `review-dismissed-${entry.review.id}`;
+    case "comment":
+      return `comment-${entry.comment.id}`;
+  }
+}
+
+/**
  * Reads a `#comment-…` hash from the URL and, when it matches a loaded comment,
  * returns its id so the comment can be highlighted. The highlight clears on the
  * next click anywhere, after 3 seconds, or when the component unmounts.
@@ -174,17 +194,20 @@ export function ReviewActivitySection(props: { build: Build }) {
         <SubscribeToggleButton build={build} />
       </SidebarHeader>
       <div className="px-3">
-        <Activity>
-          {entries.map((entry, index) => (
-            <ActivityEntryRow
-              key={index}
-              entry={entry}
-              highlightedCommentId={highlightedCommentId}
-            />
-          ))}
+        <Activity gap={false}>
+          <AnimatePresence initial={false}>
+            {entries.map((entry, index) => (
+              <ActivityEntryRow
+                key={getActivityEntryKey(entry)}
+                entry={entry}
+                highlightedCommentId={highlightedCommentId}
+                isFirst={index === 0}
+              />
+            ))}
+          </AnimatePresence>
         </Activity>
         {canComment ? (
-          <div className="mt-3">
+          <div className="-mx-1.5 mt-3 -mb-1.5">
             <AddCommentForm build={build} />
           </div>
         ) : null}
@@ -250,75 +273,98 @@ function SubscribeToggleButton(props: { build: Build }) {
 function ActivityEntryRow(props: {
   entry: ActivityEntry;
   highlightedCommentId: string | null;
+  isFirst: boolean;
 }) {
-  const { entry, highlightedCommentId } = props;
-  switch (entry.kind) {
-    case "created":
-      return (
-        <ActivityItem icon={<FileUpIcon className="size-3.5" />}>
-          Build created · <Time date={entry.date} />
-        </ActivityItem>
-      );
-    case "ready":
-      return (
-        <ActivityItem icon={<MailCheckIcon className="size-3.5" />}>
-          Build ready · <Time date={entry.date} />
-        </ActivityItem>
-      );
-    case "review": {
-      const { review } = entry;
-      const descriptor = buildReviewDescriptors[review.state];
-      const Icon = descriptor.icon;
-      return (
-        <ActivityItem
-          icon={<Icon className={clsx("size-3.5", descriptor.textColor)} />}
-        >
-          <span className="font-medium">{descriptor.label}</span>
-          {review.user && (
-            <>
-              {" by "}
-              <span className="text-default font-medium">
-                {review.user.name || review.user.slug}
-              </span>
-            </>
-          )}
-          {" · "}
-          <Time date={entry.date} />
-        </ActivityItem>
-      );
-    }
-    case "review-dismissed": {
-      const { review } = entry;
-      return (
-        <ActivityItem icon={<BanIcon className="text-low size-3.5" />}>
-          <span className="font-medium">Review dismissed</span>
-          {review.dismissedBy ? (
-            <>
-              {" by "}
-              <span className="text-default font-medium">
-                {review.dismissedBy.name || review.dismissedBy.slug}
-              </span>
-            </>
-          ) : null}
-          {review.user ? (
-            <>
-              {" for "}
-              <span className="text-default font-medium">
-                {review.user.name || review.user.slug}
-              </span>
-            </>
-          ) : null}
-          {" · "}
-          <Time date={entry.date} />
-        </ActivityItem>
-      );
-    }
-    case "comment":
-      return (
+  const { entry, highlightedCommentId, isFirst } = props;
+  // Each row carries its own top spacing (rather than relying on a `space-y`
+  // gap) so a collapsing comment can shrink that spacing away as part of its
+  // own height, keeping the delete animation smooth.
+  const spacing = isFirst ? undefined : "pt-4";
+
+  if (entry.kind === "comment") {
+    return (
+      <motion.div
+        className={spacing}
+        style={{ overflowY: "clip" }}
+        exit={{ height: 0, paddingTop: 0, opacity: 0 }}
+        transition={{
+          duration: 0.25,
+          ease: [0.4, 0, 0.2, 1],
+          opacity: { duration: 0.15 },
+        }}
+      >
         <CommentCard
           comment={entry.comment}
           highlighted={entry.comment.id === highlightedCommentId}
         />
-      );
+      </motion.div>
+    );
   }
+
+  const content = (() => {
+    switch (entry.kind) {
+      case "created":
+        return (
+          <ActivityItem icon={<FileUpIcon className="size-3.5" />}>
+            Build created · <Time date={entry.date} />
+          </ActivityItem>
+        );
+      case "ready":
+        return (
+          <ActivityItem icon={<MailCheckIcon className="size-3.5" />}>
+            Build ready · <Time date={entry.date} />
+          </ActivityItem>
+        );
+      case "review": {
+        const { review } = entry;
+        const descriptor = buildReviewDescriptors[review.state];
+        const Icon = descriptor.icon;
+        return (
+          <ActivityItem
+            icon={<Icon className={clsx("size-3.5", descriptor.textColor)} />}
+          >
+            <span className="font-medium">{descriptor.label}</span>
+            {review.user && (
+              <>
+                {" by "}
+                <span className="text-default font-medium">
+                  {review.user.name || review.user.slug}
+                </span>
+              </>
+            )}
+            {" · "}
+            <Time date={entry.date} />
+          </ActivityItem>
+        );
+      }
+      case "review-dismissed": {
+        const { review } = entry;
+        return (
+          <ActivityItem icon={<BanIcon className="text-low size-3.5" />}>
+            <span className="font-medium">Review dismissed</span>
+            {review.dismissedBy ? (
+              <>
+                {" by "}
+                <span className="text-default font-medium">
+                  {review.dismissedBy.name || review.dismissedBy.slug}
+                </span>
+              </>
+            ) : null}
+            {review.user ? (
+              <>
+                {" for "}
+                <span className="text-default font-medium">
+                  {review.user.name || review.user.slug}
+                </span>
+              </>
+            ) : null}
+            {" · "}
+            <Time date={entry.date} />
+          </ActivityItem>
+        );
+      }
+    }
+  })();
+
+  return <div className={spacing}>{content}</div>;
 }

--- a/apps/frontend/src/ui/Activity.tsx
+++ b/apps/frontend/src/ui/Activity.tsx
@@ -1,10 +1,21 @@
 import clsx from "clsx";
 
-export function Activity(props: { children: React.ReactNode }) {
+export function Activity(props: {
+  children: React.ReactNode;
+  /**
+   * Apply the default vertical gap between items. Disable it when the items
+   * carry their own spacing (e.g. so a collapsing item can animate it away).
+   * @default true
+   */
+  gap?: boolean;
+}) {
+  const { gap = true } = props;
   return (
     <div className="relative px-1">
       <div className="w-thin absolute top-1 bottom-0 left-[10.5px] bg-(--gray-6)" />
-      <div className="relative space-y-4 text-xs">{props.children}</div>
+      <div className={clsx("relative text-xs", gap && "space-y-4")}>
+        {props.children}
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/ui/Sidebar.tsx
+++ b/apps/frontend/src/ui/Sidebar.tsx
@@ -15,7 +15,7 @@ export function SidebarSection(props: {
   return (
     <div
       className={clsx(
-        "bg-app border-thin rounded-md py-3 shadow-xs",
+        "bg-app border-thin rounded-xl py-3 shadow-xs",
         className,
       )}
     >

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -599,6 +599,9 @@ importers:
       moment:
         specifier: ^2.30.1
         version: 2.30.1
+      motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       nuqs:
         specifier: ^2.8.9
         version: 2.8.9(react-router-dom@7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-router@7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
@@ -5698,6 +5701,20 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  framer-motion@12.40.0:
+    resolution: {integrity: sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^19.2.6
+      react-dom: ^19.2.6
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -6637,6 +6654,26 @@ packages:
 
   monaco-editor@0.55.1:
     resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
+
+  motion-dom@12.40.0:
+    resolution: {integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==}
+
+  motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
+
+  motion@12.40.0:
+    resolution: {integrity: sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^19.2.6
+      react-dom: ^19.2.6
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -13456,6 +13493,15 @@ snapshots:
 
   forwarded@0.2.0: {}
 
+  framer-motion@12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      motion-dom: 12.40.0
+      motion-utils: 12.39.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
   fresh@2.0.0: {}
 
   fsevents@2.3.2:
@@ -14257,6 +14303,20 @@ snapshots:
     dependencies:
       dompurify: 3.4.7
       marked: 14.0.0
+
+  motion-dom@12.40.0:
+    dependencies:
+      motion-utils: 12.39.0
+
+  motion-utils@12.39.0: {}
+
+  motion@12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      framer-motion: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
   mrmime@2.0.1: {}
 


### PR DESCRIPTION
## What

Lets a comment's author **delete** it from a build. It's a **soft delete** (`deletedAt` timestamp), so the row is retained but filtered out everywhere in the UI.

This builds on the recent "edit a comment" work — same author-only permission model.

## Backend

- **Model + migration**: add `deletedAt` to `Comment`. Migration adds the column plus a partial index `comments_buildid_createdat_active_index ON ("buildId", "createdAt") WHERE "deletedAt" IS NULL`, created `CONCURRENTLY`, matching the published-comments query.
- **Loader**: published-comments loader now filters `.whereNull("deletedAt")`.
- **Permissions**: the author now gets `delete` in addition to `edit`.
- **Mutation**: new `deleteComment(input: DeleteCommentInput!): Comment!` — author-only and **idempotent** (deleting an already-deleted comment is a no-op, no error).

## Frontend

- **CommentActionsMenu**: author-only, danger-styled "Delete comment" entry.
- **DeleteCommentDialog**: confirmation alert dialog ("Delete this comment?" / "You cannot undo this action."), evicts the comment from the Apollo cache on success.
- **Exit animation**: uses `motion`'s `AnimatePresence`. Each activity row owns its spacing (via `Activity`'s new `gap={false}` + per-row padding) so a deleted comment collapses **height + padding + opacity** as one self-contained, smooth motion before unmounting.

> Note: the dialog copy follows the design screenshot ("You cannot undo this action.").
> Also includes a tiny unrelated tweak made while working: `SidebarSection` corner radius `rounded-md` → `rounded-xl`.

## Tests
- New `deleteComment.e2e.test.ts` (author deletes, idempotent re-delete, non-author forbidden, unauthenticated, malformed id).
- Updated `permissions.test.ts` and `updateComment.e2e.test.ts` for the new `delete` permission.
- Full backend suite green (412 e2e / 175 unit); frontend `tsc` + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)