### PR TITLE
feat(notification): send comment reaction emails to thread subscribers

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -131,5 +131,8 @@
     "openapi3-ts": "^4.5.0",
     "pino-pretty": "^13.1.3",
     "supertest": "^7.2.2"
+  },
+  "optionalDependencies": {
+    "@argos-ci/mask-fingerprint-darwin-arm64": "^0.1.3"
   }
 }

--- a/apps/backend/src/comment/addCommentReaction.ts
+++ b/apps/backend/src/comment/addCommentReaction.ts
@@ -1,16 +1,20 @@
 import { invariant } from "@argos/util/invariant";
+import type { JSONContent } from "@tiptap/core";
 
 import { knex } from "@/database";
 import { Comment, User } from "@/database/models";
+import { getCommentThreadSubscribedUserIds } from "@/database/services/comment-notification-subscription";
 import { sendNotification } from "@/notification";
 import { boom } from "@/util/error";
 
+import { renderCommentHtml } from "./html";
 import { formatCommentId } from "./id";
 import { isValidEmoji } from "./reactions";
 
 /**
- * Add an emoji reaction from a user to a comment and notify the comment author.
- * The operation is idempotent: reacting again with the same emoji is a no-op.
+ * Add an emoji reaction from a user to a comment and notify the comment thread
+ * subscribers. The operation is idempotent: reacting again with the same emoji
+ * is a no-op.
  */
 export async function addCommentReaction(input: {
   comment: Comment;
@@ -38,23 +42,28 @@ export async function addCommentReaction(input: {
     return comment;
   }
 
-  await notifyCommentAuthor({ comment, userId, emoji });
+  await notifyCommentThreadSubscribers({ comment, userId, emoji });
 
   return comment;
 }
 
 /**
- * Notify the comment author that someone reacted to their comment. Reacting to
- * your own comment does not send a notification.
+ * Notify everyone subscribed to the reacted-to comment's thread. The reactor is
+ * never notified of their own reaction.
  */
-async function notifyCommentAuthor(input: {
+async function notifyCommentThreadSubscribers(input: {
   comment: Comment;
   userId: string;
   emoji: string;
 }): Promise<void> {
   const { comment, userId, emoji } = input;
 
-  if (comment.userId === userId) {
+  // A standalone comment is its own thread root; a reply points at the root
+  // via `threadId`. Subscriptions are keyed on the root comment.
+  const threadId = comment.threadId ?? comment.id;
+  const subscribedUserIds = await getCommentThreadSubscribedUserIds(threadId);
+  const recipients = subscribedUserIds.filter((id) => id !== userId);
+  if (recipients.length === 0) {
     return;
   }
 
@@ -81,9 +90,11 @@ async function notifyCommentAuthor(input: {
       buildNumber: build.number,
       buildName: build.name,
       commentUrl,
+      commentAuthorId: comment.userId,
       reactorName,
       emoji,
+      bodyHtml: renderCommentHtml(comment.content as JSONContent),
     },
-    recipients: [comment.userId],
+    recipients,
   });
 }

--- a/apps/backend/src/email/components.tsx
+++ b/apps/backend/src/email/components.tsx
@@ -83,6 +83,19 @@ export function HighlightBlock(props: { children: React.ReactNode }) {
   );
 }
 
+/**
+ * Box displaying the rendered HTML of a comment (see `renderCommentHtml`).
+ * Shared by the comment and review notification emails.
+ */
+export function CommentBox(props: { html: string }) {
+  return (
+    <div
+      className="my-4 rounded bg-[#f6f6f6] p-4 text-sm text-gray-950"
+      dangerouslySetInnerHTML={{ __html: props.html }}
+    />
+  );
+}
+
 export function OTPCode(props: { children: React.ReactNode }) {
   return (
     <Text className="inline-block rounded bg-[#f6f6f6] p-4 text-2xl font-bold tracking-[0.2em]">

--- a/apps/backend/src/notification/express.tsx
+++ b/apps/backend/src/notification/express.tsx
@@ -20,7 +20,10 @@ export function getNotificationPreviewMiddleware(options: { path: string }) {
       `/${handler.type}`,
       asyncHandler(async (req, res) => {
         const rendered = handler.email({
-          ctx: { user: { name: "James" }, preferencesUrl: null },
+          ctx: {
+            user: { id: "preview-user", name: "James" },
+            preferencesUrl: null,
+          },
           ...(handler.previewData as any),
           ...queryStringToObject(req.query),
         });

--- a/apps/backend/src/notification/handlers/comment_added.tsx
+++ b/apps/backend/src/notification/handlers/comment_added.tsx
@@ -1,6 +1,13 @@
 import { z } from "zod";
 
-import { EmailLayout, H1, Hi, Link, Paragraph } from "../../email/components";
+import {
+  CommentBox,
+  EmailLayout,
+  H1,
+  Hi,
+  Link,
+  Paragraph,
+} from "../../email/components";
 import { defineNotificationHandler } from "../workflow-types";
 
 export const handler = defineNotificationHandler({
@@ -56,10 +63,7 @@ export const handler = defineNotificationHandler({
             </Link>
             .
           </Paragraph>
-          <div
-            className="my-4 rounded bg-[#f6f6f6] p-4 text-sm text-gray-950"
-            dangerouslySetInnerHTML={{ __html: bodyHtml }}
-          />
+          <CommentBox html={bodyHtml} />
           <Paragraph>
             <Link href={commentUrl}>View the comment on Argos →</Link>
           </Paragraph>

--- a/apps/backend/src/notification/handlers/comment_reaction.tsx
+++ b/apps/backend/src/notification/handlers/comment_reaction.tsx
@@ -1,6 +1,13 @@
 import { z } from "zod";
 
-import { EmailLayout, H1, Hi, Link, Paragraph } from "../../email/components";
+import {
+  CommentBox,
+  EmailLayout,
+  H1,
+  Hi,
+  Link,
+  Paragraph,
+} from "../../email/components";
 import { defineNotificationHandler } from "../workflow-types";
 
 export const handler = defineNotificationHandler({
@@ -12,8 +19,11 @@ export const handler = defineNotificationHandler({
     buildNumber: z.number(),
     buildName: z.string().nullish(),
     commentUrl: z.url(),
+    /** Author of the reacted-to comment; used to say "your comment" to them. */
+    commentAuthorId: z.string(),
     reactorName: z.string().nullish(),
     emoji: z.string(),
+    bodyHtml: z.string(),
   }),
   previewData: {
     accountSlug: "argos",
@@ -22,8 +32,10 @@ export const handler = defineNotificationHandler({
     buildName: "default",
     commentUrl:
       "https://app.argos-ci.com/argos/my-project/builds/42#comment-xf23d",
+    commentAuthorId: "preview-user",
     reactorName: "Jane Doe",
     emoji: "👍",
+    bodyHtml: "<p>Could you double-check the header spacing?</p>",
   },
   email: (props) => {
     const {
@@ -32,32 +44,39 @@ export const handler = defineNotificationHandler({
       buildNumber,
       buildName,
       commentUrl,
+      commentAuthorId,
       reactorName,
       emoji,
+      bodyHtml,
       ctx,
     } = props;
     const buildLabel = buildName
       ? `${buildName} #${buildNumber}`
       : `#${buildNumber}`;
     const reactor = reactorName || "Someone";
+    // The notification goes to every thread subscriber, but only its author
+    // owns the reacted-to comment.
+    const commentRef =
+      ctx.user.id === commentAuthorId ? "your comment" : "a comment";
     return {
-      subject: `[${accountSlug}/${projectName}] ${reactor} reacted ${emoji} to your comment`,
+      subject: `[${accountSlug}/${projectName}] ${reactor} reacted ${emoji} to ${commentRef}`,
       body: (
         <EmailLayout
-          preview={`${reactor} reacted ${emoji} to your comment on build ${buildLabel} in ${accountSlug}/${projectName}.`}
+          preview={`${reactor} reacted ${emoji} to ${commentRef} on build ${buildLabel} in ${accountSlug}/${projectName}.`}
           preferencesUrl={ctx.preferencesUrl}
         >
           <H1>New reaction</H1>
           <Hi name={ctx.user.name} />
           <Paragraph>
             <strong>{reactor}</strong> reacted{" "}
-            <span style={{ fontSize: "18px" }}>{emoji}</span> to your comment on
+            <span style={{ fontSize: "18px" }}>{emoji}</span> to {commentRef} on
             build{" "}
             <Link href={commentUrl}>
               {accountSlug}/{projectName} {buildLabel}
             </Link>
             .
           </Paragraph>
+          <CommentBox html={bodyHtml} />
           <Paragraph>
             <Link href={commentUrl}>View the comment on Argos →</Link>
           </Paragraph>

--- a/apps/backend/src/notification/handlers/comment_replied.tsx
+++ b/apps/backend/src/notification/handlers/comment_replied.tsx
@@ -1,6 +1,13 @@
 import { z } from "zod";
 
-import { EmailLayout, H1, Hi, Link, Paragraph } from "../../email/components";
+import {
+  CommentBox,
+  EmailLayout,
+  H1,
+  Hi,
+  Link,
+  Paragraph,
+} from "../../email/components";
 import { defineNotificationHandler } from "../workflow-types";
 
 export const handler = defineNotificationHandler({
@@ -56,10 +63,7 @@ export const handler = defineNotificationHandler({
             </Link>
             .
           </Paragraph>
-          <div
-            className="my-4 rounded bg-[#f6f6f6] p-4 text-sm text-gray-950"
-            dangerouslySetInnerHTML={{ __html: bodyHtml }}
-          />
+          <CommentBox html={bodyHtml} />
           <Paragraph>
             <Link href={commentUrl}>View the reply on Argos →</Link>
           </Paragraph>

--- a/apps/backend/src/notification/handlers/review_submitted.tsx
+++ b/apps/backend/src/notification/handlers/review_submitted.tsx
@@ -1,7 +1,14 @@
 import { assertNever } from "@argos/util/assertNever";
 import { z } from "zod";
 
-import { EmailLayout, H1, Hi, Link, Paragraph } from "../../email/components";
+import {
+  CommentBox,
+  EmailLayout,
+  H1,
+  Hi,
+  Link,
+  Paragraph,
+} from "../../email/components";
 import { defineNotificationHandler } from "../workflow-types";
 
 const reviewStateSchema = z.enum(["approved", "rejected", "commented"]);
@@ -91,12 +98,7 @@ export const handler = defineNotificationHandler({
             </Link>
             .
           </Paragraph>
-          {bodyHtml ? (
-            <div
-              className="my-4 rounded bg-[#f6f6f6] p-4 text-sm text-gray-950"
-              dangerouslySetInnerHTML={{ __html: bodyHtml }}
-            />
-          ) : null}
+          {bodyHtml ? <CommentBox html={bodyHtml} /> : null}
           <Paragraph>
             <Link href={buildUrl}>View the build on Argos →</Link>
           </Paragraph>

--- a/apps/backend/src/notification/message-job.ts
+++ b/apps/backend/src/notification/message-job.ts
@@ -46,6 +46,7 @@ async function processMessage(message: NotificationMessage) {
 
   const ctx = {
     user: {
+      id: message.userId,
       name: message.user.account.name
         ? extractFirstName(message.user.account.name)
         : null,

--- a/apps/backend/src/notification/workflow-types.ts
+++ b/apps/backend/src/notification/workflow-types.ts
@@ -2,6 +2,8 @@ import type { z } from "zod";
 
 type HandlerContext = {
   user: {
+    /** ID of the recipient. Lets handlers personalize copy (e.g. "your comment"). */
+    id: string;
     name: string | null;
   };
   /**

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -279,12 +279,12 @@ function CommentMessage(props: {
         ref={ref}
         id={comment.id}
         className={clsx(
-          "ring-primary transition",
+          "group/comment ring-primary transition",
           separated && "border-t-thin",
           highlighted ? "ring-2" : "ring-0",
         )}
       >
-        <div className="group/comment-header relative flex items-center gap-2 px-2 py-1.5 pr-1.5">
+        <div className="relative flex items-center gap-2 px-2 py-1.5 pr-1.5">
           {comment.user ? (
             <AccountAvatar
               avatar={comment.user.avatar}
@@ -323,7 +323,7 @@ function CommentMessage(props: {
               </Tooltip>
             </div>
           </div>
-          <div className="bg-app pointer-events-none absolute top-1 right-1 flex items-center rounded-md pl-1 opacity-0 transition group-focus-within/comment-header:pointer-events-auto group-focus-within/comment-header:opacity-100 group-hover/comment-header:pointer-events-auto group-hover/comment-header:opacity-100 has-[button[aria-expanded=true]]:pointer-events-auto has-[button[aria-expanded=true]]:opacity-100">
+          <div className="bg-app pointer-events-none absolute top-1 right-1 flex items-center rounded-md pl-1 opacity-0 transition group-focus-within/comment:pointer-events-auto group-focus-within/comment:opacity-100 group-hover/comment:pointer-events-auto group-hover/comment:opacity-100 has-[button[aria-expanded=true]]:pointer-events-auto has-[button[aria-expanded=true]]:opacity-100">
             <CommentAddReactionButton comment={comment} />
             <CommentActionsMenu
               onCopyLink={copyLink}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,6 +419,10 @@ importers:
       supertest:
         specifier: ^7.2.2
         version: 7.2.2
+    optionalDependencies:
+      '@argos-ci/mask-fingerprint-darwin-arm64':
+        specifier: ^0.1.3
+        version: 0.1.3
 
   apps/frontend:
     devDependencies:


### PR DESCRIPTION
## Summary

Comment reaction notifications previously went **only to the comment author** and contained just a link. Now that comment threads have subscriptions, this reworks the reaction email to:

- **Notify all thread subscribers** (minus the reactor) instead of only the comment author — reusing the same `getCommentThreadSubscribedUserIds` service that `createBuildComment` already uses. A standalone comment is its own thread root; a reply resolves to its root via `threadId`.
- **Embed the reacted-to comment's HTML** in the email (via `renderCommentHtml`), in addition to the link.
- **Personalize the copy per recipient**: the email says *"your comment"* to the comment's author and *"a comment"* to other thread subscribers.

## A general per-recipient mechanism

The notification `data` payload is shared across all recipients, so personalization has to happen at render time. I exposed the recipient's identity in the handler context (`ctx.user.id`) so **any** notification handler can personalize copy — `comment_reaction` is the first consumer, comparing it against the new `commentAuthorId` field in the payload.

## Reusable `CommentBox` component

The identical comment-box markup was duplicated across four handlers. Extracted it into a shared `CommentBox` email component and replaced all usages:

- `comment_added`, `comment_replied`, `comment_reaction` → `<CommentBox html={bodyHtml} />`
- `review_submitted` → keeps its existing optional-body null guard

## Test plan

- [x] `pnpm run check-types` passes
- [x] `eslint` passes on all changed files
- [ ] Visual check via the notification preview route (`/comment_reaction`) — defaults render the "your comment" variant; override `commentAuthorId` in the query string to see "a comment"

🤖 Generated with [Claude Code](https://claude.com/claude-code)