### PR TITLE
feat: add requested reviewers on builds

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -130,6 +130,54 @@ mutation. Always enforce the check in the mutation — never trust the client.
 - Return consistent, typed errors.
 - Do not expose internal errors.
 
+## Notifications
+
+Notifications are sent through a two-stage async pipeline (`src/notification/`):
+
+1. `sendNotification({ type, data, recipients })` creates one
+   `NotificationWorkflow` (the event) + a `NotificationWorkflowRecipient` per
+   user, then queues `notificationWorkflowJob`.
+2. `notificationWorkflowJob` applies opt-outs (see categories below) and creates
+   one `NotificationMessage` per remaining recipient, queuing
+   `notificationMessageJob`.
+3. `notificationMessageJob` renders the handler's email and sends it.
+
+### Adding a notification handler
+
+1. **Create the handler** `src/notification/handlers/<type>.tsx` exporting
+   `handler = defineNotificationHandler({ type, category, schema, previewData, email })`.
+   Model it on an existing one (e.g. `handlers/review_submitted.tsx`):
+   - `type` is the unique string discriminator.
+   - `schema` is a Zod schema for `data` — it both types `sendNotification` and
+     validates the persisted `NotificationWorkflow.data`.
+   - `previewData` feeds the email preview; `email(props)` returns
+     `{ subject, body }` (a React email built from `../../email/components`).
+
+2. **Register it** in `src/notification/handlers/index.ts` (import + add to the
+   `notificationHandlers` array). The `NotificationWorkflowType` union and the
+   typed `sendNotification` props are derived from this array automatically — no
+   other type wiring needed.
+
+3. **Pick a `category`** from the union in `workflow-types.ts`. Category metadata
+   (label/description/`configurable`) lives in `categories.ts`. Configurable
+   categories (`review`, `billing`, `project`, `integration`) can be opted out
+   via `UserNotificationPreference`; `account`/`security` always send. Add a new
+   category to both files only if none fit.
+
+4. **Dispatch** from app code with `sendNotification({ type, data, recipients })`.
+   `recipients` is an array of **user ids you compute** (the system never
+   discovers recipients) — typically the interested users minus the actor (see
+   `notifyBuildSubscribers` in `src/build/createBuildReview.ts`). Opt-outs for
+   configurable categories are applied automatically by the workflow job. For
+   "notify once" semantics on an idempotent action, derive `recipients` from the
+   rows the insert actually created (see the Idempotent inserts section).
+
+5. **Preview** the rendered email via the notification preview route
+   (`src/notification/express.tsx`) using `previewData`.
+
+No DB migration is needed for a new type: `notification_workflows` /
+`notification_messages` are polymorphic via the `data` JSON column.
+
 ## Rich-text comment editor (TipTap)
 
 Comment `content` is TipTap JSON. The list of TipTap extensions is **duplicated**

--- a/apps/backend/db/migrations/20260614202438_build-requested-reviewers.js
+++ b/apps/backend/db/migrations/20260614202438_build-requested-reviewers.js
@@ -1,0 +1,29 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+export async function up(knex) {
+  await knex.schema.createTable("build_requested_reviewers", (table) => {
+    table.dateTime("createdAt").notNullable().defaultTo(knex.fn.now());
+    table.dateTime("updatedAt").notNullable().defaultTo(knex.fn.now());
+
+    table.bigInteger("buildId").notNullable();
+    table.foreign("buildId").references("builds.id").onDelete("CASCADE");
+
+    table.bigInteger("userId").notNullable();
+    table.foreign("userId").references("users.id").onDelete("CASCADE");
+
+    table.bigInteger("requestedById");
+    table.foreign("requestedById").references("users.id").onDelete("SET NULL");
+
+    table.primary(["buildId", "userId"]);
+
+    table.index("userId");
+  });
+}
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+export async function down(knex) {
+  await knex.schema.dropTable("build_requested_reviewers");
+}

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -400,6 +400,21 @@ ALTER SEQUENCE public.build_notifications_id_seq OWNED BY public.build_notificat
 
 
 --
+-- Name: build_requested_reviewers; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.build_requested_reviewers (
+    "createdAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "updatedAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "buildId" bigint NOT NULL,
+    "userId" bigint NOT NULL,
+    "requestedById" bigint
+);
+
+
+ALTER TABLE public.build_requested_reviewers OWNER TO postgres;
+
+--
 -- Name: build_reviews; Type: TABLE; Schema: public; Owner: postgres
 --
 
@@ -2852,6 +2867,14 @@ ALTER TABLE ONLY public.build_notifications
 
 
 --
+-- Name: build_requested_reviewers build_requested_reviewers_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.build_requested_reviewers
+    ADD CONSTRAINT build_requested_reviewers_pkey PRIMARY KEY ("buildId", "userId");
+
+
+--
 -- Name: build_reviews build_reviews_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
@@ -3543,6 +3566,13 @@ CREATE INDEX build_notification_subscriptions_userid_index ON public.build_notif
 --
 
 CREATE INDEX build_notifications_buildid_index ON public.build_notifications USING btree ("buildId");
+
+
+--
+-- Name: build_requested_reviewers_userid_index; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX build_requested_reviewers_userid_index ON public.build_requested_reviewers USING btree ("userId");
 
 
 --
@@ -4248,6 +4278,30 @@ ALTER TABLE ONLY public.build_notification_subscriptions
 
 ALTER TABLE ONLY public.build_notifications
     ADD CONSTRAINT build_notifications_buildid_foreign FOREIGN KEY ("buildId") REFERENCES public.builds(id);
+
+
+--
+-- Name: build_requested_reviewers build_requested_reviewers_buildid_foreign; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.build_requested_reviewers
+    ADD CONSTRAINT build_requested_reviewers_buildid_foreign FOREIGN KEY ("buildId") REFERENCES public.builds(id) ON DELETE CASCADE;
+
+
+--
+-- Name: build_requested_reviewers build_requested_reviewers_requestedbyid_foreign; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.build_requested_reviewers
+    ADD CONSTRAINT build_requested_reviewers_requestedbyid_foreign FOREIGN KEY ("requestedById") REFERENCES public.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: build_requested_reviewers build_requested_reviewers_userid_foreign; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.build_requested_reviewers
+    ADD CONSTRAINT build_requested_reviewers_userid_foreign FOREIGN KEY ("userId") REFERENCES public.users(id) ON DELETE CASCADE;
 
 
 --
