### PR TITLE
feat: live user presence and local time in the UserCard

### DIFF
--- a/apps/backend/src/auth/presence.e2e.test.ts
+++ b/apps/backend/src/auth/presence.e2e.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { factory, setupDatabase } from "@/database/testing";
+import { redisPubSub } from "@/util/redis";
+import { getRedisClient } from "@/util/redis/client";
+import { setupRedis } from "@/util/redis/testing";
+
+import { getPresence, getPresences, touchPresence } from "./presence";
+
+setupRedis();
+
+describe("presence service", () => {
+  let userId: string;
+
+  beforeEach(async () => {
+    await setupDatabase();
+    const user = await factory.User.create();
+    userId = user.id;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("stores presence and publishes on first activity", async () => {
+    const publish = vi
+      .spyOn(redisPubSub, "publish")
+      .mockResolvedValue(undefined);
+
+    await touchPresence({ userId, timezone: "Europe/Paris" });
+
+    const presence = await getPresence(userId);
+    expect(presence?.timezone).toBe("Europe/Paris");
+    expect(presence?.lastSeenAt).toBeTypeOf("string");
+
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish).toHaveBeenCalledWith(`user-presence-change:${userId}`, {
+      userId,
+    });
+  });
+
+  test("does not republish while the user stays active", async () => {
+    await touchPresence({ userId, timezone: "Europe/Paris" });
+
+    const publish = vi
+      .spyOn(redisPubSub, "publish")
+      .mockResolvedValue(undefined);
+    await touchPresence({ userId, timezone: "Europe/Paris" });
+
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  test("republishes after the active window elapses", async () => {
+    const redis = await getRedisClient();
+    // Seed a stale entry (last seen 6 minutes ago), past the active window.
+    const stale = new Date(Date.now() - 6 * 60 * 1000).toISOString();
+    await redis.set(
+      `presence:${userId}`,
+      JSON.stringify({ lastSeenAt: stale, timezone: "Europe/Paris" }),
+    );
+
+    const publish = vi
+      .spyOn(redisPubSub, "publish")
+      .mockResolvedValue(undefined);
+    await touchPresence({ userId, timezone: "Europe/Paris" });
+
+    expect(publish).toHaveBeenCalledTimes(1);
+  });
+
+  test("refreshes the entry with a TTL", async () => {
+    await touchPresence({ userId });
+
+    const redis = await getRedisClient();
+    const ttl = await redis.ttl(`presence:${userId}`);
+    expect(ttl).toBeGreaterThan(0);
+  });
+
+  test("getPresences returns entries in order, null for unknown users", async () => {
+    await touchPresence({ userId, timezone: "Europe/Paris" });
+
+    const result = await getPresences([userId, "999999999"]);
+    expect(result[0]?.timezone).toBe("Europe/Paris");
+    expect(result[1]).toBeNull();
+  });
+});

--- a/apps/backend/src/auth/presence.ts
+++ b/apps/backend/src/auth/presence.ts
@@ -1,0 +1,114 @@
+import { getRedisClient } from "@/util/redis/client";
+
+import { publishUserPresenceChanged } from "./presenceEvents";
+
+/**
+ * How recent `lastSeenAt` must be for a user to count as "active". Used only to
+ * decide when to publish a presence event — so we emit on a genuine "came back
+ * active" transition rather than on every request. The frontend derives the
+ * online/away/offline dot from `lastSeenAt` itself.
+ */
+const ACTIVE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * How long a presence entry is retained (refreshed on every touch). Long enough
+ * that `lastSeenAt` stays available to render "last seen …" for a while after a
+ * user goes idle. Presence lives only in Redis — there is no Postgres fallback.
+ */
+const PRESENCE_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+export type UserPresence = {
+  /** ISO timestamp of the user's last activity. */
+  lastSeenAt: string;
+  /** IANA timezone (e.g. "Europe/Paris"), or null when unknown. */
+  timezone: string | null;
+};
+
+function getRedisKey(userId: string): string {
+  return `presence:${userId}`;
+}
+
+/**
+ * Parse a stored entry, returning `null` for anything corrupt or in an older
+ * format so a bad value is treated as "no presence" rather than throwing.
+ */
+function parsePresence(raw: string | null): UserPresence | null {
+  if (!raw) {
+    return null;
+  }
+  try {
+    const value = JSON.parse(raw);
+    if (
+      value &&
+      typeof value === "object" &&
+      typeof value.lastSeenAt === "string"
+    ) {
+      return {
+        lastSeenAt: value.lastSeenAt,
+        timezone: typeof value.timezone === "string" ? value.timezone : null,
+      };
+    }
+  } catch {
+    // Fall through to treat as missing.
+  }
+  return null;
+}
+
+/**
+ * Record that a user is active right now. Refreshes the Redis presence entry
+ * (sliding its TTL) and, when the user has transitioned from inactive to active,
+ * publishes a presence event so open cards flip live.
+ *
+ * The write + transition-detect is a single atomic `SET … GET`: it always
+ * writes (sliding the window) and returns the prior value, so the "became
+ * active" decision is race-safe across web instances (a lost race only ever
+ * costs a harmless duplicate event).
+ */
+export async function touchPresence(input: {
+  userId: string;
+  timezone?: string | null;
+}): Promise<void> {
+  const { userId } = input;
+  const now = Date.now();
+  const entry: UserPresence = {
+    lastSeenAt: new Date(now).toISOString(),
+    timezone: input.timezone ?? null,
+  };
+  const redis = await getRedisClient();
+  const prev = await redis.set(getRedisKey(userId), JSON.stringify(entry), {
+    expiration: { type: "EX", value: PRESENCE_TTL_SECONDS },
+    GET: true,
+  });
+  const before = parsePresence(prev);
+  const becameActive =
+    !before || now - Date.parse(before.lastSeenAt) >= ACTIVE_THRESHOLD_MS;
+  if (becameActive) {
+    await publishUserPresenceChanged({ userId });
+  }
+}
+
+/**
+ * Read a single user's presence, or `null` when there is no recent activity.
+ */
+export async function getPresence(
+  userId: string,
+): Promise<UserPresence | null> {
+  const redis = await getRedisClient();
+  const raw = await redis.get(getRedisKey(userId));
+  return parsePresence(raw);
+}
+
+/**
+ * Read many users' presence at once (for the GraphQL loader). Order matches the
+ * input; entries with no recent activity are `null`.
+ */
+export async function getPresences(
+  userIds: readonly string[],
+): Promise<(UserPresence | null)[]> {
+  if (userIds.length === 0) {
+    return [];
+  }
+  const redis = await getRedisClient();
+  const raws = await redis.mGet(userIds.map(getRedisKey));
+  return raws.map((raw) => parsePresence(raw));
+}

--- a/apps/backend/src/auth/presenceEvents.ts
+++ b/apps/backend/src/auth/presenceEvents.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+import { redisPubSub } from "@/util/redis";
+
+const presenceChangeSchema = z.object({
+  userId: z.string(),
+});
+
+export type PresenceChange = z.infer<typeof presenceChangeSchema>;
+
+function getPresenceChannel(userId: string): string {
+  return `user-presence-change:${userId}`;
+}
+
+/**
+ * Publish that a user has become active so every client subscribed to them
+ * receives it live. Only the user id travels through Redis; the presence fields
+ * (`lastSeenAt`, `timezone`) are re-read per subscriber by the field resolvers.
+ */
+export async function publishUserPresenceChanged(input: {
+  userId: string;
+}): Promise<void> {
+  await redisPubSub.publish(getPresenceChannel(input.userId), {
+    userId: input.userId,
+  });
+}
+
+/**
+ * Yield every presence change published for a user until the iterator is closed
+ * (when the GraphQL subscription ends). Each payload is validated before being
+ * surfaced (these values come off the wire).
+ */
+export async function* subscribeToUserPresenceChanges(
+  userId: string,
+): AsyncGenerator<PresenceChange> {
+  const iterator = redisPubSub.subscribe(getPresenceChannel(userId));
+  for await (const raw of iterator) {
+    yield presenceChangeSchema.parse(raw);
+  }
+}

--- a/apps/backend/src/graphql/context.ts
+++ b/apps/backend/src/graphql/context.ts
@@ -1,9 +1,11 @@
 import type { IncomingMessage } from "node:http";
 import type { BaseContext } from "@apollo/server";
+import { captureException } from "@sentry/node";
 import type { Request, Response } from "express";
 import { GraphQLError } from "graphql";
 
 import type { AuthSessionPayload } from "@/auth/payload";
+import { touchPresence } from "@/auth/presence";
 import { readSessionCookie } from "@/auth/session-cookie";
 import {
   safeSessionAuthFromExpressReq,
@@ -29,6 +31,15 @@ export type Context = BaseContext & {
   req?: Request;
   res?: Response;
 };
+
+/**
+ * Read a single header value as a non-empty string, or `null`.
+ */
+function getHeaderString(request: Request, name: string): string | null {
+  const value = request.headers[name];
+  const str = Array.isArray(value) ? value[0] : value;
+  return str && str.length > 0 ? str : null;
+}
 
 async function getContextAuth(
   request: Request,
@@ -57,6 +68,15 @@ export async function getContext(
   try {
     const auth = await getContextAuth(request);
     const requestLocation = extractLocationFromRequest(request);
+    if (auth) {
+      // Record live presence. Best-effort and fire-and-forget — a presence
+      // write must never turn a query into a 500. Timezone rides on the
+      // Cloudflare `cf-timezone` header (absent locally).
+      void touchPresence({
+        userId: auth.user.id,
+        timezone: getHeaderString(request, "cf-timezone"),
+      }).catch(captureException);
+    }
     return {
       auth,
       requestLocation,

--- a/apps/backend/src/graphql/definitions/User.ts
+++ b/apps/backend/src/graphql/definitions/User.ts
@@ -1,6 +1,8 @@
 import { invariant } from "@argos/util/invariant";
 import gqlTag from "graphql-tag";
 
+import { type UserPresence } from "@/auth/presence";
+import { subscribeToUserPresenceChanges } from "@/auth/presenceEvents";
 import { listActiveSessions } from "@/auth/session";
 import {
   Account,
@@ -28,12 +30,37 @@ import {
   type IResolvers,
   type ITeamUserLevel,
 } from "../__generated__/resolver-types";
+import type { Context } from "../context";
 import { deleteAccount, getAdminAccount } from "../services/account";
+import { assertCanViewUserPresence } from "../services/user-presence";
 import { badUserInput, forbidden, unauthenticated } from "../util";
 import { commonAccountResolvers } from "./Account";
 import { paginateResult } from "./PageInfo";
 
 const { gql } = gqlTag;
+
+/**
+ * Load a user's presence, but only if the viewer is allowed to see it (the user
+ * themselves or a shared-team member). Returns `null` otherwise. Both the
+ * visibility check and the presence read are batched via the request loaders.
+ */
+async function loadVisiblePresence(
+  ctx: Context,
+  targetUserId: string,
+): Promise<UserPresence | null> {
+  const viewerId = ctx.auth?.user.id;
+  if (!viewerId) {
+    return null;
+  }
+  const canView = await ctx.loaders.UsersShareTeam.load({
+    aUserId: viewerId,
+    bUserId: targetUserId,
+  });
+  if (!canView) {
+    return null;
+  }
+  return ctx.loaders.Presence.load(targetUserId);
+}
 
 export const typeDefs = gql`
   type User implements Node & Account {
@@ -85,8 +112,21 @@ export const typeDefs = gql`
     userAccessTokens: [UserAccessToken!]!
     "List of active login sessions for the user, most recently seen first"
     sessions: [UserSession!]!
+    "Last activity timestamp, for presence. Null unless the viewer shares a team with the user."
+    lastSeenAt: DateTime
+    "IANA timezone, for rendering the user's local time. Null unless the viewer shares a team with the user."
+    timezone: String
     "Team role of the user on the given project, null if not a team member"
     role(accountSlug: String!, projectName: String!): TeamUserLevel
+  }
+
+  type UserPresenceChangeEvent {
+    user: User!
+  }
+
+  extend type Subscription {
+    "Emitted when the given user becomes active again."
+    userPresenceChanged(userId: ID!): UserPresenceChangeEvent!
   }
 
   type UserEmail {
@@ -481,6 +521,41 @@ export const resolvers: IResolvers = {
         throw forbidden();
       }
       return listActiveSessions(account.userId);
+    },
+    lastSeenAt: async (account, _args, ctx) => {
+      if (!account.userId) {
+        return null;
+      }
+      const presence = await loadVisiblePresence(ctx, account.userId);
+      return presence ? new Date(presence.lastSeenAt) : null;
+    },
+    timezone: async (account, _args, ctx) => {
+      if (!account.userId) {
+        return null;
+      }
+      const presence = await loadVisiblePresence(ctx, account.userId);
+      return presence?.timezone ?? null;
+    },
+  },
+  Subscription: {
+    userPresenceChanged: {
+      // Authorize before opening the stream so an unpermitted subscription is
+      // rejected upfront rather than after the first event.
+      subscribe: async (_root, args, ctx) => {
+        await assertCanViewUserPresence(args.userId, ctx.auth?.user ?? null);
+        return (async function* () {
+          for await (const change of subscribeToUserPresenceChanges(
+            args.userId,
+          )) {
+            const account = await Account.query().findOne({
+              userId: change.userId,
+            });
+            if (account) {
+              yield { userPresenceChanged: { user: account } };
+            }
+          }
+        })();
+      },
     },
   },
 };

--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -4,6 +4,7 @@ import DataLoader from "dataloader";
 import { memoize } from "lodash-es";
 import type { ModelClass } from "objection";
 
+import { getPresences, type UserPresence } from "@/auth/presence";
 import { knex } from "@/database";
 import {
   Account,
@@ -1262,8 +1263,59 @@ function createLatestCompareScreenshotLoader() {
   });
 }
 
+function createPresenceLoader() {
+  return new DataLoader<string, UserPresence | null>(async (userIds) =>
+    getPresences(userIds as string[]),
+  );
+}
+
+/**
+ * Whether the two users in each pair share a team (or are the same user).
+ * Batches every requested pair into a single membership query — so a card list
+ * full of comment authors costs one query, not one per author.
+ */
+function createUsersShareTeamLoader() {
+  return new DataLoader<{ aUserId: string; bUserId: string }, boolean, string>(
+    async (pairs) => {
+      const userIds = [
+        ...new Set(pairs.flatMap((pair) => [pair.aUserId, pair.bUserId])),
+      ];
+      const rows = userIds.length
+        ? await TeamUser.query()
+            .whereIn("userId", userIds)
+            .select("userId", "teamId")
+        : [];
+      const teamIdsByUser = new Map<string, Set<string>>();
+      for (const row of rows) {
+        const set = teamIdsByUser.get(row.userId) ?? new Set<string>();
+        set.add(row.teamId);
+        teamIdsByUser.set(row.userId, set);
+      }
+      return pairs.map(({ aUserId, bUserId }) => {
+        if (aUserId === bUserId) {
+          return true;
+        }
+        const aTeamIds = teamIdsByUser.get(aUserId);
+        const bTeamIds = teamIdsByUser.get(bUserId);
+        if (!aTeamIds || !bTeamIds) {
+          return false;
+        }
+        for (const teamId of aTeamIds) {
+          if (bTeamIds.has(teamId)) {
+            return true;
+          }
+        }
+        return false;
+      });
+    },
+    { cacheKeyFn: (input) => `${input.aUserId}:${input.bUserId}` },
+  );
+}
+
 export const createLoaders = () => ({
   Account: createModelLoader(Account),
+  Presence: createPresenceLoader(),
+  UsersShareTeam: createUsersShareTeamLoader(),
   AccountFromRelation: createAccountFromRelationLoader(),
   ProjectTeamUserLevel: createProjectTeamUserLevelLoader(),
   AutomationRunActionRuns: createAutomationRunActionRunsLoader(),

--- a/apps/backend/src/graphql/services/user-presence.ts
+++ b/apps/backend/src/graphql/services/user-presence.ts
@@ -1,0 +1,43 @@
+import { TeamUser, type User } from "@/database/models";
+
+import { forbidden, unauthenticated } from "../util";
+
+/**
+ * Whether two users share at least one team. A user always "shares" with
+ * themselves.
+ */
+export async function usersShareTeam(
+  aUserId: string,
+  bUserId: string,
+): Promise<boolean> {
+  if (aUserId === bUserId) {
+    return true;
+  }
+  const rows = await TeamUser.query()
+    .whereIn("userId", [aUserId, bUserId])
+    .select("userId", "teamId");
+  const aTeamIds = new Set(
+    rows.filter((row) => row.userId === aUserId).map((row) => row.teamId),
+  );
+  return rows.some((row) => row.userId === bUserId && aTeamIds.has(row.teamId));
+}
+
+/**
+ * Presence (last seen, timezone) is personal data: visible only to the user
+ * themselves or someone who shares a team with them. Mirrors how `User.sessions`
+ * is owner-gated. Used by the subscription, which must authorize before opening
+ * the stream; the equivalent field-level gate is batched via the
+ * `UsersShareTeam` loader.
+ */
+export async function assertCanViewUserPresence(
+  targetUserId: string,
+  viewer: User | null,
+): Promise<void> {
+  if (!viewer) {
+    throw unauthenticated();
+  }
+  if (await usersShareTeam(viewer.id, targetUserId)) {
+    return;
+  }
+  throw forbidden();
+}

--- a/apps/backend/src/graphql/services/user-presence.ts
+++ b/apps/backend/src/graphql/services/user-presence.ts
@@ -6,7 +6,7 @@ import { forbidden, unauthenticated } from "../util";
  * Whether two users share at least one team. A user always "shares" with
  * themselves.
  */
-export async function usersShareTeam(
+async function usersShareTeam(
   aUserId: string,
   bUserId: string,
 ): Promise<boolean> {

--- a/apps/frontend/src/containers/BuildReviewersStatusList.tsx
+++ b/apps/frontend/src/containers/BuildReviewersStatusList.tsx
@@ -5,6 +5,7 @@ import moment from "moment";
 
 import { ReviewState } from "@/gql/graphql";
 import { Tooltip } from "@/ui/Tooltip";
+import { UserHoverCard, type UserCardData } from "@/ui/UserCard";
 import {
   buildReviewDescriptors,
   getLatestReviewByUser,
@@ -12,20 +13,20 @@ import {
 
 import { AccountAvatar } from "./AccountAvatar";
 
+type ReviewerUser = {
+  id: string;
+  name: string | null;
+  slug: string;
+  avatar: ComponentProps<typeof AccountAvatar>["avatar"];
+};
+
 type ReviewerStatusReview = {
   id: string;
   date: string;
   state: ReviewState;
   dismissedAt?: string | null;
-  user: {
-    id: string;
-    name: string | null;
-    slug: string;
-    avatar: ComponentProps<typeof AccountAvatar>["avatar"];
-  } | null;
+  user: ReviewerUser | null;
 };
-
-type ReviewerUser = NonNullable<ReviewerStatusReview["user"]>;
 
 const dismissedReviewDescriptor = {
   label: "Dismissed",
@@ -47,11 +48,17 @@ export function BuildReviewersStatusList<
    * Users requested as reviewers that haven't submitted a review yet. Rendered
    * as "pending" rows after the submitted reviews.
    */
-  pendingUsers?: readonly ReviewerUser[];
+  pendingUsers?: readonly NonNullable<T["user"]>[];
   className?: string;
   itemClassName?: string;
   avatarClassName?: string;
   renderAction?: (review: T) => ReactNode;
+  /**
+   * When provided, the reviewer's avatar + name are wrapped in a {@link
+   * UserHoverCard}. The user type is the caller's, so a richer selection
+   * (presence, role) flows through to the card.
+   */
+  getUserCardData?: (user: NonNullable<T["user"]>) => UserCardData;
 }) {
   const reviewers = getLatestReviewByUser(props.reviews);
   const pendingUsers = props.pendingUsers ?? [];
@@ -60,11 +67,36 @@ export function BuildReviewersStatusList<
   }
   const pendingDescriptor = buildReviewDescriptors[ReviewState.Pending];
   const PendingIcon = pendingDescriptor.icon;
+
+  const renderUserContent = (user: NonNullable<T["user"]>) => {
+    const content = (
+      <span className="flex min-w-0 flex-1 items-center gap-2">
+        <AccountAvatar
+          className={clsx("size-5 shrink-0", props.avatarClassName)}
+          avatar={user.avatar}
+          alt={user.name ?? undefined}
+        />
+        <strong className="truncate font-medium">
+          {user.name || user.slug}
+        </strong>
+      </span>
+    );
+    if (props.getUserCardData) {
+      return (
+        <UserHoverCard user={props.getUserCardData(user)}>
+          {content}
+        </UserHoverCard>
+      );
+    }
+    return content;
+  };
+
   return (
     <ul className={clsx("flex flex-col", props.className)}>
       {reviewers.map((review) => {
         const descriptor = getReviewDescriptor(review);
         const Icon = descriptor.icon;
+        const user = review.user as NonNullable<T["user"]> | null;
         return (
           <li
             key={review.id}
@@ -73,16 +105,11 @@ export function BuildReviewersStatusList<
               props.itemClassName,
             )}
           >
-            {review.user && (
-              <AccountAvatar
-                className={clsx("size-5 shrink-0", props.avatarClassName)}
-                avatar={review.user.avatar}
-                alt={review.user.name ?? undefined}
-              />
+            {user ? (
+              renderUserContent(user)
+            ) : (
+              <span className="flex-1 truncate font-medium">Unknown user</span>
             )}
-            <strong className="flex-1 truncate font-medium">
-              {review.user?.name || review.user?.slug}
-            </strong>
             <Tooltip
               content={`${descriptor.label} · ${moment(review.dismissedAt ?? review.date).fromNow()}`}
             >
@@ -102,14 +129,7 @@ export function BuildReviewersStatusList<
             props.itemClassName,
           )}
         >
-          <AccountAvatar
-            className={clsx("size-5 shrink-0", props.avatarClassName)}
-            avatar={user.avatar}
-            alt={user.name ?? undefined}
-          />
-          <strong className="flex-1 truncate font-medium">
-            {user.name || user.slug}
-          </strong>
+          {renderUserContent(user)}
           <Tooltip content={pendingDescriptor.label}>
             <PendingIcon
               className={clsx("size-3.5 shrink-0", pendingDescriptor.textColor)}

--- a/apps/frontend/src/pages/Build/sidebar/ReviewersSection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewersSection.tsx
@@ -40,6 +40,7 @@ import { Menu, MenuItem, MenuItemIcon, MenuTrigger } from "@/ui/Menu";
 import { Modal } from "@/ui/Modal";
 import { Popover } from "@/ui/Popover";
 import { SidebarHeader, SidebarHeading, SidebarSection } from "@/ui/Sidebar";
+import { getUserCardData } from "@/ui/UserCard";
 import {
   getLatestActiveReviewByUser,
   getLatestReviewByUser,
@@ -59,12 +60,7 @@ const _BuildFragment = graphql(`
       state
       dismissedAt
       user {
-        id
-        name
-        slug
-        avatar {
-          ...AccountAvatarFragment
-        }
+        ...UserCard_user
       }
     }
     members {
@@ -76,12 +72,7 @@ const _BuildFragment = graphql(`
       }
     }
     reviewers {
-      id
-      name
-      slug
-      avatar {
-        ...AccountAvatarFragment
-      }
+      ...UserCard_user
     }
   }
 `);
@@ -103,7 +94,11 @@ const DismissReviewMutation = graphql(`
 `);
 
 const AddBuildReviewersMutation = graphql(`
-  mutation ReviewersSection_addBuildReviewers($input: AddBuildReviewersInput!) {
+  mutation ReviewersSection_addBuildReviewers(
+    $input: AddBuildReviewersInput!
+    $accountSlug: String!
+    $projectName: String!
+  ) {
     addBuildReviewers(input: $input) {
       id
       ...ReviewersSection_Build
@@ -114,6 +109,8 @@ const AddBuildReviewersMutation = graphql(`
 const RemoveBuildReviewersMutation = graphql(`
   mutation ReviewersSection_removeBuildReviewers(
     $input: RemoveBuildReviewersInput!
+    $accountSlug: String!
+    $projectName: String!
   ) {
     removeBuildReviewers(input: $input) {
       id
@@ -197,6 +194,7 @@ export function ReviewersSection(props: { build: Build }) {
           pendingUsers={pendingReviewers}
           className="gap-3"
           itemClassName={clsx("px-4 has-data-actions-menu:pr-3")}
+          getUserCardData={getUserCardData}
           renderAction={
             canDismissReview
               ? (review) => (
@@ -251,6 +249,8 @@ export function ReviewersSection(props: { build: Build }) {
  */
 function RequestReviewersMenu(props: { build: Build }) {
   const { build } = props;
+  const projectParams = useProjectParams();
+  invariant(projectParams);
   const { contains } = useFilter({ sensitivity: "base" });
   const [isOpen, setIsOpen] = useState(false);
   const hotkey = useBuildHotkey("requestReviewers", () => setIsOpen(true));
@@ -324,12 +324,20 @@ function RequestReviewersMenu(props: { build: Build }) {
     const revert = () => setRequested(new Set(requestedKeys));
     if (added.length > 0) {
       addReviewers({
-        variables: { input: { buildId: build.id, userIds: added } },
+        variables: {
+          input: { buildId: build.id, userIds: added },
+          accountSlug: projectParams.accountSlug,
+          projectName: projectParams.projectName,
+        },
       }).catch(revert);
     }
     if (removed.length > 0) {
       removeReviewers({
-        variables: { input: { buildId: build.id, userIds: removed } },
+        variables: {
+          input: { buildId: build.id, userIds: removed },
+          accountSlug: projectParams.accountSlug,
+          projectName: projectParams.projectName,
+        },
       }).catch(revert);
     }
   };

--- a/apps/frontend/src/ui/Editor/mention.tsx
+++ b/apps/frontend/src/ui/Editor/mention.tsx
@@ -27,6 +27,10 @@ export interface MentionUser {
   initial?: string | null;
   /** Team role, shown in the hover card (e.g. "owner"). */
   role?: string | null;
+  /** Last activity timestamp, for the hover card's presence dot. */
+  lastSeenAt?: string | null;
+  /** IANA timezone, for the hover card's local time. */
+  timezone?: string | null;
 }
 
 const MAX_SUGGESTIONS = 8;
@@ -236,11 +240,14 @@ export function createMentionExtension(options: MentionExtensionOptions) {
         {user ? (
           <UserHoverCard
             user={{
+              id: user.id,
               name: user.label,
               slug: user.secondaryLabel ?? user.label,
               imageUrl: user.imageUrl,
               initial: user.initial,
               role: user.role,
+              lastSeenAt: user.lastSeenAt,
+              timezone: user.timezone,
             }}
           >
             {trigger}

--- a/apps/frontend/src/ui/UserCard.tsx
+++ b/apps/frontend/src/ui/UserCard.tsx
@@ -93,6 +93,8 @@ export function getMentionUser(
     imageUrl: user.avatar.url,
     initial: user.avatar.initial,
     role: user.role,
+    lastSeenAt: user.lastSeenAt,
+    timezone: user.timezone,
   };
 }
 
@@ -197,7 +199,7 @@ function UserCardPresence(props: {
   const localTime = timezone ? formatLocalTime(timezone, now) : null;
 
   return (
-    <div className="text-low mt-2 flex flex-col gap-1.5 border-t pt-2 text-xs">
+    <div className="text-low border-t-thin mt-3 flex flex-col gap-1.5 pt-3 text-xs">
       <div className="flex items-center gap-2">
         <span
           className={clsx("size-2 shrink-0 rounded-full", PRESENCE_DOT[status])}

--- a/apps/frontend/src/ui/UserCard.tsx
+++ b/apps/frontend/src/ui/UserCard.tsx
@@ -1,14 +1,20 @@
+import { useEffect, useState } from "react";
+import { useSubscription } from "@apollo/client/react";
 import { clsx } from "clsx";
+import { ClockIcon } from "lucide-react";
 
 import { DocumentType, graphql } from "@/gql";
 
 import { type MentionUser } from "./Editor/mention";
+import { Time } from "./Time";
 import { Tooltip } from "./Tooltip";
 
 /**
  * Fields the user card needs. Colocated so any query rendering a card selects
  * them. `role` is scoped to a project via its slug/name — the embedding
- * operation must provide `$accountSlug` and `$projectName`.
+ * operation must provide `$accountSlug` and `$projectName`. `lastSeenAt` and
+ * `timezone` power the presence dot and local-time line (both null unless the
+ * viewer shares a team with the user).
  */
 export const UserCardFragment = graphql(`
   fragment UserCard_user on User {
@@ -18,17 +24,42 @@ export const UserCardFragment = graphql(`
     avatar {
       ...AccountAvatarFragment
     }
+    lastSeenAt
+    timezone
     role(accountSlug: $accountSlug, projectName: $projectName)
   }
 `);
 
+/**
+ * Pushes a fresh `lastSeenAt` whenever the user becomes active again. The
+ * returned `user` is normalized by id, so Apollo merges it into the cache and
+ * any open card recolors its dot live — no manual cache write needed.
+ */
+const UserPresenceChangedSubscription = graphql(`
+  subscription UserCard_userPresenceChanged($userId: ID!) {
+    userPresenceChanged(userId: $userId) {
+      user {
+        id
+        lastSeenAt
+        timezone
+      }
+    }
+  }
+`);
+
 export interface UserCardData {
+  /** Public account id; needed to subscribe to live presence. */
+  id?: string | null;
   name?: string | null;
   slug: string;
   imageUrl?: string | null;
   initial?: string | null;
   /** Team role (e.g. "owner"), shown as a humanized label when present. */
   role?: string | null;
+  /** ISO timestamp of last activity; null when unknown/not visible. */
+  lastSeenAt?: string | null;
+  /** IANA timezone (e.g. "Europe/Paris"); null when unknown/not visible. */
+  timezone?: string | null;
 }
 
 /** Map the `UserCard_user` fragment to the data the card renders. */
@@ -36,11 +67,14 @@ export function getUserCardData(
   user: DocumentType<typeof UserCardFragment>,
 ): UserCardData {
   return {
+    id: user.id,
     name: user.name,
     slug: user.slug,
     imageUrl: user.avatar.url,
     initial: user.avatar.initial,
     role: user.role,
+    lastSeenAt: user.lastSeenAt,
+    timezone: user.timezone,
   };
 }
 
@@ -72,6 +106,54 @@ function getRoleLabel(role: string): string {
   return ROLE_LABELS[role] ?? role.charAt(0).toUpperCase() + role.slice(1);
 }
 
+/** A user is "online" within this window of their last activity, "away" until the next. */
+const ONLINE_THRESHOLD_MS = 5 * 60 * 1000;
+const AWAY_THRESHOLD_MS = 30 * 60 * 1000;
+/** How often the dot/clock re-evaluate while the card is open. */
+const PRESENCE_TICK_MS = 30 * 1000;
+
+type PresenceStatus = "online" | "away" | "offline";
+
+function getPresenceStatus(lastSeenAt: string, nowMs: number): PresenceStatus {
+  const age = nowMs - new Date(lastSeenAt).getTime();
+  if (age < ONLINE_THRESHOLD_MS) {
+    return "online";
+  }
+  if (age < AWAY_THRESHOLD_MS) {
+    return "away";
+  }
+  return "offline";
+}
+
+const PRESENCE_DOT: Record<PresenceStatus, string> = {
+  online: "bg-success-solid",
+  away: "bg-warning-solid",
+  offline: "bg-current opacity-40",
+};
+
+/** Re-render on an interval so the dot ages and the clock ticks while open. */
+function useNow(intervalMs: number): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+  return now;
+}
+
+function formatLocalTime(timezone: string, nowMs: number): string | null {
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      timeZone: timezone,
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(new Date(nowMs));
+  } catch {
+    // Invalid/unknown timezone — hide the row rather than crash the card.
+    return null;
+  }
+}
+
 function UserCardAvatar(props: { user: UserCardData; className?: string }) {
   const { user, className } = props;
   if (user.imageUrl) {
@@ -96,28 +178,97 @@ function UserCardAvatar(props: { user: UserCardData; className?: string }) {
 }
 
 /**
- * The body of the user hover card: avatar, name, slug and (optional) role.
- * Rendered inside a {@link Tooltip} by {@link UserHoverCard}, but exported so it
- * can be embedded elsewhere if needed.
+ * The presence + local-time block shown below the divider. Renders nothing when
+ * there's no presence data (e.g. a user the viewer doesn't share a team with, or
+ * a mention card built without it).
+ */
+function UserCardPresence(props: {
+  lastSeenAt?: string | null;
+  timezone?: string | null;
+}) {
+  const { lastSeenAt, timezone } = props;
+  const now = useNow(PRESENCE_TICK_MS);
+
+  // No `lastSeenAt` means no recent activity (or presence isn't visible to the
+  // viewer) — treat the user as offline.
+  const status: PresenceStatus = lastSeenAt
+    ? getPresenceStatus(lastSeenAt, now)
+    : "offline";
+  const localTime = timezone ? formatLocalTime(timezone, now) : null;
+
+  return (
+    <div className="text-low mt-2 flex flex-col gap-1.5 border-t pt-2 text-xs">
+      <div className="flex items-center gap-2">
+        <span
+          className={clsx("size-2 shrink-0 rounded-full", PRESENCE_DOT[status])}
+        />
+        {status === "offline" ? (
+          lastSeenAt ? (
+            <span>
+              Last seen <Time date={lastSeenAt} tooltip="none" />
+            </span>
+          ) : (
+            <span>Offline</span>
+          )
+        ) : (
+          <span>{status === "online" ? "Online" : "Away"}</span>
+        )}
+      </div>
+      {localTime ? (
+        <div className="flex items-center gap-2">
+          <ClockIcon className="size-3.5 shrink-0 opacity-70" />
+          <span>{localTime} local time</span>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The body of the user hover card: avatar, name, slug, role, then a live
+ * presence dot and local time. Rendered inside a {@link Tooltip} by
+ * {@link UserHoverCard}, but exported so it can be embedded elsewhere if needed.
+ *
+ * Mounting is lazy (the tooltip renders its content on open), so the presence
+ * subscription and ticking timer only run while a card is actually shown.
  */
 function UserCard(props: { user: UserCardData }) {
   const { user } = props;
   const name = user.name || user.slug;
+
+  // Keep presence live while the card is open. Apollo merges the normalized
+  // `user` result into the cache, so the dot recolors without an explicit
+  // handler. Skipped for cards built without an id (e.g. mention resolution).
+  useSubscription(UserPresenceChangedSubscription, {
+    variables: { userId: user.id ?? "" },
+    skip: !user.id,
+  });
+
   return (
-    <div className="flex items-center gap-2">
-      <UserCardAvatar user={user} className="size-8 shrink-0" />
-      <div className="min-w-0 leading-tight">
-        <div className="text-default truncate text-sm font-medium">{name}</div>
-        <div className="text-low flex items-center gap-1 truncate text-xs">
-          <span className="truncate">{user.slug}</span>
-          {user.role ? (
-            <>
-              <span aria-hidden>·</span>
-              <span>{getRoleLabel(user.role)}</span>
-            </>
-          ) : null}
+    <div className="min-w-52">
+      <div className="flex items-center gap-3">
+        <UserCardAvatar user={user} className="size-10 shrink-0" />
+        <div className="min-w-0 leading-tight">
+          <div className="text-default truncate text-sm font-semibold">
+            {name}
+          </div>
+          <div className="text-low flex items-center gap-1 truncate text-xs">
+            <span className="truncate">{user.slug}</span>
+            {user.role ? (
+              <>
+                <span aria-hidden>·</span>
+                <span>{getRoleLabel(user.role)}</span>
+              </>
+            ) : null}
+          </div>
         </div>
       </div>
+      {user.id ? (
+        <UserCardPresence
+          lastSeenAt={user.lastSeenAt}
+          timezone={user.timezone}
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## What

Adds live **presence** (online/away/offline) and **local time** to the user hover card (`UserCard`), like the GitHub-style reference (green dot + "Online" + "11:56 AM local time").

## How it works

**Presence lives only in Redis** — no Postgres column, no periodic DB write.

- `touchPresence` ([presence.ts](apps/backend/src/auth/presence.ts)) runs on every authenticated request (from `getContext`, fire-and-forget). It writes `presence:{userId}` → `{ lastSeenAt, timezone }` with a single atomic `SET … EX … GET`: the call always slides the TTL and returns the prior value, so we detect an offline→active transition race-free in one round-trip and **publish a presence event only when the user becomes active again** (not on every request).
- `timezone` comes from the Cloudflare `cf-timezone` header (IANA tz).
- GraphQL: `User.lastSeenAt` + `User.timezone`, and a `userPresenceChanged(userId)` subscription returning the normalized `User`. **No `online` boolean** — the dot color is derived client-side from `lastSeenAt` age.
- **Privacy:** all three are gated to the user themselves or **shared-team members** (mirrors how `User.sessions` is owner-gated). Field reads batch through a `UsersShareTeam` loader; the subscription authorizes before opening the stream.

**Frontend** ([UserCard.tsx](apps/frontend/src/ui/UserCard.tsx)): redesigned card with a presence dot (green < 5 min, yellow < 30 min, grey/"Last seen …" older, grey **"Offline"** when `lastSeenAt` is null) and an `Intl`-formatted local-time line. A 30s timer ages the dot/clock; the subscription (mounted only while the card is open) recolors it live via Apollo's normalized cache.

## ⚠️ Requires the Cloudflare "Add visitor location headers" Managed Transform

This is also why `city`/`region` were empty before — Cloudflare only sends `cf-ipcountry` by default. The transform has been **enabled**, so `cf-ipcity`/`cf-region`/`cf-timezone` now reach the origin. Without it, the local-time row simply hides (absent locally too).

## Testing

- New `presence.e2e.test.ts` (5 tests): stores presence, publishes on first activity, no republish while active, republishes after the active window, TTL refresh, batched reads. ✅
- Full backend suite (455 tests) ✅, backend + frontend typecheck ✅, prettier ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)