### PR TITLE
feat(comments): resolve and reopen threads (ARG-373)

### DIFF
--- a/apps/backend/db/migrations/20260610120000_comment-resolved-at.js
+++ b/apps/backend/db/migrations/20260610120000_comment-resolved-at.js
@@ -1,0 +1,17 @@
+/**
+ * @param { import("knex").Knex } knex
+ */
+export async function up(knex) {
+  await knex.schema.alterTable("comments", (table) => {
+    table.dateTime("resolvedAt").nullable();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+export async function down(knex) {
+  await knex.schema.alterTable("comments", (table) => {
+    table.dropColumn("resolvedAt");
+  });
+}

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -648,7 +648,8 @@ CREATE TABLE public.comments (
     "threadId" bigint,
     content jsonb NOT NULL,
     "editedAt" timestamp with time zone,
-    "deletedAt" timestamp with time zone
+    "deletedAt" timestamp with time zone,
+    "resolvedAt" timestamp with time zone
 );
 
 
@@ -5104,3 +5105,4 @@ INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('2026053
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260531130000_comment-mentions.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260608120000_user-sessions.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260609120000_encrypt-sensitive-data.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260610120000_comment-resolved-at.js', 1, NOW());

--- a/apps/backend/src/comment/resolveCommentThread.ts
+++ b/apps/backend/src/comment/resolveCommentThread.ts
@@ -1,0 +1,39 @@
+import type { Comment } from "@/database/models";
+
+/**
+ * Mark a comment thread as resolved by stamping `resolvedAt` on its root
+ * comment. The operation is idempotent: resolving an already-resolved thread is
+ * a no-op and returns the root comment unchanged. No notification is sent.
+ */
+export async function resolveCommentThread(input: {
+  thread: Comment;
+}): Promise<Comment> {
+  const { thread } = input;
+
+  if (thread.resolvedAt) {
+    return thread;
+  }
+
+  return thread.$query().patchAndFetch({
+    resolvedAt: new Date().toISOString(),
+  });
+}
+
+/**
+ * Reopen a resolved comment thread by clearing `resolvedAt` on its root
+ * comment. The operation is idempotent: reopening a thread that isn't resolved
+ * is a no-op and returns the root comment unchanged.
+ */
+export async function unresolveCommentThread(input: {
+  thread: Comment;
+}): Promise<Comment> {
+  const { thread } = input;
+
+  if (!thread.resolvedAt) {
+    return thread;
+  }
+
+  return thread.$query().patchAndFetch({
+    resolvedAt: null,
+  });
+}

--- a/apps/backend/src/database/models/Comment.ts
+++ b/apps/backend/src/database/models/Comment.ts
@@ -28,6 +28,7 @@ export class Comment extends Model {
           threadId: { type: ["string", "null"] },
           editedAt: { type: ["string", "null"] },
           deletedAt: { type: ["string", "null"] },
+          resolvedAt: { type: ["string", "null"] },
           content: {
             anyOf: [
               { type: "array" },
@@ -49,6 +50,11 @@ export class Comment extends Model {
   threadId!: string | null;
   editedAt!: string | null;
   deletedAt!: string | null;
+  /**
+   * When set, the thread is resolved. Only ever set on a root comment (one with
+   * a null `threadId`); replies leave it null and inherit their thread's state.
+   */
+  resolvedAt!: string | null;
   content!: unknown;
 
   static override get relationMappings(): RelationMappings {

--- a/apps/backend/src/graphql/definitions/Comment.ts
+++ b/apps/backend/src/graphql/definitions/Comment.ts
@@ -9,6 +9,10 @@ import { formatCommentId, parseCommentId } from "@/comment/id";
 import { getCommentPermissions } from "@/comment/permissions";
 import { groupCommentReactions } from "@/comment/reactions";
 import { removeCommentReaction } from "@/comment/removeCommentReaction";
+import {
+  resolveCommentThread,
+  unresolveCommentThread,
+} from "@/comment/resolveCommentThread";
 import { updateBuildComment } from "@/comment/updateBuildComment";
 import { Build } from "@/database/models/Build";
 import { Comment } from "@/database/models/Comment";
@@ -143,6 +147,8 @@ export const typeDefs = gql`
     date: DateTime!
     "Date the comment was last edited, null if never edited"
     editedAt: DateTime
+    "Date the thread was resolved, null if not resolved. Only set on a root comment."
+    resolvedAt: DateTime
     "Rich-text JSON content of the comment"
     content: JSONObject!
     "Author of the comment"
@@ -191,6 +197,14 @@ export const typeDefs = gql`
     commentId: ID!
   }
 
+  input ResolveCommentThreadInput {
+    commentId: ID!
+  }
+
+  input UnresolveCommentThreadInput {
+    commentId: ID!
+  }
+
   extend type Mutation {
     "Post a comment on a build"
     addBuildComment(input: AddBuildCommentInput!): Build!
@@ -208,6 +222,10 @@ export const typeDefs = gql`
     unsubscribeFromCommentThread(
       input: UnsubscribeFromCommentThreadInput!
     ): Comment!
+    "Mark a comment thread as resolved"
+    resolveCommentThread(input: ResolveCommentThreadInput!): Comment!
+    "Reopen a resolved comment thread"
+    unresolveCommentThread(input: UnresolveCommentThreadInput!): Comment!
   }
 `;
 
@@ -219,6 +237,9 @@ export const resolvers: IResolvers = {
     },
     editedAt: (comment) => {
       return comment.editedAt ? new Date(comment.editedAt) : null;
+    },
+    resolvedAt: (comment) => {
+      return comment.resolvedAt ? new Date(comment.resolvedAt) : null;
     },
     content: (comment) => {
       return comment.content as Record<string, unknown>;
@@ -433,6 +454,30 @@ export const resolvers: IResolvers = {
         userId: auth.user.id,
       });
       return thread;
+    },
+    resolveCommentThread: async (_root, args, ctx) => {
+      const { auth } = ctx;
+      if (!auth) {
+        throw unauthenticated();
+      }
+      const thread = await getCommentThreadForUser({
+        id: args.input.commentId,
+        user: auth.user,
+        permission: "review",
+      });
+      return resolveCommentThread({ thread });
+    },
+    unresolveCommentThread: async (_root, args, ctx) => {
+      const { auth } = ctx;
+      if (!auth) {
+        throw unauthenticated();
+      }
+      const thread = await getCommentThreadForUser({
+        id: args.input.commentId,
+        user: auth.user,
+        permission: "review",
+      });
+      return unresolveCommentThread({ thread });
     },
   },
 };

--- a/apps/backend/src/graphql/tests/resolveCommentThread.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/resolveCommentThread.e2e.test.ts
@@ -1,0 +1,216 @@
+import { invariant } from "@argos/util/invariant";
+import request from "supertest";
+import { test as base, expect } from "vitest";
+
+import { formatCommentId } from "@/comment/id";
+import { Comment, Project, type Account, type Build } from "@/database/models";
+import { factory, setupDatabase } from "@/database/testing";
+
+import { apolloServer, createApolloMiddleware } from "../apollo";
+import { expectNoGraphQLError } from "../testing";
+import { createApolloServerApp } from "./util";
+
+const RESOLVE_MUTATION = `
+  mutation ResolveCommentThread($input: ResolveCommentThreadInput!) {
+    resolveCommentThread(input: $input) {
+      id
+      resolvedAt
+    }
+  }
+`;
+
+const UNRESOLVE_MUTATION = `
+  mutation UnresolveCommentThread($input: UnresolveCommentThreadInput!) {
+    unresolveCommentThread(input: $input) {
+      id
+      resolvedAt
+    }
+  }
+`;
+
+function commentBody(text: string) {
+  return {
+    type: "doc",
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  };
+}
+
+type Fixtures = {
+  fixture: {
+    /** A team member with the `review` permission on the project. */
+    reviewerAccount: Account;
+    project: Project;
+    build: Build;
+    /** Root comment of the thread. */
+    comment: Comment;
+    /** A reply in the same thread. */
+    reply: Comment;
+  };
+};
+
+const test = base.extend<Fixtures>({
+  fixture: async ({}, use) => {
+    await setupDatabase();
+    const [reviewerAccount, teamAccount] = await Promise.all([
+      factory.UserAccount.create(),
+      factory.TeamAccount.create(),
+    ]);
+    invariant(teamAccount.teamId);
+    invariant(reviewerAccount.userId);
+    const [project] = await Promise.all([
+      factory.Project.create({ accountId: teamAccount.id }),
+      factory.TeamUser.create({
+        teamId: teamAccount.teamId,
+        userId: reviewerAccount.userId,
+        userLevel: "member",
+      }),
+      reviewerAccount.$fetchGraph("user"),
+    ]);
+    const build = await factory.Build.create({ projectId: project.id });
+    const comment = await factory.Comment.create({
+      buildId: build.id,
+      userId: reviewerAccount.userId,
+      content: commentBody("Root"),
+    });
+    const reply = await factory.Comment.create({
+      buildId: build.id,
+      userId: reviewerAccount.userId,
+      threadId: comment.id,
+      content: commentBody("Reply"),
+    });
+    await use({ reviewerAccount, project, build, comment, reply });
+  },
+});
+
+function appForReviewer(fixture: Fixtures["fixture"]) {
+  return createApolloServerApp(apolloServer, createApolloMiddleware, {
+    user: fixture.reviewerAccount.user!,
+    account: fixture.reviewerAccount,
+  });
+}
+
+test("resolves a thread", async ({ fixture }) => {
+  const app = await appForReviewer(fixture);
+  const res = await request(app)
+    .post("/graphql")
+    .send({
+      query: RESOLVE_MUTATION,
+      variables: { input: { commentId: formatCommentId(fixture.comment.id) } },
+    });
+
+  expectNoGraphQLError(res);
+  expect(res.status).toBe(200);
+  expect(res.body.data.resolveCommentThread.resolvedAt).not.toBeNull();
+
+  const stored = await Comment.query().findById(fixture.comment.id);
+  expect(stored!.resolvedAt).not.toBeNull();
+});
+
+test("reopens a resolved thread", async ({ fixture }) => {
+  await fixture.comment
+    .$query()
+    .patch({ resolvedAt: new Date().toISOString() });
+
+  const app = await appForReviewer(fixture);
+  const res = await request(app)
+    .post("/graphql")
+    .send({
+      query: UNRESOLVE_MUTATION,
+      variables: { input: { commentId: formatCommentId(fixture.comment.id) } },
+    });
+
+  expectNoGraphQLError(res);
+  expect(res.status).toBe(200);
+  expect(res.body.data.unresolveCommentThread.resolvedAt).toBeNull();
+
+  const stored = await Comment.query().findById(fixture.comment.id);
+  expect(stored!.resolvedAt).toBeNull();
+});
+
+test("resolving is idempotent", async ({ fixture }) => {
+  const resolvedAt = new Date("2026-01-01T00:00:00.000Z").toISOString();
+  await fixture.comment.$query().patch({ resolvedAt });
+
+  const app = await appForReviewer(fixture);
+  const res = await request(app)
+    .post("/graphql")
+    .send({
+      query: RESOLVE_MUTATION,
+      variables: { input: { commentId: formatCommentId(fixture.comment.id) } },
+    });
+
+  expectNoGraphQLError(res);
+  expect(res.status).toBe(200);
+
+  // The original resolvedAt is preserved (no error, no overwrite).
+  const stored = await Comment.query().findById(fixture.comment.id);
+  expect(new Date(stored!.resolvedAt!).toISOString()).toBe(resolvedAt);
+});
+
+test("resolving from a reply resolves the whole thread", async ({
+  fixture,
+}) => {
+  const app = await appForReviewer(fixture);
+  const res = await request(app)
+    .post("/graphql")
+    .send({
+      query: RESOLVE_MUTATION,
+      variables: { input: { commentId: formatCommentId(fixture.reply.id) } },
+    });
+
+  expectNoGraphQLError(res);
+  expect(res.status).toBe(200);
+  // The returned comment is the root, not the reply.
+  expect(res.body.data.resolveCommentThread.id).toBe(
+    formatCommentId(fixture.comment.id),
+  );
+
+  const root = await Comment.query().findById(fixture.comment.id);
+  const reply = await Comment.query().findById(fixture.reply.id);
+  expect(root!.resolvedAt).not.toBeNull();
+  // The flag lives only on the root; replies stay untouched.
+  expect(reply!.resolvedAt).toBeNull();
+});
+
+test("forbids a user without review permission", async ({ fixture }) => {
+  const outsiderAccount = await factory.UserAccount.create();
+  await outsiderAccount.$fetchGraph("user");
+  const app = await createApolloServerApp(
+    apolloServer,
+    createApolloMiddleware,
+    {
+      user: outsiderAccount.user!,
+      account: outsiderAccount,
+    },
+  );
+  const res = await request(app)
+    .post("/graphql")
+    .send({
+      query: RESOLVE_MUTATION,
+      variables: { input: { commentId: formatCommentId(fixture.comment.id) } },
+    });
+
+  expect(res.status).toBe(200);
+  expect(res.body.errors[0].message).toBe("You cannot access this thread");
+
+  const stored = await Comment.query().findById(fixture.comment.id);
+  expect(stored!.resolvedAt).toBeNull();
+});
+
+test("requires authentication", async ({ fixture }) => {
+  const app = await createApolloServerApp(
+    apolloServer,
+    createApolloMiddleware,
+    null,
+  );
+  const res = await request(app)
+    .post("/graphql")
+    .send({
+      query: RESOLVE_MUTATION,
+      variables: { input: { commentId: formatCommentId(fixture.comment.id) } },
+    });
+
+  expect(res.body.errors).toBeDefined();
+  const stored = await Comment.query().findById(fixture.comment.id);
+  expect(stored!.resolvedAt).toBeNull();
+});

--- a/apps/frontend/src/pages/Automation/AutomationRulesList.tsx
+++ b/apps/frontend/src/pages/Automation/AutomationRulesList.tsx
@@ -78,7 +78,7 @@ function LastTriggerStatusIcon({
         </IconButton>
       </Tooltip>
       <Popover className="bg-app">
-        <div className="flex flex-col gap-2 p-2">
+        <div className="flex flex-col gap-2 p-3">
           <div className="text-xs font-semibold">Runs</div>
           {automationRun.actionRuns.map((actionRun) => {
             const action = ACTIONS.find((a) => a.type === actionRun.actionName);

--- a/apps/frontend/src/pages/Build/sidebar/CommentActionsMenu.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentActionsMenu.tsx
@@ -1,6 +1,7 @@
 import {
   BellIcon,
   BellOffIcon,
+  CheckIcon,
   LinkIcon,
   MoreHorizontalIcon,
   PencilIcon,
@@ -22,6 +23,10 @@ export function CommentActionsMenu(props: {
   threadSubscribed: boolean;
   onSubscribeThread: () => void;
   onUnsubscribeThread: () => void;
+  /** Whether the thread is currently resolved. */
+  resolved: boolean;
+  /** When provided, a "Resolve thread"/"Reopen thread" action is shown. */
+  onToggleResolved?: () => void;
   /** When provided, an "Edit comment" action is shown. */
   onEdit?: () => void;
   /** When provided, a "Delete comment" action is shown. */
@@ -32,6 +37,8 @@ export function CommentActionsMenu(props: {
     onSubscribeThread,
     onUnsubscribeThread,
     threadSubscribed,
+    resolved,
+    onToggleResolved,
     onEdit,
     onDelete,
   } = props;
@@ -50,12 +57,6 @@ export function CommentActionsMenu(props: {
               Edit
             </MenuItem>
           ) : null}
-          <MenuItem onAction={onCopyLink}>
-            <MenuItemIcon>
-              <LinkIcon />
-            </MenuItemIcon>
-            Copy link to comment
-          </MenuItem>
           <MenuItem
             onAction={
               threadSubscribed ? onUnsubscribeThread : onSubscribeThread
@@ -67,6 +68,24 @@ export function CommentActionsMenu(props: {
             {threadSubscribed
               ? "Unsubscribe from thread"
               : "Subscribe to thread"}
+          </MenuItem>
+          {onToggleResolved ? (
+            <>
+              <MenuSeparator />
+              <MenuItem onAction={onToggleResolved}>
+                <MenuItemIcon>
+                  <CheckIcon />
+                </MenuItemIcon>
+                {resolved ? "Reopen thread" : "Resolve thread"}
+              </MenuItem>
+            </>
+          ) : null}
+          <MenuSeparator />
+          <MenuItem onAction={onCopyLink}>
+            <MenuItemIcon>
+              <LinkIcon />
+            </MenuItemIcon>
+            Copy link to comment
           </MenuItem>
           {onDelete ? (
             <>

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -2,7 +2,12 @@ import { useEffect, useId, useRef, useState } from "react";
 import { useMutation } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { clsx } from "clsx";
-import { ArrowUpIcon } from "lucide-react";
+import {
+  ArrowUpIcon,
+  ChevronsDownUpIcon,
+  ChevronsUpDownIcon,
+  MessageSquareCheckIcon,
+} from "lucide-react";
 import moment from "moment";
 import { AnimatePresence, motion } from "motion/react";
 import { Button } from "react-aria-components";
@@ -33,6 +38,7 @@ import {
 } from "./CommentReactions";
 import { DeleteCommentDialog } from "./DeleteCommentDialog";
 import { useMentionableUsers } from "./MentionableUsersContext";
+import { useCollapsedThread } from "./useCollapsedThread";
 
 // Shared id so copying a comment link reuses a single toast instead of stacking.
 const COPY_TOAST_ID = "comment-link-copied";
@@ -40,11 +46,21 @@ const COPY_TOAST_ID = "comment-link-copied";
 // Detailed date format used in the date tooltip, e.g. "Thu May 21, 2026, 15:47:43".
 const DETAILED_DATE_FORMAT = "ddd MMM D, YYYY, HH:mm:ss";
 
+// Shared height/opacity transition for content that animates in and out: the
+// reply list, and the thread body collapsing when a thread is resolved. Kept in
+// sync with the comment-removal animation so both feel the same.
+const COLLAPSE_TRANSITION = {
+  duration: 0.25,
+  ease: [0.4, 0, 0.2, 1],
+  opacity: { duration: 0.15 },
+} as const;
+
 const _CommentFragment = graphql(`
   fragment CommentCard_Comment on Comment {
     id
     date
     editedAt
+    resolvedAt
     content
     threadId
     threadSubscribed
@@ -111,6 +127,28 @@ const UnsubscribeFromCommentThreadMutation = graphql(`
   }
 `);
 
+const ResolveCommentThreadMutation = graphql(`
+  mutation CommentCard_resolveCommentThread(
+    $input: ResolveCommentThreadInput!
+  ) {
+    resolveCommentThread(input: $input) {
+      id
+      resolvedAt
+    }
+  }
+`);
+
+const UnresolveCommentThreadMutation = graphql(`
+  mutation CommentCard_unresolveCommentThread(
+    $input: UnresolveCommentThreadInput!
+  ) {
+    unresolveCommentThread(input: $input) {
+      id
+      resolvedAt
+    }
+  }
+`);
+
 export function CommentCard(props: {
   buildId: string;
   comment: Comment;
@@ -154,6 +192,36 @@ export function CommentCard(props: {
       },
     },
   );
+  const [resolveCommentThread] = useMutation(ResolveCommentThreadMutation, {
+    variables: { input: { commentId: comment.id } },
+    optimisticResponse: {
+      resolveCommentThread: {
+        __typename: "Comment",
+        id: comment.id,
+        resolvedAt: new Date().toISOString(),
+      },
+    },
+  });
+  const [unresolveCommentThread] = useMutation(UnresolveCommentThreadMutation, {
+    variables: { input: { commentId: comment.id } },
+    optimisticResponse: {
+      unresolveCommentThread: {
+        __typename: "Comment",
+        id: comment.id,
+        resolvedAt: null,
+      },
+    },
+  });
+
+  const resolved = Boolean(comment.resolvedAt);
+  const [collapsed, setCollapsed] = useCollapsedThread(comment.id, resolved);
+  // Keep a deep-linked comment visible even inside a collapsed resolved thread,
+  // so the highlight from the URL hash isn't hidden away.
+  const containsHighlighted =
+    highlightedCommentId != null &&
+    (highlightedCommentId === comment.id ||
+      replies.some((reply) => reply.id === highlightedCommentId));
+  const showBody = !resolved || !collapsed || containsHighlighted;
 
   const handleReplySubmit = async (body: EditorValue) => {
     try {
@@ -193,41 +261,120 @@ export function CommentCard(props: {
       });
   };
 
+  const toggleResolved = () => {
+    if (resolved) {
+      unresolveCommentThread()
+        .then(() => {
+          toast.success("Thread reopened.");
+        })
+        .catch((error) => {
+          toast.error(getErrorMessage(error));
+        });
+    } else {
+      resolveCommentThread()
+        .then(() => {
+          toast.success("Thread resolved.");
+        })
+        .catch((error) => {
+          toast.error(getErrorMessage(error));
+        });
+    }
+  };
+
+  // Only reviewers can resolve a thread; gate the menu action accordingly.
+  const onToggleResolved = canReply ? toggleResolved : undefined;
+
   return (
     <div className="border-thin bg-app -mx-2.5 rounded-md">
-      <CommentMessage
-        comment={comment}
-        highlighted={comment.id === highlightedCommentId}
-        threadSubscribed={comment.threadSubscribed}
-        onSubscribeThread={subscribeThread}
-        onUnsubscribeThread={unsubscribeThread}
-      />
+      {resolved ? (
+        <ResolvedThreadHeader
+          collapsed={!showBody}
+          commentCount={replies.length + 1}
+          authorName={
+            comment.user?.name || comment.user?.slug || "Unknown user"
+          }
+          onToggle={() => setCollapsed(showBody)}
+        />
+      ) : null}
       <AnimatePresence initial={false}>
-        {replies.map((reply) => (
+        {showBody ? (
           <motion.div
-            key={reply.id}
+            key="thread-body"
             style={{ overflowY: "clip" }}
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
-            transition={{
-              duration: 0.25,
-              ease: [0.4, 0, 0.2, 1],
-              opacity: { duration: 0.15 },
-            }}
+            transition={COLLAPSE_TRANSITION}
           >
             <CommentMessage
-              comment={reply}
-              highlighted={reply.id === highlightedCommentId}
-              isReply
-              separated
+              comment={comment}
+              highlighted={comment.id === highlightedCommentId}
+              separated={resolved}
+              resolved={resolved}
               threadSubscribed={comment.threadSubscribed}
               onSubscribeThread={subscribeThread}
               onUnsubscribeThread={unsubscribeThread}
+              onToggleResolved={onToggleResolved}
             />
+            <AnimatePresence initial={false}>
+              {replies.map((reply) => (
+                <motion.div
+                  key={reply.id}
+                  style={{ overflowY: "clip" }}
+                  exit={{ height: 0, opacity: 0 }}
+                  transition={COLLAPSE_TRANSITION}
+                >
+                  <CommentMessage
+                    comment={reply}
+                    highlighted={reply.id === highlightedCommentId}
+                    isReply
+                    separated
+                    resolved={resolved}
+                    threadSubscribed={comment.threadSubscribed}
+                    onSubscribeThread={subscribeThread}
+                    onUnsubscribeThread={unsubscribeThread}
+                    onToggleResolved={onToggleResolved}
+                  />
+                </motion.div>
+              ))}
+            </AnimatePresence>
+            {canReply ? <ReplyComposer onSubmit={handleReplySubmit} /> : null}
           </motion.div>
-        ))}
+        ) : null}
       </AnimatePresence>
-      {canReply ? <ReplyComposer onSubmit={handleReplySubmit} /> : null}
     </div>
+  );
+}
+
+function ResolvedThreadHeader(props: {
+  collapsed: boolean;
+  commentCount: number;
+  authorName: string;
+  onToggle: () => void;
+}) {
+  const { collapsed, commentCount, authorName, onToggle } = props;
+  return (
+    <Button
+      onPress={onToggle}
+      aria-label={collapsed ? "Expand thread" : "Collapse thread"}
+      className="text-low hover:text-default flex w-full items-center gap-1.5 px-2 py-1.5 text-left text-xs transition select-none"
+    >
+      {collapsed ? (
+        <>
+          <MessageSquareCheckIcon className="size-3.5 shrink-0" />
+          <span className="min-w-0 flex-1 truncate">
+            {commentCount} resolved comment{commentCount > 1 ? "s" : ""} from{" "}
+            {authorName}
+          </span>
+          <ChevronsUpDownIcon className="size-3.5 shrink-0" />
+        </>
+      ) : (
+        <>
+          <span className="min-w-0 flex-1">Collapse</span>
+          <ChevronsDownUpIcon className="size-3.5 shrink-0" />
+        </>
+      )}
+    </Button>
   );
 }
 
@@ -237,6 +384,8 @@ function CommentMessage(props: {
   threadSubscribed: boolean;
   onSubscribeThread: () => void;
   onUnsubscribeThread: () => void;
+  resolved: boolean;
+  onToggleResolved?: () => void;
   separated?: boolean;
   isReply?: boolean;
 }) {
@@ -246,6 +395,8 @@ function CommentMessage(props: {
     threadSubscribed,
     onSubscribeThread,
     onUnsubscribeThread,
+    resolved,
+    onToggleResolved,
     separated = false,
     isReply = false,
   } = props;
@@ -371,6 +522,8 @@ function CommentMessage(props: {
               threadSubscribed={threadSubscribed}
               onSubscribeThread={onSubscribeThread}
               onUnsubscribeThread={onUnsubscribeThread}
+              resolved={resolved}
+              onToggleResolved={onToggleResolved}
               onEdit={canEdit ? () => setIsEditing(true) : undefined}
               onDelete={
                 canDelete ? () => setIsDeleteDialogOpen(true) : undefined

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -214,9 +214,11 @@ export function CommentCard(props: {
   });
 
   const resolved = Boolean(comment.resolvedAt);
+  // `collapsed` is the stored preference and drives the header label and toggle.
   const [collapsed, setCollapsed] = useCollapsedThread(comment.id, resolved);
   // Keep a deep-linked comment visible even inside a collapsed resolved thread,
-  // so the highlight from the URL hash isn't hidden away.
+  // so the highlight from the URL hash isn't hidden away. This only affects what
+  // is shown, not the stored `collapsed` preference.
   const containsHighlighted =
     highlightedCommentId != null &&
     (highlightedCommentId === comment.id ||
@@ -288,12 +290,12 @@ export function CommentCard(props: {
     <div className="border-thin bg-app -mx-2.5 rounded-md">
       {resolved ? (
         <ResolvedThreadHeader
-          collapsed={!showBody}
+          collapsed={collapsed}
           commentCount={replies.length + 1}
           authorName={
             comment.user?.name || comment.user?.slug || "Unknown user"
           }
-          onToggle={() => setCollapsed(showBody)}
+          onToggle={() => setCollapsed(!collapsed)}
         />
       ) : null}
       <AnimatePresence initial={false}>

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -216,14 +216,19 @@ export function CommentCard(props: {
   const resolved = Boolean(comment.resolvedAt);
   // `collapsed` is the stored preference and drives the header label and toggle.
   const [collapsed, setCollapsed] = useCollapsedThread(comment.id, resolved);
-  // Keep a deep-linked comment visible even inside a collapsed resolved thread,
-  // so the highlight from the URL hash isn't hidden away. This only affects what
-  // is shown, not the stored `collapsed` preference.
+  const showBody = !resolved || !collapsed;
+  // Deep-linking to a comment inside a resolved thread opens the thread for
+  // good (not just for the highlight's lifetime), so the target comment stays
+  // visible instead of vanishing when the highlight clears.
   const containsHighlighted =
     highlightedCommentId != null &&
     (highlightedCommentId === comment.id ||
       replies.some((reply) => reply.id === highlightedCommentId));
-  const showBody = !resolved || !collapsed || containsHighlighted;
+  useEffect(() => {
+    if (resolved && collapsed && containsHighlighted) {
+      setCollapsed(false);
+    }
+  }, [resolved, collapsed, containsHighlighted, setCollapsed]);
 
   const handleReplySubmit = async (body: EditorValue) => {
     try {

--- a/apps/frontend/src/pages/Build/sidebar/useCollapsedThread.ts
+++ b/apps/frontend/src/pages/Build/sidebar/useCollapsedThread.ts
@@ -1,15 +1,40 @@
-import { useCallback } from "react";
-import { useAtom } from "jotai";
-import { atomWithStorage } from "jotai/utils";
+import { atom, useAtom } from "jotai";
+import { atomFamily } from "jotai-family";
+import { atomWithStorage, RESET } from "jotai/utils";
 
 /**
- * Per-thread collapse preference, persisted in local storage and keyed by the
- * root comment id. Only resolved threads are collapsible; unresolved threads
- * are always shown in full.
+ * Ids of resolved threads the user has explicitly expanded, persisted in local
+ * storage. Resolved threads are collapsed by default, so only these exceptions
+ * are stored: an id is dropped as soon as its thread collapses back to the
+ * default, and the key is removed entirely once none remain.
  */
-const collapsedThreadsAtom = atomWithStorage<Record<string, boolean>>(
-  "preferences.collapsedCommentThreads",
-  {},
+const expandedThreadsAtom = atomWithStorage<string[]>(
+  "preferences.expandedCommentThreads",
+  [],
+);
+
+/**
+ * Per-thread collapse state derived from {@link expandedThreadsAtom}. A family
+ * of derived atoms keeps threads isolated — toggling one re-renders only that
+ * thread, since every other thread's derived value is unchanged.
+ */
+const collapsedThreadAtomFamily = atomFamily((commentId: string) =>
+  atom(
+    (get) => !get(expandedThreadsAtom).includes(commentId),
+    (get, set, collapsed: boolean) => {
+      const expanded = get(expandedThreadsAtom);
+      if (collapsed) {
+        if (!expanded.includes(commentId)) {
+          return;
+        }
+        const next = expanded.filter((id) => id !== commentId);
+        // Forget the whole key once no thread is expanded anymore.
+        set(expandedThreadsAtom, next.length === 0 ? RESET : next);
+      } else if (!expanded.includes(commentId)) {
+        set(expandedThreadsAtom, [...expanded, commentId]);
+      }
+    },
+  ),
 );
 
 /**
@@ -21,13 +46,8 @@ export function useCollapsedThread(
   commentId: string,
   resolved: boolean,
 ): readonly [boolean, (collapsed: boolean) => void] {
-  const [collapsedThreads, setCollapsedThreads] = useAtom(collapsedThreadsAtom);
-  const collapsed = resolved ? (collapsedThreads[commentId] ?? true) : false;
-  const setCollapsed = useCallback(
-    (value: boolean) => {
-      setCollapsedThreads((prev) => ({ ...prev, [commentId]: value }));
-    },
-    [commentId, setCollapsedThreads],
+  const [collapsed, setCollapsed] = useAtom(
+    collapsedThreadAtomFamily(commentId),
   );
-  return [collapsed, setCollapsed] as const;
+  return [resolved && collapsed, setCollapsed] as const;
 }

--- a/apps/frontend/src/pages/Build/sidebar/useCollapsedThread.ts
+++ b/apps/frontend/src/pages/Build/sidebar/useCollapsedThread.ts
@@ -1,0 +1,33 @@
+import { useCallback } from "react";
+import { useAtom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+
+/**
+ * Per-thread collapse preference, persisted in local storage and keyed by the
+ * root comment id. Only resolved threads are collapsible; unresolved threads
+ * are always shown in full.
+ */
+const collapsedThreadsAtom = atomWithStorage<Record<string, boolean>>(
+  "preferences.collapsedCommentThreads",
+  {},
+);
+
+/**
+ * Read and update whether a comment thread is collapsed. Resolved threads
+ * default to collapsed until the user expands them; unresolved threads are
+ * never collapsed regardless of the stored preference.
+ */
+export function useCollapsedThread(
+  commentId: string,
+  resolved: boolean,
+): readonly [boolean, (collapsed: boolean) => void] {
+  const [collapsedThreads, setCollapsedThreads] = useAtom(collapsedThreadsAtom);
+  const collapsed = resolved ? (collapsedThreads[commentId] ?? true) : false;
+  const setCollapsed = useCallback(
+    (value: boolean) => {
+      setCollapsedThreads((prev) => ({ ...prev, [commentId]: value }));
+    },
+    [commentId, setCollapsedThreads],
+  );
+  return [collapsed, setCollapsed] as const;
+}

--- a/apps/frontend/src/ui/ListBox.stories.tsx
+++ b/apps/frontend/src/ui/ListBox.stories.tsx
@@ -15,7 +15,7 @@ export const Default: Story = {
   render: () => (
     <div className="flex flex-col">
       <StoryTitle>Single Selection</StoryTitle>
-      <div className="max-w-xs rounded-lg border p-1">
+      <div className="border-thin max-w-xs rounded-lg">
         <ListBox aria-label="Options" selectionMode="single">
           <ListBoxItem id="edit">Edit</ListBoxItem>
           <ListBoxItem id="duplicate">Duplicate</ListBoxItem>
@@ -25,7 +25,7 @@ export const Default: Story = {
       </div>
 
       <StoryTitle>Multiple Selection</StoryTitle>
-      <div className="max-w-xs rounded-lg border p-1">
+      <div className="border-thin max-w-xs rounded-lg">
         <ListBox aria-label="Browsers" selectionMode="multiple">
           <ListBoxItem id="chrome">Chrome</ListBoxItem>
           <ListBoxItem id="firefox">Firefox</ListBoxItem>

--- a/apps/frontend/src/ui/ListBox.tsx
+++ b/apps/frontend/src/ui/ListBox.tsx
@@ -22,7 +22,7 @@ export function ListBox<T extends object>({
 }
 
 export function ListBoxSeparator() {
-  return <Separator className="-mx-1 my-1 border-t" />;
+  return <Separator className="border-t-thin -mx-1 my-1" />;
 }
 
 export { MenuItemIcon as ListBoxItemIcon } from "./Menu";

--- a/apps/frontend/src/ui/ListBox.tsx
+++ b/apps/frontend/src/ui/ListBox.tsx
@@ -15,7 +15,7 @@ export function ListBox<T extends object>({
 }: ListBoxProps<T>) {
   return (
     <RACListBox<T>
-      className={clsx("overflow-auto outline-hidden", className)}
+      className={clsx("overflow-auto p-1 outline-hidden", className)}
       {...props}
     />
   );
@@ -38,7 +38,7 @@ export function ListBoxItem(
       className={clsx(
         className,
         "group/item",
-        "text-default data-focused:bg-active data-pressed:bg-active data-disabled:opacity-disabled flex items-center gap-2 rounded-sm px-3 py-1.5 text-sm transition select-none focus:outline-hidden",
+        "text-default data-focused:bg-active data-pressed:bg-active data-disabled:opacity-disabled flex items-center gap-2 rounded-sm px-3 py-1.5 text-sm select-none focus:outline-hidden",
       )}
       {...restProps}
     >

--- a/apps/frontend/src/ui/Menu.tsx
+++ b/apps/frontend/src/ui/Menu.tsx
@@ -22,7 +22,7 @@ import {
 import { Tooltip } from "./Tooltip";
 
 export function MenuSeparator() {
-  return <Separator className="my-1 border-t" />;
+  return <Separator className="border-t-thin -mx-1 my-1" />;
 }
 
 export { MenuTrigger, SubmenuTrigger } from "react-aria-components";
@@ -36,7 +36,7 @@ export function Menu<T extends object>(
     <RACMenu<T>
       {...props}
       className={clsx(
-        "overflow-auto outline-hidden select-none",
+        "overflow-auto p-1 outline-hidden select-none",
         props.className,
       )}
     />

--- a/apps/frontend/src/ui/Popover.tsx
+++ b/apps/frontend/src/ui/Popover.tsx
@@ -32,7 +32,7 @@ export function Popover(
       {...props}
       className={(values) =>
         clsx(
-          "bg-subtle border-thin z-50 flex rounded-lg bg-clip-padding p-1 shadow-md has-[>[role=dialog]]:p-0",
+          "bg-subtle border-thin z-50 flex rounded-lg bg-clip-padding shadow-md",
           getPopoverAnimationClassName(values),
           props.className,
         )


### PR DESCRIPTION
## Overview

Adds the ability to **resolve / reopen a comment thread** on a build.

A resolved thread collapses to a summary bar in the build activity sidebar and can be expanded/collapsed on demand.

## Backend

- **Migration**: nullable `resolvedAt` column on `comments` (`structure.sql` dumped).
- **Model**: `resolvedAt` on the `Comment` model — only ever set on a root comment; replies inherit their thread's state.
- **GraphQL**: `resolvedAt: DateTime` field + `resolveCommentThread` / `unresolveCommentThread` mutations.
  - Require the project `review` permission.
  - Resolve to the thread **root**, so passing any reply's id resolves the whole thread.
  - Idempotent, and **no notification is sent**.
- **Tests**: `resolveCommentThread.e2e.test.ts` covers resolve, reopen, idempotency, resolving-from-a-reply, permission, and auth.

## Frontend

- **`useCollapsedThread`**: per-thread collapse preference persisted in local storage (jotai `atomWithStorage`). Resolved threads default to collapsed; unresolved threads are never collapsed.
- **`CommentActionsMenu`**: new "Resolve thread" / "Reopen thread" item. Menu order: *Edit · Unsubscribe — Resolve — Copy link — Delete*.
- **`CommentCard`**: resolved threads render a collapse/expand header ("N resolved comments from …" ⇄ "Collapse"), with optimistic resolve/unresolve. The body animates open/closed using the **same transition as comment removal**. A deep-linked (URL-hash) comment stays visible even inside a collapsed thread.
- **Styling**: modernized popover/menu/listbox — padding moved from the popover into the menu/listbox, full-bleed separators.

## Verification

- `pnpm lint` — clean
- `pnpm check-types` — 7/7 packages pass
- `pnpm test:integration` — 442 tests pass (incl. 6 new resolve/reopen e2e tests)

> Not yet verified visually in the running app — animation/layout vs. the design screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)