### PR TITLE
feat: open the linked comment when going to its snapshot

### DIFF
--- a/apps/frontend/src/containers/Build/CommentTool.ts
+++ b/apps/frontend/src/containers/Build/CommentTool.ts
@@ -21,6 +21,15 @@ export const commentsVisibleAtom = atomWithStorage<boolean>(
 );
 
 /**
+ * A one-shot request to open a point-anchored comment's thread on the changes
+ * image, carrying the thread root's comment id. Set when jumping to a comment
+ * from outside the viewer (the sidebar's "Go to this snapshot"); the screenshot
+ * layer consumes it — opening the matching marker's thread, then resetting it to
+ * null — once that comment's diff is shown. Null when there's nothing to open.
+ */
+export const requestedScreenshotCommentIdAtom = atom<string | null>(null);
+
+/**
  * Comment-tool state with its cross-field invariants in one place: picking the
  * Comment tool always reveals comments, and hiding comments always drops back to
  * the Hand tool — you can't place a comment you can't see.

--- a/apps/frontend/src/pages/Build/screenshotComments/ScreenshotCommentLayer.tsx
+++ b/apps/frontend/src/pages/Build/screenshotComments/ScreenshotCommentLayer.tsx
@@ -9,13 +9,14 @@ import {
 } from "react";
 import { useMutation } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
-import { useAtomValue } from "jotai/react";
+import { useAtom, useAtomValue } from "jotai/react";
 import { toast } from "sonner";
 
 import { useAuthTokenPayload } from "@/containers/Auth";
 import {
   commentsVisibleAtom,
   commentToolModeAtom,
+  requestedScreenshotCommentIdAtom,
 } from "@/containers/Build/CommentTool";
 import {
   ZOOMER_OVERLAY_INTERACTIVE_CLASS,
@@ -150,6 +151,30 @@ export function ScreenshotCommentLayer(props: {
     () => threads.find((thread) => thread.root.id === openThreadId) ?? null,
     [threads, openThreadId],
   );
+
+  // Honor a request to open a specific thread, set when jumping to a comment
+  // from outside the viewer (the sidebar's "Go to this snapshot"). Once the
+  // requested comment is one of this diff's threads — which happens after
+  // navigating to its diff — open it and clear the request. Any in-progress
+  // draft is dropped so the thread, not a half-placed pin, is shown.
+  const [requestedCommentId, setRequestedCommentId] = useAtom(
+    requestedScreenshotCommentIdAtom,
+  );
+  useEffect(() => {
+    if (!requestedCommentId) {
+      return;
+    }
+    const requested = threads.find(
+      (thread) => thread.root.id === requestedCommentId,
+    );
+    if (requested) {
+      setRequestedCommentId(null);
+      // Move the external open request into this layer's local state.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setDraft(null);
+      setOpenThreadId(requestedCommentId);
+    }
+  }, [requestedCommentId, threads, setRequestedCommentId]);
 
   const mentionUsers = useMemo(
     () => build.members.map(getMentionUser),
@@ -380,6 +405,10 @@ export function ScreenshotCommentLayer(props: {
       openThread &&
       openThread.root.anchor?.__typename === "CommentPointAnchor" ? (
         <CommentThreadPopover
+          // Remount per thread so the reply composer re-runs its autofocus and
+          // reads its own draft when switching directly between markers (the
+          // popover stays mounted across that switch).
+          key={openThread.root.id}
           point={toViewport(
             toScreen({
               x: openThread.root.anchor.x,

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -333,6 +333,7 @@ export function CommentCard(props: {
       {!hideScreenshotReference && comment.screenshotDiff ? (
         <div className="border-b-thin">
           <CommentScreenshotReference
+            commentId={comment.id}
             screenshotDiff={comment.screenshotDiff}
             anchor={(comment.anchor as CommentAnchor | null) ?? null}
           />

--- a/apps/frontend/src/pages/Build/sidebar/CommentScreenshotReference.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentScreenshotReference.tsx
@@ -1,6 +1,11 @@
+import { useSetAtom } from "jotai/react";
 import { MapPinIcon } from "lucide-react";
 import { Button } from "react-aria-components";
 
+import {
+  commentsVisibleAtom,
+  requestedScreenshotCommentIdAtom,
+} from "@/containers/Build/CommentTool";
 import { DocumentType, graphql } from "@/gql";
 import { Tooltip } from "@/ui/Tooltip";
 
@@ -48,11 +53,14 @@ function getAnchorLabel(anchor: CommentAnchor | null): string | null {
  * comment thread. Clicking it navigates to that diff in the viewer.
  */
 export function CommentScreenshotReference(props: {
+  commentId: string;
   screenshotDiff: ScreenshotDiff;
   anchor: CommentAnchor | null;
 }) {
-  const { screenshotDiff, anchor } = props;
+  const { commentId, screenshotDiff, anchor } = props;
   const { allDiffs, setActiveDiff } = useBuildDiffState();
+  const setCommentsVisible = useSetAtom(commentsVisibleAtom);
+  const requestOpenComment = useSetAtom(requestedScreenshotCommentIdAtom);
   const linesLabel = getAnchorLabel(anchor);
   const isPoint = anchor?.__typename === "CommentPointAnchor";
 
@@ -62,8 +70,17 @@ export function CommentScreenshotReference(props: {
     const diff = allDiffs.find(
       (candidate) => candidate.id === screenshotDiff.id,
     );
-    if (diff) {
-      setActiveDiff(diff, true);
+    if (!diff) {
+      return;
+    }
+    setActiveDiff(diff, true);
+    // A point-anchored comment lives as a marker on the image: reveal comments
+    // and ask the screenshot layer to open this one's thread once its diff is
+    // shown. (Line-anchored comments render inline on the diff, so navigating
+    // there already surfaces them.)
+    if (isPoint) {
+      setCommentsVisible(true);
+      requestOpenComment(commentId);
     }
   };
 


### PR DESCRIPTION
## What

Two fixes to screenshot comment navigation:

### 1. "Go to this snapshot" now opens the comment

Previously the sidebar's **Go to this snapshot** button only navigated to the diff — it never opened the comment it referenced. For a point-anchored comment it now also opens that comment's thread on the image once the diff is shown.

This is wired through a new one-shot `requestedScreenshotCommentIdAtom`: the sidebar sets it (and reveals comments) on click, and `ScreenshotCommentLayer` consumes it — opening the matching marker's thread and clearing the atom — after navigation settles. Line-anchored comments render inline on the diff, so navigating already surfaces them and they're unchanged.

### 2. Fix reply field only autofocusing on the first marker (regression)

Clicking another marker while one thread is open doesn't unmount the popover (markers carry the overlay-interactive class, so the outside-click handler skips them) — `openThreadId` just flips and React reuses the editor. TipTap's `autofocus: "end"` only runs at editor creation, so it never re-fired.

The thread popover is now keyed by its comment id, so a fresh editor mounts per thread and autofocus runs on every switch. As a bonus this also stops the reused editor from showing the previous thread's draft.

## Notes

- A **resolved** point comment has no marker on the image, so "Go to this snapshot" navigates to the diff but won't open a popover (the parked request is harmless and gets overwritten by the next one). Kept scope to the unresolved/positioned case.
- Verified via type-check + lint and code-path tracing; there are no existing tests/stories for these components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
