### PR TITLE
feat(comment): emoji reactions on comments

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -48,6 +48,26 @@ To add/change a column or table:
    NODE_ENV=test pnpm run --filter @argos/backend db:reset
    ```
 
+### Idempotent inserts
+
+Never gate an insert on a prior existence check (read-then-insert) — two
+concurrent requests can both pass the check and then race on the primary key.
+Insert atomically with `onConflict([...]).ignore()` (or `.merge(...)` for
+upserts). When you need to know whether the row was actually created (e.g. to
+send a notification only once), read the `.returning(...)` rows: an empty array
+means the conflict was ignored.
+
+```js
+const inserted = await knex("comment_reactions")
+  .insert({ commentId, userId, emoji })
+  .onConflict(["commentId", "userId", "emoji"])
+  .ignore()
+  .returning("commentId");
+if (inserted.length === 0) {
+  return; // already existed, nothing to do
+}
+```
+
 ## GraphQL
 
 - Keep the schema as the **source of truth**.

--- a/apps/backend/src/comment/addCommentReaction.ts
+++ b/apps/backend/src/comment/addCommentReaction.ts
@@ -1,0 +1,89 @@
+import { invariant } from "@argos/util/invariant";
+
+import { Comment, CommentReaction, User } from "@/database/models";
+import { sendNotification } from "@/notification";
+import { boom } from "@/util/error";
+
+import { formatCommentId } from "./id";
+import { isValidEmoji } from "./reactions";
+
+/**
+ * Add an emoji reaction from a user to a comment and notify the comment author.
+ * The operation is idempotent: reacting again with the same emoji is a no-op.
+ */
+export async function addCommentReaction(input: {
+  comment: Comment;
+  userId: string;
+  emoji: string;
+}): Promise<Comment> {
+  const { comment, userId, emoji } = input;
+
+  if (!isValidEmoji(emoji)) {
+    throw boom(400, "Invalid emoji");
+  }
+
+  const existing = await CommentReaction.query().findById([
+    comment.id,
+    userId,
+    emoji,
+  ]);
+
+  if (existing) {
+    return comment;
+  }
+
+  await CommentReaction.query().insert({
+    commentId: comment.id,
+    userId,
+    emoji,
+  });
+
+  await notifyCommentAuthor({ comment, userId, emoji });
+
+  return comment;
+}
+
+/**
+ * Notify the comment author that someone reacted to their comment. Reacting to
+ * your own comment does not send a notification.
+ */
+async function notifyCommentAuthor(input: {
+  comment: Comment;
+  userId: string;
+  emoji: string;
+}): Promise<void> {
+  const { comment, userId, emoji } = input;
+
+  if (comment.userId === userId) {
+    return;
+  }
+
+  const build = await comment
+    .$relatedQuery("build")
+    .withGraphFetched("project.account");
+  invariant(build, "build not found");
+  invariant(build.project, "project not found");
+  invariant(build.project.account, "project account not found");
+
+  const [reactor, buildUrl] = await Promise.all([
+    User.query().findById(userId).withGraphFetched("account"),
+    build.getUrl(),
+  ]);
+
+  const reactorName = reactor?.account?.displayName ?? null;
+  const commentUrl = `${buildUrl}#${formatCommentId(comment.id)}`;
+
+  await sendNotification({
+    type: "comment_reaction",
+    data: {
+      accountSlug: build.project.account.slug,
+      projectName: build.project.name,
+      buildNumber: build.number,
+      buildName: build.name,
+      commentUrl,
+      reactorName,
+      emoji,
+    },
+    recipients: [comment.userId],
+  });
+}

--- a/apps/backend/src/comment/addCommentReaction.ts
+++ b/apps/backend/src/comment/addCommentReaction.ts
@@ -1,6 +1,7 @@
 import { invariant } from "@argos/util/invariant";
 
-import { Comment, CommentReaction, User } from "@/database/models";
+import { knex } from "@/database";
+import { Comment, User } from "@/database/models";
 import { sendNotification } from "@/notification";
 import { boom } from "@/util/error";
 
