### PR TITLE
feat: add comments on a specific point of a screenshot

### DIFF
--- a/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
@@ -30,6 +30,7 @@ import { toast } from "sonner";
 import { DocumentType, graphql } from "@/gql";
 import { BuildType, ScreenshotDiffStatus } from "@/gql/graphql";
 import { BuildDialogs } from "@/pages/Build/BuildDialogs";
+import { ScreenshotCommentLayer } from "@/pages/Build/screenshotComments/ScreenshotCommentLayer";
 import { Code } from "@/ui/Code";
 import { IconButton } from "@/ui/IconButton";
 import { ImageKitPicture, imgkit } from "@/ui/ImageKitPicture";
@@ -91,6 +92,7 @@ const _BuildFragment = graphql(`
       merged
     }
     ...BuildDialogs_Build
+    ...ScreenshotCommentLayer_Build
   }
 `);
 
@@ -812,9 +814,10 @@ function DownloadCompareScreenshotButton({
 
 function CompareScreenshot(props: {
   diff: BuildDiffDetailDocument;
-  buildId: string;
+  build: BuildFragmentDocument;
 }) {
-  const { diff, buildId } = props;
+  const { diff, build } = props;
+  const buildId = build.id;
   const visible = useAtomValue(overlayVisibleAtom);
   const contained = useAtomValue(buildDiffFitContainedAtom);
   switch (diff.status) {
@@ -828,6 +831,18 @@ function CompareScreenshot(props: {
             dimensions={dimensions}
             controls={
               <DownloadCompareScreenshotButton diff={diff} buildId={buildId} />
+            }
+            overlay={
+              dimensions
+                ? (paneSize) => (
+                    <ScreenshotCommentLayer
+                      build={build}
+                      screenshotDiffId={diff.id}
+                      imgSize={dimensions}
+                      paneSize={paneSize}
+                    />
+                  )
+                : undefined
             }
           >
             <ScreenshotContainer dimensions={dimensions} contained={contained}>
@@ -935,7 +950,7 @@ function CompareScreenshot(props: {
       return (
         <CompareScreenshotChanged
           diff={diff}
-          buildId={buildId}
+          build={build}
           contained={contained}
           diffVisible={visible}
         />
@@ -950,11 +965,12 @@ function CompareScreenshot(props: {
 
 function CompareScreenshotChanged(props: {
   diff: BuildDiffDetailDocument;
-  buildId: string;
+  build: BuildFragmentDocument;
   diffVisible: boolean;
   contained: boolean;
 }) {
-  const { diff, buildId, diffVisible, contained } = props;
+  const { diff, build, diffVisible, contained } = props;
+  const buildId = build.id;
   const { url } = diff;
   const dimensions = useMemo(() => extractDimensions(diff), [diff]);
   invariant(url);
@@ -979,6 +995,18 @@ function CompareScreenshotChanged(props: {
           dimensions={dimensions}
           controls={
             <DownloadCompareScreenshotButton diff={diff} buildId={buildId} />
+          }
+          overlay={
+            dimensions
+              ? (paneSize) => (
+                  <ScreenshotCommentLayer
+                    build={build}
+                    screenshotDiffId={diff.id}
+                    imgSize={dimensions}
+                    paneSize={paneSize}
+                  />
+                )
+              : undefined
           }
         >
           <ScreenshotContainer dimensions={dimensions} contained={contained}>
@@ -1357,7 +1385,7 @@ const BuildScreenshots = memo(
           />
           <div className="relative flex min-h-0 flex-1 justify-center">
             <ScaleProvider>
-              <CompareScreenshot diff={diff} buildId={build.id} />
+              <CompareScreenshot diff={diff} build={build} />
             </ScaleProvider>
           </div>
         </div>

--- a/apps/frontend/src/containers/Build/BuildDiffDetailToolbar.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetailToolbar.tsx
@@ -1,11 +1,16 @@
+import { use } from "react";
 import { invariant } from "@argos/util/invariant";
 
-import { ScreenshotDiffStatus } from "@/gql/graphql";
+import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
+import { ProjectPermission, ScreenshotDiffStatus } from "@/gql/graphql";
 import { useProjectParams } from "@/pages/Project/ProjectParams";
 import { ButtonGroup } from "@/ui/ButtonGroup";
 import { Separator } from "@/ui/Separator";
+import { checkIsImageContentType } from "@/util/content-type";
 
 import type { BuildDiffDetailDocument } from "./BuildDiffDetail";
+import { CommentsVisibilityToggle } from "./toolbar/CommentsVisibilityToggle";
+import { CommentToolToggle } from "./toolbar/CommentToolToggle";
 import { FitToggle } from "./toolbar/FitToggle";
 import { HighlightButton } from "./toolbar/HighlightButton";
 import {
@@ -22,6 +27,19 @@ interface BuildDiffDetailToolbarProps {
   children?: React.ReactNode;
 }
 
+/** Whether point comments can be placed on this diff's changes image. */
+function checkCanCommentOnDiff(diff: BuildDiffDetailDocument): boolean {
+  switch (diff.status) {
+    case ScreenshotDiffStatus.Changed:
+    case ScreenshotDiffStatus.Ignored:
+      return checkIsImageContentType(diff.contentType ?? "");
+    case ScreenshotDiffStatus.Added:
+      return checkIsImageContentType(diff.compareScreenshot?.contentType ?? "");
+    default:
+      return false;
+  }
+}
+
 export function BuildDiffDetailToolbar(props: BuildDiffDetailToolbarProps) {
   const { diff, children, fitControls } = props;
   const shouldShowToolbarControls =
@@ -30,6 +48,10 @@ export function BuildDiffDetailToolbar(props: BuildDiffDetailToolbarProps) {
 
   const params = useProjectParams();
   invariant(params, "can't be used outside of a project route");
+
+  const permissions = use(ProjectPermissionsContext);
+  const canComment = permissions?.includes(ProjectPermission.Review) ?? false;
+  const showCommentTools = canComment && checkCanCommentOnDiff(diff);
 
   return (
     <div className="flex shrink-0 items-center gap-1.5">
@@ -47,6 +69,13 @@ export function BuildDiffDetailToolbar(props: BuildDiffDetailToolbarProps) {
             <GoToNextChangesButton />
           </ButtonGroup>
           <SettingsButton />
+        </>
+      )}
+      {showCommentTools && (
+        <>
+          <Separator orientation="vertical" className="mx-1 h-6" />
+          <CommentToolToggle />
+          <CommentsVisibilityToggle />
         </>
       )}
       <div className="group contents">

--- a/apps/frontend/src/containers/Build/BuildHotkeys.tsx
+++ b/apps/frontend/src/containers/Build/BuildHotkeys.tsx
@@ -203,6 +203,12 @@ const hotkeyGroups = [
         description: "Switch between screenshot and aria view",
         envs: ["build"],
       },
+      toggleCommentTool: {
+        keys: ["KeyC"],
+        displayKeys: ["C"],
+        description: "Toggle comment tool",
+        envs: ["build"],
+      },
       showDetails: {
         keys: ["["],
         displayKeys: ["["],

--- a/apps/frontend/src/containers/Build/CommentTool.ts
+++ b/apps/frontend/src/containers/Build/CommentTool.ts
@@ -1,0 +1,50 @@
+import { useCallback } from "react";
+import { atom, useAtom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+
+export type CommentToolMode = "hand" | "comment";
+
+/**
+ * The active viewer tool. `hand` pans/zooms (the default behavior); `comment`
+ * lets the user click a point on the changes image to leave a comment. Kept in
+ * memory (not persisted) so it resets to `hand` on reload.
+ */
+export const commentToolModeAtom = atom<CommentToolMode>("hand");
+
+/**
+ * Whether on-screenshot comments (pins and their threads) are shown. Persisted
+ * like the other viewer preferences (see `overlayVisibleAtom`).
+ */
+export const commentsVisibleAtom = atomWithStorage<boolean>(
+  "preferences.comments.visible",
+  true,
+);
+
+/**
+ * Comment-tool state with its cross-field invariants in one place: picking the
+ * Comment tool always reveals comments, and hiding comments always drops back to
+ * the Hand tool — you can't place a comment you can't see.
+ */
+export function useCommentTool() {
+  const [mode, setMode] = useAtom(commentToolModeAtom);
+  const [visible, setVisible] = useAtom(commentsVisibleAtom);
+
+  const activateHand = useCallback(() => setMode("hand"), [setMode]);
+
+  const activateComment = useCallback(() => {
+    setMode("comment");
+    setVisible(true);
+  }, [setMode, setVisible]);
+
+  const setCommentsVisible = useCallback(
+    (next: boolean) => {
+      setVisible(next);
+      if (!next) {
+        setMode("hand");
+      }
+    },
+    [setVisible, setMode],
+  );
+
+  return { mode, visible, activateHand, activateComment, setCommentsVisible };
+}

--- a/apps/frontend/src/containers/Build/Zoomer.tsx
+++ b/apps/frontend/src/containers/Build/Zoomer.tsx
@@ -22,9 +22,13 @@ import { useObjectRef } from "react-aria";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 import { IconButton } from "@/ui/IconButton";
 import { Tooltip } from "@/ui/Tooltip";
+import { useResizeObserver } from "@/ui/useResizeObserver";
 
 import { useBuildHotkey } from "./BuildHotkeys";
 import { useScaleContext } from "./ScaleContext";
+
+/** The content-box size of a {@link ZoomPane}, used to position overlays. */
+export type PaneSize = { width: number; height: number };
 
 type ZoomPaneEvent = {
   state: Transform;
@@ -43,6 +47,14 @@ const isWrappedWithClass = (event: any, className: string | undefined) =>
 
 const ZOOMER_CONTROLS_CLASS = "zoomer-controls";
 
+/**
+ * Elements drawn over the image that handle their own pointer and wheel events
+ * (comment pins, the comment prompt and threads). Marking them with this class
+ * stops d3 from starting a pan/zoom from them, so a drag selects text and a
+ * scroll scrolls the popover instead of moving the image.
+ */
+export const ZOOMER_OVERLAY_INTERACTIVE_CLASS = "zoomer-overlay-interactive";
+
 class Zoomer {
   zoom: ZoomBehavior<Element, unknown>;
   selection: Selection<Element, unknown, null, undefined>;
@@ -59,7 +71,10 @@ class Zoomer {
     this.zoom = zoom()
       .scaleExtent([scales.minScale, scales.maxScale])
       .filter((event: any) => {
-        if (isWrappedWithClass(event, ZOOMER_CONTROLS_CLASS)) {
+        if (
+          isWrappedWithClass(event, ZOOMER_CONTROLS_CLASS) ||
+          isWrappedWithClass(event, ZOOMER_OVERLAY_INTERACTIVE_CLASS)
+        ) {
           return false;
         }
 
@@ -85,6 +100,10 @@ class Zoomer {
     this.selection.on(
       "wheel.zoom",
       (event: any) => {
+        // Let interactive overlays (comment prompt/threads) scroll themselves.
+        if (isWrappedWithClass(event, ZOOMER_OVERLAY_INTERACTIVE_CLASS)) {
+          return;
+        }
         event.preventDefault();
         event.stopImmediatePropagation();
 
@@ -393,13 +412,32 @@ export function ZoomPane(props: {
   children: React.ReactNode;
   dimensions: { width: number; height: number } | undefined;
   controls?: React.ReactNode;
+  /**
+   * Content drawn on top of the (transformed) image but outside its transform,
+   * so it can position elements at fixed screen size against the live pane size.
+   * Receives the pane's content-box size (null until first measured). The
+   * wrapper is `pointer-events-none`; opt individual children back in. Events on
+   * those children still bubble to the pane, so pan/zoom keep working.
+   */
+  overlay?: (paneSize: PaneSize | null) => React.ReactNode;
   ref?: React.Ref<HTMLDivElement>;
 }) {
-  const { dimensions, children, controls, ref } = props;
+  const { dimensions, children, controls, overlay, ref } = props;
   const paneRef = useObjectRef(ref);
   const { register, getInitialTransform } = useZoomerSyncContext();
   const [imgScale] = useScaleContext();
   const [transform, setTransform] = useState<Transform>(identityTransform);
+  const [paneSize, setPaneSize] = useState<PaneSize | null>(null);
+  // Forwards the node to `paneRef` (for d3) while also observing its size so
+  // overlays can map image coordinates onto the current pane.
+  const setPaneNode = useResizeObserver((entry) => {
+    startTransition(() => {
+      setPaneSize({
+        width: entry.contentRect.width,
+        height: entry.contentRect.height,
+      });
+    });
+  }, paneRef);
   const [scales, setScales] = useState<{ minScale: number; maxScale: number }>({
     minScale: MIN_ZOOM_SCALE,
     maxScale: MAX_ZOOM_SCALE,
@@ -436,8 +474,8 @@ export function ZoomPane(props: {
 
   return (
     <div
-      ref={paneRef}
-      className="group/pane bg-app border-thin flex min-h-0 flex-1 cursor-grab overflow-hidden rounded-md shadow-xs select-none"
+      ref={setPaneNode}
+      className="group/pane bg-app border-thin relative flex min-h-0 flex-1 cursor-grab overflow-hidden rounded-md shadow-xs select-none"
     >
       <div
         className="flex min-h-0 min-w-0 flex-1 origin-top-left justify-center"
@@ -445,6 +483,11 @@ export function ZoomPane(props: {
       >
         {children}
       </div>
+      {overlay && (
+        <div className="pointer-events-none absolute inset-0">
+          {overlay(paneSize)}
+        </div>
+      )}
       {controls && (
         <div className="opacity-0 transition group-focus-within/pane:opacity-100 group-hover/pane:opacity-100 group-has-[button[aria-expanded=true]]/pane:opacity-100">
           <div

--- a/apps/frontend/src/containers/Build/toolbar/CommentToolToggle.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/CommentToolToggle.tsx
@@ -1,0 +1,51 @@
+import { memo } from "react";
+import { HandIcon, MessageSquarePlusIcon } from "lucide-react";
+
+import { ButtonGroup } from "@/ui/ButtonGroup";
+import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
+import { IconButton } from "@/ui/IconButton";
+import { Tooltip } from "@/ui/Tooltip";
+
+import { useBuildHotkey } from "../BuildHotkeys";
+import { useCommentTool } from "../CommentTool";
+
+/**
+ * Switches between the Hand tool (pan/zoom) and the Comment tool (click the
+ * changes image to leave a comment). Mirrors `ViewToggle`'s button group.
+ */
+export const CommentToolToggle = memo(() => {
+  const { mode, activateHand, activateComment } = useCommentTool();
+  const hotkey = useBuildHotkey(
+    "toggleCommentTool",
+    () => (mode === "comment" ? activateHand() : activateComment()),
+    { preventDefault: true },
+  );
+  return (
+    <ButtonGroup>
+      <Tooltip content="Move tool — drag to pan, scroll to zoom">
+        <IconButton
+          variant="contained"
+          aria-pressed={mode === "hand"}
+          aria-label="Move tool"
+          onPress={activateHand}
+        >
+          <HandIcon />
+        </IconButton>
+      </Tooltip>
+      <HotkeyTooltip
+        description="Comment tool — click the image to comment"
+        keys={hotkey.displayKeys}
+        keysEnabled={mode !== "comment"}
+      >
+        <IconButton
+          variant="contained"
+          aria-pressed={mode === "comment"}
+          aria-label="Comment tool"
+          onPress={activateComment}
+        >
+          <MessageSquarePlusIcon />
+        </IconButton>
+      </HotkeyTooltip>
+    </ButtonGroup>
+  );
+});

--- a/apps/frontend/src/containers/Build/toolbar/CommentsVisibilityToggle.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/CommentsVisibilityToggle.tsx
@@ -1,0 +1,24 @@
+import { memo } from "react";
+import { MessageSquareIcon, MessageSquareOffIcon } from "lucide-react";
+
+import { IconButton } from "@/ui/IconButton";
+import { Tooltip } from "@/ui/Tooltip";
+
+import { useCommentTool } from "../CommentTool";
+
+/** Shows or hides the comments drawn on the changes image. */
+export const CommentsVisibilityToggle = memo(() => {
+  const { visible, setCommentsVisible } = useCommentTool();
+  const label = visible ? "Hide comments" : "Show comments";
+  return (
+    <Tooltip content={label}>
+      <IconButton
+        aria-pressed={visible}
+        aria-label={label}
+        onPress={() => setCommentsVisible(!visible)}
+      >
+        {visible ? <MessageSquareIcon /> : <MessageSquareOffIcon />}
+      </IconButton>
+    </Tooltip>
+  );
+});

--- a/apps/frontend/src/pages/Build/screenshotComments/CommentDraftPopover.tsx
+++ b/apps/frontend/src/pages/Build/screenshotComments/CommentDraftPopover.tsx
@@ -1,0 +1,106 @@
+import { useId, useState } from "react";
+import { ArrowUpIcon } from "lucide-react";
+import { toast } from "sonner";
+
+import { Editor, type EditorValue } from "@/ui/Editor/Editor";
+import { MOD } from "@/ui/Editor/EditorToolbar.shortcuts";
+import { hasEditorContent } from "@/ui/Editor/util";
+import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
+import { IconButton } from "@/ui/IconButton";
+
+import { useMentionableUsers } from "../sidebar/MentionableUsersContext";
+import { CommentPopoverFrame } from "./CommentPopoverFrame";
+import type { ScreenPoint } from "./geometry";
+
+/**
+ * The compact floating "Add a comment" prompt shown to the right of the pin
+ * after clicking a point on the changes image with the comment tool. A
+ * single-line pill (input + send) that grows with the content; the author's
+ * avatar lives on the pin, so it's not repeated here. Submitting anchors the
+ * comment to the point; the content is kept if the request fails.
+ */
+export function CommentDraftPopover(props: {
+  point: ScreenPoint;
+  onSubmit: (body: EditorValue) => Promise<void>;
+}) {
+  const { point, onSubmit } = props;
+  const mentions = useMentionableUsers();
+  const [value, setValue] = useState<EditorValue>(null);
+  // Remounts the editor to clear it after a successful submit.
+  const [editorKey, setEditorKey] = useState(0);
+  const [isPending, setIsPending] = useState(false);
+  const emptyToastId = useId();
+  const isEmpty = !hasEditorContent(value);
+
+  const submit = () => {
+    if (isPending) {
+      return;
+    }
+    if (isEmpty) {
+      toast.warning("Comment required", {
+        id: emptyToastId,
+        description: "Please add a comment before submitting.",
+      });
+      return;
+    }
+    setIsPending(true);
+    onSubmit(value)
+      .then(() => {
+        setValue(null);
+        setEditorKey((key) => key + 1);
+      })
+      .catch(() => {
+        // Keep the content so the user can retry.
+      })
+      .finally(() => {
+        setIsPending(false);
+      });
+  };
+
+  return (
+    <CommentPopoverFrame
+      point={point}
+      // Anchor at the pin's vertical center (the 36px pin's center is 18px above
+      // the point) and offset right of it; the pill pulls itself up by half its
+      // height to stay centered on the pin regardless of how tall it grows.
+      offset={{ x: 42, y: -18 }}
+      role="dialog"
+      aria-label="Add a comment"
+      className="w-80"
+    >
+      <div className="bg-app border-thin flex -translate-y-1/2 items-end gap-2 rounded-2xl p-1.5 shadow-xl">
+        <Editor
+          key={editorKey}
+          onChange={setValue}
+          onSubmit={submit}
+          mentions={mentions}
+          placeholder="Add a comment"
+          disabled={isPending}
+          autoFocus
+          aria-label="Add a comment"
+          variant="plain"
+          className="min-w-0 flex-1 px-1.5 text-sm"
+          contentClassName="max-h-32 min-h-6 overflow-y-auto py-0.5"
+        />
+        <HotkeyTooltip
+          description="Submit the comment"
+          keys={[MOD, "Enter"]}
+          placement="top"
+        >
+          <IconButton
+            variant="contained"
+            size="small"
+            rounded
+            aria-label="Submit the comment"
+            aria-disabled={isEmpty}
+            isDisabled={isPending}
+            onPress={submit}
+            className="shrink-0"
+          >
+            <ArrowUpIcon />
+          </IconButton>
+        </HotkeyTooltip>
+      </div>
+    </CommentPopoverFrame>
+  );
+}

--- a/apps/frontend/src/pages/Build/screenshotComments/CommentMarker.tsx
+++ b/apps/frontend/src/pages/Build/screenshotComments/CommentMarker.tsx
@@ -1,0 +1,135 @@
+import { useState } from "react";
+import { clsx } from "clsx";
+import { MessageSquareIcon } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import { createPortal } from "react-dom";
+
+import { AccountAvatar } from "@/containers/AccountAvatar";
+import { ZOOMER_OVERLAY_INTERACTIVE_CLASS } from "@/containers/Build/Zoomer";
+import { ReadOnlyEditor } from "@/ui/Editor/ReadOnlyEditor";
+import { Time } from "@/ui/Time";
+import { getMentionUser } from "@/ui/UserCard";
+
+import { CommentCard } from "../sidebar/CommentCard";
+import type { ScreenPoint } from "./geometry";
+
+type CommentCardProps = React.ComponentProps<typeof CommentCard>;
+type Comment = CommentCardProps["comment"];
+
+/** Pin badge size: a size-7 (28px) avatar with 4px (`p-1`) padding all around. */
+const PIN_SIZE = 36;
+/** Width of the expanded preview card (`w-72`). */
+const PREVIEW_WIDTH = 288;
+const TRANSITION = { duration: 0.18, ease: [0.4, 0, 0.2, 1] } as const;
+
+/**
+ * A comment anchored on the changes image, drawn as a pin whose bottom-left tip
+ * sits on the anchor point. On hover it expands in place — extending up and to
+ * the right — into a preview: the avatar rises to the top, the author/time slide
+ * in beside it and the comment appears below. Clicking opens the full thread,
+ * shown as a separate popover beside the pin (see {@link CommentThreadPopover}),
+ * so while open the pin stays put as a selected marker.
+ */
+export function CommentMarker(props: {
+  /** Anchor point (the pin's bottom-left tip) in viewport coordinates. */
+  point: ScreenPoint;
+  comment: Comment;
+  open: boolean;
+  onOpen: () => void;
+}) {
+  const { point, comment, open, onOpen } = props;
+  const [hovered, setHovered] = useState(false);
+  const mentionedUsers = comment.mentionedUsers.map(getMentionUser);
+  const name = comment.user?.name || comment.user?.slug || "Unknown user";
+  // The preview only shows on hover while the thread popover is closed; once
+  // open the pin is just a selected marker beside the popover.
+  const expanded = hovered && !open;
+
+  return createPortal(
+    <div
+      className={clsx(
+        ZOOMER_OVERLAY_INTERACTIVE_CLASS,
+        "pointer-events-none fixed",
+        expanded || open ? "z-50" : "z-40",
+      )}
+      // Pin the bottom-left tip at the point: `translateY(-100%)` keeps the
+      // bottom edge on the point as the card grows, so it extends upward; the
+      // left edge stays put, so it also extends to the right.
+      style={{
+        left: point.left,
+        top: point.top,
+        transform: "translateY(-100%)",
+      }}
+    >
+      <motion.div
+        role="button"
+        tabIndex={0}
+        aria-label={`Open comment from ${name}`}
+        onHoverStart={() => setHovered(true)}
+        onHoverEnd={() => setHovered(false)}
+        onClick={onOpen}
+        onKeyDown={(event: React.KeyboardEvent) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            onOpen();
+          }
+        }}
+        initial={{ width: PIN_SIZE }}
+        animate={{ width: expanded ? PREVIEW_WIDTH : PIN_SIZE }}
+        transition={TRANSITION}
+        className={clsx(
+          "bg-app rounded-chip pointer-events-auto cursor-pointer overflow-hidden rounded-bl-none shadow-md outline-none",
+          open ? "ring-primary ring-2" : "border-thin",
+        )}
+      >
+        {/* Top row, laid out at the full preview width so the avatar stays put
+            while the author/time are revealed as the card widens. */}
+        <div className="flex w-72 items-center">
+          <div className="shrink-0 p-1">
+            {comment.user ? (
+              <AccountAvatar
+                avatar={comment.user.avatar}
+                className="size-7 rounded-full"
+              />
+            ) : (
+              <div className="bg-ui text-low flex size-7 items-center justify-center rounded-full">
+                <MessageSquareIcon className="size-4" />
+              </div>
+            )}
+          </div>
+          <div className="flex min-w-0 items-baseline gap-1.5 pr-3 pl-1">
+            <span className="text-default min-w-0 truncate text-xs font-medium">
+              {name}
+            </span>
+            <Time
+              date={comment.date}
+              tooltip="none"
+              className="text-low text-xxs shrink-0"
+            />
+          </div>
+        </div>
+        {/* The comment grows the card upward (the bottom stays pinned). */}
+        <AnimatePresence initial={false}>
+          {expanded ? (
+            <motion.div
+              key="preview-body"
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: "auto", opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={TRANSITION}
+              className="w-72 overflow-hidden"
+            >
+              <div className="text-default line-clamp-4 px-2 pb-2 text-sm">
+                <ReadOnlyEditor
+                  content={comment.content}
+                  mentionedUsers={mentionedUsers}
+                />
+              </div>
+            </motion.div>
+          ) : null}
+        </AnimatePresence>
+      </motion.div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/frontend/src/pages/Build/screenshotComments/CommentPin.tsx
+++ b/apps/frontend/src/pages/Build/screenshotComments/CommentPin.tsx
@@ -1,0 +1,39 @@
+import { MessageSquareIcon } from "lucide-react";
+
+import { AccountAvatar } from "@/containers/AccountAvatar";
+import { ZOOMER_OVERLAY_INTERACTIVE_CLASS } from "@/containers/Build/Zoomer";
+
+import type { ScreenPoint } from "./geometry";
+
+type Avatar = React.ComponentProps<typeof AccountAvatar>["avatar"];
+
+/**
+ * A static indicator for the comment being drafted, drawn at the click point
+ * with the current user's avatar. It mirrors a {@link CommentMarker}'s collapsed
+ * (pin) look so the spot reads as "your comment will go here".
+ */
+export function CommentPin(props: {
+  point: ScreenPoint;
+  avatar: Avatar | null;
+}) {
+  const { point, avatar } = props;
+  return (
+    <div
+      aria-hidden
+      // Anchor the pin's bottom-left tip at the point, matching CommentMarker so
+      // a draft pin doesn't jump when it becomes a real comment.
+      style={{
+        left: point.left,
+        top: point.top,
+        transform: "translateY(-100%)",
+      }}
+      className={`${ZOOMER_OVERLAY_INTERACTIVE_CLASS} bg-app border-primary rounded-chip pointer-events-none absolute z-10 flex size-9 items-center justify-center rounded-bl-none border shadow-md`}
+    >
+      {avatar ? (
+        <AccountAvatar avatar={avatar} className="size-7 rounded-full" />
+      ) : (
+        <MessageSquareIcon className="text-low size-4" />
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/Build/screenshotComments/CommentPopoverFrame.tsx
+++ b/apps/frontend/src/pages/Build/screenshotComments/CommentPopoverFrame.tsx
@@ -1,0 +1,46 @@
+import { clsx } from "clsx";
+import { createPortal } from "react-dom";
+
+import { ZOOMER_OVERLAY_INTERACTIVE_CLASS } from "@/containers/Build/Zoomer";
+
+import type { ScreenPoint } from "./geometry";
+
+/**
+ * Positioning shell for a comment prompt, thread or preview. Rendered in a
+ * portal with `position: fixed` so it escapes the zoom pane's `overflow-hidden`
+ * clipping, anchored at its point (given in viewport coordinates) plus a
+ * per-popover pixel `offset`. Visual chrome is left to the children. Marked
+ * interactive so the outside-click logic and build hotkeys treat it as part of
+ * the overlay.
+ */
+export function CommentPopoverFrame(props: {
+  /** Anchor point in viewport coordinates. */
+  point: ScreenPoint;
+  /** Pixel offset from the anchor point. */
+  offset?: { x: number; y: number };
+  className?: string;
+  role?: string;
+  "aria-label"?: string;
+  children: React.ReactNode;
+}) {
+  const { point, offset = { x: 12, y: 8 }, className, role } = props;
+  return createPortal(
+    <div
+      role={role}
+      aria-label={props["aria-label"]}
+      style={{
+        left: point.left,
+        top: point.top,
+        transform: `translate(${offset.x}px, ${offset.y}px)`,
+      }}
+      className={clsx(
+        ZOOMER_OVERLAY_INTERACTIVE_CLASS,
+        "fixed z-50",
+        className,
+      )}
+    >
+      {props.children}
+    </div>,
+    document.body,
+  );
+}

--- a/apps/frontend/src/pages/Build/screenshotComments/CommentThreadPopover.tsx
+++ b/apps/frontend/src/pages/Build/screenshotComments/CommentThreadPopover.tsx
@@ -1,0 +1,48 @@
+import { CommentCard } from "../sidebar/CommentCard";
+import { CommentPopoverFrame } from "./CommentPopoverFrame";
+import type { ScreenPoint } from "./geometry";
+
+type CommentCardProps = React.ComponentProps<typeof CommentCard>;
+
+/**
+ * The full comment thread, shown as a floating card beside its pin once opened.
+ * Reuses {@link CommentCard} (reply, resolve, react, edit, delete) without its
+ * own border/chrome — the popover frame provides that — and without the
+ * snapshot-reference header, which is redundant when drawn on the screenshot it
+ * points to. Closing is handled by the layer (outside-click / Escape).
+ */
+export function CommentThreadPopover(props: {
+  /** Anchor point (the pin's bottom-left tip) in viewport coordinates. */
+  point: ScreenPoint;
+  comment: CommentCardProps["comment"];
+  replies: NonNullable<CommentCardProps["replies"]>;
+  canReply: boolean;
+  buildId: string;
+}) {
+  const { point, comment, replies, canReply, buildId } = props;
+  const name = comment.user?.name || comment.user?.slug || "Unknown user";
+  return (
+    <CommentPopoverFrame
+      point={point}
+      offset={{ x: 44, y: -40 }}
+      role="dialog"
+      aria-label={`Comment from ${name}`}
+      className="w-80"
+    >
+      {/* No horizontal padding so the thread (and its full-width reply divider)
+          spans the whole card; the card's sections carry their own insets. */}
+      <div className="bg-app border-thin max-h-96 w-full overflow-y-auto rounded-xl shadow-xl">
+        <CommentCard
+          buildId={buildId}
+          comment={comment}
+          replies={replies}
+          highlightedCommentId={null}
+          canReply={canReply}
+          hideScreenshotReference
+          embedded
+          autoFocusReply
+        />
+      </div>
+    </CommentPopoverFrame>
+  );
+}

--- a/apps/frontend/src/pages/Build/screenshotComments/ScreenshotCommentLayer.tsx
+++ b/apps/frontend/src/pages/Build/screenshotComments/ScreenshotCommentLayer.tsx
@@ -1,0 +1,403 @@
+import {
+  use,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useMutation } from "@apollo/client/react";
+import { invariant } from "@argos/util/invariant";
+import { useAtomValue } from "jotai/react";
+import { toast } from "sonner";
+
+import { useAuthTokenPayload } from "@/containers/Auth";
+import {
+  commentsVisibleAtom,
+  commentToolModeAtom,
+} from "@/containers/Build/CommentTool";
+import {
+  ZOOMER_OVERLAY_INTERACTIVE_CLASS,
+  type PaneSize,
+} from "@/containers/Build/Zoomer";
+import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
+import { DocumentType, graphql } from "@/gql";
+import { ProjectPermission } from "@/gql/graphql";
+import { useProjectParams } from "@/pages/Project/ProjectParams";
+import { type EditorValue } from "@/ui/Editor/Editor";
+import { getMentionUser } from "@/ui/UserCard";
+import { getErrorMessage } from "@/util/error";
+
+import { getCommentThreads } from "../sidebar/commentThreads";
+import { MentionableUsersProvider } from "../sidebar/MentionableUsersContext";
+import { CommentDraftPopover } from "./CommentDraftPopover";
+import { CommentMarker } from "./CommentMarker";
+import { CommentPin } from "./CommentPin";
+import { CommentThreadPopover } from "./CommentThreadPopover";
+import {
+  isPointInImage,
+  useScreenshotProjection,
+  type NormalizedPoint,
+  type ScreenPoint,
+} from "./geometry";
+
+const _BuildFragment = graphql(`
+  fragment ScreenshotCommentLayer_Build on Build {
+    id
+    members {
+      id
+      ...UserCard_user
+    }
+    comments {
+      ...CommentCard_Comment
+    }
+  }
+`);
+
+type Build = DocumentType<typeof _BuildFragment>;
+
+const AddBuildCommentMutation = graphql(`
+  mutation ScreenshotCommentLayer_addBuildComment(
+    $input: AddBuildCommentInput!
+    $accountSlug: String!
+    $projectName: String!
+  ) {
+    addBuildComment(input: $input) {
+      id
+      comments {
+        ...CommentCard_Comment
+      }
+    }
+  }
+`);
+
+/** How close pointerdown and click must be to count as a click, not a pan. */
+const CLICK_MOVE_THRESHOLD = 4;
+
+// A comment-bubble cursor with the same silhouette as the pin: a rounded body
+// with a sharp bottom-left tip (matching `rounded-full rounded-bl-none`), a dark
+// outline and a soft drop shadow so it reads over any image. It's smaller than
+// the marker. The hotspot is the bottom-left tip, where the comment is dropped.
+const PIN_CURSOR_PATH =
+  "M2 19 L2 10 A9 9 0 0 1 11 1 A9 9 0 0 1 20 10 A9 9 0 0 1 11 19 Z";
+// A double inset border: each stroke is clipped to the shape, so only its inner
+// half shows. The dark 4px stroke leaves a 2px inner band; the white 2px stroke
+// on top covers the outer 1px of that — yielding 1px white at the edge, then 1px
+// dark, then the white fill. The shadow lives on the wrapping group, which isn't
+// clipped, so it still spreads outside.
+const PIN_CURSOR_SVG =
+  "<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'>" +
+  "<defs>" +
+  `<clipPath id='c'><path d='${PIN_CURSOR_PATH}'/></clipPath>` +
+  "<filter id='s' x='-40%' y='-40%' width='180%' height='180%'>" +
+  "<feDropShadow dx='0' dy='1' stdDeviation='0.9' flood-color='black' flood-opacity='0.3'/>" +
+  "</filter>" +
+  "</defs>" +
+  "<g filter='url(#s)'>" +
+  `<path d='${PIN_CURSOR_PATH}' fill='white' stroke='#3f3f46' stroke-width='4' stroke-linejoin='round' clip-path='url(#c)'/>` +
+  `<path d='${PIN_CURSOR_PATH}' fill='none' stroke='white' stroke-width='2' stroke-linejoin='round' clip-path='url(#c)'/>` +
+  "</g>" +
+  "</svg>";
+const PIN_CURSOR = `url("data:image/svg+xml,${encodeURIComponent(PIN_CURSOR_SVG)}") 2 19, crosshair`;
+
+/**
+ * Draws point-anchored comments on the changes image and, with the comment tool
+ * active, lets the user click a point to leave a new one. The click-capture
+ * layer and the draft indicator live inside the `ZoomPane` overlay slot (so they
+ * track pan/zoom and clip to the image); the comment markers and the draft
+ * prompt are portaled and fixed-positioned so they escape the pane's overflow
+ * clipping while still following the image.
+ */
+export function ScreenshotCommentLayer(props: {
+  build: Build;
+  screenshotDiffId: string;
+  imgSize: { width: number; height: number };
+  paneSize: PaneSize | null;
+}) {
+  const { build, screenshotDiffId, imgSize, paneSize } = props;
+  const mode = useAtomValue(commentToolModeAtom);
+  const visible = useAtomValue(commentsVisibleAtom);
+  const permissions = use(ProjectPermissionsContext);
+  const canComment = permissions?.includes(ProjectPermission.Review) ?? false;
+  const { accountSlug, projectName } = useProjectParams() ?? {};
+  invariant(accountSlug && projectName, "Missing project route params");
+  const accountId = useAuthTokenPayload()?.account.id;
+  const [addBuildComment] = useMutation(AddBuildCommentMutation);
+
+  const { toScreen, toNormalized, ready } = useScreenshotProjection({
+    paneSize,
+    imgSize,
+  });
+
+  const [draft, setDraft] = useState<NormalizedPoint | null>(null);
+  const [openThreadId, setOpenThreadId] = useState<string | null>(null);
+
+  // Threads anchored to a point on this diff. Resolved threads drop off the
+  // image (they remain in the sidebar).
+  const threads = useMemo(
+    () =>
+      getCommentThreads(build.comments).filter(
+        (thread) =>
+          thread.root.screenshotDiff?.id === screenshotDiffId &&
+          thread.root.anchor?.__typename === "CommentPointAnchor" &&
+          !thread.root.resolvedAt,
+      ),
+    [build.comments, screenshotDiffId],
+  );
+
+  const openThread = useMemo(
+    () => threads.find((thread) => thread.root.id === openThreadId) ?? null,
+    [threads, openThreadId],
+  );
+
+  const mentionUsers = useMemo(
+    () => build.members.map(getMentionUser),
+    [build.members],
+  );
+
+  const currentAvatar = useMemo(() => {
+    if (!accountId) {
+      return null;
+    }
+    return (
+      build.members.find((member) => member.id === accountId)?.avatar ?? null
+    );
+  }, [accountId, build.members]);
+
+  // What's shown is derived from the tool state (no effects resetting state):
+  // `useCommentTool` keeps mode/visibility consistent — the comment tool implies
+  // comments are visible, and hiding them drops back to the hand tool.
+  const draftShown = mode === "comment" && draft !== null;
+  const threadShown = visible && openThread !== null;
+  const hasMarkers = visible && threads.length > 0;
+
+  // The portaled markers/prompt are fixed-positioned at the pane's viewport
+  // origin plus the in-pane point. The origin only moves on scroll/resize (not
+  // on pan/zoom, which moves the image inside the pane), so it's measured in a
+  // layout effect and kept fresh with listeners — never read from a ref during
+  // render.
+  const rootRef = useRef<HTMLDivElement>(null);
+  const shouldProject = hasMarkers || draftShown;
+  const [origin, setOrigin] = useState<ScreenPoint | null>(null);
+  useLayoutEffect(() => {
+    if (!shouldProject) {
+      return;
+    }
+    const measure = () => {
+      const rect = rootRef.current?.getBoundingClientRect();
+      if (rect) {
+        setOrigin({ left: rect.left, top: rect.top });
+      }
+    };
+    measure();
+    window.addEventListener("scroll", measure, {
+      capture: true,
+      passive: true,
+    });
+    window.addEventListener("resize", measure);
+    return () => {
+      window.removeEventListener("scroll", measure, { capture: true });
+      window.removeEventListener("resize", measure);
+    };
+  }, [shouldProject, paneSize]);
+
+  // Map an in-pane point to the viewport for the portaled elements.
+  const toViewport = (point: ScreenPoint): ScreenPoint =>
+    origin
+      ? { left: origin.left + point.left, top: origin.top + point.top }
+      : point;
+
+  // Whether an in-pane point is within the visible pane (used to clip markers
+  // panned out of view, mirroring the pane's `overflow-hidden`).
+  const isInPane = (point: ScreenPoint): boolean =>
+    paneSize != null &&
+    point.left >= 0 &&
+    point.left <= paneSize.width &&
+    point.top >= 0 &&
+    point.top <= paneSize.height;
+
+  // Close the prompt/thread when clicking outside it, or on Escape. A click is
+  // "outside" only when it lands inside the app root but not on an overlay
+  // element — clicks in portaled menus, the emoji picker, dialogs and our own
+  // popovers (all rendered outside `#root`) don't close it, which is what lets
+  // the thread's actions menu work.
+  const hasActivePopover = draftShown || threadShown;
+  useEffect(() => {
+    if (!hasActivePopover) {
+      return;
+    }
+    const close = () => {
+      setDraft(null);
+      setOpenThreadId(null);
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element)) {
+        return;
+      }
+      if (target.closest(`.${ZOOMER_OVERLAY_INTERACTIVE_CLASS}`)) {
+        return;
+      }
+      const root = document.getElementById("root");
+      if (root && !root.contains(target)) {
+        return;
+      }
+      close();
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        close();
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown, { capture: true });
+    // Bubble phase so the editor handles Escape first (e.g. dismissing a mention
+    // popup or collapsing a selection); it only reaches us when unhandled.
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, {
+        capture: true,
+      });
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [hasActivePopover]);
+
+  // Distinguish a click (place a comment) from a drag (pan the image).
+  const pointerDownRef = useRef<{ x: number; y: number } | null>(null);
+  const handlePlacementPointerDown = (event: React.PointerEvent) => {
+    pointerDownRef.current = { x: event.clientX, y: event.clientY };
+  };
+  const handlePlacementClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    const start = pointerDownRef.current;
+    pointerDownRef.current = null;
+    if (
+      start &&
+      Math.hypot(event.clientX - start.x, event.clientY - start.y) >
+        CLICK_MOVE_THRESHOLD
+    ) {
+      return;
+    }
+    const rect = event.currentTarget.getBoundingClientRect();
+    const point = toNormalized(
+      event.clientX - rect.left,
+      event.clientY - rect.top,
+    );
+    setOpenThreadId(null);
+    setDraft(point && isPointInImage(point) ? point : null);
+  };
+
+  const handleCreate = useCallback(
+    async (body: EditorValue) => {
+      if (!draft) {
+        return;
+      }
+      const priorIds = new Set(build.comments.map((comment) => comment.id));
+      try {
+        const result = await addBuildComment({
+          variables: {
+            input: {
+              buildId: build.id,
+              screenshotDiffId,
+              anchor: { point: { x: draft.x, y: draft.y } },
+              body,
+            },
+            accountSlug,
+            projectName,
+          },
+        });
+        const created = result.data?.addBuildComment.comments.find(
+          (comment) => !priorIds.has(comment.id) && !comment.threadId,
+        );
+        setDraft(null);
+        if (created) {
+          setOpenThreadId(created.id);
+        }
+      } catch (error) {
+        toast.error(getErrorMessage(error));
+        // Rethrow so the editor keeps the content and the user can retry.
+        throw error;
+      }
+    },
+    [
+      addBuildComment,
+      build.comments,
+      build.id,
+      draft,
+      screenshotDiffId,
+      accountSlug,
+      projectName,
+    ],
+  );
+
+  if (!ready) {
+    return null;
+  }
+
+  return (
+    <MentionableUsersProvider value={mentionUsers}>
+      <div ref={rootRef} className="pointer-events-none absolute inset-0">
+        {mode === "comment" && canComment ? (
+          <div
+            role="presentation"
+            className="pointer-events-auto absolute inset-0"
+            style={{ cursor: PIN_CURSOR }}
+            onPointerDown={handlePlacementPointerDown}
+            onClick={handlePlacementClick}
+          />
+        ) : null}
+        {/* The comment being drafted gets an immediate indicator at its point. */}
+        {mode === "comment" && draft ? (
+          <CommentPin point={toScreen(draft)} avatar={currentAvatar} />
+        ) : null}
+      </div>
+      {visible
+        ? threads.map((thread) => {
+            const { root } = thread;
+            if (root.anchor?.__typename !== "CommentPointAnchor") {
+              return null;
+            }
+            const open = root.id === openThreadId;
+            const point = toScreen({ x: root.anchor.x, y: root.anchor.y });
+            if (!open && !isInPane(point)) {
+              return null;
+            }
+            return (
+              <CommentMarker
+                key={root.id}
+                point={toViewport(point)}
+                comment={root}
+                open={open}
+                onOpen={() => {
+                  setDraft(null);
+                  setOpenThreadId(root.id);
+                }}
+              />
+            );
+          })
+        : null}
+      {/* The open thread is a separate popover beside its pin. */}
+      {threadShown &&
+      openThread &&
+      openThread.root.anchor?.__typename === "CommentPointAnchor" ? (
+        <CommentThreadPopover
+          point={toViewport(
+            toScreen({
+              x: openThread.root.anchor.x,
+              y: openThread.root.anchor.y,
+            }),
+          )}
+          comment={openThread.root}
+          replies={openThread.replies}
+          canReply={canComment}
+          buildId={build.id}
+        />
+      ) : null}
+      {draftShown ? (
+        <CommentDraftPopover
+          point={toViewport(toScreen(draft))}
+          onSubmit={handleCreate}
+        />
+      ) : null}
+    </MentionableUsersProvider>
+  );
+}

--- a/apps/frontend/src/pages/Build/screenshotComments/geometry.ts
+++ b/apps/frontend/src/pages/Build/screenshotComments/geometry.ts
@@ -1,0 +1,61 @@
+import { useCallback } from "react";
+
+import { useScaleContext } from "@/containers/Build/ScaleContext";
+import { useZoomTransform, type PaneSize } from "@/containers/Build/Zoomer";
+
+export type NormalizedPoint = { x: number; y: number };
+export type ScreenPoint = { left: number; top: number };
+
+/**
+ * Maps between a screenshot's normalized coordinates (0–1 of its width/height)
+ * and pixel positions within the pane's content box. It accounts for the image
+ * being horizontally centered and top-aligned, scaled by `imgScale`, then moved
+ * by the live pan/zoom transform — the same `imgToWorkspace` math that places
+ * the change highlights (see `RectHighlights`).
+ */
+export function useScreenshotProjection(params: {
+  paneSize: PaneSize | null;
+  imgSize: { width: number; height: number };
+}) {
+  const { paneSize, imgSize } = params;
+  const transform = useZoomTransform();
+  const [imgScale] = useScaleContext();
+
+  const toScreen = useCallback(
+    (point: NormalizedPoint): ScreenPoint => {
+      const offsetX = paneSize
+        ? (paneSize.width - imgSize.width * imgScale) / 2
+        : 0;
+      const workspaceX = point.x * imgSize.width * imgScale + offsetX;
+      const workspaceY = point.y * imgSize.height * imgScale;
+      return {
+        left: workspaceX * transform.scale + transform.x,
+        top: workspaceY * transform.scale + transform.y,
+      };
+    },
+    [paneSize, imgSize.width, imgSize.height, imgScale, transform],
+  );
+
+  const toNormalized = useCallback(
+    (paneX: number, paneY: number): NormalizedPoint | null => {
+      if (!paneSize || !imgScale) {
+        return null;
+      }
+      const offsetX = (paneSize.width - imgSize.width * imgScale) / 2;
+      const workspaceX = (paneX - transform.x) / transform.scale;
+      const workspaceY = (paneY - transform.y) / transform.scale;
+      return {
+        x: (workspaceX - offsetX) / (imgSize.width * imgScale),
+        y: workspaceY / (imgSize.height * imgScale),
+      };
+    },
+    [paneSize, imgSize.width, imgSize.height, imgScale, transform],
+  );
+
+  return { toScreen, toNormalized, ready: Boolean(paneSize && imgScale) };
+}
+
+/** Whether a normalized point falls within the image bounds. */
+export function isPointInImage(point: NormalizedPoint): boolean {
+  return point.x >= 0 && point.x <= 1 && point.y >= 0 && point.y <= 1;
+}

--- a/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
+import { ComponentProps, useState } from "react";
 import { useMutation } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { clsx } from "clsx";
-import { EyeOffIcon, ImageIcon } from "lucide-react";
+import { EyeOffIcon } from "lucide-react";
 import { Button } from "react-aria-components";
 import { toast } from "sonner";
 
@@ -10,12 +10,12 @@ import { DocumentType, graphql } from "@/gql";
 import { useProjectParams } from "@/pages/Project/ProjectParams";
 import { type EditorValue } from "@/ui/Editor/Editor";
 import { StandaloneEditor } from "@/ui/Editor/StandaloneEditor";
-import { ImageKitPicture } from "@/ui/ImageKitPicture";
 import { Tooltip } from "@/ui/Tooltip";
 import { getErrorMessage } from "@/util/error";
 
 import { useBuildDiffState } from "../BuildDiffState";
 import { useMentionableUsers } from "./MentionableUsersContext";
+import { ScreenshotDiffThumbnail } from "./ScreenshotDiffThumbnail";
 
 const _BuildFragment = graphql(`
   fragment AddCommentForm_Build on Build {
@@ -47,11 +47,13 @@ const AddBuildCommentMutation = graphql(`
  */
 function AttachedSnapshotToggle(props: {
   name: string;
-  thumbnailUrl: string | null;
+  screenshotDiff: ComponentProps<
+    typeof ScreenshotDiffThumbnail
+  >["screenshotDiff"];
   attached: boolean;
   onToggle: () => void;
 }) {
-  const { name, thumbnailUrl, attached, onToggle } = props;
+  const { name, screenshotDiff, attached, onToggle } = props;
   return (
     <Tooltip
       content={
@@ -65,24 +67,20 @@ function AttachedSnapshotToggle(props: {
         aria-pressed={attached}
         aria-label={`${attached ? "Detach" : "Attach"} snapshot ${name}`}
         className={clsx(
-          "border-thin hover:bg-hover rac-focus flex min-w-0 items-center gap-1.5 rounded-md py-0.5 pr-2 pl-0.5 text-xs transition",
+          "border-thin hover:bg-hover rac-focus flex min-w-0 items-center gap-1.5 rounded-md py-0.5 pr-2 pl-1 text-xs transition",
           attached ? "text-default" : "text-low opacity-60",
         )}
       >
         <span className="flex size-4 shrink-0 items-center justify-center">
-          {!attached ? (
-            <EyeOffIcon className="text-low size-3" />
-          ) : thumbnailUrl ? (
-            <span className="block size-4 overflow-hidden rounded-sm border bg-white">
-              <ImageKitPicture
-                src={thumbnailUrl}
-                transformations={["w-32", "h-32", "c-at_max"]}
-                className="size-full object-cover"
-                alt=""
-              />
-            </span>
+          {attached ? (
+            <ScreenshotDiffThumbnail
+              screenshotDiff={screenshotDiff}
+              className="size-4"
+              iconClassName="size-3.5"
+              fit="cover"
+            />
           ) : (
-            <ImageIcon className="size-4" />
+            <EyeOffIcon className="text-low size-3.5" />
           )}
         </span>
         <span className="min-w-0 truncate font-medium">{name}</span>
@@ -125,10 +123,6 @@ export function AddCommentForm(props: {
       throw error;
     }
   };
-  const thumbnailUrl =
-    activeDiff?.compareScreenshot?.url ??
-    activeDiff?.baseScreenshot?.url ??
-    null;
   return (
     <StandaloneEditor
       onSubmit={handleSubmit}
@@ -145,7 +139,7 @@ export function AddCommentForm(props: {
         activeDiff ? (
           <AttachedSnapshotToggle
             name={activeDiff.name}
-            thumbnailUrl={thumbnailUrl}
+            screenshotDiff={activeDiff}
             attached={attachedDiff != null}
             onToggle={() => setDetached((value) => !value)}
           />

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -174,6 +174,21 @@ export function CommentCard(props: {
   replies?: Comment[];
   highlightedCommentId: string | null;
   canReply: boolean;
+  /**
+   * Hide the snapshot-reference header. Used when the thread is rendered
+   * directly on the screenshot it points to, where the reference is redundant.
+   */
+  hideScreenshotReference?: boolean;
+  /**
+   * Drop the card's own border/background/rounding so a surrounding container
+   * (e.g. a floating popover on the screenshot) can provide that chrome.
+   */
+  embedded?: boolean;
+  /**
+   * Focus the reply composer on mount. Used when the thread opens in a floating
+   * popover, where replying is the primary action.
+   */
+  autoFocusReply?: boolean;
 }) {
   const {
     buildId,
@@ -181,6 +196,9 @@ export function CommentCard(props: {
     replies = [],
     highlightedCommentId,
     canReply,
+    hideScreenshotReference = false,
+    embedded = false,
+    autoFocusReply = false,
   } = props;
   const projectParams = useProjectParams();
   invariant(projectParams);
@@ -311,8 +329,8 @@ export function CommentCard(props: {
   const onToggleResolved = canReply ? toggleResolved : undefined;
 
   return (
-    <div className="border-thin bg-app -mx-2.5 rounded-md">
-      {comment.screenshotDiff ? (
+    <div className={clsx(!embedded && "border-thin bg-app -mx-2.5 rounded-md")}>
+      {!hideScreenshotReference && comment.screenshotDiff ? (
         <div className="border-b-thin">
           <CommentScreenshotReference
             screenshotDiff={comment.screenshotDiff}
@@ -376,6 +394,7 @@ export function CommentCard(props: {
               <ReplyComposer
                 draftKey={`build.${buildId}.thread.${comment.id}.reply`}
                 onSubmit={handleReplySubmit}
+                autoFocus={autoFocusReply}
               />
             ) : null}
           </motion.div>
@@ -617,8 +636,9 @@ function CommentMessage(props: {
 function ReplyComposer(props: {
   draftKey: string;
   onSubmit: (body: EditorValue) => Promise<void>;
+  autoFocus?: boolean;
 }) {
-  const { draftKey, onSubmit } = props;
+  const { draftKey, onSubmit, autoFocus = false } = props;
   const mentions = useMentionableUsers();
   const { initialContent, value, setValue, clear } = useEditorDraft(draftKey);
   const [editorKey, setEditorKey] = useState(0);
@@ -664,6 +684,7 @@ function ReplyComposer(props: {
           mentions={mentions}
           placeholder="Leave a reply…"
           disabled={isPending}
+          autoFocus={autoFocus}
           aria-label="Add a reply"
           variant="plain"
           className="min-w-0 flex-1 text-sm"

--- a/apps/frontend/src/pages/Build/sidebar/CommentScreenshotReference.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentScreenshotReference.tsx
@@ -1,24 +1,17 @@
-import { ImageIcon, MapPinIcon } from "lucide-react";
+import { MapPinIcon } from "lucide-react";
 import { Button } from "react-aria-components";
 
 import { DocumentType, graphql } from "@/gql";
-import { ImageKitPicture } from "@/ui/ImageKitPicture";
 import { Tooltip } from "@/ui/Tooltip";
 
 import { useBuildDiffState } from "../BuildDiffState";
+import { ScreenshotDiffThumbnail } from "./ScreenshotDiffThumbnail";
 
 const _ScreenshotDiffFragment = graphql(`
   fragment CommentScreenshotReference_ScreenshotDiff on ScreenshotDiff {
     id
     name
-    compareScreenshot {
-      id
-      url
-    }
-    baseScreenshot {
-      id
-      url
-    }
+    ...ScreenshotDiffThumbnail_ScreenshotDiff
   }
 `);
 
@@ -60,10 +53,6 @@ export function CommentScreenshotReference(props: {
 }) {
   const { screenshotDiff, anchor } = props;
   const { allDiffs, setActiveDiff } = useBuildDiffState();
-  const thumbnailUrl =
-    screenshotDiff.compareScreenshot?.url ??
-    screenshotDiff.baseScreenshot?.url ??
-    null;
   const linesLabel = getAnchorLabel(anchor);
   const isPoint = anchor?.__typename === "CommentPointAnchor";
 
@@ -85,18 +74,11 @@ export function CommentScreenshotReference(props: {
         aria-label={`Go to snapshot ${screenshotDiff.name}`}
         className="text-low hover:bg-hover hover:text-default rac-focus flex w-full items-center gap-2 rounded-t-md px-2 py-1.5 text-left text-xs transition select-none"
       >
-        {thumbnailUrl ? (
-          <span className="block size-6 shrink-0 overflow-hidden rounded-sm border bg-white">
-            <ImageKitPicture
-              src={thumbnailUrl}
-              transformations={["w-32", "h-32", "c-at_max"]}
-              className="size-full object-contain"
-              alt=""
-            />
-          </span>
-        ) : (
-          <ImageIcon className="size-4 shrink-0" />
-        )}
+        <ScreenshotDiffThumbnail
+          screenshotDiff={screenshotDiff}
+          className="size-6"
+          iconClassName="size-4"
+        />
         <span className="min-w-0 flex-1 truncate font-medium">
           {screenshotDiff.name}
         </span>

--- a/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
@@ -35,6 +35,7 @@ import { useNonNullable } from "@/util/useNonNullable";
 
 import { AddCommentForm } from "./AddCommentForm";
 import { CommentCard } from "./CommentCard";
+import { getCommentThreads, type CommentThread } from "./commentThreads";
 import { MentionableUsersProvider } from "./MentionableUsersContext";
 
 const _BuildFragment = graphql(`
@@ -130,7 +131,6 @@ const BuildReviewChangedSubscription = graphql(`
 
 type Build = DocumentType<typeof _BuildFragment>;
 type Comment = Build["comments"][number];
-type CommentThread = { root: Comment; replies: Comment[] };
 type ReviewUser = NonNullable<Build["reviews"][number]["user"]>;
 
 /**
@@ -157,36 +157,7 @@ type ActivityEntry =
       date: string;
       review: Build["reviews"][number];
     }
-  | { kind: "comment"; date: string; thread: CommentThread };
-
-function getCommentThreads(comments: Comment[]): CommentThread[] {
-  const commentsById = new Map(
-    comments.map((comment) => [comment.id, comment]),
-  );
-  const repliesByThreadId = new Map<string, Comment[]>();
-  const roots: Comment[] = [];
-
-  for (const comment of comments) {
-    if (!comment.threadId) {
-      roots.push(comment);
-      continue;
-    }
-    if (!commentsById.has(comment.threadId)) {
-      continue;
-    }
-    const replies = repliesByThreadId.get(comment.threadId);
-    if (replies) {
-      replies.push(comment);
-    } else {
-      repliesByThreadId.set(comment.threadId, [comment]);
-    }
-  }
-
-  return roots.map((root) => ({
-    root,
-    replies: repliesByThreadId.get(root.id) ?? [],
-  }));
-}
+  | { kind: "comment"; date: string; thread: CommentThread<Comment> };
 
 function getActivityEntries(build: Build): ActivityEntry[] {
   const entries: ActivityEntry[] = [{ kind: "created", date: build.createdAt }];

--- a/apps/frontend/src/pages/Build/sidebar/ScreenshotDiffThumbnail.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ScreenshotDiffThumbnail.tsx
@@ -1,0 +1,73 @@
+import { clsx } from "clsx";
+import { FileIcon, ImageIcon } from "lucide-react";
+
+import { DocumentType, graphql } from "@/gql";
+import { ImageKitPicture } from "@/ui/ImageKitPicture";
+import { checkIsImageContentType } from "@/util/content-type";
+
+const _ScreenshotDiffFragment = graphql(`
+  fragment ScreenshotDiffThumbnail_ScreenshotDiff on ScreenshotDiff {
+    compareScreenshot {
+      id
+      url
+      contentType
+    }
+    baseScreenshot {
+      id
+      url
+      contentType
+    }
+  }
+`);
+
+/**
+ * A small preview of a screenshot diff: the image itself when the snapshot is
+ * an image, or a file icon otherwise (e.g. a Markdown or other non-image file
+ * uploaded as a snapshot, which would not render as a picture).
+ */
+export function ScreenshotDiffThumbnail(props: {
+  screenshotDiff: DocumentType<typeof _ScreenshotDiffFragment>;
+  /** Size class for the thumbnail box. */
+  className?: string;
+  /** Size class for the fallback icon; defaults to `className`. */
+  iconClassName?: string;
+  /** How the image fills the box. */
+  fit?: "contain" | "cover";
+}) {
+  const {
+    screenshotDiff,
+    className,
+    iconClassName = className,
+    fit = "contain",
+  } = props;
+  const screenshot =
+    screenshotDiff.compareScreenshot ?? screenshotDiff.baseScreenshot ?? null;
+  const thumbnailUrl = screenshot?.url ?? null;
+  const isImage = screenshot
+    ? checkIsImageContentType(screenshot.contentType)
+    : false;
+
+  if (isImage && thumbnailUrl) {
+    return (
+      <span
+        className={clsx(
+          "block shrink-0 overflow-hidden rounded-sm border bg-white",
+          className,
+        )}
+      >
+        <ImageKitPicture
+          src={thumbnailUrl}
+          transformations={["w-32", "h-32", "c-at_max"]}
+          className={clsx(
+            "size-full",
+            fit === "cover" ? "object-cover" : "object-contain",
+          )}
+          alt=""
+        />
+      </span>
+    );
+  }
+
+  const Icon = isImage ? ImageIcon : FileIcon;
+  return <Icon className={clsx("text-low shrink-0", iconClassName)} />;
+}

--- a/apps/frontend/src/pages/Build/sidebar/commentThreads.ts
+++ b/apps/frontend/src/pages/Build/sidebar/commentThreads.ts
@@ -1,0 +1,45 @@
+/**
+ * A root comment together with its replies. Replies are the comments whose
+ * `threadId` points back at the root.
+ */
+export type CommentThread<T> = { root: T; replies: T[] };
+
+/**
+ * Group a flat list of comments into threads. Comments with no `threadId` are
+ * roots; the others are attached as replies to their root, in their original
+ * order. Replies whose root isn't in the list are dropped (the root was
+ * filtered out or not yet loaded).
+ *
+ * Generic over the comment shape so it works wherever `CommentCard_Comment` is
+ * selected (the sidebar activity feed and the on-screenshot overlay).
+ */
+export function getCommentThreads<
+  T extends { id: string; threadId: string | null },
+>(comments: readonly T[]): CommentThread<T>[] {
+  const commentsById = new Map(
+    comments.map((comment) => [comment.id, comment]),
+  );
+  const repliesByThreadId = new Map<string, T[]>();
+  const roots: T[] = [];
+
+  for (const comment of comments) {
+    if (!comment.threadId) {
+      roots.push(comment);
+      continue;
+    }
+    if (!commentsById.has(comment.threadId)) {
+      continue;
+    }
+    const replies = repliesByThreadId.get(comment.threadId);
+    if (replies) {
+      replies.push(comment);
+    } else {
+      repliesByThreadId.set(comment.threadId, [comment]);
+    }
+  }
+
+  return roots.map((root) => ({
+    root,
+    replies: repliesByThreadId.get(root.id) ?? [],
+  }));
+}


### PR DESCRIPTION
## What

Adds the UI to anchor a comment to a specific point on a screenshot's **changes** image (the backend `addBuildComment(anchor: { point })` already existed; only the viewer UI was missing).

- **Toolbar** — a hand/comment tool switch (hotkey `C`) and a show/hide-comments toggle, shown only with Review permission on image diffs (Changed, Ignored, Added).
- **Placing** — with the comment tool active, a comment-bubble cursor marks the spot; clicking a point on the changes image opens a compact floating prompt that anchors the comment to that normalized (0–1) point on submit.
- **Viewing** — point-anchored comments render as avatar pins that expand to a preview on hover and open the full thread in a floating popover beside the pin (reuses `CommentCard`, with the reply box auto-focused).

## How

- `ZoomPane` gains an `overlay` slot (with measured pane size) so the layer tracks pan/zoom and clips to the image; interactive overlay elements are excluded from d3 pan/zoom via a marker class, so a drag still pans and a scroll still scrolls the popover.
- Coordinate mapping reuses the existing `RectHighlights` image→screen math plus its inverse for click placement.
- Pins and popovers are portaled and fixed-positioned so they escape the pane's `overflow-hidden` while still following the image on pan/zoom.
- `getCommentThreads` was extracted from `ReviewActivitySection` into a shared `commentThreads` module.

## Test plan

- [ ] On a **Changed** diff: pick the comment tool, click a point on the changes image, write + submit → a pin and thread appear at that point; the comment also shows in the sidebar Activity with its reference.
- [ ] Hover a pin → preview expands in place; click → thread popover opens beside it; reply / resolve / react / edit all work without closing the thread.
- [ ] Toggle show/hide comments; confirm pan and zoom still work with the comment tool active and that pins track the image.
- [ ] Repeat on an **Added** (new) screenshot; confirm clicks outside the image bounds do nothing.
- [ ] Non-reviewers don't see the comment tools.

> Note: verified with typecheck / lint / format; the interaction (morph, cursor, placement) hasn't been visually exercised in a browser yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
