### PR TITLE
feat: live comments via GraphQL subscriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ All checks must pass.
 
 - Do not use `!` (non-null assertion)
 - Use `invariant` for required values
+- Avoid `as` type assertions; prefer proper typing, type guards, or
+  `satisfies`. `as const` is fine.
 
 ## Testing (Vitest)
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -73,6 +73,7 @@
     "graphql": "^16.14.2",
     "graphql-scalars": "^1.25.0",
     "graphql-tag": "^2.12.6",
+    "graphql-ws": "^6.0.8",
     "happy-dom": "^20.10.3",
     "helmet": "^8.2.0",
     "jsonwebtoken": "^9.0.3",
@@ -104,6 +105,7 @@
     "stripe": "^22.2.1",
     "tmp": "^0.2.7",
     "undici": "catalog:",
+    "ws": "^8.21.0",
     "yaml": "^2.9.0",
     "zod": "catalog:",
     "zod-openapi": "^5.4.6"
@@ -125,6 +127,7 @@
     "@types/semver": "^7.7.1",
     "@types/supertest": "^7.2.0",
     "@types/tmp": "^0.2.6",
+    "@types/ws": "^8.18.1",
     "concurrently": "^10.0.3",
     "eslint": "catalog:",
     "factory-girl-ts": "^2.3.1",

