### PR TITLE
feat: persist comment drafts in local storage

### DIFF
--- a/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
@@ -58,6 +58,7 @@ export function AddCommentForm(props: {
   return (
     <StandaloneEditor
       onSubmit={handleSubmit}
+      draftKey={`build.${build.id}.comment`}
       mentions={mentions}
       placeholder="Leave a comment…"
       submitLabel="Submit the comment"

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -22,6 +22,7 @@ import { Editor, type EditorValue } from "@/ui/Editor/Editor";
 import { MOD } from "@/ui/Editor/EditorToolbar.shortcuts";
 import { ReadOnlyEditor } from "@/ui/Editor/ReadOnlyEditor";
 import { StandaloneEditor } from "@/ui/Editor/StandaloneEditor";
+import { useEditorDraft } from "@/ui/Editor/useEditorDraft";
 import { hasEditorContent } from "@/ui/Editor/util";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 import { IconButton } from "@/ui/IconButton";
@@ -345,7 +346,12 @@ export function CommentCard(props: {
                 </motion.div>
               ))}
             </AnimatePresence>
-            {canReply ? <ReplyComposer onSubmit={handleReplySubmit} /> : null}
+            {canReply ? (
+              <ReplyComposer
+                draftKey={`build.${buildId}.thread.${comment.id}.reply`}
+                onSubmit={handleReplySubmit}
+              />
+            ) : null}
           </motion.div>
         ) : null}
       </AnimatePresence>
