### PR TITLE
fix: show a file icon for non-image comment snapshots

### DIFF
--- a/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
+import { ComponentProps, useState } from "react";
 import { useMutation } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { clsx } from "clsx";
-import { EyeOffIcon, ImageIcon } from "lucide-react";
+import { EyeOffIcon } from "lucide-react";
 import { Button } from "react-aria-components";
 import { toast } from "sonner";
 
@@ -10,12 +10,12 @@ import { DocumentType, graphql } from "@/gql";
 import { useProjectParams } from "@/pages/Project/ProjectParams";
 import { type EditorValue } from "@/ui/Editor/Editor";
 import { StandaloneEditor } from "@/ui/Editor/StandaloneEditor";
-import { ImageKitPicture } from "@/ui/ImageKitPicture";
 import { Tooltip } from "@/ui/Tooltip";
 import { getErrorMessage } from "@/util/error";
 
 import { useBuildDiffState } from "../BuildDiffState";
 import { useMentionableUsers } from "./MentionableUsersContext";
+import { ScreenshotDiffThumbnail } from "./ScreenshotDiffThumbnail";
 
 const _BuildFragment = graphql(`
   fragment AddCommentForm_Build on Build {
@@ -47,11 +47,13 @@ const AddBuildCommentMutation = graphql(`
  */
 function AttachedSnapshotToggle(props: {
   name: string;
-  thumbnailUrl: string | null;
+  screenshotDiff: ComponentProps<
+    typeof ScreenshotDiffThumbnail
+  >["screenshotDiff"];
   attached: boolean;
   onToggle: () => void;
 }) {
-  const { name, thumbnailUrl, attached, onToggle } = props;
+  const { name, screenshotDiff, attached, onToggle } = props;
   return (
     <Tooltip
       content={
@@ -65,24 +67,20 @@ function AttachedSnapshotToggle(props: {
         aria-pressed={attached}
         aria-label={`${attached ? "Detach" : "Attach"} snapshot ${name}`}
         className={clsx(
-          "border-thin hover:bg-hover rac-focus flex min-w-0 items-center gap-1.5 rounded-md py-0.5 pr-2 pl-0.5 text-xs transition",
+          "border-thin hover:bg-hover rac-focus flex min-w-0 items-center gap-1.5 rounded-md py-0.5 pr-2 pl-1 text-xs transition",
           attached ? "text-default" : "text-low opacity-60",
         )}
       >
         <span className="flex size-4 shrink-0 items-center justify-center">
-          {!attached ? (
-            <EyeOffIcon className="text-low size-3" />
-          ) : thumbnailUrl ? (
-            <span className="block size-4 overflow-hidden rounded-sm border bg-white">
-              <ImageKitPicture
-                src={thumbnailUrl}
-                transformations={["w-32", "h-32", "c-at_max"]}
-                className="size-full object-cover"
-                alt=""
-              />
-            </span>
+          {attached ? (
+            <ScreenshotDiffThumbnail
+              screenshotDiff={screenshotDiff}
+              className="size-4"
+              iconClassName="size-3.5"
+              fit="cover"
+            />
           ) : (
-            <ImageIcon className="size-4" />
+            <EyeOffIcon className="text-low size-3.5" />
           )}
         </span>
         <span className="min-w-0 truncate font-medium">{name}</span>
@@ -125,10 +123,6 @@ export function AddCommentForm(props: {
       throw error;
     }
   };
-  const thumbnailUrl =
-    activeDiff?.compareScreenshot?.url ??
-    activeDiff?.baseScreenshot?.url ??
-    null;
   return (
     <StandaloneEditor
       onSubmit={handleSubmit}
@@ -145,7 +139,7 @@ export function AddCommentForm(props: {
         activeDiff ? (
           <AttachedSnapshotToggle
             name={activeDiff.name}
-            thumbnailUrl={thumbnailUrl}
+            screenshotDiff={activeDiff}
             attached={attachedDiff != null}
             onToggle={() => setDetached((value) => !value)}
           />

--- a/apps/frontend/src/pages/Build/sidebar/CommentScreenshotReference.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentScreenshotReference.tsx
@@ -1,24 +1,17 @@
-import { ImageIcon, MapPinIcon } from "lucide-react";
+import { MapPinIcon } from "lucide-react";
 import { Button } from "react-aria-components";
 
 import { DocumentType, graphql } from "@/gql";
-import { ImageKitPicture } from "@/ui/ImageKitPicture";
 import { Tooltip } from "@/ui/Tooltip";
 
 import { useBuildDiffState } from "../BuildDiffState";
+import { ScreenshotDiffThumbnail } from "./ScreenshotDiffThumbnail";
 
 const _ScreenshotDiffFragment = graphql(`
   fragment CommentScreenshotReference_ScreenshotDiff on ScreenshotDiff {
     id
     name
-    compareScreenshot {
-      id
-      url
-    }
-    baseScreenshot {
-      id
-      url
-    }
+    ...ScreenshotDiffThumbnail_ScreenshotDiff
   }
 `);
 
@@ -60,10 +53,6 @@ export function CommentScreenshotReference(props: {
 }) {
   const { screenshotDiff, anchor } = props;
   const { allDiffs, setActiveDiff } = useBuildDiffState();
-  const thumbnailUrl =
-    screenshotDiff.compareScreenshot?.url ??
-    screenshotDiff.baseScreenshot?.url ??
-    null;
   const linesLabel = getAnchorLabel(anchor);
   const isPoint = anchor?.__typename === "CommentPointAnchor";
 
@@ -85,18 +74,11 @@ export function CommentScreenshotReference(props: {
         aria-label={`Go to snapshot ${screenshotDiff.name}`}
         className="text-low hover:bg-hover hover:text-default rac-focus flex w-full items-center gap-2 rounded-t-md px-2 py-1.5 text-left text-xs transition select-none"
       >
-        {thumbnailUrl ? (
-          <span className="block size-6 shrink-0 overflow-hidden rounded-sm border bg-white">
-            <ImageKitPicture
-              src={thumbnailUrl}
-              transformations={["w-32", "h-32", "c-at_max"]}
-              className="size-full object-contain"
-              alt=""
-            />
-          </span>
-        ) : (
-          <ImageIcon className="size-4 shrink-0" />
-        )}
+        <ScreenshotDiffThumbnail
+          screenshotDiff={screenshotDiff}
+          className="size-6"
+          iconClassName="size-4"
+        />
         <span className="min-w-0 flex-1 truncate font-medium">
           {screenshotDiff.name}
         </span>

--- a/apps/frontend/src/pages/Build/sidebar/ScreenshotDiffThumbnail.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ScreenshotDiffThumbnail.tsx
@@ -1,0 +1,73 @@
+import { clsx } from "clsx";
+import { FileIcon, ImageIcon } from "lucide-react";
+
+import { DocumentType, graphql } from "@/gql";
+import { ImageKitPicture } from "@/ui/ImageKitPicture";
+import { checkIsImageContentType } from "@/util/content-type";
+
+const _ScreenshotDiffFragment = graphql(`
+  fragment ScreenshotDiffThumbnail_ScreenshotDiff on ScreenshotDiff {
+    compareScreenshot {
+      id
+      url
+      contentType
+    }
+    baseScreenshot {
+      id
+      url
+      contentType
+    }
+  }
+`);
+
+/**
+ * A small preview of a screenshot diff: the image itself when the snapshot is
+ * an image, or a file icon otherwise (e.g. a Markdown or other non-image file
+ * uploaded as a snapshot, which would not render as a picture).
+ */
+export function ScreenshotDiffThumbnail(props: {
+  screenshotDiff: DocumentType<typeof _ScreenshotDiffFragment>;
+  /** Size class for the thumbnail box. */
+  className?: string;
+  /** Size class for the fallback icon; defaults to `className`. */
+  iconClassName?: string;
+  /** How the image fills the box. */
+  fit?: "contain" | "cover";
+}) {
+  const {
+    screenshotDiff,
+    className,
+    iconClassName = className,
+    fit = "contain",
+  } = props;
+  const screenshot =
+    screenshotDiff.compareScreenshot ?? screenshotDiff.baseScreenshot ?? null;
+  const thumbnailUrl = screenshot?.url ?? null;
+  const isImage = screenshot
+    ? checkIsImageContentType(screenshot.contentType)
+    : false;
+
+  if (isImage && thumbnailUrl) {
+    return (
+      <span
+        className={clsx(
+          "block shrink-0 overflow-hidden rounded-sm border bg-white",
+          className,
+        )}
+      >
+        <ImageKitPicture
+          src={thumbnailUrl}
+          transformations={["w-32", "h-32", "c-at_max"]}
+          className={clsx(
+            "size-full",
+            fit === "cover" ? "object-cover" : "object-contain",
+          )}
+          alt=""
+        />
+      </span>
+    );
+  }
+
+  const Icon = isImage ? ImageIcon : FileIcon;
+  return <Icon className={clsx("text-low shrink-0", iconClassName)} />;
+}


### PR DESCRIPTION
## Problem

When a comment is anchored to a non-image snapshot (e.g. a Markdown file like `docs/README.md`), the small thumbnail tried to render the file as an `<img>` and showed a broken/empty picture.

## Fix

Detect the snapshot's `contentType` and render a file icon instead of a picture when it's not an image.

The shared thumbnail logic is now isolated in a reusable `ScreenshotDiffThumbnail` component with its own colocated fragment, used by both:
- `CommentScreenshotReference` (the snapshot quote at the top of a comment thread)
- `AddCommentForm`'s attached-snapshot toggle (next to the send button)

## Notes

- Uses a generic `FileIcon` for any non-image type (not Markdown-specific), since a snapshot can be any non-image file.
- `fragmentMasking` is off, so the fragment composes structurally — `activeDiff` already carries `contentType`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)