### PR TITLE
[codex] Clarify disabled GitHub Actions OIDC error

### DIFF
--- a/apps/backend/src/api/handlers/exchangeGitHubActionsOidcToken.e2e.test.ts
+++ b/apps/backend/src/api/handlers/exchangeGitHubActionsOidcToken.e2e.test.ts
@@ -116,7 +116,29 @@ describe("exchangeGitHubActionsOidcToken", () => {
       .expect(403)
       .expect((res) => {
         expect(res.body.error).toBe(
-          "GitHub Actions OIDC authentication is not enabled for this project.",
+          "GitHub Actions OIDC authentication is not enabled for this project. Enable it in the project settings.",
+        );
+      });
+  });
+
+  test("rejects with project settings guidance when OIDC is disabled and the commit does not match", async ({
+    linkedProject,
+  }) => {
+    await linkedProject.project.$query().patch({
+      githubActionsOidcEnabled: false,
+    });
+
+    await request(app)
+      .post("/auth/github-actions/oidc/exchange")
+      .send({
+        oidcToken: signGitHubActionsToken(),
+        repository: "argos-ci/argos",
+        commit: "0000000000000000000000000000000000000000",
+      })
+      .expect(403)
+      .expect((res) => {
+        expect(res.body.error).toBe(
+          "GitHub Actions OIDC authentication is not enabled for this project. Enable it in the project settings.",
         );
       });
   });

--- a/apps/backend/src/auth/github-actions-oidc-exchange.ts
+++ b/apps/backend/src/auth/github-actions-oidc-exchange.ts
@@ -22,7 +22,7 @@ function parseGitHubRepositoryId(repositoryId: string) {
   return parsed;
 }
 
-function assertOptionalClaimsMatchInput(
+function assertOptionalRepositoryClaimMatchesInput(
   claims: Awaited<ReturnType<typeof verifyGitHubActionsOidcToken>>,
   input: GitHubActionsOidcExchangeInput,
 ) {
@@ -32,7 +32,12 @@ function assertOptionalClaimsMatchInput(
   ) {
     throw boom(401, "GitHub Actions OIDC token does not match repository.");
   }
+}
 
+function assertOptionalCommitClaimMatchesInput(
+  claims: Awaited<ReturnType<typeof verifyGitHubActionsOidcToken>>,
+  input: GitHubActionsOidcExchangeInput,
+) {
   if (input.commit && claims.sha !== input.commit) {
     throw boom(401, "GitHub Actions OIDC token does not match commit.");
   }
@@ -42,7 +47,7 @@ export async function exchangeGitHubActionsOidcToken(
   input: GitHubActionsOidcExchangeInput,
 ) {
   const claims = await verifyGitHubActionsOidcToken(input.oidcToken);
-  assertOptionalClaimsMatchInput(claims, input);
+  assertOptionalRepositoryClaimMatchesInput(claims, input);
 
   const repository = await GithubRepository.query()
     .withGraphFetched("[repoInstallations.installation, projects]")
@@ -71,9 +76,11 @@ export async function exchangeGitHubActionsOidcToken(
   if (!project.githubActionsOidcEnabled) {
     throw boom(
       403,
-      "GitHub Actions OIDC authentication is not enabled for this project.",
+      "GitHub Actions OIDC authentication is not enabled for this project. Enable it in the project settings.",
     );
   }
+
+  assertOptionalCommitClaimMatchesInput(claims, input);
 
   return createShortLivedProjectToken({
     projectId: project.id,


### PR DESCRIPTION
## Summary

- clarify the disabled GitHub Actions OIDC exchange error with project settings guidance
- ensure disabled OIDC is reported before optional commit mismatch validation
- add an e2e regression test for disabled OIDC plus a mismatching commit

## Validation

- `./node_modules/.bin/prettier --write apps/backend/src/auth/github-actions-oidc-exchange.ts apps/backend/src/api/handlers/exchangeGitHubActionsOidcToken.e2e.test.ts`
- `./node_modules/.bin/tsc --noEmit -p apps/backend/tsconfig.json`
- `./node_modules/.bin/eslint apps/backend/src/auth/github-actions-oidc-exchange.ts apps/backend/src/api/handlers/exchangeGitHubActionsOidcToken.e2e.test.ts --max-warnings 0`
- `./node_modules/.bin/vitest run -c vitest/vitest.e2e.config.mts apps/backend/src/api/handlers/exchangeGitHubActionsOidcToken.e2e.test.ts`
- `git diff --check`
