### PR TITLE
feat: add comments on specific lines of a text diff

### DIFF
--- a/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
@@ -30,6 +30,7 @@ import { toast } from "sonner";
 import { DocumentType, graphql } from "@/gql";
 import { BuildType, ScreenshotDiffStatus } from "@/gql/graphql";
 import { BuildDialogs } from "@/pages/Build/BuildDialogs";
+import { DiffCommentLayer } from "@/pages/Build/diffComments/DiffCommentLayer";
 import { ScreenshotCommentLayer } from "@/pages/Build/screenshotComments/ScreenshotCommentLayer";
 import { Code } from "@/ui/Code";
 import { IconButton } from "@/ui/IconButton";
@@ -58,7 +59,7 @@ import {
   SkippedBuildEmptyState,
 } from "./BuildEmptyStates";
 import { buildViewModeAtom } from "./BuildViewMode";
-import { DiffEditor, Editor, getLanguageFromContentType } from "./DiffEditor";
+import { Editor, getLanguageFromContentType } from "./DiffEditor";
 import {
   overlayColorAtom,
   overlayOpacityAtom,
@@ -93,6 +94,7 @@ const _BuildFragment = graphql(`
     }
     ...BuildDialogs_Build
     ...ScreenshotCommentLayer_Build
+    ...DiffCommentLayer_Build
   }
 `);
 
@@ -1347,6 +1349,8 @@ const BuildScreenshots = memo(
                   />
                 ),
               }}
+              build={build}
+              screenshotDiffId={diff.id}
             />
           </div>
         );
@@ -1418,11 +1422,15 @@ function DiffSnapshots(props: {
   base: { url: string; contentType: string };
   head: { url: string; contentType: string };
   renderSideBySide: boolean;
+  build: BuildFragmentDocument;
+  screenshotDiffId: string;
 }) {
-  const { base, head, renderSideBySide } = props;
+  const { base, head, renderSideBySide, build, screenshotDiffId } = props;
   const [baseText, headText] = useTextContent([base.url, head.url]);
   return (
-    <DiffEditor
+    <DiffCommentLayer
+      build={build}
+      screenshotDiffId={screenshotDiffId}
       original={baseText}
       originalLanguage={getLanguageFromContentType(base.contentType)}
       modified={headText}
@@ -1441,8 +1449,10 @@ type DiffSnapshotEntry = {
 function BuildSnapshotsDiff(props: {
   base: DiffSnapshotEntry;
   head: DiffSnapshotEntry;
+  build: BuildFragmentDocument;
+  screenshotDiffId: string;
 }) {
-  const { base, head } = props;
+  const { base, head, build, screenshotDiffId } = props;
   const isDiffOverlayVisible = useAtomValue(overlayVisibleAtom);
   const viewMode = useAtomValue(buildViewModeAtom);
   // const [headText, baseText] = useTextContent([props.base, props.head]);
@@ -1479,7 +1489,13 @@ function BuildSnapshotsDiff(props: {
               </div>
             }
           >
-            <DiffSnapshots base={base} head={head} renderSideBySide={isSplit} />
+            <DiffSnapshots
+              base={base}
+              head={head}
+              renderSideBySide={isSplit}
+              build={build}
+              screenshotDiffId={screenshotDiffId}
+            />
           </Suspense>
         </>
       );

--- a/apps/frontend/src/containers/Build/BuildDiffDetailToolbar.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetailToolbar.tsx
@@ -40,6 +40,22 @@ function checkCanCommentOnDiff(diff: BuildDiffDetailDocument): boolean {
   }
 }
 
+/**
+ * Whether line comments can be placed on this diff's textual changes. Mirrors
+ * the condition under which the text diff (and its `DiffCommentLayer`) renders.
+ */
+function checkCanCommentOnTextDiff(diff: BuildDiffDetailDocument): boolean {
+  switch (diff.status) {
+    case ScreenshotDiffStatus.Changed:
+    case ScreenshotDiffStatus.Ignored:
+      return !checkIsImageContentType(
+        diff.compareScreenshot?.contentType ?? "",
+      );
+    default:
+      return false;
+  }
+}
+
 export function BuildDiffDetailToolbar(props: BuildDiffDetailToolbarProps) {
   const { diff, children, fitControls } = props;
   const shouldShowToolbarControls =
@@ -52,6 +68,9 @@ export function BuildDiffDetailToolbar(props: BuildDiffDetailToolbarProps) {
   const permissions = use(ProjectPermissionsContext);
   const canComment = permissions?.includes(ProjectPermission.Review) ?? false;
   const showCommentTools = canComment && checkCanCommentOnDiff(diff);
+  // Text diffs use the gutter "+" (no hand/comment tool switch), so they only
+  // get the show/hide toggle.
+  const showTextCommentTools = canComment && checkCanCommentOnTextDiff(diff);
 
   return (
     <div className="flex shrink-0 items-center gap-1.5">
@@ -75,6 +94,12 @@ export function BuildDiffDetailToolbar(props: BuildDiffDetailToolbarProps) {
         <>
           <Separator orientation="vertical" className="mx-1 h-6" />
           <CommentToolToggle />
+          <CommentsVisibilityToggle />
+        </>
+      )}
+      {showTextCommentTools && (
+        <>
+          <Separator orientation="vertical" className="mx-1 h-6" />
           <CommentsVisibilityToggle />
         </>
       )}

--- a/apps/frontend/src/containers/Build/DiffEditor.tsx
+++ b/apps/frontend/src/containers/Build/DiffEditor.tsx
@@ -1,6 +1,8 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, type ReactNode } from "react";
 import type {
   BaseCodeOptions,
+  DiffLineAnnotation,
+  SelectedLineRange,
   SupportedLanguages,
   ThemeTypes,
 } from "@pierre/diffs/react";
@@ -15,11 +17,14 @@ const File = lazy(() =>
   })),
 );
 
+// `lazy()` collapses the component's `<LAnnotation>` generic, so cast back to the
+// original generic signature to keep typed line annotations at the call site.
+// The runtime value is still the lazy (Suspense-driven) component.
 const MultiFileDiff = lazy(() =>
   import("@pierre/diffs/react").then(({ MultiFileDiff }) => ({
     default: MultiFileDiff,
   })),
-);
+) as unknown as typeof import("@pierre/diffs/react").MultiFileDiff;
 
 // Shared options matching the previous Monaco read-only viewer behavior:
 // word wrapping on, no file header, JS highlighter (avoids a WASM CSP relaxation).