@@ -574,11 +580,12 @@ function CommentMessage(props: {
 }
 
 function ReplyComposer(props: {
+  draftKey: string;
   onSubmit: (body: EditorValue) => Promise<void>;
 }) {
-  const { onSubmit } = props;
+  const { draftKey, onSubmit } = props;
   const mentions = useMentionableUsers();
-  const [value, setValue] = useState<EditorValue>(null);
+  const { initialContent, value, setValue, clear } = useEditorDraft(draftKey);
   const [editorKey, setEditorKey] = useState(0);
   const [isPending, setIsPending] = useState(false);
   const emptyToastId = useId();
@@ -588,7 +595,7 @@ function ReplyComposer(props: {
     setIsPending(true);
     try {
       await onSubmit(value);
-      setValue(null);
+      clear();
       setEditorKey((key) => key + 1);
     } catch {
       // Keep the content so the user can retry.
@@ -616,6 +623,7 @@ function ReplyComposer(props: {
       <div className="flex items-start gap-1.5">
         <Editor
           key={editorKey}
+          defaultValue={initialContent}
           onChange={setValue}
           onSubmit={submit}
           mentions={mentions}

--- a/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
+++ b/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
@@ -9,6 +9,7 @@ import { IconButton } from "../IconButton";
 import { Editor, type EditorValue, type EditorVariant } from "./Editor";
 import { MOD } from "./EditorToolbar.shortcuts";
 import { type MentionUser } from "./mention";
+import { useEditorDraft } from "./useEditorDraft";
 import { hasEditorContent } from "./util";
 
 type EmptyMessage = { title: string; description?: string };
@@ -55,6 +56,12 @@ export interface StandaloneEditorProps {
   mentions?: MentionUser[];
   /** Users to resolve existing mentions against, forwarded to the {@link Editor}. */
   mentionedUsers?: MentionUser[];
+  /**
+   * When provided, the editor content is persisted in local storage under this
+   * key so a draft survives a page refresh. The key must encode the context so
+   * a draft only reappears where it was written (see {@link useEditorDraft}).
+   */
+  draftKey?: string;
 }
 
 /**
@@ -80,8 +87,12 @@ export function StandaloneEditor(props: StandaloneEditorProps) {
     contentClassName,
     mentions,
     mentionedUsers,
+    draftKey,
   } = props;
-  const [value, setValue] = useState<EditorValue>(defaultValue);
+  const { initialContent, value, setValue, clear } = useEditorDraft(
+    draftKey,
+    defaultValue,
+  );
   // Remounts the editor after a successful submit to clear its content.
   const [editorKey, setEditorKey] = useState(0);
   const [isPending, setIsPending] = useState(false);
@@ -93,7 +104,7 @@ export function StandaloneEditor(props: StandaloneEditorProps) {
     setIsPending(true);
     try {
       await onSubmit(value);
-      setValue(null);
+      clear();
       setEditorKey((key) => key + 1);
     } catch {
       // Keep the content so the user can retry.
@@ -119,7 +130,7 @@ export function StandaloneEditor(props: StandaloneEditorProps) {
   return (
     <Editor
       key={editorKey}
-      defaultValue={defaultValue}
+      defaultValue={initialContent}
       onChange={setValue}
       onSubmit={submit}
       mentions={mentions}

--- a/apps/frontend/src/ui/Editor/useEditorDraft.ts
+++ b/apps/frontend/src/ui/Editor/useEditorDraft.ts
@@ -1,0 +1,86 @@
+import { useCallback, useRef, useState } from "react";
+
+import { getItem, removeItem, setItem } from "@/util/storage";
+
+import { type EditorValue } from "./Editor";
+import { hasEditorContent } from "./util";
+
+// Local-storage keys are namespaced to avoid clashing with other features. The
+// caller-provided key encodes the context (build, thread, …) so a draft only
+// reappears where it was written.
+const DRAFT_KEY_PREFIX = "editor.draft.";
+
+function readDraft(key: string): EditorValue {
+  const raw = getItem(DRAFT_KEY_PREFIX + key);
+  if (raw == null) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as EditorValue;
+  } catch {
+    // Corrupted draft (e.g. truncated write); ignore it.
+    return null;
+  }
+}
+
+export interface EditorDraft {
+  /**
+   * Content the editor should mount with — the restored draft when one exists,
+   * otherwise the provided default. Pass to the {@link Editor} `defaultValue`.
+   */
+  initialContent: EditorValue;
+  /** Current value, kept in sync with the editor through {@link setValue}. */
+  value: EditorValue;
+  /** Update the value and persist (or remove) the draft in local storage. */
+  setValue: (value: EditorValue) => void;
+  /** Discard the draft, e.g. after a successful submit. */
+  clear: () => void;
+}
+
+/**
+ * Persists an editor's content in local storage so a draft survives a refresh.
+ *
+ * When `key` is undefined drafts are disabled and nothing is persisted — useful
+ * for editors (like in-place edits) that should never restore a draft. The key
+ * must encode the context so a draft only reappears where it was written: a new
+ * comment on a build should not show up on another build, and a reply should
+ * not show up on another thread.
+ */
+export function useEditorDraft(
+  key: string | undefined,
+  defaultValue: EditorValue = null,
+): EditorDraft {
+  const [initialContent, setInitialContent] = useState<EditorValue>(() =>
+    key ? (readDraft(key) ?? defaultValue) : defaultValue,
+  );
+  const [value, setValueState] = useState<EditorValue>(initialContent);
+  // Read lazily so the persisting callbacks stay stable as the key changes.
+  const keyRef = useRef(key);
+  keyRef.current = key;
+
+  const setValue = useCallback((next: EditorValue) => {
+    setValueState(next);
+    const key = keyRef.current;
+    if (!key) {
+      return;
+    }
+    // Only keep meaningful drafts around; drop empty ones so a cleared editor
+    // doesn't leave a stale key behind.
+    if (hasEditorContent(next)) {
+      setItem(DRAFT_KEY_PREFIX + key, JSON.stringify(next));
+    } else {
+      removeItem(DRAFT_KEY_PREFIX + key);
+    }
+  }, []);
+
+  const clear = useCallback(() => {
+    setValueState(null);
+    setInitialContent(null);
+    const key = keyRef.current;
+    if (key) {
+      removeItem(DRAFT_KEY_PREFIX + key);
+    }
+  }, []);
+
+  return { initialContent, value, setValue, clear };
+}


### PR DESCRIPTION
## What

Persists comment and reply drafts in the editor to `localStorage`, scoped by context, so an unsent draft survives a page refresh.

## Why

If a user types a comment or reply and accidentally refreshes (or navigates away), their text was lost. Drafts now come back automatically — but only where they were written.

## How

- New `useEditorDraft` hook ([useEditorDraft.ts](apps/frontend/src/ui/Editor/useEditorDraft.ts)) owns the editor value and mirrors it to `localStorage` (via the existing safe `storage.ts` helpers) under a namespaced `editor.draft.<key>` key. It restores the draft on mount, drops the key once the editor is emptied, and clears the draft on a successful submit. Passing `undefined` disables persistence (used for the in-place *edit* flow, which already has content).
- `StandaloneEditor` gains an optional `draftKey` prop and uses the hook.
- New comments use `build.<buildId>.comment`; replies use `build.<buildId>.thread.<threadId>.reply`.

### Context isolation

Keys encode the build (and thread for replies), so a new-comment draft on one build won't show on another build, and a reply draft is tied to its specific thread.

## Notes

The review form (`BuildReviewForm`) uses a separate react-hook-form flow and is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)