### PR TITLE
feat: accept a project slug in tokenless GitHub Actions auth

### DIFF
--- a/apps/backend/src/api/handlers/exchangeGitHubActionsTokenlessToken.e2e.test.ts
+++ b/apps/backend/src/api/handlers/exchangeGitHubActionsTokenlessToken.e2e.test.ts
@@ -32,6 +32,7 @@ function createTokenlessBearer(authData: {
   repository: string;
   jobId: string;
   runId: string;
+  project?: string;
 }) {
   const payload = Buffer.from(JSON.stringify(authData)).toString("base64");
   return `tokenless-github-${payload}`;
@@ -218,5 +219,114 @@ describe("exchangeGitHubActionsTokenlessToken", () => {
           "GitHub Actions workflow run does not match branch.",
         );
       });
+  });
+
+  describe("when multiple projects are linked to the GitHub repository", () => {
+    async function createRepositoryWithProjects() {
+      const account = await factory.GithubAccount.create({
+        githubId: 456,
+        login: "argos-ci",
+        type: "organization",
+      });
+      const repository = await factory.GithubRepository.create({
+        githubAccountId: account.id,
+        githubId: 123,
+        name: "argos",
+      });
+      const installation = await factory.GithubInstallation.create({
+        githubId: 789,
+      });
+      await factory.GithubRepositoryInstallation.create({
+        githubRepositoryId: repository.id,
+        githubInstallationId: installation.id,
+      });
+
+      const teamA = await factory.TeamAccount.create({ slug: "team-a" });
+      const teamB = await factory.TeamAccount.create({ slug: "team-b" });
+
+      const projectA = await factory.Project.create({
+        name: "project-a",
+        accountId: teamA.id,
+        tokenlessAuthEnabled: true,
+        githubRepositoryId: repository.id,
+      });
+      const projectB = await factory.Project.create({
+        name: "project-b",
+        accountId: teamB.id,
+        tokenlessAuthEnabled: true,
+        githubRepositoryId: repository.id,
+      });
+
+      return { projectA, projectB };
+    }
+
+    test("rejects when no project slug is provided", async () => {
+      await setupDatabase();
+      await createRepositoryWithProjects();
+      mockWorkflowRun({});
+
+      const bearer = createTokenlessBearer({
+        owner: "argos-ci",
+        repository: "argos",
+        jobId: "1",
+        runId: "42",
+      });
+
+      await request(app)
+        .post("/auth/github-actions/tokenless/exchange")
+        .send({ tokenlessToken: bearer, commit: commitSha, branch })
+        .expect(400)
+        .expect((res) => {
+          expect(res.body.error).toBe(
+            `Multiple projects found for GitHub repository (token: "${bearer}"). Please specify a project slug or a project token.`,
+          );
+        });
+    });
+
+    test("resolves the project matching the provided slug", async () => {
+      await setupDatabase();
+      const { projectB } = await createRepositoryWithProjects();
+      mockWorkflowRun({});
+
+      const bearer = createTokenlessBearer({
+        owner: "argos-ci",
+        repository: "argos",
+        jobId: "1",
+        runId: "42",
+        project: "team-b/project-b",
+      });
+
+      const res = await request(app)
+        .post("/auth/github-actions/tokenless/exchange")
+        .send({ tokenlessToken: bearer, commit: commitSha, branch })
+        .expect(200);
+
+      const auth = await getAuthProjectPayloadFromBearerToken(res.body.token);
+      expect(auth.project.id).toBe(projectB.id);
+    });
+
+    test("rejects when the provided slug does not match any linked project", async () => {
+      await setupDatabase();
+      await createRepositoryWithProjects();
+      mockWorkflowRun({});
+
+      const bearer = createTokenlessBearer({
+        owner: "argos-ci",
+        repository: "argos",
+        jobId: "1",
+        runId: "42",
+        project: "team-a/unknown",
+      });
+
+      await request(app)
+        .post("/auth/github-actions/tokenless/exchange")
+        .send({ tokenlessToken: bearer, commit: commitSha, branch })
+        .expect(400)
+        .expect((res) => {
+          expect(res.body.error).toBe(
+            `Project "team-a/unknown" not found for GitHub repository (token: "${bearer}"). Ensure the project slug matches an Argos project linked to this repository.`,
+          );
+        });
+    });
   });
 });