@@ -22,21 +23,20 @@ export async function addCommentReaction(input: {
     throw boom(400, "Invalid emoji");
   }
 
-  const existing = await CommentReaction.query().findById([
-    comment.id,
-    userId,
-    emoji,
-  ]);
+  // Insert atomically: `onConflict().ignore()` makes concurrent requests safe
+  // (no read-then-insert race, no primary-key violation) and the returning rows
+  // tell us whether this call actually created the reaction. `createdAt` and
+  // `updatedAt` fall back to their database defaults.
+  const inserted = await knex("comment_reactions")
+    .insert({ commentId: comment.id, userId, emoji })
+    .onConflict(["commentId", "userId", "emoji"])
+    .ignore()
+    .returning("commentId");
 
-  if (existing) {
+  // Already reacted with this emoji: nothing inserted, nothing to notify.
+  if (inserted.length === 0) {
     return comment;
   }
-
-  await CommentReaction.query().insert({
-    commentId: comment.id,
-    userId,
-    emoji,
-  });
 
   await notifyCommentAuthor({ comment, userId, emoji });
 

--- a/apps/backend/src/comment/reactions.test.ts
+++ b/apps/backend/src/comment/reactions.test.ts
@@ -29,8 +29,12 @@ describe("isValidEmoji", () => {
     expect(isValidEmoji("")).toBe(false);
   });
 
-  it("rejects overly long input", () => {
-    expect(isValidEmoji("👍".repeat(64))).toBe(false);
+  it("rejects an emoji with trailing text", () => {
+    expect(isValidEmoji("👍lgtm")).toBe(false);
+  });
+
+  it("rejects multiple emojis", () => {
+    expect(isValidEmoji("👍🎉")).toBe(false);
   });
 
   it("rejects non-string values", () => {

--- a/apps/backend/src/comment/reactions.test.ts
+++ b/apps/backend/src/comment/reactions.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import type { CommentReaction } from "@/database/models";
+
+import { groupCommentReactions, isValidEmoji } from "./reactions";
+
+describe("isValidEmoji", () => {
+  it("accepts a simple emoji", () => {
+    expect(isValidEmoji("👍")).toBe(true);
+  });
+
+  it("accepts an emoji with a skin-tone modifier", () => {
+    expect(isValidEmoji("👍🏽")).toBe(true);
+  });
+
+  it("accepts a ZWJ sequence", () => {
+    expect(isValidEmoji("👨‍👩‍👧‍👦")).toBe(true);
+  });
+
+  it("rejects plain text", () => {
+    expect(isValidEmoji("lgtm")).toBe(false);
+  });
+
+  it("rejects digits", () => {
+    expect(isValidEmoji("123")).toBe(false);
+  });
+
+  it("rejects an empty string", () => {
+    expect(isValidEmoji("")).toBe(false);
+  });
+
+  it("rejects overly long input", () => {
+    expect(isValidEmoji("👍".repeat(64))).toBe(false);
+  });
+
+  it("rejects non-string values", () => {
+    expect(isValidEmoji(undefined)).toBe(false);
+    expect(isValidEmoji(42)).toBe(false);
+  });
+});
+
+describe("groupCommentReactions", () => {
+  function reaction(emoji: string, userId: string): CommentReaction {
+    return { emoji, userId, commentId: "1" } as CommentReaction;
+  }
+
+  it("returns an empty array for no reactions", () => {
+    expect(groupCommentReactions([])).toEqual([]);
+  });
+
+  it("groups reactions by emoji preserving first-seen order", () => {
+    const groups = groupCommentReactions([
+      reaction("👍", "1"),
+      reaction("🎉", "2"),
+      reaction("👍", "3"),
+    ]);
+    expect(groups).toEqual([
+      { emoji: "👍", userIds: ["1", "3"] },
+      { emoji: "🎉", userIds: ["2"] },
+    ]);
+  });
+});

--- a/apps/backend/src/comment/reactions.ts
+++ b/apps/backend/src/comment/reactions.ts
@@ -10,28 +10,19 @@ export type CommentReactionGroup = {
 };
 
 /**
- * Upper bound on the stored emoji length. A single emoji can be several code
- * points long (skin-tone modifiers, ZWJ sequences like 👨‍👩‍👧‍👦), so we allow
- * some room while still rejecting arbitrary text.
+ * Matches a string that is *exactly* one emoji and nothing else. `\p{RGI_Emoji}`
+ * (requires the `v` flag) matches a whole recommended-for-interchange emoji,
+ * including multi-code-point ones (skin-tone modifiers, ZWJ sequences like
+ * 👨‍👩‍👧‍👦). Anchoring with `^…$` rejects embedded text such as "👍lgtm" and
+ * multi-emoji strings, so only a single emoji can be stored as a reaction.
  */
-const MAX_EMOJI_LENGTH = 64;
+const EMOJI_REGEX = /^\p{RGI_Emoji}$/v;
 
 /**
- * Matches at least one pictographic code point. Anyone can craft a request
- * directly, so this guards against storing plain text or digits as a reaction.
- */
-const EMOJI_REGEX = /\p{Extended_Pictographic}/u;
-
-/**
- * Check that a value is a valid emoji that can be stored as a reaction.
+ * Check that a value is a single emoji that can be stored as a reaction.
  */
 export function isValidEmoji(emoji: unknown): emoji is string {
-  return (
-    typeof emoji === "string" &&
-    emoji.length > 0 &&
-    emoji.length <= MAX_EMOJI_LENGTH &&
-    EMOJI_REGEX.test(emoji)
-  );
+  return typeof emoji === "string" && EMOJI_REGEX.test(emoji);
 }
 
 /**

--- a/apps/backend/src/comment/reactions.ts
+++ b/apps/backend/src/comment/reactions.ts
@@ -1,0 +1,54 @@
+import type { CommentReaction } from "@/database/models";
+
+/**
+ * Reactions of a single emoji on a comment, with the list of users who reacted
+ * with it. This is the shape exposed by the `Comment.reactions` GraphQL field.
+ */
+export type CommentReactionGroup = {
+  emoji: string;
+  userIds: string[];
+};
+
+/**
+ * Upper bound on the stored emoji length. A single emoji can be several code
+ * points long (skin-tone modifiers, ZWJ sequences like 👨‍👩‍👧‍👦), so we allow
+ * some room while still rejecting arbitrary text.
+ */
+const MAX_EMOJI_LENGTH = 64;
+
+/**
+ * Matches at least one pictographic code point. Anyone can craft a request
+ * directly, so this guards against storing plain text or digits as a reaction.
+ */
+const EMOJI_REGEX = /\p{Extended_Pictographic}/u;
+
+/**
+ * Check that a value is a valid emoji that can be stored as a reaction.
+ */
+export function isValidEmoji(emoji: unknown): emoji is string {
+  return (
+    typeof emoji === "string" &&
+    emoji.length > 0 &&
+    emoji.length <= MAX_EMOJI_LENGTH &&
+    EMOJI_REGEX.test(emoji)
+  );
+}
+
+/**
+ * Group a flat list of reactions by emoji, preserving the order in which each
+ * emoji was first used (callers pass reactions ordered by creation date).
+ */
+export function groupCommentReactions(
+  reactions: CommentReaction[],
+): CommentReactionGroup[] {
+  const groups = new Map<string, CommentReactionGroup>();
+  for (const reaction of reactions) {
+    let group = groups.get(reaction.emoji);
+    if (!group) {
+      group = { emoji: reaction.emoji, userIds: [] };
+      groups.set(reaction.emoji, group);
+    }
+    group.userIds.push(reaction.userId);
+  }
+  return Array.from(groups.values());
+}

--- a/apps/backend/src/comment/removeCommentReaction.ts
+++ b/apps/backend/src/comment/removeCommentReaction.ts
@@ -1,0 +1,24 @@
+import { Comment, CommentReaction } from "@/database/models";
+import { boom } from "@/util/error";
+
+import { isValidEmoji } from "./reactions";
+
+/**
+ * Remove a user's emoji reaction from a comment. The operation is idempotent:
+ * removing a reaction that doesn't exist is a no-op.
+ */
+export async function removeCommentReaction(input: {
+  comment: Comment;
+  userId: string;
+  emoji: string;
+}): Promise<Comment> {
+  const { comment, userId, emoji } = input;
+
+  if (!isValidEmoji(emoji)) {
+    throw boom(400, "Invalid emoji");
+  }
+
+  await CommentReaction.query().deleteById([comment.id, userId, emoji]);
+
+  return comment;
+}

--- a/apps/backend/src/graphql/definitions/Comment.ts
+++ b/apps/backend/src/graphql/definitions/Comment.ts
@@ -45,7 +45,7 @@ async function getCommentByGraphqlId(id: string): Promise<Comment> {
  * Ensure the user is allowed to react to a comment. Reacting requires the same
  * "review" permission on the build's project as posting a comment does.
  */
-async function checkCanReactToComment(
+async function assertCanReactToComment(
   comment: Comment,
   user: User,
 ): Promise<void> {
@@ -264,7 +264,7 @@ export const resolvers: IResolvers = {
 
       const comment = await getCommentByGraphqlId(input.commentId);
 
-      await checkCanReactToComment(comment, auth.user);
+      await assertCanReactToComment(comment, auth.user);
 
       return addCommentReaction({
         comment,
@@ -282,7 +282,7 @@ export const resolvers: IResolvers = {
 
       const comment = await getCommentByGraphqlId(input.commentId);
 
-      await checkCanReactToComment(comment, auth.user);
+      await assertCanReactToComment(comment, auth.user);
 
       return removeCommentReaction({
         comment,

--- a/apps/backend/src/graphql/definitions/Comment.ts
+++ b/apps/backend/src/graphql/definitions/Comment.ts
@@ -2,13 +2,17 @@ import { invariant } from "@argos/util/invariant";
 import type { JSONContent } from "@tiptap/core";
 import gqlTag from "graphql-tag";
 
+import { addCommentReaction } from "@/comment/addCommentReaction";
 import { createBuildComment } from "@/comment/createBuildComment";
 import { deleteBuildComment } from "@/comment/deleteBuildComment";
 import { formatCommentId, parseCommentId } from "@/comment/id";
 import { getCommentPermissions } from "@/comment/permissions";
+import { groupCommentReactions } from "@/comment/reactions";
+import { removeCommentReaction } from "@/comment/removeCommentReaction";
 import { updateBuildComment } from "@/comment/updateBuildComment";
 import { Build } from "@/database/models/Build";
 import { Comment } from "@/database/models/Comment";
+import type { User } from "@/database/models/User";
 
 import type {
   ICommentPermission,
@@ -37,10 +41,42 @@ async function getCommentByGraphqlId(id: string): Promise<Comment> {
   return comment;
 }
 
+/**
+ * Ensure the user is allowed to react to a comment. Reacting requires the same
+ * "review" permission on the build's project as posting a comment does.
+ */
+async function checkCanReactToComment(
+  comment: Comment,
+  user: User,
+): Promise<void> {
+  const build = await comment
+    .$relatedQuery("build")
+    .withGraphFetched("project.account");
+  invariant(build?.project?.account, "Build project account not found");
+  const permissions = await build.project.$getPermissions(user);
+  if (!permissions.includes("review")) {
+    throw forbidden("You cannot react to this comment");
+  }
+}
+
 export const typeDefs = gql`
   enum CommentPermission {
     edit
     delete
+  }
+
+  """
+  Reactions of a single emoji on a comment.
+  """
+  type CommentReactionGroup {
+    "The emoji used for the reaction"
+    emoji: String!
+    "Number of users who reacted with this emoji"
+    count: Int!
+    "Whether the current user reacted with this emoji"
+    reactedByMe: Boolean!
+    "Users who reacted with this emoji"
+    users: [User!]!
   }
 
   """
@@ -58,6 +94,8 @@ export const typeDefs = gql`
     user: User
     "Permissions of the current user on this comment"
     permissions: [CommentPermission!]!
+    "Emoji reactions on the comment, grouped by emoji"
+    reactions: [CommentReactionGroup!]!
   }
 
   input AddBuildCommentInput {
@@ -76,6 +114,12 @@ export const typeDefs = gql`
     id: ID!
   }
 
+  input CommentReactionInput {
+    commentId: ID!
+    "The emoji to react with"
+    emoji: String!
+  }
+
   extend type Mutation {
     "Post a comment on a build"
     addBuildComment(input: AddBuildCommentInput!): Build!
@@ -83,6 +127,10 @@ export const typeDefs = gql`
     updateComment(input: UpdateCommentInput!): Comment!
     "Delete an existing comment"
     deleteComment(input: DeleteCommentInput!): Comment!
+    "Add an emoji reaction to a comment"
+    addCommentReaction(input: CommentReactionInput!): Comment!
+    "Remove an emoji reaction from a comment"
+    removeCommentReaction(input: CommentReactionInput!): Comment!
   }
 `;
 
@@ -113,6 +161,25 @@ export const resolvers: IResolvers = {
         comment,
         ctx.auth?.user ?? null,
       ) as ICommentPermission[];
+    },
+    reactions: async (comment, _args, ctx) => {
+      const reactions = await ctx.loaders.CommentReactions.load(comment.id);
+      return groupCommentReactions(reactions);
+    },
+  },
+  CommentReactionGroup: {
+    count: (group) => group.userIds.length,
+    reactedByMe: (group, _args, ctx) => {
+      const userId = ctx.auth?.user.id;
+      return userId ? group.userIds.includes(userId) : false;
+    },
+    users: async (group, _args, ctx) => {
+      const accounts = await Promise.all(
+        group.userIds.map((userId) =>
+          ctx.loaders.AccountFromRelation.load({ userId }),
+        ),
+      );
+      return accounts.filter((account) => account !== null);
     },
   },
   Mutation: {
@@ -186,6 +253,42 @@ export const resolvers: IResolvers = {
       }
 
       return deleteBuildComment({ comment });
+    },
+    addCommentReaction: async (_root, args, ctx) => {
+      const { auth } = ctx;
+      if (!auth) {
+        throw unauthenticated();
+      }
+
+      const { input } = args;
+
+      const comment = await getCommentByGraphqlId(input.commentId);
+
+      await checkCanReactToComment(comment, auth.user);
+
+      return addCommentReaction({
+        comment,
+        userId: auth.user.id,
+        emoji: input.emoji,
+      });
+    },
+    removeCommentReaction: async (_root, args, ctx) => {
+      const { auth } = ctx;
+      if (!auth) {
+        throw unauthenticated();
+      }
+
+      const { input } = args;
+
+      const comment = await getCommentByGraphqlId(input.commentId);
+
+      await checkCanReactToComment(comment, auth.user);
+
+      return removeCommentReaction({
+        comment,
+        userId: auth.user.id,
+        emoji: input.emoji,
+      });
     },
   },
 };

--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -14,6 +14,7 @@ import {
   Build,
   BuildReview,
   Comment,
+  CommentReaction,
   Deployment,
   DeploymentAlias,
   File,
@@ -651,6 +652,24 @@ function createBuildPublishedCommentsLoader() {
   });
 }
 
+function createCommentReactionsLoader() {
+  return new DataLoader<string, CommentReaction[]>(async (commentIds) => {
+    const reactions = await CommentReaction.query()
+      .whereIn("commentId", commentIds as string[])
+      .orderBy("createdAt", "asc");
+    const reactionsMap = reactions.reduce<Record<string, CommentReaction[]>>(
+      (map, reaction) => {
+        const array = map[reaction.commentId] ?? [];
+        array.push(reaction);
+        map[reaction.commentId] = array;
+        return map;
+      },
+      {},
+    );
+    return commentIds.map((id) => reactionsMap[id] ?? []);
+  });
+}
+
 function createBuildReviewsLoader() {
   return new DataLoader<string, BuildReview[]>(async (inputs) => {
     const reviews = await BuildReview.query()
@@ -1116,6 +1135,7 @@ export const createLoaders = () => ({
   AccountSubscriptionStatusByAccountId:
     createAccountSubscriptionStatusByAccountIdLoader(),
   BuildPublishedComments: createBuildPublishedCommentsLoader(),
+  CommentReactions: createCommentReactionsLoader(),
   BuildReviews: createBuildReviewsLoader(),
   DeploymentAliasesByDeploymentId:
     createDeploymentAliasesByDeploymentIdLoader(),

--- a/apps/backend/src/notification/handlers/comment_reaction.tsx
+++ b/apps/backend/src/notification/handlers/comment_reaction.tsx
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+import { EmailLayout, H1, Hi, Link, Paragraph } from "../../email/components";
+import { defineNotificationHandler } from "../workflow-types";
+
+export const handler = defineNotificationHandler({
+  type: "comment_reaction",
+  category: "review",
+  schema: z.object({
+    accountSlug: z.string(),
+    projectName: z.string(),
+    buildNumber: z.number(),
+    buildName: z.string().nullish(),
+    commentUrl: z.url(),
+    reactorName: z.string().nullish(),
+    emoji: z.string(),
+  }),
+  previewData: {
+    accountSlug: "argos",
+    projectName: "my-project",
+    buildNumber: 42,
+    buildName: "default",
+    commentUrl:
+      "https://app.argos-ci.com/argos/my-project/builds/42#comment-xf23d",
+    reactorName: "Jane Doe",
+    emoji: "👍",
+  },
+  email: (props) => {
+    const {
+      accountSlug,
+      projectName,
+      buildNumber,
+      buildName,
+      commentUrl,
+      reactorName,
+      emoji,
+      ctx,
+    } = props;
+    const buildLabel = buildName
+      ? `${buildName} #${buildNumber}`
+      : `#${buildNumber}`;
+    const reactor = reactorName || "Someone";
+    return {
+      subject: `[${accountSlug}/${projectName}] ${reactor} reacted ${emoji} to your comment`,
+      body: (
+        <EmailLayout
+          preview={`${reactor} reacted ${emoji} to your comment on build ${buildLabel} in ${accountSlug}/${projectName}.`}
+          preferencesUrl={ctx.preferencesUrl}
+        >
+          <H1>New reaction</H1>
+          <Hi name={ctx.user.name} />
+          <Paragraph>
+            <strong>{reactor}</strong> reacted{" "}
+            <span style={{ fontSize: "18px" }}>{emoji}</span> to your comment on
+            build{" "}
+            <Link href={commentUrl}>
+              {accountSlug}/{projectName} {buildLabel}
+            </Link>
+            .
+          </Paragraph>
+          <Paragraph>
+            <Link href={commentUrl}>View the comment on Argos →</Link>
+          </Paragraph>
+        </EmailLayout>
+      ),
+    };
+  },
+});

--- a/apps/backend/src/notification/handlers/index.ts
+++ b/apps/backend/src/notification/handlers/index.ts
@@ -1,5 +1,6 @@
 import type { NotificationHandler } from "../workflow-types";
 import * as comment_added from "./comment_added";
+import * as comment_reaction from "./comment_reaction";
 import * as email_added from "./email_added";
 import * as email_removed from "./email_removed";
 import * as invalid_gitlab_token from "./invalid_gitlab_token";
@@ -13,6 +14,7 @@ import * as welcome from "./welcome";
 
 export const notificationHandlers = [
   comment_added.handler,
+  comment_reaction.handler,
   email_added.handler,
   email_removed.handler,
   invalid_gitlab_token.handler,

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -62,6 +62,7 @@
     "d3-zoom": "^3.0.0",
     "eslint": "catalog:",
     "fast-fuzzy": "^1.12.0",
+    "frimousse": "^0.3.0",
     "graphql": "^16.14.0",
     "input-otp": "^1.4.2",
     "jotai": "^2.20.0",

--- a/apps/frontend/src/pages/Build/sidebar/CommentActionsMenu.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentActionsMenu.tsx
@@ -25,12 +25,7 @@ export function CommentActionsMenu(props: {
   const { onCopyLink, onEdit, onDelete } = props;
   return (
     <MenuTrigger>
-      <IconButton
-        rounded
-        size="small"
-        aria-label="Comment actions"
-        className="ml-auto"
-      >
+      <IconButton rounded size="small" aria-label="Comment actions">
         <MoreHorizontalIcon />
       </IconButton>
       <Popover placement="bottom end">

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -18,6 +18,10 @@ import { Tooltip } from "@/ui/Tooltip";
 import { getErrorMessage } from "@/util/error";
 
 import { CommentActionsMenu } from "./CommentActionsMenu";
+import {
+  CommentAddReactionButton,
+  CommentReactionList,
+} from "./CommentReactions";
 import { DeleteCommentDialog } from "./DeleteCommentDialog";
 
 // Shared id so copying a comment link reuses a single toast instead of stacking.
@@ -41,6 +45,7 @@ const _CommentFragment = graphql(`
         ...AccountAvatarFragment
       }
     }
+    ...CommentReactions_Comment
   }
 `);
 
@@ -141,11 +146,16 @@ export function CommentCard(props: {
               {isEdited ? " (edited)" : null}
             </Button>
           </Tooltip>
-          <CommentActionsMenu
-            onCopyLink={copyLink}
-            onEdit={canEdit ? () => setIsEditing(true) : undefined}
-            onDelete={canDelete ? () => setIsDeleteDialogOpen(true) : undefined}
-          />
+          <div className="ml-auto flex items-center">
+            <CommentAddReactionButton comment={comment} />
+            <CommentActionsMenu
+              onCopyLink={copyLink}
+              onEdit={canEdit ? () => setIsEditing(true) : undefined}
+              onDelete={
+                canDelete ? () => setIsDeleteDialogOpen(true) : undefined
+              }
+            />
+          </div>
         </div>
         <div className="text-default px-1 pb-2 text-sm">
           {isEditing ? (
@@ -167,6 +177,7 @@ export function CommentCard(props: {
             <ReadOnlyEditor content={comment.content} className="px-1" />
           )}
         </div>
+        <CommentReactionList comment={comment} />
       </div>
       <Modal isOpen={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
         <DeleteCommentDialog commentId={comment.id} />

--- a/apps/frontend/src/pages/Build/sidebar/CommentReactions.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentReactions.tsx
@@ -1,0 +1,175 @@
+import { useMutation } from "@apollo/client/react";
+import { clsx } from "clsx";
+import { SmilePlusIcon } from "lucide-react";
+import { Button } from "react-aria-components";
+import { toast } from "sonner";
+
+import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
+import { DocumentType, graphql } from "@/gql";
+import { ProjectPermission } from "@/gql/graphql";
+import { EmojiPickerPopover, EmojiPickerTrigger } from "@/ui/EmojiPicker";
+import { IconButton } from "@/ui/IconButton";
+import { Tooltip } from "@/ui/Tooltip";
+import { getErrorMessage } from "@/util/error";
+import { useNonNullable } from "@/util/useNonNullable";
+
+const _CommentFragment = graphql(`
+  fragment CommentReactions_Comment on Comment {
+    id
+    reactions {
+      emoji
+      count
+      reactedByMe
+      users {
+        id
+        name
+        slug
+      }
+    }
+  }
+`);
+
+const AddCommentReactionMutation = graphql(`
+  mutation CommentReactions_addCommentReaction($input: CommentReactionInput!) {
+    addCommentReaction(input: $input) {
+      id
+      ...CommentReactions_Comment
+    }
+  }
+`);
+
+const RemoveCommentReactionMutation = graphql(`
+  mutation CommentReactions_removeCommentReaction(
+    $input: CommentReactionInput!
+  ) {
+    removeCommentReaction(input: $input) {
+      id
+      ...CommentReactions_Comment
+    }
+  }
+`);
+
+type Comment = DocumentType<typeof _CommentFragment>;
+type ReactionGroup = Comment["reactions"][number];
+
+/**
+ * Whether the current user is allowed to react. Reacting requires the same
+ * "review" permission on the project as commenting does.
+ */
+function useCanReact(): boolean {
+  const permissions = useNonNullable(ProjectPermissionsContext);
+  return permissions.includes(ProjectPermission.Review);
+}
+
+/**
+ * Shared add/remove reaction mutations for a comment. Both the picker button
+ * and the reaction pills mutate the same comment.
+ */
+function useReactionActions(commentId: string) {
+  const [addReaction] = useMutation(AddCommentReactionMutation);
+  const [removeReaction] = useMutation(RemoveCommentReactionMutation);
+
+  const react = (emoji: string) => {
+    addReaction({
+      variables: { input: { commentId, emoji } },
+    }).catch((error) => {
+      toast.error(getErrorMessage(error));
+    });
+  };
+
+  const toggle = (group: ReactionGroup) => {
+    const mutation = group.reactedByMe ? removeReaction : addReaction;
+    mutation({
+      variables: { input: { commentId, emoji: group.emoji } },
+    }).catch((error) => {
+      toast.error(getErrorMessage(error));
+    });
+  };
+
+  return { react, toggle };
+}
+
+/**
+ * Build the tooltip text listing who reacted with a given emoji, e.g.
+ * "Alice, Bob and 2 others reacted with 👍".
+ */
+function getReactionTooltip(group: ReactionGroup): string {
+  const names = group.users.map((user) => user.name || user.slug);
+  if (names.length === 1) {
+    return `${names[0]} reacted with ${group.emoji}`;
+  }
+  const head = names.slice(0, 3);
+  const rest = names.length - head.length;
+  const list =
+    rest > 0
+      ? `${head.join(", ")} and ${rest} other${rest > 1 ? "s" : ""}`
+      : `${head.slice(0, -1).join(", ")} and ${head[head.length - 1]}`;
+  return `${list} reacted with ${group.emoji}`;
+}
+
+/**
+ * Picker button that opens the emoji picker to add a reaction to a comment.
+ * Rendered in the comment header, next to the actions menu. Hidden when the
+ * current user lacks permission to react.
+ */
+export function CommentAddReactionButton(props: { comment: Comment }) {
+  const { comment } = props;
+  const canReact = useCanReact();
+  const { react } = useReactionActions(comment.id);
+
+  if (!canReact) {
+    return null;
+  }
+
+  return (
+    <EmojiPickerTrigger>
+      <Tooltip content="Add reaction">
+        <IconButton rounded size="small" aria-label="Add reaction">
+          <SmilePlusIcon />
+        </IconButton>
+      </Tooltip>
+      <EmojiPickerPopover
+        placement="bottom end"
+        onEmojiSelect={({ emoji }) => react(emoji)}
+      />
+    </EmojiPickerTrigger>
+  );
+}
+
+/**
+ * The list of reaction pills shown in the comment footer. Renders nothing when
+ * the comment has no reactions yet.
+ */
+export function CommentReactionList(props: { comment: Comment }) {
+  const { comment } = props;
+  const canReact = useCanReact();
+  const { toggle } = useReactionActions(comment.id);
+
+  if (comment.reactions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1 px-2 pb-2">
+      {comment.reactions.map((group) => (
+        <Tooltip key={group.emoji} content={getReactionTooltip(group)}>
+          <Button
+            isDisabled={!canReact}
+            onPress={() => toggle(group)}
+            className={clsx(
+              "flex h-6 items-center gap-1 rounded-full border px-2 text-xs font-medium transition",
+              "cursor-default focus:outline-hidden data-focus-visible:ring-4",
+              canReact && "data-hovered:border-hover",
+              group.reactedByMe
+                ? "border-primary bg-active text-default"
+                : "text-low",
+            )}
+          >
+            <span className="text-sm leading-none">{group.emoji}</span>
+            <span className="tabular-nums">{group.count}</span>
+          </Button>
+        </Tooltip>
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/Build/sidebar/CommentReactions.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentReactions.tsx
@@ -170,6 +170,7 @@ export function CommentReactionList(props: { comment: Comment }) {
           </Button>
         </Tooltip>
       ))}
+      <CommentAddReactionButton comment={comment} />
     </div>
   );
 }

--- a/apps/frontend/src/pages/Build/sidebar/CommentReactions.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentReactions.tsx
@@ -95,6 +95,9 @@ function useReactionActions(commentId: string) {
  */
 function getReactionTooltip(group: ReactionGroup): string {
   const names = group.users.map((user) => user.name || user.slug);
+  if (names.length === 0) {
+    return "";
+  }
   if (names.length === 1) {
     return `${names[0]} reacted with ${group.emoji}`;
   }

--- a/apps/frontend/src/ui/EmojiPicker.stories.tsx
+++ b/apps/frontend/src/ui/EmojiPicker.stories.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SmilePlusIcon } from "lucide-react";
+import { useForm } from "react-hook-form";
+
+import {
+  EmojiPicker,
+  EmojiPickerField,
+  EmojiPickerPopover,
+  EmojiPickerTrigger,
+} from "./EmojiPicker";
+import { IconButton } from "./IconButton";
+import { StoryTitle } from "./StoryTitle";
+
+const meta = {
+  title: "UI/EmojiPicker",
+  component: EmojiPicker,
+} satisfies Meta<typeof EmojiPicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function DefaultStory() {
+  const [selected, setSelected] = useState<string | null>(null);
+  return (
+    <div className="p-8">
+      <StoryTitle>Inline</StoryTitle>
+      <div className="border-thin bg-subtle w-fit rounded-lg">
+        <EmojiPicker onEmojiSelect={({ emoji }) => setSelected(emoji)} />
+      </div>
+      <p className="text-low mt-2 text-sm">Last selected: {selected ?? "—"}</p>
+
+      <StoryTitle>In a Popover</StoryTitle>
+      <EmojiPickerTrigger>
+        <IconButton aria-label="Add reaction">
+          <SmilePlusIcon />
+        </IconButton>
+        <EmojiPickerPopover onEmojiSelect={({ emoji }) => setSelected(emoji)} />
+      </EmojiPickerTrigger>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <DefaultStory />,
+};
+
+type FormValues = { emoji: string };
+
+function FieldStory() {
+  const { control, watch } = useForm<FormValues>({
+    defaultValues: { emoji: "" },
+  });
+  const value = watch("emoji");
+  return (
+    <div className="p-8">
+      <StoryTitle>EmojiPickerField (react-hook-form)</StoryTitle>
+      <div className="flex items-center gap-3">
+        <EmojiPickerField
+          control={control}
+          name="emoji"
+          aria-label="Pick an emoji"
+        />
+        <span className="text-low text-sm">Field value: {value || "—"}</span>
+      </div>
+    </div>
+  );
+}
+
+export const Field: Story = {
+  render: () => <FieldStory />,
+};

--- a/apps/frontend/src/ui/EmojiPicker.tsx
+++ b/apps/frontend/src/ui/EmojiPicker.tsx
@@ -83,7 +83,7 @@ export function EmojiPicker(props: EmojiPickerProps) {
 }
 
 export type EmojiPickerPopoverProps = Omit<PopoverProps, "children"> & {
-  /** Called with the selected emoji character. */
+  /** Called with the selected frimousse {@link Emoji} (use `emoji.emoji` for the character). */
   onEmojiSelect: (emoji: Emoji) => void;
 } & Pick<EmojiPickerProps, "locale" | "skinTone" | "columns">;
 

--- a/apps/frontend/src/ui/EmojiPicker.tsx
+++ b/apps/frontend/src/ui/EmojiPicker.tsx
@@ -1,0 +1,184 @@
+import { clsx } from "clsx";
+import {
+  EmojiPicker as Frimousse,
+  type Emoji,
+  type EmojiPickerRootProps,
+} from "frimousse";
+import { SmilePlusIcon } from "lucide-react";
+import { DialogTrigger, type PopoverProps } from "react-aria-components";
+import {
+  useController,
+  type Control,
+  type FieldValues,
+  type Path,
+} from "react-hook-form";
+
+import { mergeRefs } from "@/util/merge-refs";
+
+import { Dialog } from "./Dialog";
+import { IconButton, type IconButtonProps } from "./IconButton";
+import { Popover } from "./Popover";
+
+export { DialogTrigger as EmojiPickerTrigger } from "react-aria-components";
+
+export type EmojiPickerProps = Omit<EmojiPickerRootProps, "children">;
+
+/**
+ * A styled emoji picker built on top of {@link https://frimousse.liveblocks.io | frimousse}.
+ *
+ * It is meant to be rendered inside an overlay such as {@link EmojiPickerPopover}.
+ */
+export function EmojiPicker(props: EmojiPickerProps) {
+  return (
+    <Frimousse.Root
+      {...props}
+      className={clsx("isolate flex h-92 w-79 flex-col", props.className)}
+    >
+      <Frimousse.Search
+        autoFocus
+        placeholder="Search emoji…"
+        className={clsx(
+          "bg-app text-default placeholder:text-placeholder z-10 m-1 appearance-none rounded-sm border px-3 py-1.5 text-sm leading-tight",
+          "focus:border-active focus:outline-hidden",
+        )}
+      />
+      <Frimousse.Viewport className="relative flex-1 outline-hidden">
+        <Frimousse.Loading className="text-low absolute inset-0 flex items-center justify-center text-sm">
+          Loading…
+        </Frimousse.Loading>
+        <Frimousse.Empty className="text-low absolute inset-0 flex items-center justify-center text-sm">
+          {({ search }) =>
+            search ? `No emoji found for “${search}”` : "No emoji found."
+          }
+        </Frimousse.Empty>
+        <Frimousse.List
+          className="pb-1 select-none"
+          components={{
+            CategoryHeader: ({ category, ...props }) => (
+              <div
+                {...props}
+                className="bg-subtle text-low px-2 pt-2.5 pb-1 text-xs font-medium"
+              >
+                {category.label}
+              </div>
+            ),
+            Row: ({ children, ...props }) => (
+              <div {...props} className="scroll-my-1 px-1">
+                {children}
+              </div>
+            ),
+            Emoji: ({ emoji, ...props }) => (
+              <button
+                {...props}
+                className="data-active:bg-active flex size-8 items-center justify-center rounded-sm text-lg"
+              >
+                {emoji.emoji}
+              </button>
+            ),
+          }}
+        />
+      </Frimousse.Viewport>
+    </Frimousse.Root>
+  );
+}
+
+export type EmojiPickerPopoverProps = Omit<PopoverProps, "children"> & {
+  /** Called with the selected emoji character. */
+  onEmojiSelect: (emoji: Emoji) => void;
+} & Pick<EmojiPickerProps, "locale" | "skinTone" | "columns">;
+
+/**
+ * An {@link EmojiPicker} rendered inside our {@link Popover}.
+ *
+ * Pair it with an {@link EmojiPickerTrigger} (re-exported `DialogTrigger`) and a
+ * trigger element. The popover closes automatically once an emoji is selected.
+ *
+ * @example
+ * ```tsx
+ * <EmojiPickerTrigger>
+ *   <IconButton><SmilePlusIcon /></IconButton>
+ *   <EmojiPickerPopover onEmojiSelect={({ emoji }) => console.log(emoji)} />
+ * </EmojiPickerTrigger>
+ * ```
+ */
+export function EmojiPickerPopover(props: EmojiPickerPopoverProps) {
+  const { onEmojiSelect, locale, skinTone, columns, ...popoverProps } = props;
+  return (
+    <Popover {...popoverProps}>
+      <Dialog aria-label="Emoji picker" scrollable={false}>
+        {({ close }) => (
+          <EmojiPicker
+            locale={locale}
+            skinTone={skinTone}
+            columns={columns}
+            onEmojiSelect={(emoji) => {
+              onEmojiSelect(emoji);
+              close();
+            }}
+          />
+        )}
+      </Dialog>
+    </Popover>
+  );
+}
+
+export type EmojiPickerFieldProps<TFieldValues extends FieldValues> = {
+  ref?: React.Ref<HTMLButtonElement>;
+  control: Control<TFieldValues>;
+  name: Path<TFieldValues>;
+  /** Accessible label for the trigger button. */
+  "aria-label"?: string;
+  /** Props forwarded to the trigger {@link IconButton}. */
+  buttonProps?: Omit<IconButtonProps, "ref">;
+} & Pick<EmojiPickerProps, "locale" | "skinTone" | "columns">;
+
+/**
+ * A react-hook-form compatible emoji picker field.
+ *
+ * It stores the selected emoji character as the field value and renders an
+ * {@link IconButton} trigger that opens an {@link EmojiPickerPopover}.
+ */
+export function EmojiPickerField<TFieldValues extends FieldValues>(
+  props: EmojiPickerFieldProps<TFieldValues>,
+) {
+  const {
+    ref,
+    control,
+    name,
+    buttonProps,
+    locale,
+    skinTone,
+    columns,
+    "aria-label": ariaLabel = "Pick an emoji",
+  } = props;
+  const { field } = useController({ control, name });
+  const mergedRef = mergeRefs(field.ref, ref);
+  return (
+    <DialogTrigger>
+      <IconButton
+        aria-label={ariaLabel}
+        {...buttonProps}
+        ref={mergedRef}
+        isDisabled={field.disabled || buttonProps?.isDisabled}
+        onBlur={(event) => {
+          field.onBlur();
+          buttonProps?.onBlur?.(event);
+        }}
+      >
+        {field.value ? (
+          <span className="text-base leading-none">{field.value}</span>
+        ) : (
+          <SmilePlusIcon />
+        )}
+      </IconButton>
+      <EmojiPickerPopover
+        locale={locale}
+        skinTone={skinTone}
+        columns={columns}
+        onEmojiSelect={({ emoji }) => {
+          field.onChange(emoji);
+        }}
+      />
+    </DialogTrigger>
+  );
+}

--- a/codegen.ts
+++ b/codegen.ts
@@ -50,6 +50,8 @@ const config: CodegenConfig = {
           Build: "../../database/models/index.js#Build",
           BuildReview: "../../database/models/index.js#BuildReview",
           Comment: "../../database/models/index.js#Comment",
+          CommentReactionGroup:
+            "../../comment/reactions.js#CommentReactionGroup",
           Deployment: "../../database/models/index.js#Deployment",
           GhApiInstallation: "../../github/index.js#GhApiInstallation",
           GhApiRepository: "../../github/index.js#GhApiRepository",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -563,6 +563,9 @@ importers:
       fast-fuzzy:
         specifier: ^1.12.0
         version: 1.12.0
+      frimousse:
+        specifier: ^0.3.0
+        version: 0.3.0(react@19.2.6)(typescript@6.0.3)
       graphql:
         specifier: ^16.14.0
         version: 16.14.0
@@ -5718,6 +5721,15 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  frimousse@0.3.0:
+    resolution: {integrity: sha512-kO6LMoKY/cLAYEhXXtqLRaLIE6L/DagpFPrUZaLv3LsUa1/8Iza3HhwZcgN8eZ+weXnhv69eoclNUPohcCa/IQ==}
+    peerDependencies:
+      react: ^19.2.6
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -13503,6 +13515,12 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
 
   fresh@2.0.0: {}
+
+  frimousse@0.3.0(react@19.2.6)(typescript@6.0.3):
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      typescript: 6.0.3
 
   fsevents@2.3.2:
     optional: true


### PR DESCRIPTION
## Overview

Implements emoji reactions on build review comments (ARG-363), using the [frimousse](https://github.com/liveblocks/frimousse) emoji picker by Liveblocks.

- Allow reacting to comments with emojis
- Notify the comment author when someone else reacts
- Emoji picker built on frimousse, integrated with our `Popover`

## Changes

### New `EmojiPicker` UI component
- Styled frimousse picker integrated with our `Popover` (`EmojiPicker`, `EmojiPickerPopover`, `EmojiPickerTrigger`)
- A react-hook-form compatible `EmojiPickerField`
- Storybook story

### Backend
- `addCommentReaction` / `removeCommentReaction` services (idempotent), with emoji validation (rejects plain text/digits, bounds length, allows skin-tone + ZWJ sequences)
- `CommentReactions` dataloader batching reactions per comment
- GraphQL: `CommentReactionGroup` type (`emoji`, `count`, `reactedByMe`, `users`), a `reactions` field on `Comment`, and the two mutations — gated on the project's `review` permission
- `comment_reaction` email notification handler (category `review`); the comment author is notified when someone else reacts (no self-notification)
- Unit tests for emoji validation and grouping

### Frontend
- `CommentAddReactionButton` (emoji picker trigger) shown next to the comment actions menu, and again at the end of the reaction row when reactions exist
- `CommentReactionList` — reaction pills with per-emoji counts, a tooltip listing who reacted, and click-to-toggle; renders nothing when there are no reactions

## Notes
- No DB migration needed — the `comment_reactions` table already exists.
- Reacting reuses the **`review`** permission (same as commenting).
- frimousse fetches emoji data from the jsDelivr CDN at runtime (its default).

## Test plan
- [x] `check-types`, `eslint`, `prettier` pass for both apps
- [x] Backend unit tests pass (`reactions.test.ts`)
- [ ] Manual: react/unreact on a comment, verify counts, tooltip, and author notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)