--- a/apps/backend/src/auth/session-cookie.ts
+++ b/apps/backend/src/auth/session-cookie.ts
@@ -56,7 +56,9 @@ export function clearSessionCookies(res: Response): void {
  * Read the raw session token from the request cookies. Returns `null` when the
  * cookie is absent. We parse the header directly (no cookie-parser middleware).
  */
-export function readSessionCookie(req: Request): string | null {
+export function readSessionCookie(
+  req: Pick<Request, "headers">,
+): string | null {
   const header = req.headers.cookie;
   if (!header) {
     return null;

--- a/apps/backend/src/auth/session-request.ts
+++ b/apps/backend/src/auth/session-request.ts
@@ -14,7 +14,7 @@ import { readSessionCookie } from "./session-cookie";
  * the cookie-based counterpart of the Bearer-token auth used by the API.
  */
 export async function sessionAuthFromExpressReq(
-  req: Request,
+  req: Pick<Request, "headers">,
 ): Promise<AuthSessionPayload> {
   const rawToken = readSessionCookie(req);
   if (!rawToken) {
@@ -48,7 +48,7 @@ export async function sessionAuthFromExpressReq(
  * when there is no valid session.
  */
 export async function safeSessionAuthFromExpressReq(
-  req: Request,
+  req: Pick<Request, "headers">,
 ): Promise<AuthSessionPayload | null> {
   try {
     return await sessionAuthFromExpressReq(req);

--- a/apps/backend/src/build/createBuildReview.ts
+++ b/apps/backend/src/build/createBuildReview.ts
@@ -26,6 +26,8 @@ import { transaction } from "@/database/transaction";
 import { sendNotification } from "@/notification";
 import { boom } from "@/util/error";
 
+import { publishReviewChange } from "./reviewEvents";
+
 export type ReviewState = "approved" | "rejected" | "commented" | "pending";
 
 export type ScreenshotDiffReviewState = "approved" | "rejected";
@@ -151,6 +153,14 @@ export async function createBuildReview(input: {
     }),
     autoSubscribeUserToBuild({ buildId: build.id, userId }),
     notifyBuildSubscribers({ build, buildReview, comment }),
+    // Notify clients watching this build so the review appears live in the
+    // activity feed. Reviews created here are never pending, so they always
+    // belong in the feed.
+    publishReviewChange({
+      buildId: build.id,
+      type: "SUBMITTED",
+      review: buildReview,
+    }),
   ]);
 
   return buildReview;

--- a/apps/backend/src/build/reviewEvents.ts
+++ b/apps/backend/src/build/reviewEvents.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+import { BuildReview } from "@/database/models/BuildReview";
+import { redisPubSub } from "@/util/redis";
+
+const reviewChangeSchema = z.object({
+  type: z.enum(["SUBMITTED", "DISMISSED"]),
+  review: z.record(z.string(), z.unknown()),
+});
+
+export type ReviewChangeType = z.infer<typeof reviewChangeSchema>["type"];
+
+export type ReviewChange = {
+  type: ReviewChangeType;
+  review: BuildReview;
+};
+
+function getReviewChannel(buildId: string): string {
+  return `build-review-change:${buildId}`;
+}
+
+/**
+ * Publish a review change so every client subscribed to the build receives it
+ * live. Only the review row travels through Redis; relations (author,
+ * dismisser) are loaded per subscriber by the GraphQL field resolvers from the
+ * rehydrated review.
+ */
+export async function publishReviewChange(input: {
+  buildId: string;
+  type: ReviewChangeType;
+  review: BuildReview;
+}): Promise<void> {
+  await redisPubSub.publish(getReviewChannel(input.buildId), {
+    type: input.type,
+    review: input.review.toJSON(),
+  });
+}
+
+/**
+ * Yield every review change published for a build until the iterator is closed
+ * (when the GraphQL subscription ends). Each payload is validated then
+ * rehydrated into a {@link BuildReview} model so the existing field resolvers
+ * can resolve it.
+ */
+export async function* subscribeToReviewChanges(
+  buildId: string,
+): AsyncGenerator<ReviewChange> {
+  const iterator = redisPubSub.subscribe(getReviewChannel(buildId));
+  for await (const raw of iterator) {
+    const payload = reviewChangeSchema.parse(raw);
+    yield {
+      type: payload.type,
+      review: BuildReview.fromJson(payload.review, { skipValidation: true }),
+    };
+  }
+}

--- a/apps/backend/src/comment/addCommentReaction.ts
+++ b/apps/backend/src/comment/addCommentReaction.ts
@@ -6,6 +6,7 @@ import { getCommentThreadSubscribedUserIds } from "@/database/services/comment-n
 import { sendNotification } from "@/notification";
 import { boom } from "@/util/error";
 
+import { publishCommentChange } from "./commentEvents";
 import { formatCommentId } from "./id";
 import { renderCommentHtmlWithMentions } from "./mentions";
 import { isValidEmoji } from "./reactions";
@@ -42,6 +43,14 @@ export async function addCommentReaction(input: {
   }
 
   await notifyCommentThreadSubscribers({ comment, userId, emoji });
+
+  // Notify clients watching this build so the reaction appears live. The
+  // comment row is unchanged; subscribers re-resolve its `reactions` field.
+  await publishCommentChange({
+    buildId: comment.buildId,
+    type: "UPDATED",
+    comment,
+  });
 
   return comment;
 }

--- a/apps/backend/src/comment/commentEvents.ts
+++ b/apps/backend/src/comment/commentEvents.ts
@@ -4,7 +4,7 @@ import { Comment } from "@/database/models/Comment";
 import { redisPubSub } from "@/util/redis";
 
 const commentChangeSchema = z.object({
-  type: z.enum(["ADDED", "UPDATED"]),
+  type: z.enum(["ADDED", "UPDATED", "DELETED"]),
   comment: z.record(z.string(), z.unknown()),
 });
 

--- a/apps/backend/src/comment/commentEvents.ts
+++ b/apps/backend/src/comment/commentEvents.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+import { Comment } from "@/database/models/Comment";
+import { redisPubSub } from "@/util/redis";
+
+const commentChangeSchema = z.object({
+  type: z.enum(["ADDED", "UPDATED"]),
+  comment: z.record(z.string(), z.unknown()),
+});
+
+export type CommentChangeType = z.infer<typeof commentChangeSchema>["type"];
+
+export type CommentChange = {
+  type: CommentChangeType;
+  comment: Comment;
+};
+
+function getCommentChannel(buildId: string): string {
+  return `build-comment-change:${buildId}`;
+}
+
+/**
+ * Publish a comment change so every client subscribed to the build receives it
+ * live. Only the comment row travels through Redis; relations (author,
+ * mentions, reactions) are loaded per subscriber by the GraphQL field
+ * resolvers from the rehydrated comment.
+ */
+export async function publishCommentChange(input: {
+  buildId: string;
+  type: CommentChangeType;
+  comment: Comment;
+}): Promise<void> {
+  await redisPubSub.publish(getCommentChannel(input.buildId), {
+    type: input.type,
+    comment: input.comment.toJSON(),
+  });
+}
+
+/**
+ * Yield every comment change published for a build until the iterator is closed
+ * (when the GraphQL subscription ends). Each payload is validated then
+ * rehydrated into a {@link Comment} model so the existing field resolvers can
+ * resolve it.
+ */
+export async function* subscribeToCommentChanges(
+  buildId: string,
+): AsyncGenerator<CommentChange> {
+  const iterator = redisPubSub.subscribe(getCommentChannel(buildId));
+  for await (const raw of iterator) {
+    const payload = commentChangeSchema.parse(raw);
+    yield {
+      type: payload.type,
+      comment: Comment.fromJson(payload.comment, { skipValidation: true }),
+    };
+  }
+}

--- a/apps/backend/src/comment/createBuildComment.ts
+++ b/apps/backend/src/comment/createBuildComment.ts
@@ -13,6 +13,7 @@ import {
 import { sendNotification } from "@/notification";
 import { boom } from "@/util/error";
 
+import { publishCommentChange } from "./commentEvents";
 import {
   getCommentNotificationData,
   notifyMentionedUsers,
@@ -108,6 +109,9 @@ export async function createBuildComment(input: {
       notifyMentioned,
     ]);
   }
+
+  // Notify clients watching this build so the new comment appears live.
+  await publishCommentChange({ buildId: build.id, type: "ADDED", comment });
 
   return comment;
 }

--- a/apps/backend/src/comment/deleteBuildComment.ts
+++ b/apps/backend/src/comment/deleteBuildComment.ts
@@ -1,5 +1,7 @@
 import type { Comment } from "@/database/models";
 
+import { publishCommentChange } from "./commentEvents";
+
 /**
  * Soft-delete a build comment by stamping its `deletedAt` date. The operation
  * is idempotent: deleting an already-deleted comment is a no-op and returns the
@@ -14,7 +16,16 @@ export async function deleteBuildComment(input: {
     return comment;
   }
 
-  return comment.$query().patchAndFetch({
+  const deletedComment = await comment.$query().patchAndFetch({
     deletedAt: new Date().toISOString(),
   });
+
+  // Notify clients watching this build so the comment disappears live.
+  await publishCommentChange({
+    buildId: deletedComment.buildId,
+    type: "DELETED",
+    comment: deletedComment,
+  });
+
+  return deletedComment;
 }

--- a/apps/backend/src/comment/removeCommentReaction.ts
+++ b/apps/backend/src/comment/removeCommentReaction.ts
@@ -1,6 +1,7 @@
 import { Comment, CommentReaction } from "@/database/models";
 import { boom } from "@/util/error";
 
+import { publishCommentChange } from "./commentEvents";
 import { isValidEmoji } from "./reactions";
 
 /**
@@ -18,7 +19,24 @@ export async function removeCommentReaction(input: {
     throw boom(400, "Invalid emoji");
   }
 
-  await CommentReaction.query().deleteById([comment.id, userId, emoji]);
+  const deletedCount = await CommentReaction.query().deleteById([
+    comment.id,
+    userId,
+    emoji,
+  ]);
+
+  // No reaction to remove: nothing changed, nothing to broadcast.
+  if (deletedCount === 0) {
+    return comment;
+  }
+
+  // Notify clients watching this build so the reaction disappears live. The
+  // comment row is unchanged; subscribers re-resolve its `reactions` field.
+  await publishCommentChange({
+    buildId: comment.buildId,
+    type: "UPDATED",
+    comment,
+  });
 
   return comment;
 }

--- a/apps/backend/src/comment/resolveCommentThread.ts
+++ b/apps/backend/src/comment/resolveCommentThread.ts
@@ -1,5 +1,7 @@
 import type { Comment } from "@/database/models";
 
+import { publishCommentChange } from "./commentEvents";
+
 /**
  * Mark a comment thread as resolved by stamping `resolvedAt` on its root
  * comment. The operation is idempotent: resolving an already-resolved thread is
@@ -14,9 +16,18 @@ export async function resolveCommentThread(input: {
     return thread;
   }
 
-  return thread.$query().patchAndFetch({
+  const resolvedThread = await thread.$query().patchAndFetch({
     resolvedAt: new Date().toISOString(),
   });
+
+  // Notify clients watching this build so the thread collapses live.
+  await publishCommentChange({
+    buildId: resolvedThread.buildId,
+    type: "UPDATED",
+    comment: resolvedThread,
+  });
+
+  return resolvedThread;
 }
 
 /**
@@ -33,7 +44,16 @@ export async function unresolveCommentThread(input: {
     return thread;
   }
 
-  return thread.$query().patchAndFetch({
+  const reopenedThread = await thread.$query().patchAndFetch({
     resolvedAt: null,
   });
+
+  // Notify clients watching this build so the thread reopens live.
+  await publishCommentChange({
+    buildId: reopenedThread.buildId,
+    type: "UPDATED",
+    comment: reopenedThread,
+  });
+
+  return reopenedThread;
 }

--- a/apps/backend/src/comment/updateBuildComment.ts
+++ b/apps/backend/src/comment/updateBuildComment.ts
@@ -4,6 +4,7 @@ import type { JSONContent } from "@tiptap/core";
 import type { Comment } from "@/database/models";
 import { boom } from "@/util/error";
 
+import { publishCommentChange } from "./commentEvents";
 import { notifyMentionedUsers } from "./commentNotifications";
 import { getCommentMentionedUserIds, syncCommentMentions } from "./mentions";
 import {
@@ -73,6 +74,13 @@ export async function updateBuildComment(input: {
     userId: updatedComment.userId,
     mentionedUserIds: newlyMentionedUserIds,
     threadId: updatedComment.threadId ?? updatedComment.id,
+  });
+
+  // Notify clients watching this build so the edit appears live.
+  await publishCommentChange({
+    buildId: updatedComment.buildId,
+    type: "UPDATED",
+    comment: updatedComment,
   });
 
   return updatedComment;

--- a/apps/backend/src/graphql/buildAccess.ts
+++ b/apps/backend/src/graphql/buildAccess.ts
@@ -1,0 +1,30 @@
+import { invariant } from "@argos/util/invariant";
+
+import { Build } from "@/database/models/Build";
+import type { User } from "@/database/models/User";
+
+import { forbidden, notFound } from "./util";
+
+/**
+ * Ensure the user is allowed to watch a build's live activity. Subscribing to
+ * a build's comments or reviews requires the same "view" permission as loading
+ * the build, so a subscription can never leak data the user could not already
+ * read. Authorize before opening the stream so an unpermitted subscription is
+ * rejected upfront rather than after the first event.
+ */
+export async function assertCanViewBuild(
+  buildId: string,
+  user: User | null,
+): Promise<void> {
+  const build = await Build.query()
+    .findById(buildId)
+    .withGraphFetched("project.account");
+  if (!build) {
+    throw notFound("Build not found");
+  }
+  invariant(build.project?.account, "Build project account not found");
+  const permissions = await build.project.$getPermissions(user);
+  if (!permissions.includes("view")) {
+    throw forbidden("You cannot view this build");
+  }
+}

--- a/apps/backend/src/graphql/context.ts
+++ b/apps/backend/src/graphql/context.ts
@@ -1,10 +1,14 @@
+import type { IncomingMessage } from "node:http";
 import type { BaseContext } from "@apollo/server";
 import type { Request, Response } from "express";
 import { GraphQLError } from "graphql";
 
 import type { AuthSessionPayload } from "@/auth/payload";
 import { readSessionCookie } from "@/auth/session-cookie";
-import { sessionAuthFromExpressReq } from "@/auth/session-request";
+import {
+  safeSessionAuthFromExpressReq,
+  sessionAuthFromExpressReq,
+} from "@/auth/session-request";
 import { HTTPError } from "@/util/error";
 import {
   extractLocationFromRequest,
@@ -19,10 +23,11 @@ export type Context = BaseContext & {
   loaders: ReturnType<typeof createLoaders>;
   /**
    * The Express request/response, exposed so login mutations (email auth,
-   * invite sign-up) can create a session and set the session cookie.
+   * invite sign-up) can create a session and set the session cookie. Absent on
+   * the WebSocket (subscription) transport, which has no Express response.
    */
-  req: Request;
-  res: Response;
+  req?: Request;
+  res?: Response;
 };
 
 async function getContextAuth(
@@ -72,4 +77,22 @@ export async function getContext(
 
     throw error;
   }
+}
+
+/**
+ * Build the GraphQL context for a WebSocket (subscription) connection. The
+ * session cookie rides along on the upgrade request, so we authenticate from it
+ * the same way the HTTP transport does. A missing or invalid session resolves
+ * to an anonymous context rather than throwing — public builds can be watched
+ * without a session, and each subscription resolver enforces its own access.
+ */
+export async function getWebSocketContext(
+  request: IncomingMessage,
+): Promise<Context> {
+  const auth = await safeSessionAuthFromExpressReq(request);
+  return {
+    auth,
+    requestLocation: null,
+    loaders: createLoaders(),
+  };
 }

--- a/apps/backend/src/graphql/definitions/Account.ts
+++ b/apps/backend/src/graphql/definitions/Account.ts
@@ -688,6 +688,7 @@ export const resolvers: IResolvers = {
             })
           : false;
 
+        invariant(ctx.req && ctx.res, "Login is only available over HTTP");
         await startSession(ctx.req, ctx.res, account.userId);
 
         return {

--- a/apps/backend/src/graphql/definitions/BuildReview.ts
+++ b/apps/backend/src/graphql/definitions/BuildReview.ts
@@ -9,6 +9,11 @@ import {
   ReviewState,
   ScreenshotDiffReviewState,
 } from "@/build/createBuildReview";
+import {
+  publishReviewChange,
+  subscribeToReviewChanges,
+  type ReviewChangeType,
+} from "@/build/reviewEvents";
 import { Build } from "@/database/models/Build";
 import { BuildReview } from "@/database/models/BuildReview";
 import { User } from "@/database/models/User";
@@ -16,10 +21,12 @@ import { sendNotification } from "@/notification";
 
 import {
   IBuildReviewEvent,
+  IReviewChangeType,
   IReviewState,
   IScreenshotDiffReviewState,
   type IResolvers,
 } from "../__generated__/resolver-types";
+import { assertCanViewBuild } from "../buildAccess";
 import { badUserInput, forbidden, notFound, unauthenticated } from "../util";
 
 const { gql } = gqlTag;
@@ -88,7 +95,38 @@ export const typeDefs = gql`
     createBuildReview(input: CreateBuildReviewInput!): Build!
     dismissReview(input: DismissReviewInput!): Build!
   }
+
+  """
+  How a review changed: it was newly submitted, or an existing one was
+  dismissed.
+  """
+  enum ReviewChangeType {
+    SUBMITTED
+    DISMISSED
+  }
+
+  """
+  A review that was submitted on or dismissed from a build, pushed live to
+  subscribers.
+  """
+  type BuildReviewChangeEvent {
+    "How the review changed"
+    type: ReviewChangeType!
+    "The review that changed"
+    review: BuildReview!
+  }
+
+  extend type Subscription {
+    "Emitted when a review is submitted on or dismissed from the given build"
+    buildReviewChanged(buildId: ID!): BuildReviewChangeEvent!
+  }
 `;
+
+/** Map the internal review-change type to its GraphQL enum value. */
+const REVIEW_CHANGE_EVENT_TYPE: Record<ReviewChangeType, IReviewChangeType> = {
+  SUBMITTED: IReviewChangeType.Submitted,
+  DISMISSED: IReviewChangeType.Dismissed,
+};
 
 export const resolvers: IResolvers = {
   BuildReview: {
@@ -195,18 +233,45 @@ export const resolvers: IResolvers = {
         throw badUserInput("Review already dismissed");
       }
 
-      await review.$query().patch({
+      const dismissedReview = await review.$query().patchAndFetch({
         dismissedAt: new Date().toISOString(),
         dismissedById: auth.user.id,
       });
 
-      await notifyReviewDismissed({
-        review,
-        build,
-        dismissedById: auth.user.id,
-      });
+      await Promise.all([
+        notifyReviewDismissed({
+          review,
+          build,
+          dismissedById: auth.user.id,
+        }),
+        // Notify clients watching this build so the dismissal appears live.
+        publishReviewChange({
+          buildId: build.id,
+          type: "DISMISSED",
+          review: dismissedReview,
+        }),
+      ]);
 
       return build;
+    },
+  },
+  Subscription: {
+    buildReviewChanged: {
+      // Authorize before opening the stream so an unpermitted subscription is
+      // rejected upfront rather than after the first event.
+      subscribe: async (_root, args, ctx) => {
+        await assertCanViewBuild(args.buildId, ctx.auth?.user ?? null);
+        return (async function* () {
+          for await (const change of subscribeToReviewChanges(args.buildId)) {
+            yield {
+              buildReviewChanged: {
+                type: REVIEW_CHANGE_EVENT_TYPE[change.type],
+                review: change.review,
+              },
+            };
+          }
+        })();
+      },
     },
   },
 };

--- a/apps/backend/src/graphql/definitions/Comment.ts
+++ b/apps/backend/src/graphql/definitions/Comment.ts
@@ -32,6 +32,7 @@ import {
   type ICommentPermission,
   type IResolvers,
 } from "../__generated__/resolver-types";
+import { assertCanViewBuild } from "../buildAccess";
 import { forbidden, notFound, unauthenticated } from "../util";
 
 const { gql } = gqlTag;
@@ -70,28 +71,6 @@ async function assertCanReactToComment(
   const permissions = await build.project.$getPermissions(user);
   if (!permissions.includes("review")) {
     throw forbidden("You cannot react to this comment");
-  }
-}
-
-/**
- * Ensure the user is allowed to watch a build's comments. Viewing the live
- * comment stream requires the same "view" permission as loading the build, so
- * a subscription can never leak comments the user could not already read.
- */
-async function assertCanViewBuild(
-  buildId: string,
-  user: User | null,
-): Promise<void> {
-  const build = await Build.query()
-    .findById(buildId)
-    .withGraphFetched("project.account");
-  if (!build) {
-    throw notFound("Build not found");
-  }
-  invariant(build.project?.account, "Build project account not found");
-  const permissions = await build.project.$getPermissions(user);
-  if (!permissions.includes("view")) {
-    throw forbidden("You cannot view this build");
   }
 }
 

--- a/apps/backend/src/graphql/definitions/Comment.ts
+++ b/apps/backend/src/graphql/definitions/Comment.ts
@@ -3,6 +3,10 @@ import type { JSONContent } from "@tiptap/core";
 import gqlTag from "graphql-tag";
 
 import { addCommentReaction } from "@/comment/addCommentReaction";
+import {
+  subscribeToCommentChanges,
+  type CommentChangeType,
+} from "@/comment/commentEvents";
 import { createBuildComment } from "@/comment/createBuildComment";
 import { deleteBuildComment } from "@/comment/deleteBuildComment";
 import { formatCommentId, parseCommentId } from "@/comment/id";
@@ -23,9 +27,10 @@ import {
   unsubscribeUserFromCommentThread,
 } from "@/database/services/comment-notification-subscription";
 
-import type {
-  ICommentPermission,
-  IResolvers,
+import {
+  ICommentChangeType,
+  type ICommentPermission,
+  type IResolvers,
 } from "../__generated__/resolver-types";
 import { forbidden, notFound, unauthenticated } from "../util";
 
@@ -65,6 +70,28 @@ async function assertCanReactToComment(
   const permissions = await build.project.$getPermissions(user);
   if (!permissions.includes("review")) {
     throw forbidden("You cannot react to this comment");
+  }
+}
+
+/**
+ * Ensure the user is allowed to watch a build's comments. Viewing the live
+ * comment stream requires the same "view" permission as loading the build, so
+ * a subscription can never leak comments the user could not already read.
+ */
+async function assertCanViewBuild(
+  buildId: string,
+  user: User | null,
+): Promise<void> {
+  const build = await Build.query()
+    .findById(buildId)
+    .withGraphFetched("project.account");
+  if (!build) {
+    throw notFound("Build not found");
+  }
+  invariant(build.project?.account, "Build project account not found");
+  const permissions = await build.project.$getPermissions(user);
+  if (!permissions.includes("view")) {
+    throw forbidden("You cannot view this build");
   }
 }
 
@@ -227,7 +254,37 @@ export const typeDefs = gql`
     "Reopen a resolved comment thread"
     unresolveCommentThread(input: UnresolveCommentThreadInput!): Comment!
   }
+
+  """
+  Whether a comment change added a new comment or updated an existing one.
+  """
+  enum CommentChangeType {
+    ADDED
+    UPDATED
+  }
+
+  """
+  A comment that was added to or updated on a build, pushed live to subscribers.
+  """
+  type CommentChangeEvent {
+    "Whether the comment was newly added or an existing one was updated"
+    type: CommentChangeType!
+    "The comment that changed"
+    comment: Comment!
+  }
+
+  type Subscription {
+    "Emitted when a comment is added to or updated on the given build"
+    buildCommentChanged(buildId: ID!): CommentChangeEvent!
+  }
 `;
+
+/** Map the internal comment-change type to its GraphQL enum value. */
+const COMMENT_CHANGE_EVENT_TYPE: Record<CommentChangeType, ICommentChangeType> =
+  {
+    ADDED: ICommentChangeType.Added,
+    UPDATED: ICommentChangeType.Updated,
+  };
 
 export const resolvers: IResolvers = {
   Comment: {
@@ -478,6 +535,25 @@ export const resolvers: IResolvers = {
         permission: "review",
       });
       return unresolveCommentThread({ thread });
+    },
+  },
+  Subscription: {
+    buildCommentChanged: {
+      // Authorize before opening the stream so an unpermitted subscription is
+      // rejected upfront rather than after the first event.
+      subscribe: async (_root, args, ctx) => {
+        await assertCanViewBuild(args.buildId, ctx.auth?.user ?? null);
+        return (async function* () {
+          for await (const change of subscribeToCommentChanges(args.buildId)) {
+            yield {
+              buildCommentChanged: {
+                type: COMMENT_CHANGE_EVENT_TYPE[change.type],
+                comment: change.comment,
+              },
+            };
+          }
+        })();
+      },
     },
   },
 };

--- a/apps/backend/src/graphql/definitions/Comment.ts
+++ b/apps/backend/src/graphql/definitions/Comment.ts
@@ -256,25 +256,28 @@ export const typeDefs = gql`
   }
 
   """
-  Whether a comment change added a new comment or updated an existing one.
+  How a comment changed: a new comment was added, an existing one was updated
+  (edited, reacted to, or its thread resolved/reopened), or it was deleted.
   """
   enum CommentChangeType {
     ADDED
     UPDATED
+    DELETED
   }
 
   """
-  A comment that was added to or updated on a build, pushed live to subscribers.
+  A comment that was added to, updated on, or deleted from a build, pushed live
+  to subscribers.
   """
   type CommentChangeEvent {
-    "Whether the comment was newly added or an existing one was updated"
+    "How the comment changed"
     type: CommentChangeType!
-    "The comment that changed"
+    "The comment that changed. For a deletion, only its id is meaningful."
     comment: Comment!
   }
 
   type Subscription {
-    "Emitted when a comment is added to or updated on the given build"
+    "Emitted when a comment is added to, updated on, or deleted from the given build"
     buildCommentChanged(buildId: ID!): CommentChangeEvent!
   }
 `;
@@ -284,6 +287,7 @@ const COMMENT_CHANGE_EVENT_TYPE: Record<CommentChangeType, ICommentChangeType> =
   {
     ADDED: ICommentChangeType.Added,
     UPDATED: ICommentChangeType.Updated,
+    DELETED: ICommentChangeType.Deleted,
   };
 
 export const resolvers: IResolvers = {
@@ -545,6 +549,15 @@ export const resolvers: IResolvers = {
         await assertCanViewBuild(args.buildId, ctx.auth?.user ?? null);
         return (async function* () {
           for await (const change of subscribeToCommentChanges(args.buildId)) {
+            // Field resolvers below run with the connection's shared loaders,
+            // whose per-comment caches would otherwise pin the reactions and
+            // mentions seen on the first event. Those relations live in their
+            // own tables (not the comment row that travels through Redis), so
+            // drop the changed comment's cached entries to resolve each event
+            // against the current state — this is what makes live reactions and
+            // edited mentions reflect reality across successive events.
+            ctx.loaders.CommentReactions.clear(change.comment.id);
+            ctx.loaders.CommentMentionedUserIds.clear(change.comment.id);
             yield {
               buildCommentChanged: {
                 type: COMMENT_CHANGE_EVENT_TYPE[change.type],

--- a/apps/backend/src/graphql/definitions/Team.ts
+++ b/apps/backend/src/graphql/definitions/Team.ts
@@ -1173,6 +1173,7 @@ export const resolvers: IResolvers = {
           ]);
         });
 
+        invariant(ctx.req && ctx.res, "Login is only available over HTTP");
         await startSession(ctx.req, ctx.res, user.id);
         return { team: teamAccount };
       }

--- a/apps/backend/src/graphql/definitions/schema.ts
+++ b/apps/backend/src/graphql/definitions/schema.ts
@@ -14,6 +14,7 @@ export const typeDefs = gql`
   schema {
     query: Query
     mutation: Mutation
+    subscription: Subscription
   }
 `;
 

--- a/apps/backend/src/graphql/index.ts
+++ b/apps/backend/src/graphql/index.ts
@@ -1,1 +1,2 @@
 export * from "./apollo";
+export * from "./ws";

--- a/apps/backend/src/graphql/ws.ts
+++ b/apps/backend/src/graphql/ws.ts
@@ -1,0 +1,71 @@
+import type { Server } from "node:http";
+import { useServer } from "graphql-ws/use/ws";
+import { WebSocketServer } from "ws";
+
+import config from "@/config";
+import parentLogger from "@/logger";
+
+import { getWebSocketContext } from "./context";
+import { schema } from "./schema";
+
+const logger = parentLogger.child({ module: "graphql-ws" });
+
+/**
+ * Only accept WebSocket upgrades coming from our own app. The session cookie is
+ * sent automatically on the upgrade request and — unlike the HTTP transport — a
+ * WebSocket handshake cannot carry our CSRF header, so we guard against
+ * cross-site WebSocket hijacking by validating the Origin against the
+ * configured public URL and wildcard domains.
+ */
+function isAllowedOrigin(origin: string | undefined): boolean {
+  // Non-browser clients omit Origin and are not subject to cross-site
+  // hijacking (they carry no ambient cookies); browsers always send it.
+  if (!origin) {
+    return true;
+  }
+  // Compare on hostname (not host) so the port the app runs on — e.g. the Vite
+  // dev server proxying to the backend — does not cause a false rejection.
+  let hostname: string;
+  try {
+    hostname = new URL(origin).hostname;
+  } catch {
+    return false;
+  }
+  if (hostname === new URL(config.get("server.url")).hostname) {
+    return true;
+  }
+  return config
+    .get("server.wildcardDomains")
+    .some((domain) => hostname === domain || hostname.endsWith(`.${domain}`));
+}
+
+/**
+ * Attach a graphql-ws WebSocket server to the HTTP server so GraphQL
+ * subscriptions are served over `/graphql` — the same path as queries and
+ * mutations, since WebSocket upgrades and plain HTTP requests do not collide.
+ */
+export function createGraphQLWebSocketServer(httpServer: Server): void {
+  const wsServer = new WebSocketServer({
+    server: httpServer,
+    path: "/graphql",
+  });
+
+  useServer(
+    {
+      schema,
+      context: (ctx) => getWebSocketContext(ctx.extra.request),
+      onConnect: (ctx) => {
+        const { origin } = ctx.extra.request.headers;
+        if (!isAllowedOrigin(origin)) {
+          logger.warn(
+            { origin },
+            "Rejected WebSocket connection from disallowed origin",
+          );
+          return false;
+        }
+        return true;
+      },
+    },
+    wsServer,
+  );
+}

--- a/apps/backend/src/processes/proc/web.ts
+++ b/apps/backend/src/processes/proc/web.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import config from "@/config";
+import { createGraphQLWebSocketServer } from "@/graphql";
 import logger from "@/logger";
 import { createApp } from "@/web";
 
@@ -33,6 +34,9 @@ const createServer = (requestListener: RequestListener): Server => {
 
 const app = await createApp();
 const server = createServer(app);
+
+// Serve GraphQL subscriptions over WebSocket on the same server/path.
+createGraphQLWebSocketServer(server);
 
 server.listen(config.get("server.port"), () => {
   logger.info(`Ready on http://localhost:${config.get("server.port")}`);

--- a/apps/backend/src/util/redis/index.ts
+++ b/apps/backend/src/util/redis/index.ts
@@ -1,6 +1,8 @@
 import { createRedisCacheClient } from "./cache";
 import { getRedisClient } from "./client";
 import { createRedisLockClient } from "./lock";
+import { createRedisPubSubClient } from "./pubsub";
 
 export const redisLock = createRedisLockClient({ getRedisClient });
 export const redisCache = createRedisCacheClient({ getRedisClient });
+export const redisPubSub = createRedisPubSubClient({ getRedisClient });

--- a/apps/backend/src/util/redis/pubsub.ts
+++ b/apps/backend/src/util/redis/pubsub.ts
@@ -1,0 +1,148 @@
+import type { RedisClientType } from "redis";
+
+import parentLogger from "@/logger";
+
+const logger = parentLogger.child({ module: "redis-pubsub" });
+
+/**
+ * Create a Redis-backed publish/subscribe client used to power GraphQL
+ * subscriptions.
+ *
+ * Publishing reuses the shared Redis connection. Subscribing needs a dedicated
+ * connection (a connection in subscriber mode cannot run regular commands), so
+ * we lazily open a single duplicated connection and multiplex every
+ * subscription over it as a per-channel listener. Redis fans events out to all
+ * server instances, so this keeps working across a horizontally-scaled web
+ * tier — a mutation handled by one instance reaches subscribers on every
+ * other.
+ */
+export function createRedisPubSubClient(options: {
+  getRedisClient: () => Promise<RedisClientType>;
+}) {
+  const { getRedisClient } = options;
+
+  let subscriberPromise: Promise<RedisClientType> | null = null;
+
+  function getSubscriber(): Promise<RedisClientType> {
+    if (!subscriberPromise) {
+      const promise = (async () => {
+        const client = await getRedisClient();
+        const subscriber: RedisClientType = client.duplicate();
+        subscriber.on("error", (error: unknown) => {
+          logger.error({ error }, "Redis subscriber error");
+        });
+        await subscriber.connect();
+        return subscriber;
+      })();
+      // Drop the cached promise on failure so the next caller retries instead
+      // of reusing a rejected connection.
+      promise.catch(() => {
+        if (subscriberPromise === promise) {
+          subscriberPromise = null;
+        }
+      });
+      subscriberPromise = promise;
+    }
+    return subscriberPromise;
+  }
+
+  return {
+    /**
+     * Publish a JSON-serializable payload to a channel.
+     */
+    async publish(channel: string, payload: unknown): Promise<void> {
+      const client = await getRedisClient();
+      await client.publish(channel, JSON.stringify(payload));
+    },
+
+    /**
+     * Subscribe to a channel and yield each published payload until the
+     * iterator is closed. Closing it — which `for await` does on break/return,
+     * and GraphQL does when a subscription ends — removes the listener and
+     * leaves the shared connection open for the other subscribers.
+     */
+    subscribe(channel: string): AsyncIterableIterator<unknown> {
+      // Yields the raw parsed payloads; the caller is responsible for
+      // validating their shape (these values come off the wire).
+      //
+      // Bridge the callback-based Redis subscription to an async iterator:
+      // messages received while no consumer is waiting are buffered in
+      // `pushQueue`; consumers that call `next()` with an empty buffer park
+      // their resolver in `pullQueue` until the next message arrives.
+      const pushQueue: unknown[] = [];
+      const pullQueue: ((result: IteratorResult<unknown>) => void)[] = [];
+      let closed = false;
+      let subscriber: RedisClientType | null = null;
+
+      const listener = (message: string) => {
+        let value: unknown;
+        try {
+          value = JSON.parse(message);
+        } catch (error) {
+          logger.error({ error, channel }, "Failed to parse pub/sub message");
+          return;
+        }
+        const pull = pullQueue.shift();
+        if (pull) {
+          pull({ value, done: false });
+        } else {
+          pushQueue.push(value);
+        }
+      };
+
+      const ready = getSubscriber().then(async (sub) => {
+        subscriber = sub;
+        await sub.subscribe(channel, listener);
+      });
+
+      async function close(): Promise<void> {
+        if (closed) {
+          return;
+        }
+        closed = true;
+        for (const pull of pullQueue.splice(0)) {
+          pull({ done: true, value: undefined });
+        }
+        pushQueue.length = 0;
+        try {
+          await ready;
+          await subscriber?.unsubscribe(channel, listener);
+        } catch (error) {
+          logger.error(
+            { error, channel },
+            "Failed to unsubscribe from pub/sub channel",
+          );
+        }
+      }
+
+      const iterator: AsyncIterableIterator<unknown> = {
+        async next(): Promise<IteratorResult<unknown>> {
+          if (closed) {
+            return { done: true, value: undefined };
+          }
+          // Wait for the subscription to be established so a connection
+          // failure surfaces here instead of hanging forever.
+          await ready;
+          if (pushQueue.length > 0) {
+            return { value: pushQueue.shift(), done: false };
+          }
+          return new Promise<IteratorResult<unknown>>((resolve) => {
+            pullQueue.push(resolve);
+          });
+        },
+        async return(): Promise<IteratorResult<unknown>> {
+          await close();
+          return { done: true, value: undefined };
+        },
+        async throw(error?: unknown): Promise<IteratorResult<unknown>> {
+          await close();
+          return Promise.reject(error);
+        },
+        [Symbol.asyncIterator]() {
+          return iterator;
+        },
+      };
+      return iterator;
+    },
+  };
+}

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -66,6 +66,7 @@
     "eslint": "catalog:",
     "fast-fuzzy": "^1.12.0",
     "graphql": "^16.14.2",
+    "graphql-ws": "^6.0.8",
     "input-otp": "^1.4.2",
     "jotai": "^2.20.1",
     "jotai-family": "^1.0.2",

--- a/apps/frontend/src/containers/Apollo.tsx
+++ b/apps/frontend/src/containers/Apollo.tsx
@@ -83,6 +83,14 @@ const ApolloProvider = (props: { children: React.ReactNode }) => {
       cache: new InMemoryCache({
         possibleTypes: fragments.possibleTypes,
         typePolicies: {
+          // A comment's reaction groups are an embedded value object with no
+          // id to normalize on, and the server always returns the complete,
+          // authoritative list. Replace it wholesale instead of merging, which
+          // also silences Apollo's "cache data may be lost" warning when a live
+          // reaction update returns fewer groups than are cached.
+          CommentReactionGroup: {
+            merge: false,
+          },
           Team: {
             keyFields: (obj) => {
               invariant(obj.id, "Team.id is undefined");

--- a/apps/frontend/src/containers/Apollo.tsx
+++ b/apps/frontend/src/containers/Apollo.tsx
@@ -7,8 +7,11 @@ import {
 } from "@apollo/client";
 import { ErrorLink } from "@apollo/client/link/error";
 import { RetryLink } from "@apollo/client/link/retry";
+import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
 import { ApolloProvider as BaseApolloProvider } from "@apollo/client/react";
+import { getMainDefinition } from "@apollo/client/utilities";
 import { invariant } from "@argos/util/invariant";
+import { createClient } from "graphql-ws";
 
 import fragments from "@/gql-fragments.json";
 
@@ -48,6 +51,33 @@ const ApolloProvider = (props: { children: React.ReactNode }) => {
       },
     });
 
+    // Subscriptions ride a WebSocket; the HttpOnly session cookie is sent
+    // automatically on the same-origin upgrade request, so no extra auth is
+    // needed here. The client connects lazily on the first subscription.
+    const wsLink = new GraphQLWsLink(
+      createClient({
+        url: () => {
+          const url = new URL("/graphql", window.location.href);
+          url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+          return url.toString();
+        },
+      }),
+    );
+
+    // Route subscription operations over the WebSocket and everything else
+    // through the HTTP chain.
+    const link = ApolloLink.split(
+      ({ query }) => {
+        const definition = getMainDefinition(query);
+        return (
+          definition.kind === "OperationDefinition" &&
+          definition.operation === "subscription"
+        );
+      },
+      wsLink,
+      ApolloLink.from([logoutLink, retryLink, httpLink]),
+    );
+
     return new ApolloClient({
       dataMasking: false,
       cache: new InMemoryCache({
@@ -70,7 +100,7 @@ const ApolloProvider = (props: { children: React.ReactNode }) => {
           },
         },
       }),
-      link: ApolloLink.from([logoutLink, retryLink, httpLink]),
+      link,
     });
   }, []);
   return (

--- a/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo } from "react";
-import { useMutation } from "@apollo/client/react";
+import type { Reference } from "@apollo/client";
+import { useMutation, useSubscription } from "@apollo/client/react";
+import { invariant } from "@argos/util/invariant";
 import clsx from "clsx";
 import {
   BanIcon,
@@ -9,12 +11,12 @@ import {
   MailCheckIcon,
 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 
 import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
 import { DocumentType, graphql } from "@/gql";
-import { ProjectPermission } from "@/gql/graphql";
+import { CommentChangeType, ProjectPermission } from "@/gql/graphql";
 import { Activity, ActivityItem } from "@/ui/Activity";
 import type { MentionUser } from "@/ui/Editor/mention";
 import { IconButton } from "@/ui/IconButton";
@@ -77,6 +79,23 @@ const UnsubscribeFromBuildMutation = graphql(`
     unsubscribeFromBuild(input: $input) {
       id
       subscribed
+    }
+  }
+`);
+
+const BuildCommentChangedSubscription = graphql(`
+  subscription ReviewActivitySection_buildCommentChanged(
+    $buildId: ID!
+    $accountSlug: String!
+    $projectName: String!
+  ) {
+    buildCommentChanged(buildId: $buildId) {
+      type
+      comment {
+        id
+        threadId
+        ...CommentCard_Comment
+      }
     }
   }
 `);
@@ -228,6 +247,42 @@ function toMentionUsers(members: Build["members"]): MentionUser[] {
 
 export function ReviewActivitySection(props: { build: Build }) {
   const { build } = props;
+  // `UserCard_user` (spread by the subscription) scopes the author's role to
+  // the project, so the operation needs the project's slug/name from the route.
+  const { accountSlug, projectName } = useParams();
+  invariant(accountSlug && projectName, "Missing project route params");
+  // Keep the activity feed live: append comments added by others, and let the
+  // normalized cache merge edits in place (it dedupes by comment id).
+  useSubscription(BuildCommentChangedSubscription, {
+    variables: { buildId: build.id, accountSlug, projectName },
+    onData: ({ client, data }) => {
+      const event = data.data?.buildCommentChanged;
+      if (event?.type !== CommentChangeType.Added) {
+        return;
+      }
+      const { comment } = event;
+      client.cache.modify({
+        id: client.cache.identify({ __typename: "Build", id: build.id }),
+        fields: {
+          comments(
+            existingRefs: readonly Reference[] = [],
+            { readField, toReference },
+          ) {
+            const ref = toReference(comment);
+            if (
+              !ref ||
+              existingRefs.some(
+                (existing) => readField("id", existing) === comment.id,
+              )
+            ) {
+              return existingRefs;
+            }
+            return [...existingRefs, ref];
+          },
+        },
+      });
+    },
+  });
   const permissions = useNonNullable(ProjectPermissionsContext);
   const canComment = permissions.includes(ProjectPermission.Review);
   const entries = getActivityEntries(build);

--- a/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
@@ -16,7 +16,11 @@ import { toast } from "sonner";
 
 import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
 import { DocumentType, graphql } from "@/gql";
-import { CommentChangeType, ProjectPermission } from "@/gql/graphql";
+import {
+  CommentChangeType,
+  ProjectPermission,
+  ReviewChangeType,
+} from "@/gql/graphql";
 import { Activity, ActivityItem } from "@/ui/Activity";
 import type { MentionUser } from "@/ui/Editor/mention";
 import { IconButton } from "@/ui/IconButton";
@@ -95,6 +99,30 @@ const BuildCommentChangedSubscription = graphql(`
         id
         threadId
         ...CommentCard_Comment
+      }
+    }
+  }
+`);
+
+const BuildReviewChangedSubscription = graphql(`
+  subscription ReviewActivitySection_buildReviewChanged(
+    $buildId: ID!
+    $accountSlug: String!
+    $projectName: String!
+  ) {
+    buildReviewChanged(buildId: $buildId) {
+      type
+      review {
+        id
+        date
+        state
+        dismissedAt
+        dismissedBy {
+          ...UserCard_user
+        }
+        user {
+          ...UserCard_user
+        }
       }
     }
   }
@@ -303,6 +331,39 @@ export function ReviewActivitySection(props: { build: Build }) {
         }
         // CommentChangeType.Updated needs no manual cache work.
       }
+    },
+  });
+  // Same for reviews: a submitted review is inserted into the build's review
+  // list; a dismissal needs no handling here — the normalized cache merges
+  // `dismissedAt`/`dismissedBy` in place by review id.
+  useSubscription(BuildReviewChangedSubscription, {
+    variables: { buildId: build.id, accountSlug, projectName },
+    onData: ({ client, data }) => {
+      const event = data.data?.buildReviewChanged;
+      if (event?.type !== ReviewChangeType.Submitted) {
+        return;
+      }
+      const { review } = event;
+      client.cache.modify({
+        id: client.cache.identify({ __typename: "Build", id: build.id }),
+        fields: {
+          reviews(
+            existingRefs: readonly Reference[] = [],
+            { readField, toReference },
+          ) {
+            const ref = toReference(review);
+            if (
+              !ref ||
+              existingRefs.some(
+                (existing) => readField("id", existing) === review.id,
+              )
+            ) {
+              return existingRefs;
+            }
+            return [...existingRefs, ref];
+          },
+        },
+      });
     },
   });
   const permissions = useNonNullable(ProjectPermissionsContext);

--- a/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
@@ -251,36 +251,58 @@ export function ReviewActivitySection(props: { build: Build }) {
   // the project, so the operation needs the project's slug/name from the route.
   const { accountSlug, projectName } = useParams();
   invariant(accountSlug && projectName, "Missing project route params");
-  // Keep the activity feed live: append comments added by others, and let the
-  // normalized cache merge edits in place (it dedupes by comment id).
+  // Keep the activity feed live. Added comments are inserted into the build's
+  // comment list and deleted ones are evicted; updates (edits, reactions,
+  // resolve/reopen) need no handling here — the normalized cache merges the
+  // changed fields in place by comment id.
   useSubscription(BuildCommentChangedSubscription, {
     variables: { buildId: build.id, accountSlug, projectName },
     onData: ({ client, data }) => {
       const event = data.data?.buildCommentChanged;
-      if (event?.type !== CommentChangeType.Added) {
+      if (!event) {
         return;
       }
       const { comment } = event;
-      client.cache.modify({
-        id: client.cache.identify({ __typename: "Build", id: build.id }),
-        fields: {
-          comments(
-            existingRefs: readonly Reference[] = [],
-            { readField, toReference },
-          ) {
-            const ref = toReference(comment);
-            if (
-              !ref ||
-              existingRefs.some(
-                (existing) => readField("id", existing) === comment.id,
-              )
-            ) {
-              return existingRefs;
-            }
-            return [...existingRefs, ref];
-          },
-        },
-      });
+      switch (event.type) {
+        case CommentChangeType.Added: {
+          client.cache.modify({
+            id: client.cache.identify({ __typename: "Build", id: build.id }),
+            fields: {
+              comments(
+                existingRefs: readonly Reference[] = [],
+                { readField, toReference },
+              ) {
+                const ref = toReference(comment);
+                if (
+                  !ref ||
+                  existingRefs.some(
+                    (existing) => readField("id", existing) === comment.id,
+                  )
+                ) {
+                  return existingRefs;
+                }
+                return [...existingRefs, ref];
+              },
+            },
+          });
+          break;
+        }
+        case CommentChangeType.Deleted: {
+          // Evicting the comment drops it from the build's list (the dangling
+          // ref is garbage-collected), so `AnimatePresence` plays its exit
+          // animation — matching a local delete.
+          const cacheId = client.cache.identify({
+            __typename: "Comment",
+            id: comment.id,
+          });
+          if (cacheId) {
+            client.cache.evict({ id: cacheId });
+            client.cache.gc();
+          }
+          break;
+        }
+        // CommentChangeType.Updated needs no manual cache work.
+      }
     },
   });
   const permissions = useNonNullable(ProjectPermissionsContext);

--- a/apps/frontend/src/ui/Editor/Editor.tsx
+++ b/apps/frontend/src/ui/Editor/Editor.tsx
@@ -74,7 +74,15 @@ export type EditorValue = JSONContent | null;
 export type EditorVariant = "boxed" | "plain";
 
 export interface EditorProps {
+  /** Initial content for an uncontrolled editor. Read once, at creation. */
   defaultValue?: EditorValue;
+  /**
+   * Controlled content: the editor re-renders to reflect changes to it. Use it
+   * for read-only rendering that must stay in sync with its source (e.g. a
+   * comment edited live over the subscription). Seeds the initial content, so
+   * use it instead of — not together with — `defaultValue`.
+   */
+  value?: EditorValue;
   onChange?: (value: EditorValue) => void;
   onBlur?: () => void;
   /** Called when the user presses Cmd/Ctrl+Enter. */
@@ -129,6 +137,7 @@ const DEFAULT_CONTENT_HEIGHT_CLASS = "min-h-20";
 export function Editor(props: EditorProps) {
   const {
     defaultValue,
+    value,
     onChange,
     onBlur,
     onSubmit,
@@ -190,7 +199,7 @@ export function Editor(props: EditorProps) {
       ...(placeholder ? [Placeholder.configure({ placeholder })] : []),
     ],
     editable,
-    content: defaultValue,
+    content: value ?? defaultValue,
     autofocus: autoFocus ? "end" : false,
     editorProps: {
       attributes: {
@@ -227,6 +236,17 @@ export function Editor(props: EditorProps) {
   useEffect(() => {
     editor?.setEditable(editable);
   }, [editor, editable]);
+
+  // Keep the editor in sync with the controlled `value` — `useEditor` only
+  // seeds `content` once at creation, so a live update (e.g. a comment edited
+  // by someone else over the subscription) would otherwise render stale text.
+  // `value`'s identity only changes when the content does (Apollo shares
+  // references for unchanged data), so this stays a no-op on unrelated renders.
+  useEffect(() => {
+    if (editor && value != null) {
+      editor.commands.setContent(value);
+    }
+  }, [editor, value]);
 
   useEffect(() => {
     if (!editor || !ref) {

--- a/apps/frontend/src/ui/Editor/ReadOnlyEditor.tsx
+++ b/apps/frontend/src/ui/Editor/ReadOnlyEditor.tsx
@@ -30,7 +30,7 @@ export const ReadOnlyEditor = memo(function ReadOnlyEditor(
     <Editor
       variant="plain"
       readOnly
-      defaultValue={content}
+      value={content}
       className={className}
       mentionedUsers={mentionedUsers}
     />

--- a/apps/frontend/vite.config.mts
+++ b/apps/frontend/vite.config.mts
@@ -82,6 +82,8 @@ export default defineConfig((args) => {
               "/graphql": {
                 target: "https://app.argos-ci.dev:4001",
                 secure: false,
+                // Proxy the subscription WebSocket upgrade too.
+                ws: true,
               },
               "/config.js": {
                 target: "https://app.argos-ci.dev:4001",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,9 @@ importers:
       graphql-tag:
         specifier: ^2.12.6
         version: 2.12.6(graphql@16.14.2)
+      graphql-ws:
+        specifier: ^6.0.8
+        version: 6.0.8(graphql@16.14.2)(ws@8.21.0)
       happy-dom:
         specifier: ^20.10.3
         version: 20.10.3
@@ -348,6 +351,9 @@ importers:
       undici:
         specifier: 8.4.1
         version: 8.4.1
+      ws:
+        specifier: ^8.20.1
+        version: 8.21.0
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -403,6 +409,9 @@ importers:
       '@types/tmp':
         specifier: ^0.2.6
         version: 0.2.6
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       concurrently:
         specifier: ^10.0.3
         version: 10.0.3
@@ -584,6 +593,9 @@ importers:
       graphql:
         specifier: ^16.14.2
         version: 16.14.2
+      graphql-ws:
+        specifier: ^6.0.8
+        version: 6.0.8(graphql@16.14.2)(ws@8.21.0)
       input-otp:
         specifier: ^1.4.2
         version: 1.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
## What

Makes the build review activity reactive: **added and updated comments now appear without a refresh**, using GraphQL subscriptions over WebSocket (ARG-393).

## How

**Backend**
- New Redis-backed pub/sub engine ([`util/redis/pubsub.ts`](apps/backend/src/util/redis/pubsub.ts)), following the existing `redisCache`/`redisLock` factory style. It yields `unknown`; the payload is validated with **zod** at the comment-event boundary ([`commentEvents.ts`](apps/backend/src/comment/commentEvents.ts)). Redis pub/sub means it works across a horizontally-scaled web tier.
- A single `buildCommentChanged(buildId)` subscription carrying an `ADDED | UPDATED` event. It authorizes per build (`"view"` permission) **before** opening the stream. Events are published from `createBuildComment` / `updateBuildComment`.
- A `graphql-ws` WebSocket server mounted on the same `/graphql` path, with an **Origin check** (hostname-based, port-agnostic) to guard against cross-site WebSocket hijacking — a WS handshake can't carry our CSRF header. WS auth reuses the HttpOnly session cookie sent on the upgrade request.

**Frontend**
- Apollo client splits subscription operations onto a `GraphQLWsLink`; everything else stays on HTTP. The WS client connects lazily.
- `ReviewActivitySection` subscribes and inserts **added** comments into the build's comment list in the cache (deduped by id, so an author's own comment never doubles). **Updated** comments merge into the normalized cache by id automatically.
- `Editor` gains a controlled `value` prop so read-only content reflects live edits; `defaultValue` stays uncontrolled (an in-progress draft is never clobbered by a remote edit).

## Design notes
- **Redis pub/sub** chosen over an in-memory `PubSub` so it survives multiple web instances.
- **Single event subscription** over two separate ones: one WS operation per build, extends to deletes later for free.
- Custom node-redis engine rather than `graphql-redis-subscriptions` + `ioredis`, to keep a single Redis client library.

## Testing
- codegen, `tsc`, eslint, knip, prettier all pass on both apps.
- Not yet verified end-to-end at runtime (needs Redis + Postgres + both dev servers, two sessions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)