### PR TITLE
fix: preserve comment hash on build redirect & keep highlight in bounds

### DIFF
--- a/apps/frontend/src/pages/Build/BuildDiffState.tsx
+++ b/apps/frontend/src/pages/Build/BuildDiffState.tsx
@@ -13,7 +13,7 @@ import { useApolloClient } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { ResultOf } from "@graphql-typed-document-node/core";
 import { MatchData, Searcher } from "fast-fuzzy";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import {
   checkIsDiffGroupName,
@@ -663,15 +663,22 @@ export function BuildDiffProvider(props: {
   const [initialDiffIdParam] = useState(params.diffId);
   const initialDiffId = initialDiffIdParam ?? firstDiffId;
   const paramsRef = useLiveRef(params);
+  // Capture the hash (e.g. `#comment-XXX`) so it is preserved when we redirect
+  // to the initial diff.
+  const [initialHash] = useState(useLocation().hash);
 
   // Navigate to the initial diff if not already the case.
   useEffect(() => {
     if (!initialDiffIdParam && initialDiffId) {
-      navigate(getBuildURL({ ...paramsRef.current, diffId: initialDiffId }), {
-        replace: true,
-      });
+      navigate(
+        getBuildURL({ ...paramsRef.current, diffId: initialDiffId }) +
+          initialHash,
+        {
+          replace: true,
+        },
+      );
     }
-  }, [initialDiffId, initialDiffIdParam, paramsRef, navigate]);
+  }, [initialDiffId, initialDiffIdParam, paramsRef, navigate, initialHash]);
 
   const initialDiff =
     (initialDiffId ? indices.byId[initialDiffId] : null) ?? null;

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -463,11 +463,20 @@ function CommentMessage(props: {
         ref={ref}
         id={comment.id}
         className={clsx(
-          "group/comment ring-primary transition",
+          "group/comment relative transition",
           separated && "border-t-thin",
-          highlighted ? "ring-2" : "ring-0",
         )}
       >
+        {/* Highlight drawn as an inset overlay rather than a `ring`, so it
+            stays within the comment bounds and is never clipped by the
+            surrounding `overflow: clip` containers or the sidebar. */}
+        <div
+          aria-hidden
+          className={clsx(
+            "border-primary pointer-events-none absolute inset-0 z-10 rounded-md border-2 transition-opacity",
+            highlighted ? "opacity-100" : "opacity-0",
+          )}
+        />
         <div className="relative flex items-center gap-1.5 px-2 py-1.5 pr-1.5 select-none">
           {comment.user ? (
             <UserHoverCard user={getUserCardData(comment.user)}>


### PR DESCRIPTION
## Problem

When arriving on a build linked to a comment, the URL looks like:

```
https://app.argos-ci.dev:4002/smooth/big/builds/14#comment-GYQ3
```

Two issues:

1. **Hash lost on redirect** — The build page redirects to the first diff when no `diffId` is in the URL. `getBuildURL` only builds the path, so the `#comment-XXX` hash was dropped and the comment was never opened/highlighted.
2. **Highlight clipped** — The highlighted comment used a Tailwind `ring`, which renders *outside* the element's box. The comment lives inside `overflow: clip` containers and the scrollable sidebar, so the ring got cut off.

## Fix

- **BuildDiffState** — Capture the initial location hash and append it to the redirect URL so it survives the navigation to the first diff. The existing hash-reading logic then opens the Review tab and highlights/scrolls to the comment.
- **CommentCard** — Replace the `ring-2` highlight with an absolutely-positioned inset border (`absolute inset-0 border-2`) that draws *inside* the comment bounds, so it can't be clipped by any ancestor. Fade preserved via `transition-opacity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)