--- a/apps/backend/src/auth/tokenless/github-actions.ts
+++ b/apps/backend/src/auth/tokenless/github-actions.ts
@@ -13,6 +13,11 @@ const AuthTokenPayloadSchema = z.object({
   repository: z.string(),
   jobId: z.string(),
   runId: z.string(),
+  /**
+   * Optional Argos project slug ("account/project-name") used to disambiguate
+   * when several projects are linked to the same GitHub repository.
+   */
+  project: z.string().optional(),
 });
 
 /**
@@ -29,6 +34,15 @@ function decodeToken(bearerToken: string, marker: string) {
   } catch {
     throw boom(401, `Invalid token (token: "${bearerToken}")`);
   }
+}
+
+/**
+ * Compute the slug ("account/project-name") of a project. Requires the
+ * `account` relation to be fetched.
+ */
+function getProjectSlug(project: Project): string {
+  invariant(project.account, "account is not fetched");
+  return `${project.account.slug}/${project.name}`;
 }
 
 type TokenlessGitHubActionsRun = {
@@ -53,7 +67,7 @@ export async function resolveTokenlessGitHubActionsContext(
 
   const repository = await GithubRepository.query()
     .joinRelated("githubAccount")
-    .withGraphJoined("[repoInstallations.installation, projects]")
+    .withGraphJoined("[repoInstallations.installation, projects.account]")
     .where("githubAccount.login", authData.owner)
     .findOne("github_repositories.name", authData.repository)
     .orderBy("github_repositories.updatedAt", "desc")
@@ -69,11 +83,34 @@ export async function resolveTokenlessGitHubActionsContext(
     return null;
   }
 
-  if (repository.projects.length > 1) {
-    throw boom(
-      400,
-      `Multiple projects found for GitHub repository (token: "${bearerToken}"). Please specify a Project token.`,
+  let project: Project;
+
+  if (authData.project) {
+    // A project slug was provided: pick the matching project. This is what lets
+    // a repository with several linked projects authenticate tokenless-ly.
+    const matching = repository.projects.find(
+      (candidate) => getProjectSlug(candidate) === authData.project,
     );
+
+    if (!matching) {
+      throw boom(
+        400,
+        `Project "${authData.project}" not found for GitHub repository (token: "${bearerToken}"). Ensure the project slug matches an Argos project linked to this repository.`,
+      );
+    }
+
+    project = matching;
+  } else {
+    // No project slug: keep the legacy behavior and reject when the repository
+    // is linked to more than one project, since we cannot disambiguate.
+    if (repository.projects.length > 1) {
+      throw boom(
+        400,
+        `Multiple projects found for GitHub repository (token: "${bearerToken}"). Please specify a project slug or a project token.`,
+      );
+    }
+
+    project = repository.projects[0];
   }
 
   const installation = GithubRepository.pickBestInstallation(repository);
@@ -129,7 +166,7 @@ export async function resolveTokenlessGitHubActionsContext(
   }
 
   return {
-    project: repository.projects[0],
+    project,
     run: {
       status: githubRun.data.status,
       head_sha: githubRun.data.head_sha,


### PR DESCRIPTION
## Problem

In tokenless mode, auth rejects with a `400` when it finds more than one Argos project linked to the same GitHub repository, because it cannot disambiguate which one to use.

## Solution

Add an optional **project slug** (`account/project-name`) to the tokenless GitHub Actions token payload. The client can now embed the slug so the backend selects the right project.

- `AuthTokenPayloadSchema` gains an optional `project` field.
- The repository query now fetches `projects.account` so each project's slug can be computed (`getProjectSlug` → `${account.slug}/${name}`).
- Resolution logic:
  - **slug provided** → pick the matching project; `400` if none matches.
  - **no slug** → legacy behavior (reject `400` only when >1 project is linked).

Both consumers (`tokenlessGitHubActionsStrategy.getProject` and the `/auth/github-actions/tokenless/exchange` endpoint) go through `resolveTokenlessGitHubActionsContext`, so they both benefit — no API handler/schema change needed since the slug rides inside the token.

## Follow-up

The client (`@argos-ci` CLI/core) needs to add `project: "account/project-name"` to the token payload it generates. The backend is ready to accept it.

## Tests

Added e2e coverage: multiple projects with no slug → `400`; correct slug → resolves the right project; non-matching slug → `400`. All passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)