@@ -5106,3 +5160,4 @@ INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('2026053
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260608120000_user-sessions.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260609120000_encrypt-sensitive-data.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260610120000_comment-resolved-at.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260614202438_build-requested-reviewers.js', 1, NOW());

--- a/apps/backend/src/build/requestedReviewers.ts
+++ b/apps/backend/src/build/requestedReviewers.ts
@@ -1,0 +1,147 @@
+import { invariant } from "@argos/util/invariant";
+
+import { knex } from "@/database";
+import {
+  Account,
+  Build,
+  BuildRequestedReviewer,
+  User,
+} from "@/database/models";
+import { sendNotification } from "@/notification";
+import { getProjectMemberIds } from "@/project/members";
+
+/**
+ * Resolve a list of public account ids to the database user ids of users who are
+ * members of (have access to) the build's project. Account ids that don't map to
+ * a user, or whose user isn't a project member, are dropped — the server-side
+ * enforcement of "you can only request members as reviewers" (mirrors the
+ * mention security in `src/comment/mentions.ts`).
+ */
+async function resolveEligibleReviewerUserIds(input: {
+  build: Build;
+  accountIds: string[];
+}): Promise<string[]> {
+  const { build, accountIds } = input;
+  if (accountIds.length === 0) {
+    return [];
+  }
+  const { project } = build;
+  invariant(project, "Build project not found");
+  const [accounts, memberIds] = await Promise.all([
+    Account.query()
+      .findByIds(accountIds)
+      .whereNotNull("userId")
+      .select("userId"),
+    getProjectMemberIds(project).then((ids) => new Set(ids)),
+  ]);
+  const userIds = new Set<string>();
+  for (const account of accounts) {
+    if (account.userId && memberIds.has(account.userId)) {
+      userIds.add(account.userId);
+    }
+  }
+  return [...userIds];
+}
+
+/**
+ * Request the given users (by public account id) to review a build. Idempotent:
+ * users already requested are ignored (no duplicate, no second notification).
+ * Newly-requested reviewers receive a `review_requested` notification.
+ */
+export async function addBuildReviewers(input: {
+  build: Build;
+  accountIds: string[];
+  requestedById: string;
+}): Promise<void> {
+  const { build, accountIds, requestedById } = input;
+  const userIds = await resolveEligibleReviewerUserIds({ build, accountIds });
+  if (userIds.length === 0) {
+    return;
+  }
+
+  // Insert atomically: `onConflict().ignore()` makes concurrent requests safe
+  // and the returning rows tell us which reviewers were actually added, so we
+  // notify each person only once. `createdAt`/`updatedAt` fall back to their
+  // database defaults.
+  const inserted = await knex("build_requested_reviewers")
+    .insert(
+      userIds.map((userId) => ({ buildId: build.id, userId, requestedById })),
+    )
+    .onConflict(["buildId", "userId"])
+    .ignore()
+    .returning("userId");
+
+  const newReviewerIds = inserted
+    .map((row) => row.userId as string)
+    .filter((userId) => userId !== requestedById);
+
+  if (newReviewerIds.length > 0) {
+    await notifyReviewersRequested({
+      build,
+      requestedById,
+      recipients: newReviewerIds,
+    });
+  }
+}
+
+/**
+ * Cancel the review requests for the given users (by public account id) on a
+ * build. Removing a reviewer that wasn't requested is a no-op.
+ */
+export async function removeBuildReviewers(input: {
+  build: Build;
+  accountIds: string[];
+}): Promise<void> {
+  const { build, accountIds } = input;
+  if (accountIds.length === 0) {
+    return;
+  }
+  const accounts = await Account.query()
+    .findByIds(accountIds)
+    .whereNotNull("userId")
+    .select("userId");
+  const userIds = accounts
+    .map((account) => account.userId)
+    .filter((userId): userId is string => userId != null);
+  if (userIds.length === 0) {
+    return;
+  }
+  await BuildRequestedReviewer.query()
+    .delete()
+    .where("buildId", build.id)
+    .whereIn("userId", userIds);
+}
+
+/**
+ * Notify the newly-requested reviewers that their review was requested. The
+ * requester is never notified of their own request.
+ */
+async function notifyReviewersRequested(input: {
+  build: Build;
+  requestedById: string;
+  recipients: string[];
+}): Promise<void> {
+  const { build, requestedById, recipients } = input;
+  if (recipients.length === 0) {
+    return;
+  }
+  const { project } = build;
+  invariant(project?.account, "project account not found");
+  const [requester, buildUrl] = await Promise.all([
+    User.query().findById(requestedById).withGraphFetched("account"),
+    build.getUrl(),
+  ]);
+  const requesterName = requester?.account?.displayName ?? null;
+  await sendNotification({
+    type: "review_requested",
+    data: {
+      accountSlug: project.account.slug,
+      projectName: project.name,
+      buildNumber: build.number,
+      buildName: build.name,
+      buildUrl,
+      requesterName,
+    },
+    recipients,
+  });
+}

--- a/apps/backend/src/comment/mentions.e2e.test.ts
+++ b/apps/backend/src/comment/mentions.e2e.test.ts
@@ -4,11 +4,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { Account, Comment, CommentMention } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
 
-import {
-  getCommentMentionLabels,
-  getMentionableUserIds,
-  syncCommentMentions,
-} from "./mentions";
+import { getCommentMentionLabels, syncCommentMentions } from "./mentions";
 
 function mentionDoc(accountIds: string[]) {
   return {
@@ -27,63 +23,6 @@ function mentionDoc(accountIds: string[]) {
     ],
   };
 }
-
-describe("getMentionableUserIds", () => {
-  beforeEach(async () => {
-    await setupDatabase();
-  });
-
-  it("includes team owners and members but not bare contributors", async () => {
-    const teamAccount = await factory.TeamAccount.create();
-    invariant(teamAccount.teamId);
-    const project = await factory.Project.create({ accountId: teamAccount.id });
-    const [owner, member, contributor] = await Promise.all([
-      factory.User.create(),
-      factory.User.create(),
-      factory.User.create(),
-    ]);
-    await Promise.all([
-      factory.TeamUser.create({
-        teamId: teamAccount.teamId,
-        userId: owner.id,
-        userLevel: "owner",
-      }),
-      factory.TeamUser.create({
-        teamId: teamAccount.teamId,
-        userId: member.id,
-        userLevel: "member",
-      }),
-      factory.TeamUser.create({
-        teamId: teamAccount.teamId,
-        userId: contributor.id,
-        userLevel: "contributor",
-      }),
-    ]);
-
-    const userIds = await getMentionableUserIds(project);
-    expect([...userIds].sort()).toEqual([owner.id, member.id].sort());
-  });
-
-  it("includes contributors that have explicit project access", async () => {
-    const teamAccount = await factory.TeamAccount.create();
-    invariant(teamAccount.teamId);
-    const project = await factory.Project.create({ accountId: teamAccount.id });
-    const contributor = await factory.User.create();
-    await factory.TeamUser.create({
-      teamId: teamAccount.teamId,
-      userId: contributor.id,
-      userLevel: "contributor",
-    });
-    await factory.ProjectUser.create({
-      projectId: project.id,
-      userId: contributor.id,
-      userLevel: "viewer",
-    });
-
-    const userIds = await getMentionableUserIds(project);
-    expect(userIds).toEqual([contributor.id]);
-  });
-});
 
 describe("syncCommentMentions", () => {
   beforeEach(async () => {

--- a/apps/backend/src/comment/mentions.ts
+++ b/apps/backend/src/comment/mentions.ts
@@ -1,14 +1,7 @@
-import { invariant } from "@argos/util/invariant";
 import type { JSONContent } from "@tiptap/core";
 
-import {
-  Account,
-  Comment,
-  CommentMention,
-  Project,
-  ProjectUser,
-  TeamUser,
-} from "@/database/models";
+import { Account, Comment, CommentMention, Project } from "@/database/models";
+import { getProjectMemberIds } from "@/project/members";
 
 import { renderCommentHtml } from "./html";
 
@@ -46,60 +39,6 @@ function visit(node: JSONContent | null | undefined, ids: Set<string>): void {
 }
 
 /**
- * Get the database ids of every user who has at least "view" access to the
- * project, i.e. the users that may legitimately be mentioned in a comment on
- * one of its builds. Mirrors the "view" branch of {@link Project.getPermissions}.
- */
-export async function getMentionableUserIds(
-  project: Project,
-): Promise<string[]> {
-  await project.$fetchGraph("account", { skipFetched: true });
-  invariant(project.account, "Project account not found");
-  const { account } = project;
-
-  // Personal project: only the owner can access it.
-  if (account.type === "user") {
-    return account.userId ? [account.userId] : [];
-  }
-
-  const { teamId } = account;
-  invariant(teamId, "Team account without teamId");
-
-  const teamUsers = await TeamUser.query()
-    .where("teamId", teamId)
-    .select("userId", "userLevel");
-
-  const userIds = new Set<string>();
-  const contributorIds: string[] = [];
-  for (const teamUser of teamUsers) {
-    if (teamUser.userLevel === "contributor") {
-      contributorIds.push(teamUser.userId);
-    } else {
-      // Owners and members always have access.
-      userIds.add(teamUser.userId);
-    }
-  }
-
-  if (contributorIds.length > 0) {
-    if (project.defaultUserLevel) {
-      // Every contributor inherits at least the project's default level, which
-      // always grants "view".
-      contributorIds.forEach((id) => userIds.add(id));
-    } else {
-      // Otherwise only contributors with an explicit project-level access.
-      const projectUsers = await ProjectUser.query()
-        .where("projectId", project.id)
-        .whereIn("userId", contributorIds)
-        .whereNotNull("userLevel")
-        .select("userId");
-      projectUsers.forEach((projectUser) => userIds.add(projectUser.userId));
-    }
-  }
-
-  return [...userIds];
-}
-
-/**
  * Resolve the mention ids stored in a comment to the database ids of users who
  * are actually allowed to be mentioned on the comment's project. Any mention
  * that doesn't resolve to a mentionable user (unknown id, a non-user account,
@@ -119,7 +58,7 @@ async function resolveMentionedUserIds(input: {
       .findByIds(accountIds)
       .whereNotNull("userId")
       .select("userId"),
-    getMentionableUserIds(project).then((ids) => new Set(ids)),
+    getProjectMemberIds(project).then((ids) => new Set(ids)),
   ]);
   const userIds = new Set<string>();
   for (const account of accounts) {

--- a/apps/backend/src/database/models/BuildRequestedReviewer.ts
+++ b/apps/backend/src/database/models/BuildRequestedReviewer.ts
@@ -1,0 +1,66 @@
+import type { RelationMappings } from "objection";
+
+import { Model } from "../util/model";
+import { timestampsSchema } from "../util/schemas";
+import { Build } from "./Build";
+import { User } from "./User";
+
+export class BuildRequestedReviewer extends Model {
+  static override tableName = "build_requested_reviewers";
+
+  static override get idColumn() {
+    return ["buildId", "userId"];
+  }
+
+  static override jsonSchema = {
+    allOf: [
+      timestampsSchema,
+      {
+        type: "object",
+        required: ["buildId", "userId"],
+        properties: {
+          buildId: { type: "string" },
+          userId: { type: "string" },
+          requestedById: { type: ["string", "null"] },
+        },
+      },
+    ],
+  };
+
+  buildId!: string;
+  userId!: string;
+  requestedById!: string | null;
+
+  static override get relationMappings(): RelationMappings {
+    return {
+      build: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: Build,
+        join: {
+          from: "build_requested_reviewers.buildId",
+          to: "builds.id",
+        },
+      },
+      user: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: User,
+        join: {
+          from: "build_requested_reviewers.userId",
+          to: "users.id",
+        },
+      },
+      requestedBy: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: User,
+        join: {
+          from: "build_requested_reviewers.requestedById",
+          to: "users.id",
+        },
+      },
+    };
+  }
+
+  build?: Build;
+  user?: User;
+  requestedBy?: User | null;
+}

--- a/apps/backend/src/database/models/index.ts
+++ b/apps/backend/src/database/models/index.ts
@@ -7,6 +7,7 @@ export * from "./Build";
 export * from "./BuildMergeQueueGhPullRequest";
 export * from "./BuildNotification";
 export * from "./BuildNotificationSubscription";
+export * from "./BuildRequestedReviewer";
 export * from "./BuildReview";
 export * from "./BuildShard";
 export * from "./Deployment";

--- a/apps/backend/src/graphql/definitions/Build.ts
+++ b/apps/backend/src/graphql/definitions/Build.ts
@@ -3,9 +3,9 @@ import { invariant } from "@argos/util/invariant";
 import gqlTag from "graphql-tag";
 
 import { getPreviousDiffApprovalIds } from "@/build/approval";
-import { getMentionableUserIds } from "@/comment/mentions";
 import { Build, BuildNotificationSubscription } from "@/database/models";
 import { sortScreenshotDiffsForBuild } from "@/database/services/screenshot-diffs";
+import { getProjectMemberIds } from "@/project/members";
 
 import {
   IBaseBranchResolution,
@@ -135,8 +135,10 @@ export const typeDefs = gql`
     subset: Boolean!
     "Whether the current user is subscribed to this build's notifications"
     subscribed: Boolean!
-    "Users that can be mentioned in comments on this build"
-    mentionableUsers: [User!]!
+    "Users with access to this build's project (can be mentioned or requested as reviewers)"
+    members: [User!]!
+    "Users requested to review this build"
+    reviewers: [User!]!
   }
 
   type BuildMetadata {
@@ -356,16 +358,30 @@ export const resolvers: IResolvers = {
       });
       return subscription?.isSubscribed() ?? false;
     },
-    mentionableUsers: async (build, _args, ctx) => {
+    members: async (build, _args, ctx) => {
       if (!ctx.auth) {
         return [];
       }
       const project = await ctx.loaders.Project.load(build.projectId);
       invariant(project, "Project not found");
-      const userIds = await getMentionableUserIds(project);
+      const userIds = await getProjectMemberIds(project);
       const accounts = await Promise.all(
         userIds.map((userId) =>
           ctx.loaders.AccountFromRelation.load({ userId }),
+        ),
+      );
+      return accounts.filter((account) => account !== null);
+    },
+    reviewers: async (build, _args, ctx) => {
+      if (!ctx.auth) {
+        return [];
+      }
+      const requestedReviewers = await ctx.loaders.BuildRequestedReviewers.load(
+        build.id,
+      );
+      const accounts = await Promise.all(
+        requestedReviewers.map((reviewer) =>
+          ctx.loaders.AccountFromRelation.load({ userId: reviewer.userId }),
         ),
       );
       return accounts.filter((account) => account !== null);

--- a/apps/backend/src/graphql/definitions/BuildReviewer.ts
+++ b/apps/backend/src/graphql/definitions/BuildReviewer.ts
@@ -1,0 +1,94 @@
+import { invariant } from "@argos/util/invariant";
+import gqlTag from "graphql-tag";
+
+import {
+  addBuildReviewers,
+  removeBuildReviewers,
+} from "@/build/requestedReviewers";
+import { Build } from "@/database/models/Build";
+import { User } from "@/database/models/User";
+
+import type { IResolvers } from "../__generated__/resolver-types";
+import { forbidden, notFound, unauthenticated } from "../util";
+
+const { gql } = gqlTag;
+
+export const typeDefs = gql`
+  input AddBuildReviewersInput {
+    buildId: ID!
+    "Public ids of the users to request as reviewers"
+    userIds: [ID!]!
+  }
+
+  input RemoveBuildReviewersInput {
+    buildId: ID!
+    "Public ids of the users whose review request should be cancelled"
+    userIds: [ID!]!
+  }
+
+  extend type Mutation {
+    "Request users to review a build"
+    addBuildReviewers(input: AddBuildReviewersInput!): Build!
+    "Cancel review requests on a build"
+    removeBuildReviewers(input: RemoveBuildReviewersInput!): Build!
+  }
+`;
+
+/**
+ * Load a build for a reviewer mutation, enforcing that the current user has the
+ * `review` permission on its project. Never trust the client — the same check
+ * gates who can see the picker in the UI.
+ */
+async function loadBuildForReviewerMutation(
+  buildId: string,
+  user: User,
+): Promise<Build> {
+  const build = await Build.query()
+    .findById(buildId)
+    .withGraphFetched("project.account");
+  if (!build) {
+    throw notFound("Build not found");
+  }
+  invariant(build.project?.account);
+  const permissions = await build.project.$getPermissions(user);
+  if (!permissions.includes("review")) {
+    throw forbidden("You cannot request reviewers for this build");
+  }
+  return build;
+}
+
+export const resolvers: IResolvers = {
+  Mutation: {
+    addBuildReviewers: async (_root, args, ctx) => {
+      const { auth } = ctx;
+      if (!auth) {
+        throw unauthenticated();
+      }
+      const build = await loadBuildForReviewerMutation(
+        args.input.buildId,
+        auth.user,
+      );
+      await addBuildReviewers({
+        build,
+        accountIds: args.input.userIds,
+        requestedById: auth.user.id,
+      });
+      return build;
+    },
+    removeBuildReviewers: async (_root, args, ctx) => {
+      const { auth } = ctx;
+      if (!auth) {
+        throw unauthenticated();
+      }
+      const build = await loadBuildForReviewerMutation(
+        args.input.buildId,
+        auth.user,
+      );
+      await removeBuildReviewers({
+        build,
+        accountIds: args.input.userIds,
+      });
+      return build;
+    },
+  },
+};

--- a/apps/backend/src/graphql/definitions/index.ts
+++ b/apps/backend/src/graphql/definitions/index.ts
@@ -6,6 +6,7 @@ import * as AutomationRule from "./AutomationRule";
 import * as Build from "./Build";
 import * as BuildNotificationSubscription from "./BuildNotificationSubscription";
 import * as BuildReview from "./BuildReview";
+import * as BuildReviewer from "./BuildReviewer";
 import * as Comment from "./Comment";
 import * as Connection from "./Connection";
 import * as DateDefs from "./Date";
@@ -50,6 +51,7 @@ export const definitions: { resolvers?: object; typeDefs?: DocumentNode }[] = [
   Build,
   BuildNotificationSubscription,
   BuildReview,
+  BuildReviewer,
   Comment,
   Connection,
   DateDefs,

--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -12,6 +12,7 @@ import {
   AutomationActionRun,
   AutomationRun,
   Build,
+  BuildRequestedReviewer,
   BuildReview,
   Comment,
   CommentMention,
@@ -814,6 +815,23 @@ function createBuildReviewsLoader() {
   });
 }
 
+function createBuildRequestedReviewersLoader() {
+  return new DataLoader<string, BuildRequestedReviewer[]>(async (inputs) => {
+    const reviewers = await BuildRequestedReviewer.query()
+      .whereIn("buildId", inputs as string[])
+      .orderBy("createdAt", "asc");
+    const reviewersMap = reviewers.reduce<
+      Record<string, BuildRequestedReviewer[]>
+    >((map, reviewer) => {
+      const array = map[reviewer.buildId] ?? [];
+      array.push(reviewer);
+      map[reviewer.buildId] = array;
+      return map;
+    }, {});
+    return inputs.map((id) => reviewersMap[id] ?? []);
+  });
+}
+
 function createChangeOccurrencesLoader(): (
   from: string,
 ) => DataLoader<{ testId: string; fingerprint: string }, number, string> {
@@ -1264,6 +1282,7 @@ export const createLoaders = () => ({
   CommentReactions: createCommentReactionsLoader(),
   CommentMentionedUserIds: createCommentMentionedUserIdsLoader(),
   BuildReviews: createBuildReviewsLoader(),
+  BuildRequestedReviewers: createBuildRequestedReviewersLoader(),
   DeploymentAliasesByDeploymentId:
     createDeploymentAliasesByDeploymentIdLoader(),
   LatestBuildByProjectAndCommit: createLatestBuildByProjectAndCommitLoader(),

--- a/apps/backend/src/graphql/tests/buildReviewers.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/buildReviewers.e2e.test.ts
@@ -1,0 +1,318 @@
+import { invariant } from "@argos/util/invariant";
+import request from "supertest";
+import { test as base, beforeEach, describe, expect, vi } from "vitest";
+
+import {
+  Account,
+  Build,
+  BuildRequestedReviewer,
+  Project,
+} from "@/database/models";
+import { factory, setupDatabase } from "@/database/testing";
+import { sendNotification } from "@/notification";
+
+import { apolloServer, createApolloMiddleware } from "../apollo";
+import { expectNoGraphQLError } from "../testing";
+import { createApolloServerApp } from "./util";
+
+vi.mock("@/notification", () => ({
+  sendNotification: vi.fn(),
+}));
+
+const mockSendNotification = vi.mocked(sendNotification);
+
+const ADD_MUTATION = `
+  mutation AddBuildReviewers($input: AddBuildReviewersInput!) {
+    addBuildReviewers(input: $input) {
+      id
+      reviewers {
+        id
+      }
+    }
+  }
+`;
+
+const REMOVE_MUTATION = `
+  mutation RemoveBuildReviewers($input: RemoveBuildReviewersInput!) {
+    removeBuildReviewers(input: $input) {
+      id
+      reviewers {
+        id
+      }
+    }
+  }
+`;
+
+function getAccountUser(account: Account) {
+  invariant(account.user);
+  return account.user;
+}
+
+function getAccountUserId(account: Account) {
+  invariant(account.userId);
+  return account.userId;
+}
+
+type Fixtures = {
+  fixture: {
+    ownerAccount: Account;
+    member1: Account;
+    member2: Account;
+    outsiderAccount: Account;
+    project: Project;
+    build: Build;
+  };
+};
+
+const test = base.extend<Fixtures>({
+  fixture: async ({}, use) => {
+    await setupDatabase();
+    const [ownerAccount, member1, member2, outsiderAccount, teamAccount] =
+      await Promise.all([
+        factory.UserAccount.create(),
+        factory.UserAccount.create(),
+        factory.UserAccount.create(),
+        factory.UserAccount.create(),
+        factory.TeamAccount.create(),
+      ]);
+    invariant(teamAccount.teamId);
+    const project = await factory.Project.create({ accountId: teamAccount.id });
+    await Promise.all([
+      factory.TeamUser.create({
+        teamId: teamAccount.teamId,
+        userId: getAccountUserId(ownerAccount),
+        userLevel: "owner",
+      }),
+      factory.TeamUser.create({
+        teamId: teamAccount.teamId,
+        userId: getAccountUserId(member1),
+        userLevel: "member",
+      }),
+      factory.TeamUser.create({
+        teamId: teamAccount.teamId,
+        userId: getAccountUserId(member2),
+        userLevel: "member",
+      }),
+      ownerAccount.$fetchGraph("user"),
+      outsiderAccount.$fetchGraph("user"),
+    ]);
+    const build = await factory.Build.create({ projectId: project.id });
+    await use({
+      ownerAccount,
+      member1,
+      member2,
+      outsiderAccount,
+      project,
+      build,
+    });
+  },
+});
+
+/** Build an authenticated GraphQL app acting as the given user account. */
+function appAs(account: Account) {
+  return createApolloServerApp(apolloServer, createApolloMiddleware, {
+    user: getAccountUser(account),
+    account,
+  });
+}
+
+describe("GraphQL build reviewers mutations", () => {
+  beforeEach(() => {
+    mockSendNotification.mockReset();
+  });
+
+  test("requests reviewers, lists them and notifies them", async ({
+    fixture,
+  }) => {
+    const app = await appAs(fixture.ownerAccount);
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: ADD_MUTATION,
+        variables: {
+          input: {
+            buildId: fixture.build.id,
+            userIds: [fixture.member1.id, fixture.member2.id],
+          },
+        },
+      });
+
+    expectNoGraphQLError(res);
+    const reviewerIds = res.body.data.addBuildReviewers.reviewers
+      .map((reviewer: { id: string }) => reviewer.id)
+      .sort();
+    expect(reviewerIds).toEqual(
+      [fixture.member1.id, fixture.member2.id].sort(),
+    );
+
+    const rows = await BuildRequestedReviewer.query().where(
+      "buildId",
+      fixture.build.id,
+    );
+    expect(rows).toHaveLength(2);
+    expect(
+      rows.every((row) => row.requestedById === fixture.ownerAccount.userId),
+    ).toBe(true);
+
+    expect(mockSendNotification).toHaveBeenCalledTimes(1);
+    const call = mockSendNotification.mock.calls[0]?.[0];
+    invariant(call);
+    expect(call.type).toBe("review_requested");
+    expect([...call.recipients].sort()).toEqual(
+      [
+        getAccountUserId(fixture.member1),
+        getAccountUserId(fixture.member2),
+      ].sort(),
+    );
+  });
+
+  test("ignores users that are not project members", async ({ fixture }) => {
+    const app = await appAs(fixture.ownerAccount);
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: ADD_MUTATION,
+        variables: {
+          input: {
+            buildId: fixture.build.id,
+            userIds: [fixture.member1.id, fixture.outsiderAccount.id],
+          },
+        },
+      });
+
+    expectNoGraphQLError(res);
+    const reviewerIds = res.body.data.addBuildReviewers.reviewers.map(
+      (reviewer: { id: string }) => reviewer.id,
+    );
+    expect(reviewerIds).toEqual([fixture.member1.id]);
+
+    expect(mockSendNotification).toHaveBeenCalledTimes(1);
+    const call = mockSendNotification.mock.calls[0]?.[0];
+    invariant(call);
+    expect(call.recipients).toEqual([getAccountUserId(fixture.member1)]);
+  });
+
+  test("is idempotent and notifies only newly added reviewers", async ({
+    fixture,
+  }) => {
+    const app = await appAs(fixture.ownerAccount);
+    const firstRes = await request(app)
+      .post("/graphql")
+      .send({
+        query: ADD_MUTATION,
+        variables: {
+          input: { buildId: fixture.build.id, userIds: [fixture.member1.id] },
+        },
+      });
+    expectNoGraphQLError(firstRes);
+    expect(mockSendNotification).toHaveBeenCalledTimes(1);
+    mockSendNotification.mockReset();
+
+    const secondRes = await request(app)
+      .post("/graphql")
+      .send({
+        query: ADD_MUTATION,
+        variables: {
+          input: {
+            buildId: fixture.build.id,
+            userIds: [fixture.member1.id, fixture.member2.id],
+          },
+        },
+      });
+    expectNoGraphQLError(secondRes);
+
+    // No duplicate row for member1.
+    const rows = await BuildRequestedReviewer.query().where(
+      "buildId",
+      fixture.build.id,
+    );
+    expect(rows).toHaveLength(2);
+
+    // Only member2 (the newly added one) is notified.
+    expect(mockSendNotification).toHaveBeenCalledTimes(1);
+    const call = mockSendNotification.mock.calls[0]?.[0];
+    invariant(call);
+    expect(call.recipients).toEqual([getAccountUserId(fixture.member2)]);
+  });
+
+  test("does not notify the requester when requesting themselves", async ({
+    fixture,
+  }) => {
+    const app = await appAs(fixture.ownerAccount);
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: ADD_MUTATION,
+        variables: {
+          input: {
+            buildId: fixture.build.id,
+            userIds: [fixture.ownerAccount.id, fixture.member1.id],
+          },
+        },
+      });
+
+    expectNoGraphQLError(res);
+    expect(mockSendNotification).toHaveBeenCalledTimes(1);
+    const call = mockSendNotification.mock.calls[0]?.[0];
+    invariant(call);
+    expect(call.recipients).toEqual([getAccountUserId(fixture.member1)]);
+  });
+
+  test("removes a requested reviewer", async ({ fixture }) => {
+    const app = await appAs(fixture.ownerAccount);
+    await request(app)
+      .post("/graphql")
+      .send({
+        query: ADD_MUTATION,
+        variables: {
+          input: {
+            buildId: fixture.build.id,
+            userIds: [fixture.member1.id, fixture.member2.id],
+          },
+        },
+      });
+
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: REMOVE_MUTATION,
+        variables: {
+          input: { buildId: fixture.build.id, userIds: [fixture.member1.id] },
+        },
+      });
+
+    expectNoGraphQLError(res);
+    const reviewerIds = res.body.data.removeBuildReviewers.reviewers.map(
+      (reviewer: { id: string }) => reviewer.id,
+    );
+    expect(reviewerIds).toEqual([fixture.member2.id]);
+
+    const rows = await BuildRequestedReviewer.query().where(
+      "buildId",
+      fixture.build.id,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.userId).toBe(getAccountUserId(fixture.member2));
+  });
+
+  test("forbids users without the review permission", async ({ fixture }) => {
+    const app = await appAs(fixture.outsiderAccount);
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: ADD_MUTATION,
+        variables: {
+          input: { buildId: fixture.build.id, userIds: [fixture.member1.id] },
+        },
+      });
+
+    expect(res.body.errors).toHaveLength(1);
+    expect(res.body.errors[0].extensions.code).toBe("FORBIDDEN");
+    const rows = await BuildRequestedReviewer.query().where(
+      "buildId",
+      fixture.build.id,
+    );
+    expect(rows).toHaveLength(0);
+    expect(mockSendNotification).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/notification/handlers/index.ts
+++ b/apps/backend/src/notification/handlers/index.ts
@@ -8,6 +8,7 @@ import * as email_removed from "./email_removed";
 import * as invalid_gitlab_token from "./invalid_gitlab_token";
 import * as project_deleted from "./project_deleted";
 import * as review_dismissed from "./review_dismissed";
+import * as review_requested from "./review_requested";
 import * as review_submitted from "./review_submitted";
 import * as saml_certificate_expiration from "./saml_certificate_expiration";
 import * as slack_automation_action_unavailable from "./slack_automation_action_unavailable";
@@ -24,6 +25,7 @@ export const notificationHandlers = [
   invalid_gitlab_token.handler,
   project_deleted.handler,
   review_dismissed.handler,
+  review_requested.handler,
   review_submitted.handler,
   saml_certificate_expiration.handler,
   spend_limit.handler,

--- a/apps/backend/src/notification/handlers/review_requested.tsx
+++ b/apps/backend/src/notification/handlers/review_requested.tsx
@@ -1,0 +1,62 @@
+import { z } from "zod";
+
+import { EmailLayout, H1, Hi, Link, Paragraph } from "../../email/components";
+import { defineNotificationHandler } from "../workflow-types";
+
+export const handler = defineNotificationHandler({
+  type: "review_requested",
+  category: "review",
+  schema: z.object({
+    accountSlug: z.string(),
+    projectName: z.string(),
+    buildNumber: z.number(),
+    buildName: z.string().nullish(),
+    buildUrl: z.url(),
+    requesterName: z.string().nullish(),
+  }),
+  previewData: {
+    accountSlug: "argos",
+    projectName: "my-project",
+    buildNumber: 42,
+    buildName: "default",
+    buildUrl: "https://app.argos-ci.com/argos/my-project/builds/42",
+    requesterName: "Jane Doe",
+  },
+  email: (props) => {
+    const {
+      accountSlug,
+      projectName,
+      buildNumber,
+      buildName,
+      buildUrl,
+      requesterName,
+      ctx,
+    } = props;
+    const buildLabel = buildName
+      ? `${buildName} #${buildNumber}`
+      : `#${buildNumber}`;
+    const requester = requesterName || "Someone";
+    return {
+      subject: `[${accountSlug}/${projectName}] Your review is requested on build ${buildLabel}`,
+      body: (
+        <EmailLayout
+          preview={`${requester} requested your review on build ${buildLabel} in ${accountSlug}/${projectName}.`}
+          preferencesUrl={ctx.preferencesUrl}
+        >
+          <H1>Review requested</H1>
+          <Hi name={ctx.user.name} />
+          <Paragraph>
+            <strong>{requester}</strong> requested your review on build{" "}
+            <Link href={buildUrl}>
+              {accountSlug}/{projectName} {buildLabel}
+            </Link>
+            .
+          </Paragraph>
+          <Paragraph>
+            <Link href={buildUrl}>Review the build on Argos →</Link>
+          </Paragraph>
+        </EmailLayout>
+      ),
+    };
+  },
+});

--- a/apps/backend/src/project/members.e2e.test.ts
+++ b/apps/backend/src/project/members.e2e.test.ts
@@ -1,0 +1,63 @@
+import { invariant } from "@argos/util/invariant";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { factory, setupDatabase } from "@/database/testing";
+
+import { getProjectMemberIds } from "./members";
+
+describe("getProjectMemberIds", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  it("includes team owners and members but not bare contributors", async () => {
+    const teamAccount = await factory.TeamAccount.create();
+    invariant(teamAccount.teamId);
+    const project = await factory.Project.create({ accountId: teamAccount.id });
+    const [owner, member, contributor] = await Promise.all([
+      factory.User.create(),
+      factory.User.create(),
+      factory.User.create(),
+    ]);
+    await Promise.all([
+      factory.TeamUser.create({
+        teamId: teamAccount.teamId,
+        userId: owner.id,
+        userLevel: "owner",
+      }),
+      factory.TeamUser.create({
+        teamId: teamAccount.teamId,
+        userId: member.id,
+        userLevel: "member",
+      }),
+      factory.TeamUser.create({
+        teamId: teamAccount.teamId,
+        userId: contributor.id,
+        userLevel: "contributor",
+      }),
+    ]);
+
+    const userIds = await getProjectMemberIds(project);
+    expect([...userIds].sort()).toEqual([owner.id, member.id].sort());
+  });
+
+  it("includes contributors that have explicit project access", async () => {
+    const teamAccount = await factory.TeamAccount.create();
+    invariant(teamAccount.teamId);
+    const project = await factory.Project.create({ accountId: teamAccount.id });
+    const contributor = await factory.User.create();
+    await factory.TeamUser.create({
+      teamId: teamAccount.teamId,
+      userId: contributor.id,
+      userLevel: "contributor",
+    });
+    await factory.ProjectUser.create({
+      projectId: project.id,
+      userId: contributor.id,
+      userLevel: "viewer",
+    });
+
+    const userIds = await getProjectMemberIds(project);
+    expect(userIds).toEqual([contributor.id]);
+  });
+});

--- a/apps/backend/src/project/members.e2e.test.ts
+++ b/apps/backend/src/project/members.e2e.test.ts
@@ -10,6 +10,17 @@ describe("getProjectMemberIds", () => {
     await setupDatabase();
   });
 
+  it("returns only the owner for a personal project", async () => {
+    const userAccount = await factory.UserAccount.create();
+    invariant(userAccount.userId);
+    const project = await factory.Project.create({
+      accountId: userAccount.id,
+    });
+
+    const userIds = await getProjectMemberIds(project);
+    expect(userIds).toEqual([userAccount.userId]);
+  });
+
   it("includes team owners and members but not bare contributors", async () => {
     const teamAccount = await factory.TeamAccount.create();
     invariant(teamAccount.teamId);

--- a/apps/backend/src/project/members.ts
+++ b/apps/backend/src/project/members.ts
@@ -1,0 +1,56 @@
+import { invariant } from "@argos/util/invariant";
+
+import { Project, ProjectUser, TeamUser } from "@/database/models";
+
+/**
+ * Get the database ids of every user who has at least "view" access to the
+ * project. These are the users that may legitimately be mentioned in a comment
+ * on one of its builds, or requested as a reviewer. Mirrors the "view" branch of
+ * {@link Project.getPermissions}.
+ */
+export async function getProjectMemberIds(project: Project): Promise<string[]> {
+  await project.$fetchGraph("account", { skipFetched: true });
+  invariant(project.account, "Project account not found");
+  const { account } = project;
+
+  // Personal project: only the owner can access it.
+  if (account.type === "user") {
+    return account.userId ? [account.userId] : [];
+  }
+
+  const { teamId } = account;
+  invariant(teamId, "Team account without teamId");
+
+  const teamUsers = await TeamUser.query()
+    .where("teamId", teamId)
+    .select("userId", "userLevel");
+
+  const userIds = new Set<string>();
+  const contributorIds: string[] = [];
+  for (const teamUser of teamUsers) {
+    if (teamUser.userLevel === "contributor") {
+      contributorIds.push(teamUser.userId);
+    } else {
+      // Owners and members always have access.
+      userIds.add(teamUser.userId);
+    }
+  }
+
+  if (contributorIds.length > 0) {
+    if (project.defaultUserLevel) {
+      // Every contributor inherits at least the project's default level, which
+      // always grants "view".
+      contributorIds.forEach((id) => userIds.add(id));
+    } else {
+      // Otherwise only contributors with an explicit project-level access.
+      const projectUsers = await ProjectUser.query()
+        .where("projectId", project.id)
+        .whereIn("userId", contributorIds)
+        .whereNotNull("userLevel")
+        .select("userId");
+      projectUsers.forEach((projectUser) => userIds.add(projectUser.userId));
+    }
+  }
+
+  return [...userIds];
+}

--- a/apps/frontend/src/containers/Build/BuildHotkeys.tsx
+++ b/apps/frontend/src/containers/Build/BuildHotkeys.tsx
@@ -214,6 +214,12 @@ const hotkeyGroups = [
   {
     name: "Actions",
     hotkeys: {
+      requestReviewers: {
+        keys: ["KeyA"],
+        displayKeys: ["A"],
+        description: "Add reviewer",
+        envs: ["build"],
+      },
       acceptDiff: {
         keys: ["KeyY"],
         displayKeys: ["Y"],

--- a/apps/frontend/src/containers/Build/BuildHotkeys.tsx
+++ b/apps/frontend/src/containers/Build/BuildHotkeys.tsx
@@ -400,13 +400,7 @@ const BuildHotkeysDialogWithState = memo(
             >
               <XIcon />
             </IconButton>
-            <div
-              className={clsx(
-                "gap-12 space-y-6 md:columns-2",
-                { test: "md:max-h-[20rem]", build: "md:max-h-[32rem]" }[env],
-              )}
-              style={{ columnFill: "auto" }}
-            >
+            <div className={clsx("gap-12 space-y-6 pb-4 md:columns-2")}>
               {plainHotkeyGroups.map((group, index) => {
                 const entries = Object.entries(group.hotkeys).filter(
                   ([, hotKey]) =>

--- a/apps/frontend/src/containers/BuildReviewersStatusList.tsx
+++ b/apps/frontend/src/containers/BuildReviewersStatusList.tsx
@@ -3,7 +3,7 @@ import clsx from "clsx";
 import { BanIcon } from "lucide-react";
 import moment from "moment";
 
-import type { ReviewState } from "@/gql/graphql";
+import { ReviewState } from "@/gql/graphql";
 import { Tooltip } from "@/ui/Tooltip";
 import {
   buildReviewDescriptors,
@@ -25,6 +25,8 @@ type ReviewerStatusReview = {
   } | null;
 };
 
+type ReviewerUser = NonNullable<ReviewerStatusReview["user"]>;
+
 const dismissedReviewDescriptor = {
   label: "Dismissed",
   icon: BanIcon,
@@ -41,15 +43,23 @@ export function BuildReviewersStatusList<
   T extends ReviewerStatusReview,
 >(props: {
   reviews: readonly T[];
+  /**
+   * Users requested as reviewers that haven't submitted a review yet. Rendered
+   * as "pending" rows after the submitted reviews.
+   */
+  pendingUsers?: readonly ReviewerUser[];
   className?: string;
   itemClassName?: string;
   avatarClassName?: string;
   renderAction?: (review: T) => ReactNode;
 }) {
   const reviewers = getLatestReviewByUser(props.reviews);
-  if (reviewers.length === 0) {
+  const pendingUsers = props.pendingUsers ?? [];
+  if (reviewers.length === 0 && pendingUsers.length === 0) {
     return null;
   }
+  const pendingDescriptor = buildReviewDescriptors[ReviewState.Pending];
+  const PendingIcon = pendingDescriptor.icon;
   return (
     <ul className={clsx("flex flex-col", props.className)}>
       {reviewers.map((review) => {
@@ -84,6 +94,29 @@ export function BuildReviewersStatusList<
           </li>
         );
       })}
+      {pendingUsers.map((user) => (
+        <li
+          key={`pending-${user.id}`}
+          className={clsx(
+            "flex items-center gap-2 text-sm",
+            props.itemClassName,
+          )}
+        >
+          <AccountAvatar
+            className={clsx("size-5 shrink-0", props.avatarClassName)}
+            avatar={user.avatar}
+            alt={user.name ?? undefined}
+          />
+          <strong className="flex-1 truncate font-medium">
+            {user.name || user.slug}
+          </strong>
+          <Tooltip content={pendingDescriptor.label}>
+            <PendingIcon
+              className={clsx("size-3.5 shrink-0", pendingDescriptor.textColor)}
+            />
+          </Tooltip>
+        </li>
+      ))}
     </ul>
   );
 }

--- a/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
@@ -38,7 +38,7 @@ const _BuildFragment = graphql(`
     concludedAt
     subscribed
     ...AddCommentForm_Build
-    mentionableUsers {
+    members {
       ...UserCard_user
     }
     reviews {
@@ -222,10 +222,8 @@ function useHighlightedCommentId(commentIds: string[]): string | null {
   return matchedId;
 }
 
-function toMentionUsers(
-  mentionableUsers: Build["mentionableUsers"],
-): MentionUser[] {
-  return mentionableUsers.map(getMentionUser);
+function toMentionUsers(members: Build["members"]): MentionUser[] {
+  return members.map(getMentionUser);
 }
 
 export function ReviewActivitySection(props: { build: Build }) {
@@ -237,8 +235,8 @@ export function ReviewActivitySection(props: { build: Build }) {
     build.comments.map((comment) => comment.id),
   );
   const mentionableUsers = useMemo(
-    () => toMentionUsers(build.mentionableUsers),
-    [build.mentionableUsers],
+    () => toMentionUsers(build.members),
+    [build.members],
   );
   return (
     <MentionableUsersProvider value={mentionableUsers}>

--- a/apps/frontend/src/pages/Build/sidebar/ReviewersSection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewersSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useMutation } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import clsx from "clsx";
@@ -285,11 +285,14 @@ function RequestReviewersMenu(props: { build: Build }) {
   }, [build.reviewers, memberIds, reviewedKeys]);
 
   // Optimistic selection: reflect the click immediately, then reconcile with the
-  // server response (or revert on error).
+  // server's requested set whenever it changes (React's "adjust state during
+  // render" pattern — avoids a setState-in-effect).
   const [requested, setRequested] = useState(() => new Set(requestedKeys));
-  useEffect(() => {
+  const [syncedKeys, setSyncedKeys] = useState(requestedKeys);
+  if (syncedKeys !== requestedKeys) {
+    setSyncedKeys(requestedKeys);
     setRequested(new Set(requestedKeys));
-  }, [requestedKeys]);
+  }
 
   const selectedKeys = useMemo(
     () => new Set([...requested, ...reviewedKeys]),

--- a/apps/frontend/src/pages/Build/sidebar/ReviewersSection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewersSection.tsx
@@ -1,9 +1,23 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useMutation } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import clsx from "clsx";
-import { BanIcon, MoreHorizontalIcon } from "lucide-react";
+import {
+  BanIcon,
+  MoreHorizontalIcon,
+  PlusIcon,
+  SearchIcon,
+} from "lucide-react";
+import {
+  Autocomplete,
+  Input,
+  SearchField,
+  useFilter,
+  type Selection,
+} from "react-aria-components";
 
+import { AccountAvatar } from "@/containers/AccountAvatar";
+import { useBuildHotkey } from "@/containers/Build/BuildHotkeys";
 import { BuildReviewersStatusList } from "@/containers/BuildReviewersStatusList";
 import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
 import { DocumentType, graphql } from "@/gql";
@@ -19,17 +33,22 @@ import {
   DialogTitle,
 } from "@/ui/Dialog";
 import { ErrorMessage } from "@/ui/ErrorMessage";
+import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 import { IconButton } from "@/ui/IconButton";
 import { Menu, MenuItem, MenuItemIcon, MenuTrigger } from "@/ui/Menu";
 import { Modal } from "@/ui/Modal";
 import { Popover } from "@/ui/Popover";
 import { SidebarHeader, SidebarHeading, SidebarSection } from "@/ui/Sidebar";
-import { getLatestReviewByUser } from "@/util/build-review";
+import {
+  getLatestActiveReviewByUser,
+  getLatestReviewByUser,
+} from "@/util/build-review";
 import { getErrorMessage } from "@/util/error";
 import { useNonNullable } from "@/util/useNonNullable";
 
 const _BuildFragment = graphql(`
   fragment ReviewersSection_Build on Build {
+    id
     status
     type
     mergeQueue
@@ -47,6 +66,22 @@ const _BuildFragment = graphql(`
         }
       }
     }
+    members {
+      id
+      name
+      slug
+      avatar {
+        ...AccountAvatarFragment
+      }
+    }
+    reviewers {
+      id
+      name
+      slug
+      avatar {
+        ...AccountAvatarFragment
+      }
+    }
   }
 `);
 
@@ -62,6 +97,26 @@ const DismissReviewMutation = graphql(`
       ...BuildStatusChip_Build
       ...ReviewersSection_Build
       ...ReviewActivitySection_Build
+    }
+  }
+`);
+
+const AddBuildReviewersMutation = graphql(`
+  mutation ReviewersSection_addBuildReviewers($input: AddBuildReviewersInput!) {
+    addBuildReviewers(input: $input) {
+      id
+      ...ReviewersSection_Build
+    }
+  }
+`);
+
+const RemoveBuildReviewersMutation = graphql(`
+  mutation ReviewersSection_removeBuildReviewers(
+    $input: RemoveBuildReviewersInput!
+  ) {
+    removeBuildReviewers(input: $input) {
+      id
+      ...ReviewersSection_Build
     }
   }
 `);
@@ -111,19 +166,34 @@ export function ReviewersSection(props: { build: Build }) {
   const canDismissReview = permissions.includes(
     ProjectPermission.ReviewDismiss,
   );
-  const reviewers = getLatestReviewByUser(build.reviews);
+  const canRequestReviewers = permissions.includes(ProjectPermission.Review);
+
+  // Requested reviewers that haven't reviewed yet are shown as pending, after
+  // the submitted reviews.
+  const reviewedUserIds = new Set(
+    getLatestReviewByUser(build.reviews)
+      .map((review) => review.user?.id)
+      .filter((id): id is string => Boolean(id)),
+  );
+  const pendingReviewers = build.reviewers.filter(
+    (reviewer) => !reviewedUserIds.has(reviewer.id),
+  );
+  const hasReviewers = reviewedUserIds.size > 0 || pendingReviewers.length > 0;
+
   return (
     <SidebarSection>
       <SidebarHeader>
         <SidebarHeading>Reviewers</SidebarHeading>
+        {canRequestReviewers ? <RequestReviewersMenu build={build} /> : null}
       </SidebarHeader>
-      {reviewers.length === 0 ? (
+      {!hasReviewers ? (
         <div className="text-low px-4 text-xs">
           {getEmptyStateMessage(build)}
         </div>
       ) : (
         <BuildReviewersStatusList
-          reviews={reviewers}
+          reviews={build.reviews}
+          pendingUsers={pendingReviewers}
           className="gap-3"
           itemClassName={clsx("px-4 has-data-actions-menu:pr-3")}
           renderAction={
@@ -170,6 +240,144 @@ export function ReviewersSection(props: { build: Build }) {
         ) : null}
       </Modal>
     </SidebarSection>
+  );
+}
+
+/**
+ * "+" button in the Reviewers header that opens a searchable, multi-select menu
+ * of project members. Checking a member requests their review; unchecking
+ * cancels the request.
+ */
+function RequestReviewersMenu(props: { build: Build }) {
+  const { build } = props;
+  const { contains } = useFilter({ sensitivity: "base" });
+  const [isOpen, setIsOpen] = useState(false);
+  const hotkey = useBuildHotkey("requestReviewers", () => setIsOpen(true));
+  const [addReviewers] = useMutation(AddBuildReviewersMutation);
+  const [removeReviewers] = useMutation(RemoveBuildReviewersMutation);
+
+  const memberIds = useMemo(
+    () => new Set(build.members.map((member) => member.id)),
+    [build.members],
+  );
+
+  // Members who already submitted an active review can't be toggled: they show
+  // up selected and disabled.
+  const reviewedKeys = useMemo(() => {
+    const reviewed = new Set(
+      getLatestActiveReviewByUser(build.reviews)
+        .map((review) => review.user?.id)
+        .filter((id): id is string => Boolean(id)),
+    );
+    return build.members
+      .map((member) => member.id)
+      .filter((id) => reviewed.has(id));
+  }, [build.members, build.reviews]);
+
+  // Requested reviewers that are still toggleable (members that haven't reviewed
+  // yet). A requested user who lost access stays pending but isn't manageable
+  // here.
+  const requestedKeys = useMemo(() => {
+    const reviewed = new Set(reviewedKeys);
+    return build.reviewers
+      .map((reviewer) => reviewer.id)
+      .filter((id) => memberIds.has(id) && !reviewed.has(id));
+  }, [build.reviewers, memberIds, reviewedKeys]);
+
+  // Optimistic selection: reflect the click immediately, then reconcile with the
+  // server response (or revert on error).
+  const [requested, setRequested] = useState(() => new Set(requestedKeys));
+  useEffect(() => {
+    setRequested(new Set(requestedKeys));
+  }, [requestedKeys]);
+
+  const selectedKeys = useMemo(
+    () => new Set([...requested, ...reviewedKeys]),
+    [requested, reviewedKeys],
+  );
+  const disabledKeys = useMemo(() => new Set(reviewedKeys), [reviewedKeys]);
+
+  const handleSelectionChange = (keys: Selection) => {
+    if (keys === "all") {
+      return;
+    }
+    // Disabled (already reviewed) keys stay selected — only diff the toggleable
+    // ones.
+    const reviewed = new Set(reviewedKeys);
+    const next = new Set(
+      Array.from(keys, String).filter((id) => !reviewed.has(id)),
+    );
+    const added = [...next].filter((id) => !requested.has(id));
+    const removed = [...requested].filter((id) => !next.has(id));
+    setRequested(next);
+    const revert = () => setRequested(new Set(requestedKeys));
+    if (added.length > 0) {
+      addReviewers({
+        variables: { input: { buildId: build.id, userIds: added } },
+      }).catch(revert);
+    }
+    if (removed.length > 0) {
+      removeReviewers({
+        variables: { input: { buildId: build.id, userIds: removed } },
+      }).catch(revert);
+    }
+  };
+
+  return (
+    <MenuTrigger isOpen={isOpen} onOpenChange={setIsOpen}>
+      <HotkeyTooltip description="Add reviewer" keys={hotkey.displayKeys}>
+        <IconButton rounded size="small" aria-label="Add reviewer">
+          <PlusIcon />
+        </IconButton>
+      </HotkeyTooltip>
+      <Popover placement="bottom end" className="bg-app min-w-56">
+        <Autocomplete filter={contains}>
+          <div className="flex w-full flex-col gap-1" data-hotkeys-disabled>
+            <SearchField
+              aria-label="Search members"
+              autoFocus
+              className="border-b"
+            >
+              <div className="relative flex items-center px-3 py-1.5">
+                <SearchIcon className="text-placeholder mr-2 size-4 shrink-0" />
+                <Input
+                  className="placeholder:text-placeholder w-full bg-transparent text-sm outline-none"
+                  placeholder="Search members…"
+                />
+              </div>
+            </SearchField>
+            <Menu
+              aria-label="Project members"
+              className="max-h-64 w-full overflow-y-auto"
+              selectionMode="multiple"
+              selectedKeys={selectedKeys}
+              disabledKeys={disabledKeys}
+              onSelectionChange={handleSelectionChange}
+              items={build.members}
+              renderEmptyState={() => (
+                <p className="text-low px-2 py-1.5 text-xs">No members found</p>
+              )}
+            >
+              {(member) => (
+                <MenuItem
+                  id={member.id}
+                  textValue={[member.name, member.slug]
+                    .filter(Boolean)
+                    .join(" ")}
+                >
+                  <AccountAvatar
+                    avatar={member.avatar}
+                    className="mr-2 size-5 shrink-0"
+                    alt={member.name ?? undefined}
+                  />
+                  <span className="truncate">{member.name || member.slug}</span>
+                </MenuItem>
+              )}
+            </Menu>
+          </div>
+        </Autocomplete>
+      </Popover>
+    </MenuTrigger>
   );
 }
 


### PR DESCRIPTION
## What

Adds GitHub-style **requested reviewers** on builds (ARG-379). A maintainer picks project members from a searchable menu in the build *Reviewers* section; requested reviewers appear as **pending** and receive an email, and can be un-requested.

## Backend

- **DB**: new `build_requested_reviewers` join table (composite PK `(buildId, userId)`, nullable `requestedById`) + `BuildRequestedReviewer` model.
- **GraphQL**:
  - Renamed `Build.mentionableUsers` → `Build.members` (the access-resolution helper moved to `src/project/members.ts` as `getProjectMemberIds`) — one shared list powers both @mentions and the reviewer picker.
  - New `Build.reviewers: [User!]!` field (via a `BuildRequestedReviewers` DataLoader).
  - New `addBuildReviewers` / `removeBuildReviewers` mutations, gated by the `review` permission, with server-side member-eligibility enforcement and idempotent inserts.
- **Notification**: new `review_requested` handler (category `review`), dispatched only to newly-added reviewers (excluding the requester). Documented "how to add a notification handler" in `apps/backend/AGENTS.md`.

## Frontend

- "+" button in the Reviewers header (shown with the `review` permission) — `rounded`, with a tooltip and an **`A`** keyboard shortcut.
- Searchable multi-select `Menu` of project members; checking requests / unchecking cancels.
- Requested-but-unreviewed members render as **Pending**; members who already left a review appear **selected + disabled**.

## Tests

- New `buildReviewers.e2e.test.ts` (6 cases: add/list/notify, non-member filtering, idempotent re-add, requester self-exclusion, remove, permission denial).
- Relocated the access-resolution tests to `members.e2e.test.ts`.
- All affected e2e suites (177) + full unit suite (216) pass; `codegen`, `check-types`, `lint`, `knip`, `check-format` clean.

> Note: `Build.reviewers` returns `[User!]!`, so pending rows show "Pending" without a precise requested-at time — easy to enrich later with `requestedAt` if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)