### PR TITLE
feat: strip empty paragraphs and line breaks from comments

### DIFF
--- a/apps/backend/src/comment/createBuildComment.ts
+++ b/apps/backend/src/comment/createBuildComment.ts
@@ -21,6 +21,7 @@ import { syncCommentMentions } from "./mentions";
 import {
   isCommentEmpty,
   isCommentTooLarge,
+  sanitizeCommentJson,
   validateCommentJson,
 } from "./validate";
 
@@ -34,11 +35,13 @@ export async function createBuildComment(input: {
   body: JSONContent;
   threadId?: string | null;
 }): Promise<Comment> {
-  const { build, userId, body, threadId = null } = input;
+  const { build, userId, threadId = null } = input;
 
-  if (!validateCommentJson(body)) {
+  if (!validateCommentJson(input.body)) {
     throw boom(400, "Invalid comment body");
   }
+
+  const body = sanitizeCommentJson(input.body);
 
   if (isCommentEmpty(body)) {
     throw boom(400, "Comment cannot be empty");

--- a/apps/backend/src/comment/updateBuildComment.ts
+++ b/apps/backend/src/comment/updateBuildComment.ts
@@ -9,6 +9,7 @@ import { getCommentMentionedUserIds, syncCommentMentions } from "./mentions";
 import {
   isCommentEmpty,
   isCommentTooLarge,
+  sanitizeCommentJson,
   validateCommentJson,
 } from "./validate";
 
@@ -24,11 +25,13 @@ export async function updateBuildComment(input: {
   comment: Comment;
   body: JSONContent;
 }): Promise<Comment> {
-  const { comment, body } = input;
+  const { comment } = input;
 
-  if (!validateCommentJson(body)) {
+  if (!validateCommentJson(input.body)) {
     throw boom(400, "Invalid comment body");
   }
+
+  const body = sanitizeCommentJson(input.body);
 
   if (isCommentEmpty(body)) {
     throw boom(400, "Comment cannot be empty");

--- a/apps/backend/src/comment/validate.test.ts
+++ b/apps/backend/src/comment/validate.test.ts
@@ -1,7 +1,16 @@
 import type { JSONContent } from "@tiptap/core";
 import { describe, expect, it } from "vitest";
 
-import { isCommentTooLarge, validateCommentJson } from "./validate";
+import {
+  isCommentTooLarge,
+  sanitizeCommentJson,
+  validateCommentJson,
+} from "./validate";
+
+const paragraph = (text?: string) =>
+  text === undefined
+    ? { type: "paragraph" }
+    : { type: "paragraph", content: [{ type: "text", text }] };
 
 function docWithText(text: string) {
   return {
@@ -200,6 +209,145 @@ describe("validateCommentJson", () => {
         }),
       ).toBe(false);
     });
+  });
+});
+
+describe("sanitizeCommentJson", () => {
+  it("strips leading blank paragraphs", () => {
+    expect(
+      sanitizeCommentJson({
+        type: "doc",
+        content: [paragraph(), paragraph(), paragraph("Hello")],
+      }),
+    ).toEqual({ type: "doc", content: [paragraph("Hello")] });
+  });
+
+  it("strips trailing blank paragraphs", () => {
+    expect(
+      sanitizeCommentJson({
+        type: "doc",
+        content: [paragraph("Hello"), paragraph(), paragraph()],
+      }),
+    ).toEqual({ type: "doc", content: [paragraph("Hello")] });
+  });
+
+  it("strips both leading and trailing blank paragraphs", () => {
+    expect(
+      sanitizeCommentJson({
+        type: "doc",
+        content: [paragraph(), paragraph("Hello"), paragraph()],
+      }),
+    ).toEqual({ type: "doc", content: [paragraph("Hello")] });
+  });
+
+  it("treats whitespace-only paragraphs as blank", () => {
+    expect(
+      sanitizeCommentJson({
+        type: "doc",
+        content: [paragraph("   "), paragraph("Hello")],
+      }),
+    ).toEqual({ type: "doc", content: [paragraph("Hello")] });
+  });
+
+  it("keeps blank paragraphs between content", () => {
+    const content = [paragraph("a"), paragraph(), paragraph("b")];
+    expect(sanitizeCommentJson({ type: "doc", content })).toEqual({
+      type: "doc",
+      content,
+    });
+  });
+
+  it("returns the same value when there is nothing to trim", () => {
+    const value = { type: "doc", content: [paragraph("Hello")] };
+    expect(sanitizeCommentJson(value)).toBe(value);
+  });
+
+  it("strips leading and trailing line breaks within a paragraph", () => {
+    expect(
+      sanitizeCommentJson({
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              { type: "hardBreak" },
+              { type: "text", text: "Hello" },
+              { type: "hardBreak" },
+            ],
+          },
+        ],
+      }),
+    ).toEqual({ type: "doc", content: [paragraph("Hello")] });
+  });
+
+  it("keeps line breaks between text", () => {
+    const content = [
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "a" },
+          { type: "hardBreak" },
+          { type: "text", text: "b" },
+        ],
+      },
+    ];
+    expect(sanitizeCommentJson({ type: "doc", content })).toEqual({
+      type: "doc",
+      content,
+    });
+  });
+
+  it("treats line-break-only paragraphs as blank", () => {
+    expect(
+      sanitizeCommentJson({
+        type: "doc",
+        content: [
+          { type: "paragraph", content: [{ type: "hardBreak" }] },
+          paragraph("Hello"),
+        ],
+      }),
+    ).toEqual({ type: "doc", content: [paragraph("Hello")] });
+  });
+
+  it("trims trailing breaks on the last block and leading on the first", () => {
+    expect(
+      sanitizeCommentJson({
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "hardBreak" }, { type: "text", text: "a" }],
+          },
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "b" }, { type: "hardBreak" }],
+          },
+        ],
+      }),
+    ).toEqual({
+      type: "doc",
+      content: [paragraph("a"), paragraph("b")],
+    });
+  });
+
+  it("does not strip non-paragraph blocks (e.g. headings)", () => {
+    const content = [
+      { type: "heading", attrs: { level: 2 }, content: [] },
+      paragraph("Hello"),
+    ];
+    expect(sanitizeCommentJson({ type: "doc", content })).toEqual({
+      type: "doc",
+      content,
+    });
+  });
+
+  it("leaves an all-blank doc reducible to empty (then rejected by isCommentEmpty)", () => {
+    expect(
+      sanitizeCommentJson({
+        type: "doc",
+        content: [paragraph(), paragraph()],
+      }),
+    ).toEqual({ type: "doc", content: [] });
   });
 });
 

