### PR TITLE
feat(frontend): show review date in reviewer status tooltip

### DIFF
--- a/apps/frontend/src/containers/BuildReviewersStatusList.tsx
+++ b/apps/frontend/src/containers/BuildReviewersStatusList.tsx
@@ -74,7 +74,7 @@ export function BuildReviewersStatusList<
               {review.user?.name || review.user?.slug}
             </strong>
             <Tooltip
-              content={`${descriptor.label} · ${moment(review.date).fromNow()}`}
+              content={`${descriptor.label} · ${moment(review.dismissedAt ?? review.date).fromNow()}`}
             >
               <Icon
                 className={clsx("size-3.5 shrink-0", descriptor.textColor)}

--- a/apps/frontend/src/containers/BuildReviewersStatusList.tsx
+++ b/apps/frontend/src/containers/BuildReviewersStatusList.tsx
@@ -1,6 +1,7 @@
 import type { ComponentProps, ReactNode } from "react";
 import clsx from "clsx";
 import { BanIcon } from "lucide-react";
+import moment from "moment";
 
 import type { ReviewState } from "@/gql/graphql";
 import { Tooltip } from "@/ui/Tooltip";
@@ -72,7 +73,9 @@ export function BuildReviewersStatusList<
             <strong className="flex-1 truncate font-medium">
               {review.user?.name || review.user?.slug}
             </strong>
-            <Tooltip content={descriptor.label}>
+            <Tooltip
+              content={`${descriptor.label} · ${moment(review.date).fromNow()}`}
+            >
               <Icon
                 className={clsx("size-3.5 shrink-0", descriptor.textColor)}
               />


### PR DESCRIPTION
## Summary
- Add the review date to the tooltip on the reviewer status icon in `BuildReviewersStatusList`, shown as a relative "XX ago" time alongside the review state label (e.g. `Dismissed · 2 hours ago`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)