@@ -31,6 +36,21 @@ const BASE_OPTIONS = {
 } satisfies BaseCodeOptions;
 
 const CLASS_NAME = "overflow-hidden rounded border";
+
+// Styling for the gutter "+", injected into the viewer's shadow DOM via
+// `unsafeCSS` (its `unsafe` cascade layer outranks the library's own rules).
+const GUTTER_UTILITY_CSS =
+  // Hide the "+" on the baseline/deletions side: line comments anchor to the
+  // head (additions) line numbers only, so it would be a no-op there.
+  // `[data-deletions]` is the deletions column in split view; `change-deletion`
+  // covers pure deletion lines in unified view.
+  "[data-deletions] [data-gutter-utility-slot]," +
+  '[data-line-type="change-deletion"] [data-gutter-utility-slot]{display:none}' +
+  // Tint the "+" with the app's primary violet. The Radix `--violet-*` custom
+  // properties are defined on :root and inherit across the shadow boundary, so
+  // this also tracks light/dark.
+  "[data-utility-button]{background-color:var(--violet-9);color:#fff}" +
+  "[data-utility-button]:hover{background-color:var(--violet-10)}";
 
 function useThemeType(): ThemeTypes {
   const { colorMode } = useColorMode();
@@ -45,14 +65,52 @@ function useThemeType(): ThemeTypes {
   }
 }
 