--- a/apps/backend/src/comment/validate.ts
+++ b/apps/backend/src/comment/validate.ts
@@ -32,6 +32,120 @@ export function validateCommentJson(value: unknown): value is JSONContent {
 }
 
 /**
+ * Whether an inline node carries no meaningful content, i.e. it's a line break
+ * (`hardBreak`) or a whitespace-only text node.
+ */
+function isBlankInline(node: JSONContent): boolean {
+  if (node.type === "hardBreak") {
+    return true;
+  }
+  return node.type === "text" && (node.text ?? "").trim().length === 0;
+}
+
+/**
+ * Whether a top-level node is a "blank" paragraph, i.e. one carrying no
+ * meaningful content (no children, or only line breaks and whitespace). Such
+ * paragraphs are produced by trailing/leading newlines in the editor.
+ */
+function isBlankParagraph(node: JSONContent): boolean {
+  if (node.type !== "paragraph") {
+    return false;
+  }
+  const content = node.content;
+  if (!content || content.length === 0) {
+    return true;
+  }
+  return content.every(isBlankInline);
+}
+
+/**
+ * Trim leading and/or trailing line breaks (`hardBreak`) from a paragraph's
+ * inline content. Returns the same node when there is nothing to trim or it
+ * isn't a paragraph.
+ */
+function trimParagraphBreaks(
+  node: JSONContent,
+  options: { leading: boolean; trailing: boolean },
+): JSONContent {
+  if (node.type !== "paragraph") {
+    return node;
+  }
+  const content = node.content;
+  if (!content || content.length === 0) {
+    return node;
+  }
+
+  let start = 0;
+  let end = content.length;
+  if (options.leading) {
+    while (start < end && content[start]!.type === "hardBreak") {
+      start += 1;
+    }
+  }
+  if (options.trailing) {
+    while (end > start && content[end - 1]!.type === "hardBreak") {
+      end -= 1;
+    }
+  }
+
+  if (start === 0 && end === content.length) {
+    return node;
+  }
+
+  return { ...node, content: content.slice(start, end) };
+}
+
+/**
+ * Strip leading and trailing blank paragraphs from a (structurally valid)
+ * comment document, then trim line breaks at the very start and end of the
+ * remaining content, so empty lines and line breaks typed before/after the
+ * content don't get persisted. Returns the same value when there is nothing to
+ * trim.
+ */
+export function sanitizeCommentJson(value: JSONContent): JSONContent {
+  const content = value.content;
+  if (!Array.isArray(content)) {
+    return value;
+  }
+
+  let start = 0;
+  let end = content.length;
+  while (start < end && isBlankParagraph(content[start]!)) {
+    start += 1;
+  }
+  while (end > start && isBlankParagraph(content[end - 1]!)) {
+    end -= 1;
+  }
+
+  const trimmed = content.slice(start, end);
+
+  // Trim line breaks at the boundaries of the surviving content (leading breaks
+  // on the first block, trailing breaks on the last block).
+  if (trimmed.length > 0) {
+    const lastIndex = trimmed.length - 1;
+    trimmed[0] = trimParagraphBreaks(trimmed[0]!, {
+      leading: true,
+      trailing: lastIndex === 0,
+    });
+    if (lastIndex > 0) {
+      trimmed[lastIndex] = trimParagraphBreaks(trimmed[lastIndex]!, {
+        leading: false,
+        trailing: true,
+      });
+    }
+  }
+
+  const changed =
+    trimmed.length !== content.length ||
+    trimmed.some((node, index) => node !== content[index]);
+  if (!changed) {
+    return value;
+  }
+
+  return { ...value, content: trimmed };
+}
+
+/**
  * Check whether a (structurally valid) comment document carries no meaningful
  * content, i.e. it holds only whitespace. Used to reject empty comments
  * submitted directly through the API.


### PR DESCRIPTION
## Summary

Comment bodies are now sanitized on both create and update so stray empty lines and line breaks typed before/after the content aren't persisted.

`sanitizeCommentJson` (in `validate.ts`):
- Trims leading/trailing **blank paragraphs** — empty, whitespace-only, or containing only line breaks.
- Trims **line breaks** (`hardBreak`) at the very start of the first block and the end of the last block.
- Preserves blank paragraphs and line breaks *between* content.
- Returns the same reference when there's nothing to trim.

Wired into [createBuildComment.ts](apps/backend/src/comment/createBuildComment.ts) and [updateBuildComment.ts](apps/backend/src/comment/updateBuildComment.ts): validate → sanitize → empty/size checks → persist the sanitized body. A doc reduced to all-blank is still correctly rejected by `isCommentEmpty`.

## Test plan

- Added unit tests in [validate.test.ts](apps/backend/src/comment/validate.test.ts) covering leading/trailing/interior trimming for both paragraphs and line breaks.
- All backend unit tests pass (228).

🤖 Generated with [Claude Code](https://claude.com/claude-code)