-export function DiffEditor(props: {
+/** The line the gutter "+" is currently hovering, as reported by the viewer. */
+/**
+ * Comment integration for the diff viewer, mapped onto `@pierre/diffs`'
+ * annotation and gutter-utility APIs. Lets callers (see `DiffCommentLayer`)
+ * render inline comment threads/drafts between lines and a gutter "+" affordance
+ * without `DiffEditor` knowing anything about comments.
+ *
+ * We use the built-in gutter utility (`onGutterUtilityClick`): the library
+ * renders and positions the "+" at the gutter/code edge and reports the clicked
+ * (or drag-selected) line range, so a single click comments on one line and a
+ * drag comments on a range.
+ */
+export type DiffEditorComments<LAnnotation> = {
+  /** Inline annotations to render (one per anchored line). */
+  lineAnnotations: DiffLineAnnotation<LAnnotation>[];
+  /**
+   * Controlled line highlight (e.g. the range being commented on). Driving it
+   * keeps the highlight in sync with the draft, so clearing the draft clears it.
+   */
+  selectedLines: SelectedLineRange | null;
+  /** Whether to show the gutter "+" affordance (gated on permission). */
+  enableGutterUtility: boolean;
+  /** Renders an inline annotation (a comment thread and/or a draft composer). */
+  renderAnnotation: (annotation: DiffLineAnnotation<LAnnotation>) => ReactNode;
+  /** Fired when the gutter "+" is clicked or drag-selected over a line range. */
+  onGutterUtilityClick: (range: SelectedLineRange) => void;
+  /**
+   * Fired as a drag selection starts and updates. Controlled selection doesn't
+   * render the in-progress range on its own, so the caller echoes it back into
+   * `selectedLines` to show a live highlight while dragging.
+   */
+  onLineSelectionChange?: (range: SelectedLineRange | null) => void;
+  /** Fired when a drag selection ends (used to drop the live drag range). */
+  onLineSelectionEnd?: (range: SelectedLineRange | null) => void;
+};
+
+export function DiffEditor<LAnnotation = undefined>(props: {
   original: string;
   modified: string;
   originalLanguage: SupportedLanguages;
   modifiedLanguage: SupportedLanguages;
   renderSideBySide: boolean;
+  comments?: DiffEditorComments<LAnnotation>;
 }) {
-  const { original, modified, originalLanguage, modifiedLanguage } = props;
+  const { original, modified, originalLanguage, modifiedLanguage, comments } =
+    props;
   const themeType = useThemeType();
   const options = {
     ...BASE_OPTIONS,
@@ -60,10 +118,25 @@ export function DiffEditor(props: {
     diffStyle: props.renderSideBySide
       ? ("split" as const)
       : ("unified" as const),
+    ...(comments?.enableGutterUtility
+      ? {
+          enableGutterUtility: true,
+          // Lets the user drag the "+" to select a range; the committed range
+          // arrives via onGutterUtilityClick, and the in-progress range via the
+          // selection callbacks (echoed back into selectedLines for a live
+          // highlight, since controlled selection doesn't render it on its own).
+          enableLineSelection: true,
+          onGutterUtilityClick: comments.onGutterUtilityClick,
+          onLineSelectionStart: comments.onLineSelectionChange,
+          onLineSelectionChange: comments.onLineSelectionChange,
+          onLineSelectionEnd: comments.onLineSelectionEnd,
+          unsafeCSS: GUTTER_UTILITY_CSS,
+        }
+      : null),
   };
   return (
     <Suspense fallback={<SnapshotLoader />}>
-      <MultiFileDiff
+      <MultiFileDiff<LAnnotation>
         oldFile={{
           name: "snapshot",
           contents: original,
@@ -76,6 +149,9 @@ export function DiffEditor(props: {
         }}
         options={options}
         className={CLASS_NAME}
+        lineAnnotations={comments?.lineAnnotations}
+        selectedLines={comments?.selectedLines}
+        renderAnnotation={comments?.renderAnnotation}
       />
     </Suspense>
   );

--- a/apps/frontend/src/pages/Build/diffComments/DiffCommentDraft.tsx
+++ b/apps/frontend/src/pages/Build/diffComments/DiffCommentDraft.tsx
@@ -1,0 +1,111 @@
+import { useId, useState } from "react";
+import { toast } from "sonner";
+
+import { AccountAvatar } from "@/containers/AccountAvatar";
+import { Button } from "@/ui/Button";
+import { Editor, type EditorValue } from "@/ui/Editor/Editor";
+import { MOD } from "@/ui/Editor/EditorToolbar.shortcuts";
+import { hasEditorContent } from "@/ui/Editor/util";
+import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
+
+import { useMentionableUsers } from "../sidebar/MentionableUsersContext";
+
+type Avatar = React.ComponentProps<typeof AccountAvatar>["avatar"];
+
+/**
+ * The inline "Leave a comment" composer rendered between diff lines once the
+ * user adds a comment from the gutter. The editor sits in a bordered field with
+ * the author's avatar beside it, and the actions live *below* the field — a real
+ * "Cancel" and "Add comment" (no send arrow), matching the edit-comment UX.
+ * Submitting anchors the comment to the line range; the content is kept if the
+ * request fails so the user can retry.
+ */
+export function DiffCommentDraft(props: {
+  avatar: Avatar | null;
+  onSubmit: (body: EditorValue) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const { avatar, onSubmit, onCancel } = props;
+  const mentions = useMentionableUsers();
+  const [value, setValue] = useState<EditorValue>(null);
+  const [isPending, setIsPending] = useState(false);
+  const emptyToastId = useId();
+  const isEmpty = !hasEditorContent(value);
+
+  const submit = () => {
+    if (isPending) {
+      return;
+    }
+    if (isEmpty) {
+      toast.warning("Comment required", {
+        id: emptyToastId,
+        description: "Please add a comment before submitting.",
+      });
+      return;
+    }
+    setIsPending(true);
+    onSubmit(value)
+      .catch(() => {
+        // Keep the content so the user can retry.
+      })
+      .finally(() => {
+        setIsPending(false);
+      });
+  };
+
+  return (
+    <div className="flex items-start gap-2">
+      {avatar ? (
+        <AccountAvatar
+          avatar={avatar}
+          className="mt-1 size-6 shrink-0 border"
+        />
+      ) : null}
+      <div className="min-w-0 flex-1">
+        <div className="border-thin bg-app focus-within:border-default rounded-lg px-3 py-2 transition-colors">
+          <Editor
+            onChange={setValue}
+            onSubmit={submit}
+            mentions={mentions}
+            placeholder="Leave a comment"
+            disabled={isPending}
+            autoFocus
+            aria-label="Add a comment"
+            variant="plain"
+            className="text-sm"
+            contentClassName="max-h-48 min-h-12 overflow-y-auto"
+          />
+        </div>
+        <div className="mt-2 flex justify-end gap-1.5">
+          <Button
+            variant="ghost"
+            rounded
+            size="small"
+            onPress={onCancel}
+            isDisabled={isPending}
+          >
+            Cancel
+          </Button>
+          <HotkeyTooltip
+            description="Add comment"
+            keys={[MOD, "Enter"]}
+            placement="top"
+          >
+            <Button
+              variant="secondary"
+              rounded
+              size="small"
+              onPress={submit}
+              // Stays clickable while empty so the press can surface the toast;
+              // only truly disabled while a submit is in flight.
+              isDisabled={isPending}
+              aria-disabled={isEmpty}
+            >
+              Add comment
+            </Button>
+          </HotkeyTooltip>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/Build/diffComments/DiffCommentLayer.tsx
+++ b/apps/frontend/src/pages/Build/diffComments/DiffCommentLayer.tsx
@@ -1,0 +1,350 @@
+import { use, useCallback, useMemo, useState } from "react";
+import { useMutation } from "@apollo/client/react";
+import { invariant } from "@argos/util/invariant";
+import type {
+  DiffLineAnnotation,
+  SelectedLineRange,
+  SupportedLanguages,
+} from "@pierre/diffs/react";
+import { useAtomValue } from "jotai/react";
+import { toast } from "sonner";
+
+import { useAuthTokenPayload } from "@/containers/Auth";
+import { commentsVisibleAtom } from "@/containers/Build/CommentTool";
+import { DiffEditor } from "@/containers/Build/DiffEditor";
+import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
+import { DocumentType, graphql } from "@/gql";
+import { ProjectPermission } from "@/gql/graphql";
+import { useProjectParams } from "@/pages/Project/ProjectParams";
+import { type EditorValue } from "@/ui/Editor/Editor";
+import { getMentionUser } from "@/ui/UserCard";
+import { getErrorMessage } from "@/util/error";
+
+import { CommentCard } from "../sidebar/CommentCard";
+import {
+  getCommentThreads,
+  type CommentThread,
+} from "../sidebar/commentThreads";
+import { MentionableUsersProvider } from "../sidebar/MentionableUsersContext";
+import { DiffCommentDraft } from "./DiffCommentDraft";
+
+const _BuildFragment = graphql(`
+  fragment DiffCommentLayer_Build on Build {
+    id
+    members {
+      id
+      ...UserCard_user
+    }
+    comments {
+      ...CommentCard_Comment
+    }
+  }
+`);
+
+type Build = DocumentType<typeof _BuildFragment>;
+type Comment = Build["comments"][number];
+
+const AddBuildCommentMutation = graphql(`
+  mutation DiffCommentLayer_addBuildComment(
+    $input: AddBuildCommentInput!
+    $accountSlug: String!
+    $projectName: String!
+  ) {
+    addBuildComment(input: $input) {
+      id
+      comments {
+        ...CommentCard_Comment
+      }
+    }
+  }
+`);
+
+type LineRange = { from: number; to: number };
+
+/**
+ * Metadata carried by an inline annotation: the comment threads anchored to a
+ * head line plus, if the user is composing there, the draft range.
+ */
+type DiffCommentAnnotation = {
+  threads: CommentThread<Comment>[];
+  draftRange: LineRange | null;
+};
+
+/**
+ * Wraps the textual {@link DiffEditor} with line comments, mirroring the
+ * point-anchored {@link import("../screenshotComments/ScreenshotCommentLayer")}
+ * for image diffs. Hovering a line shows a gutter "+"; clicking (or
+ * drag-selecting) it opens an inline composer that anchors the comment to that
+ * line range. Existing line-anchored threads render inline between the lines.
+ *
+ * Anchors store a side-less `{ from, to }` range, which maps to the head
+ * (compare) snapshot's line numbers — i.e. the `additions` side of the diff.
+ * Context and addition lines report that side (the whole unified column, or the
+ * right column in split view), so commenting works on every line that exists in
+ * the new version. Pure deletions and the baseline column report `deletions` and
+ * can't be anchored to a head line, so the "+" is a no-op there.
+ */
+export function DiffCommentLayer(props: {
+  build: Build;
+  screenshotDiffId: string;
+  original: string;
+  modified: string;
+  originalLanguage: SupportedLanguages;
+  modifiedLanguage: SupportedLanguages;
+  renderSideBySide: boolean;
+}) {
+  const {
+    build,
+    screenshotDiffId,
+    original,
+    modified,
+    originalLanguage,
+    modifiedLanguage,
+    renderSideBySide,
+  } = props;
+  const visible = useAtomValue(commentsVisibleAtom);
+  const permissions = use(ProjectPermissionsContext);
+  const canComment = permissions?.includes(ProjectPermission.Review) ?? false;
+  const { accountSlug, projectName } = useProjectParams() ?? {};
+  invariant(accountSlug && projectName, "Missing project route params");
+  const accountId = useAuthTokenPayload()?.account.id;
+  const [addBuildComment] = useMutation(AddBuildCommentMutation);
+
+  const [draft, setDraft] = useState<LineRange | null>(null);
+  // The range being drag-selected right now (before it's committed to a draft).
+  // Echoed into `selectedLines` so the highlight tracks the drag live.
+  const [dragRange, setDragRange] = useState<SelectedLineRange | null>(null);
+  // The id of the comment thread currently hovered, so its lines light up while
+  // pointing at it — that's how you tell a multi-line comment's scope. Tracked by
+  // id (not a raw range) so deleting the hovered comment clears the highlight,
+  // even though its removal means `onMouseLeave` never fires.
+  const [hoveredThreadId, setHoveredThreadId] = useState<string | null>(null);
+
+  // Clearing the draft (cancel or submit) clears the line highlight too.
+  const closeDraft = useCallback(() => {
+    setDraft(null);
+    setDragRange(null);
+  }, []);
+
+  const mentionUsers = useMemo(
+    () => build.members.map(getMentionUser),
+    [build.members],
+  );
+
+  // The current user's avatar, shown on the draft composer.
+  const currentAvatar = useMemo(
+    () =>
+      accountId
+        ? (build.members.find((member) => member.id === accountId)?.avatar ??
+          null)
+        : null,
+    [accountId, build.members],
+  );
+
+  // Threads anchored to a line range on this diff. Resolved threads drop off the
+  // diff (they remain in the sidebar).
+  const threads = useMemo(
+    () =>
+      getCommentThreads(build.comments).filter(
+        (thread) =>
+          thread.root.screenshotDiff?.id === screenshotDiffId &&
+          thread.root.anchor?.__typename === "CommentLinesAnchor" &&
+          !thread.root.resolvedAt,
+      ),
+    [build.comments, screenshotDiffId],
+  );
+
+  // The hovered thread's line range, derived from the live list so it resolves
+  // to null once that thread is gone (e.g. deleted), clearing the highlight.
+  const hoveredRange = useMemo<LineRange | null>(() => {
+    const anchor = threads.find((thread) => thread.root.id === hoveredThreadId)
+      ?.root.anchor;
+    return anchor?.__typename === "CommentLinesAnchor"
+      ? { from: anchor.from, to: anchor.to }
+      : null;
+  }, [threads, hoveredThreadId]);
+
+  // The draft is only meaningful while comments are shown.
+  const activeDraft = visible ? draft : null;
+
+  // One inline annotation per head line that carries content: the threads
+  // anchored there (by the end of their range) plus the draft if it ends there.
+  const lineAnnotations = useMemo<
+    DiffLineAnnotation<DiffCommentAnnotation>[]
+  >(() => {
+    const byLine = new Map<number, DiffCommentAnnotation>();
+    const ensure = (line: number): DiffCommentAnnotation => {
+      let entry = byLine.get(line);
+      if (!entry) {
+        entry = { threads: [], draftRange: null };
+        byLine.set(line, entry);
+      }
+      return entry;
+    };
+    if (visible) {
+      for (const thread of threads) {
+        const { anchor } = thread.root;
+        if (anchor?.__typename === "CommentLinesAnchor") {
+          ensure(anchor.to).threads.push(thread);
+        }
+      }
+    }
+    if (activeDraft) {
+      ensure(activeDraft.to).draftRange = activeDraft;
+    }
+    return Array.from(byLine, ([lineNumber, metadata]) => ({
+      side: "additions",
+      lineNumber,
+      metadata,
+    }));
+  }, [threads, activeDraft, visible]);
+
+  const handleCreate = useCallback(
+    async (body: EditorValue) => {
+      if (!draft) {
+        return;
+      }
+      try {
+        await addBuildComment({
+          variables: {
+            input: {
+              buildId: build.id,
+              screenshotDiffId,
+              anchor: { lines: { from: draft.from, to: draft.to } },
+              body,
+            },
+            accountSlug,
+            projectName,
+          },
+        });
+        closeDraft();
+      } catch (error) {
+        toast.error(getErrorMessage(error));
+        // Rethrow so the composer keeps the content and the user can retry.
+        throw error;
+      }
+    },
+    [
+      addBuildComment,
+      build.id,
+      draft,
+      screenshotDiffId,
+      accountSlug,
+      projectName,
+      closeDraft,
+    ],
+  );
+
+  const renderAnnotation = useCallback(
+    (annotation: DiffLineAnnotation<DiffCommentAnnotation>) => {
+      const { threads: lineThreads, draftRange } = annotation.metadata;
+      return (
+        // `font-sans` opts out of the diff's monospace font for the comments.
+        <div className="bg-subtle flex flex-col gap-2 border-y px-3 py-2 font-sans text-sm leading-normal">
+          {lineThreads.map((thread) => (
+            <div
+              key={thread.root.id}
+              className="bg-app border-thin overflow-hidden rounded-md"
+              // Light up the lines this comment is anchored to while hovering it.
+              onMouseEnter={() => setHoveredThreadId(thread.root.id)}
+              onMouseLeave={() => setHoveredThreadId(null)}
+            >
+              <CommentCard
+                buildId={build.id}
+                comment={thread.root}
+                replies={thread.replies}
+                highlightedCommentId={null}
+                canReply={canComment}
+                hideScreenshotReference
+                embedded
+              />
+            </div>
+          ))}
+          {draftRange ? (
+            <DiffCommentDraft
+              avatar={currentAvatar}
+              onSubmit={handleCreate}
+              onCancel={closeDraft}
+            />
+          ) : null}
+        </div>
+      );
+    },
+    [build.id, canComment, currentAvatar, handleCreate, closeDraft],
+  );
+
+  const onGutterUtilityClick = useCallback((range: SelectedLineRange) => {
+    // Only the additions (head) side carries the line numbers our anchor stores;
+    // the baseline column and pure deletions can't be anchored to a head line.
+    const endSide = range.endSide ?? range.side;
+    if (range.side !== "additions" || endSide !== "additions") {
+      return;
+    }
+    setDraft({
+      from: Math.min(range.start, range.end),
+      to: Math.max(range.start, range.end),
+    });
+  }, []);
+
+  // Echo the live drag range so the highlight follows the pointer; it's dropped
+  // on release (the committed range then comes from the draft, via onGutterUtilityClick).
+  const onLineSelectionChange = useCallback(
+    (range: SelectedLineRange | null) => setDragRange(range),
+    [],
+  );
+  const onLineSelectionEnd = useCallback(() => setDragRange(null), []);
+
+  // Controlled highlight, in priority order: the live drag range, then the open
+  // draft's range, then the hovered thread's range. Driving it means clearing
+  // the draft also clears the highlight.
+  const selectedLines = useMemo<SelectedLineRange | null>(() => {
+    if (dragRange) {
+      return dragRange;
+    }
+    const range = activeDraft ?? hoveredRange;
+    return range
+      ? {
+          start: range.from,
+          side: "additions",
+          end: range.to,
+          endSide: "additions",
+        }
+      : null;
+  }, [dragRange, activeDraft, hoveredRange]);
+
+  const gutterEnabled = canComment && visible;
+
+  const comments = useMemo(
+    () => ({
+      lineAnnotations,
+      selectedLines,
+      enableGutterUtility: gutterEnabled,
+      renderAnnotation,
+      onGutterUtilityClick,
+      onLineSelectionChange,
+      onLineSelectionEnd,
+    }),
+    [
+      lineAnnotations,
+      selectedLines,
+      gutterEnabled,
+      renderAnnotation,
+      onGutterUtilityClick,
+      onLineSelectionChange,
+      onLineSelectionEnd,
+    ],
+  );
+
+  return (
+    <MentionableUsersProvider value={mentionUsers}>
+      <DiffEditor<DiffCommentAnnotation>
+        original={original}
+        modified={modified}
+        originalLanguage={originalLanguage}
+        modifiedLanguage={modifiedLanguage}
+        renderSideBySide={renderSideBySide}
+        comments={comments}
+      />
+    </MentionableUsersProvider>
+  );
+}

--- a/apps/frontend/src/ui/Editor/Editor.tsx
+++ b/apps/frontend/src/ui/Editor/Editor.tsx
@@ -243,7 +243,11 @@ export function Editor(props: EditorProps) {
   // `value`'s identity only changes when the content does (Apollo shares
   // references for unchanged data), so this stays a no-op on unrelated renders.
   useEffect(() => {
-    if (editor && value != null) {
+    // Guard against a destroyed instance: when this editor is mounted somewhere
+    // that remounts it (e.g. an inline diff comment annotation, or React strict
+    // mode), `useEditor` can briefly hand back a torn-down editor whose
+    // `commandManager` is null, so `editor.commands` would throw.
+    if (editor && !editor.isDestroyed && value != null) {
       editor.commands.setContent(value);
     }
   }, [editor, value]);
@@ -269,7 +273,7 @@ export function Editor(props: EditorProps) {
   const handleContainerMouseDown = (
     event: React.MouseEvent<HTMLDivElement>,
   ) => {
-    if (!editor || !editable) {
+    if (!editor || editor.isDestroyed || !editable) {
       return;
     }
     // Only handle primary-button clicks (avoid interfering with context menus).


### PR DESCRIPTION
## What

Adds the ability to anchor a comment to specific **lines** (a single line or a dragged range) of a textual snapshot diff — the text-diff counterpart to the existing point-anchored comments on image diffs.

The backend already supported line anchors (`CommentLinesAnchor` / `CommentLinesAnchorInput`, validated in the `Comment` model, and the sidebar reference already renders "Line N" / "Lines N–M"). This PR wires up the frontend on top of `@pierre/diffs`' gutter-utility and annotation APIs.

## How it works

- **Add:** hovering a line reveals a violet `+` in the gutter (head/`additions` side only — that's where the side-less `{from, to}` anchor maps). Click it to comment on one line, or drag it to select a range, with a live highlight while dragging.
- **Read:** existing line-anchored threads render **inline** between the lines (reusing `CommentCard` in embedded mode). Hovering a thread highlights the lines it covers, so you can tell a multi-line comment's scope.
- **Toolbar:** a comments-visibility toggle (shown for reviewers on text diffs) gates both the threads and the `+`.

## Notable details

- `DiffEditor` is now generic over its annotation type and takes an optional `comments` prop; all comment state lives in the new `DiffCommentLayer`.
- The `+` uses the library's built-in gutter utility (correct edge position + drag-to-range). It's hidden on the baseline/deletions column and tinted violet via injected `unsafeCSS` (the `unsafe` cascade layer + Radix `--violet-*` vars, which inherit across the shadow boundary and track light/dark).
- Selection is controlled and echoed during a drag so the highlight is live and clears on cancel/submit; the hovered-thread highlight is tracked by id so it clears when a comment is deleted.
- Guards the shared `Editor` against a destroyed TipTap instance (`editor.isDestroyed`) — its annotation-slot mounts remount more aggressively than the sidebar, which previously crashed on `editor.commands`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)