### PR TITLE
feat: add comments as part of a review

### DIFF
--- a/apps/backend/db/migrations/20260620120000_pending-review-unique.js
+++ b/apps/backend/db/migrations/20260620120000_pending-review-unique.js
@@ -1,0 +1,24 @@
+/**
+ * Guarantee a user can have at most one active pending review per build, so
+ * draft (review) comments always attach to a single, well-defined review.
+ *
+ * @param {import('knex').Knex} knex
+ */
+export const up = async (knex) => {
+  await knex.raw(`
+    CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS build_reviews_pending_unique
+    ON build_reviews ("buildId", "userId")
+    WHERE state = 'pending' AND "dismissedAt" IS NULL
+  `);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+export const down = async (knex) => {
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS build_reviews_pending_unique
+  `);
+};
+
+export const config = { transaction: false };

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -3593,6 +3593,13 @@ CREATE INDEX build_reviews_dismissedbyid_index ON public.build_reviews USING btr
 
 
 --
+-- Name: build_reviews_pending_unique; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX build_reviews_pending_unique ON public.build_reviews USING btree ("buildId", "userId") WHERE ((state = 'pending'::text) AND ("dismissedAt" IS NULL));
+
+
+--
 -- Name: build_reviews_userid_index; Type: INDEX; Schema: public; Owner: postgres
 --
 
@@ -5180,3 +5187,4 @@ INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('2026060
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260610120000_comment-resolved-at.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260614202438_build-requested-reviewers.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260616120000_comment-anchor.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260620120000_pending-review-unique.js', 1, NOW());

--- a/apps/backend/src/build/createBuildReview.ts
+++ b/apps/backend/src/build/createBuildReview.ts
@@ -7,6 +7,7 @@ import type { JSONContent } from "@tiptap/core";
 
 import { triggerAndRunAutomation } from "@/automation";
 import { pushBuildNotification } from "@/build-notification/notifications";
+import { notifyReviewCommentsWentLive } from "@/comment/commentNotifications";
 import { renderCommentHtmlWithMentions } from "@/comment/mentions";
 import { isCommentTooLarge, validateCommentJson } from "@/comment/validate";
 import type { BuildNotification } from "@/database/models";
@@ -26,6 +27,7 @@ import { transaction } from "@/database/transaction";
 import { sendNotification } from "@/notification";
 import { boom } from "@/util/error";
 
+import { getViewerPendingReview } from "./pendingReview";
 import { publishReviewChange } from "./reviewEvents";
 
 export type ReviewState = "approved" | "rejected" | "commented" | "pending";
@@ -92,35 +94,46 @@ export async function createBuildReview(input: {
 
   const state = getReviewStateFromEvent(event);
 
-  const { buildReview, comment } = await transaction(async (trx) => {
-    const buildReview = await BuildReview.query(trx).insert({
-      buildId: build.id,
-      userId,
-      state,
-    });
-
-    if (snapshotReviews.length > 0) {
-      await ScreenshotDiffReview.query(trx).insert(
-        snapshotReviews.map((snapshotReview) => ({
-          screenshotDiffId: snapshotReview.screenshotDiffId,
-          buildReviewId: buildReview.id,
-          state: snapshotReview.state,
-        })),
-      );
-    }
-
-    const comment =
-      body != null
-        ? await Comment.query(trx).insert({
-            userId,
+  const { buildReview, comment, hadPendingReview } = await transaction(
+    async (trx) => {
+      // Reuse the user's pending (draft) review if they have one, so the draft
+      // comments they added are submitted together; otherwise open a fresh one.
+      const pendingReview = await getViewerPendingReview({
+        buildId: build.id,
+        userId,
+        trx,
+      });
+      const buildReview = pendingReview
+        ? await pendingReview.$query(trx).patchAndFetch({ state })
+        : await BuildReview.query(trx).insert({
             buildId: build.id,
-            buildReviewId: buildReview.id,
-            content: body,
-          })
-        : null;
+            userId,
+            state,
+          });
 
-    return { buildReview, comment };
-  });
+      if (snapshotReviews.length > 0) {
+        await ScreenshotDiffReview.query(trx).insert(
+          snapshotReviews.map((snapshotReview) => ({
+            screenshotDiffId: snapshotReview.screenshotDiffId,
+            buildReviewId: buildReview.id,
+            state: snapshotReview.state,
+          })),
+        );
+      }
+
+      const comment =
+        body != null
+          ? await Comment.query(trx).insert({
+              userId,
+              buildId: build.id,
+              buildReviewId: buildReview.id,
+              content: body,
+            })
+          : null;
+
+      return { buildReview, comment, hadPendingReview: Boolean(pendingReview) };
+    },
+  );
 
   if (comment) {
     await subscribeUserToCommentThread({ commentId: comment.id, userId });
@@ -133,6 +146,22 @@ export async function createBuildReview(input: {
     compareScreenshotBucket,
     `Compare screenshot bucket not found for build: ${build.id}`,
   );
+
+  // When the submitted review was the user's pending draft, its draft comments
+  // become visible now: broadcast them and send their deferred mention
+  // notifications. A fresh review has no draft comments to promote.
+  let goLivePromise: Promise<void> = Promise.resolve();
+  if (hadPendingReview) {
+    const project = await build
+      .$relatedQuery("project")
+      .withGraphFetched("account");
+    invariant(project, "project not found");
+    goLivePromise = notifyReviewCommentsWentLive({
+      build,
+      project,
+      review: buildReview,
+    });
+  }
   const [status] = await Build.getAggregatedBuildStatuses([build]);
   invariant(status, `Build status not found for build: ${build.id}`);
   const notificationType = getBuildNotificationType(status);
@@ -153,9 +182,10 @@ export async function createBuildReview(input: {
     }),
     autoSubscribeUserToBuild({ buildId: build.id, userId }),
     notifyBuildSubscribers({ build, buildReview, comment }),
+    goLivePromise,
     // Notify clients watching this build so the review appears live in the
-    // activity feed. Reviews created here are never pending, so they always
-    // belong in the feed.
+    // activity feed. The review is now submitted (not pending), so it belongs
+    // in the feed.
     publishReviewChange({
       buildId: build.id,
       type: "SUBMITTED",

--- a/apps/backend/src/build/pendingReview.ts
+++ b/apps/backend/src/build/pendingReview.ts
@@ -1,0 +1,65 @@
+import type { TransactionOrKnex } from "objection";
+
+import { isUniqueViolationError } from "@/database/error";
+import { Build, BuildReview } from "@/database/models";
+
+/**
+ * Find the user's active (non-dismissed) pending review for a build, if any.
+ * Pending reviews hold draft comments that are only visible to their author
+ * until the review is submitted.
+ */
+export async function getViewerPendingReview(input: {
+  buildId: string;
+  userId: string;
+  trx?: TransactionOrKnex | undefined;
+}): Promise<BuildReview | null> {
+  const { buildId, userId, trx } = input;
+  const review = await BuildReview.query(trx).findOne({
+    buildId,
+    userId,
+    state: "pending",
+    dismissedAt: null,
+  });
+  return review ?? null;
+}
+
+/**
+ * Get the user's active pending review for a build, creating one if it does not
+ * exist yet. A partial unique index (`build_reviews_pending_unique`) enforces a
+ * single active pending review per (build, user); on a concurrent insert we
+ * catch the unique violation and re-read the winning row.
+ */
+export async function getOrCreatePendingBuildReview(input: {
+  build: Build;
+  userId: string;
+  trx?: TransactionOrKnex | undefined;
+}): Promise<BuildReview> {
+  const { build, userId, trx } = input;
+  const existing = await getViewerPendingReview({
+    buildId: build.id,
+    userId,
+    trx,
+  });
+  if (existing) {
+    return existing;
+  }
+  try {
+    return await BuildReview.query(trx).insert({
+      buildId: build.id,
+      userId,
+      state: "pending",
+    });
+  } catch (error) {
+    if (isUniqueViolationError(error)) {
+      const review = await getViewerPendingReview({
+        buildId: build.id,
+        userId,
+        trx,
+      });
+      if (review) {
+        return review;
+      }
+    }
+    throw error;
+  }
+}

--- a/apps/backend/src/comment/commentEvents.e2e.test.ts
+++ b/apps/backend/src/comment/commentEvents.e2e.test.ts
@@ -1,0 +1,74 @@
+import { test as base, beforeEach, describe, expect, vi } from "vitest";
+
+import { Build } from "@/database/models";
+import { factory, setupDatabase } from "@/database/testing";
+import { redisPubSub } from "@/util/redis";
+
+import { publishCommentChange } from "./commentEvents";
+
+vi.spyOn(redisPubSub, "publish").mockResolvedValue(undefined);
+const mockPublish = vi.mocked(redisPubSub.publish);
+
+type Fixtures = { build: Build };
+
+const test = base.extend<Fixtures>({
+  build: async ({}, use) => {
+    await setupDatabase();
+    const build = await factory.Build.create();
+    await use(build);
+  },
+});
+
+function content(text: string) {
+  return {
+    type: "doc",
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  };
+}
+
+describe("publishCommentChange", () => {
+  beforeEach(() => {
+    mockPublish.mockClear();
+  });
+
+  test("does not broadcast a comment that belongs to a pending review", async ({
+    build,
+  }) => {
+    const review = await factory.BuildReview.create({
+      buildId: build.id,
+      state: "pending",
+    });
+    const comment = await factory.Comment.create({
+      buildId: build.id,
+      buildReviewId: review.id,
+      content: content("draft"),
+    });
+    await publishCommentChange({ buildId: build.id, type: "UPDATED", comment });
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+
+  test("broadcasts a standalone comment", async ({ build }) => {
+    const comment = await factory.Comment.create({
+      buildId: build.id,
+      content: content("live"),
+    });
+    await publishCommentChange({ buildId: build.id, type: "UPDATED", comment });
+    expect(mockPublish).toHaveBeenCalledTimes(1);
+  });
+
+  test("broadcasts a comment once its review is submitted", async ({
+    build,
+  }) => {
+    const review = await factory.BuildReview.create({
+      buildId: build.id,
+      state: "commented",
+    });
+    const comment = await factory.Comment.create({
+      buildId: build.id,
+      buildReviewId: review.id,
+      content: content("now live"),
+    });
+    await publishCommentChange({ buildId: build.id, type: "ADDED", comment });
+    expect(mockPublish).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/comment/commentEvents.ts
+++ b/apps/backend/src/comment/commentEvents.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { BuildReview } from "@/database/models/BuildReview";
 import { Comment } from "@/database/models/Comment";
 import { redisPubSub } from "@/util/redis";
 
@@ -24,12 +25,28 @@ function getCommentChannel(buildId: string): string {
  * live. Only the comment row travels through Redis; relations (author,
  * mentions, reactions) are loaded per subscriber by the GraphQL field
  * resolvers from the rehydrated comment.
+ *
+ * Comments belonging to a pending (unsubmitted) review are drafts visible only
+ * to their author, so they are never broadcast — the channel reaches every
+ * build viewer and has no per-recipient filtering. Guarding here (rather than
+ * at each call site) keeps every path — edits, reactions, thread resolution,
+ * deletion — from leaking a draft. Once the review is submitted the comments
+ * are no longer pending and broadcast normally (e.g. from
+ * `notifyReviewCommentsWentLive`).
  */
 export async function publishCommentChange(input: {
   buildId: string;
   type: CommentChangeType;
   comment: Comment;
 }): Promise<void> {
+  if (input.comment.buildReviewId) {
+    const review = await BuildReview.query()
+      .findById(input.comment.buildReviewId)
+      .select("state");
+    if (review?.state === "pending") {
+      return;
+    }
+  }
   await redisPubSub.publish(getCommentChannel(input.buildId), {
     type: input.type,
     comment: input.comment.toJSON(),

--- a/apps/backend/src/comment/commentNotifications.ts
+++ b/apps/backend/src/comment/commentNotifications.ts
@@ -1,11 +1,15 @@
 import { invariant } from "@argos/util/invariant";
 
-import { Build, Comment, Project, User } from "@/database/models";
+import { Build, BuildReview, Comment, Project, User } from "@/database/models";
 import { subscribeUserToCommentThread } from "@/database/services/comment-notification-subscription";
 import { sendNotification } from "@/notification";
 
+import { publishCommentChange } from "./commentEvents";
 import { formatCommentId } from "./id";
-import { renderCommentHtmlWithMentions } from "./mentions";
+import {
+  getCommentMentionedUserIds,
+  renderCommentHtmlWithMentions,
+} from "./mentions";
 
 /**
  * Build the data shared by every comment notification email (author name and
@@ -70,4 +74,43 @@ export async function notifyMentionedUsers(input: {
     userId,
   });
   await sendNotification({ type: "comment_mention", data, recipients });
+}
+
+/**
+ * Called when a review leaves the `pending` state: its draft comments become
+ * visible to everyone. Broadcast each comment so other clients' activity feeds
+ * populate, and send the mention notifications that were deferred while the
+ * comments were drafts. We deliberately do NOT send `comment_added` here — the
+ * review submission notification already covers the build subscribers.
+ */
+export async function notifyReviewCommentsWentLive(input: {
+  build: Build;
+  project: Project;
+  review: BuildReview;
+}): Promise<void> {
+  const { build, project, review } = input;
+  const comments = await review
+    .$relatedQuery("comments")
+    .whereNull("deletedAt")
+    .orderBy("createdAt", "asc");
+  if (comments.length === 0) {
+    return;
+  }
+  await Promise.all(
+    comments.map(async (comment) => {
+      invariant(comment.userId, "comment should have a userId");
+      const mentionedUserIds = await getCommentMentionedUserIds(comment.id);
+      await Promise.all([
+        publishCommentChange({ buildId: build.id, type: "ADDED", comment }),
+        notifyMentionedUsers({
+          build,
+          project,
+          comment,
+          userId: comment.userId,
+          mentionedUserIds,
+          threadId: comment.threadId ?? comment.id,
+        }),
+      ]);
+    }),
+  );
 }

--- a/apps/backend/src/comment/createBuildComment.ts
+++ b/apps/backend/src/comment/createBuildComment.ts
@@ -1,7 +1,7 @@
 import { invariant } from "@argos/util/invariant";
 import type { JSONContent } from "@tiptap/core";
 
-import { Build, BuildReview, Comment, Project } from "@/database/models";
+import { Build, Comment, Project } from "@/database/models";
 import type { CommentAnchor } from "@/database/models/Comment";
 import {
   autoSubscribeUserToBuild,
@@ -31,11 +31,13 @@ import {
  * Post a comment on a build, auto-subscribe the author and notify the other
  * subscribers.
  *
- * When `buildReviewId` points to a review still in the `pending` state, the
- * comment is a draft: it is visible only to its author until the review is
+ * When `pending` is set, the comment belongs to a review still in the `pending`
+ * state — it is a draft, visible only to its author until the review is
  * submitted, so all notifications and the live broadcast are deferred to
  * submission time (see `notifyReviewCommentsWentLive` in `createBuildReview`).
- * Mentions are still persisted now so we know whom to notify then.
+ * Mentions are still persisted now so we know whom to notify then. The caller
+ * already knows the review state, so it passes `pending` rather than us
+ * re-reading the review.
  */
 export async function createBuildComment(input: {
   build: Build;
@@ -45,6 +47,7 @@ export async function createBuildComment(input: {
   screenshotDiffId?: string | null;
   anchor?: CommentAnchor | null;
   buildReviewId?: string | null;
+  pending?: boolean;
 }): Promise<Comment> {
   const {
     build,
@@ -53,6 +56,7 @@ export async function createBuildComment(input: {
     screenshotDiffId = null,
     anchor = null,
     buildReviewId = null,
+    pending = false,
   } = input;
 
   if (!validateCommentJson(input.body)) {
@@ -98,11 +102,6 @@ export async function createBuildComment(input: {
         autoSubscribeUserToBuild({ buildId: build.id, userId }),
         subscribeUserToCommentThread({ commentId: comment.id, userId }),
       ];
-
-  // A comment is a draft when it belongs to a review that is still pending.
-  const pending = buildReviewId
-    ? (await BuildReview.query().findById(buildReviewId))?.state === "pending"
-    : false;
 
   if (pending) {
     // Defer notifications and the live broadcast to submission time. The

--- a/apps/backend/src/comment/createBuildComment.ts
+++ b/apps/backend/src/comment/createBuildComment.ts
@@ -1,7 +1,7 @@
 import { invariant } from "@argos/util/invariant";
 import type { JSONContent } from "@tiptap/core";
 
-import { Build, Comment, Project } from "@/database/models";
+import { Build, BuildReview, Comment, Project } from "@/database/models";
 import type { CommentAnchor } from "@/database/models/Comment";
 import {
   autoSubscribeUserToBuild,
@@ -28,8 +28,14 @@ import {
 } from "./validate";
 
 /**
- * Post a standalone comment on a build (one that is not attached to a review),
- * auto-subscribe the author to the build and notify the other subscribers.
+ * Post a comment on a build, auto-subscribe the author and notify the other
+ * subscribers.
+ *
+ * When `buildReviewId` points to a review still in the `pending` state, the
+ * comment is a draft: it is visible only to its author until the review is
+ * submitted, so all notifications and the live broadcast are deferred to
+ * submission time (see `notifyReviewCommentsWentLive` in `createBuildReview`).
+ * Mentions are still persisted now so we know whom to notify then.
  */
 export async function createBuildComment(input: {
   build: Build;
@@ -38,6 +44,7 @@ export async function createBuildComment(input: {
   threadId?: string | null;
   screenshotDiffId?: string | null;
   anchor?: CommentAnchor | null;
+  buildReviewId?: string | null;
 }): Promise<Comment> {
   const {
     build,
@@ -45,6 +52,7 @@ export async function createBuildComment(input: {
     threadId = null,
     screenshotDiffId = null,
     anchor = null,
+    buildReviewId = null,
   } = input;
 
   if (!validateCommentJson(input.body)) {
@@ -67,6 +75,7 @@ export async function createBuildComment(input: {
     Comment.query().insert({
       userId,
       buildId: build.id,
+      buildReviewId,
       threadId,
       screenshotDiffId,
       anchor,
@@ -77,8 +86,31 @@ export async function createBuildComment(input: {
   invariant(project?.account, "Build project account not found");
 
   // Persist the user mentions found in the comment and resolve them to the
-  // users that may actually be notified (members of the project's team).
+  // users that may actually be notified (members of the project's team). Done
+  // even for draft comments so submission knows whom to notify.
   const mentionedUserIds = await syncCommentMentions({ comment, project });
+
+  // Subscribe the author so they receive updates on this thread/build, whether
+  // the comment is live now or once the review is submitted.
+  const authorSubscriptions = threadId
+    ? [subscribeUserToCommentThread({ commentId: threadId, userId })]
+    : [
+        autoSubscribeUserToBuild({ buildId: build.id, userId }),
+        subscribeUserToCommentThread({ commentId: comment.id, userId }),
+      ];
+
+  // A comment is a draft when it belongs to a review that is still pending.
+  const pending = buildReviewId
+    ? (await BuildReview.query().findById(buildReviewId))?.state === "pending"
+    : false;
+
+  if (pending) {
+    // Defer notifications and the live broadcast to submission time. The
+    // author's own client reflects the comment from the mutation result; other
+    // clients (including the author's other tabs) reconcile on next load.
+    await Promise.all(authorSubscriptions);
+    return comment;
+  }
 
   // Notifying the mentioned users is independent of notifying the thread/build
   // subscribers (those already exclude the mentioned users by id), so let it
@@ -94,7 +126,7 @@ export async function createBuildComment(input: {
 
   if (threadId) {
     await Promise.all([
-      subscribeUserToCommentThread({ commentId: threadId, userId }),
+      ...authorSubscriptions,
       notifyCommentThreadSubscribers({
         build,
         project,
@@ -108,8 +140,7 @@ export async function createBuildComment(input: {
     ]);
   } else {
     await Promise.all([
-      autoSubscribeUserToBuild({ buildId: build.id, userId }),
-      subscribeUserToCommentThread({ commentId: comment.id, userId }),
+      ...authorSubscriptions,
       notifyBuildSubscribers({
         build,
         project,

--- a/apps/backend/src/graphql/definitions/Build.ts
+++ b/apps/backend/src/graphql/definitions/Build.ts
@@ -3,11 +3,7 @@ import { invariant } from "@argos/util/invariant";
 import gqlTag from "graphql-tag";
 
 import { getPreviousDiffApprovalIds } from "@/build/approval";
-import {
-  Build,
-  BuildNotificationSubscription,
-  BuildReview,
-} from "@/database/models";
+import { Build, BuildNotificationSubscription } from "@/database/models";
 import { sortScreenshotDiffsForBuild } from "@/database/services/screenshot-diffs";
 import { getProjectMemberIds } from "@/project/members";
 
@@ -330,13 +326,13 @@ export const resolvers: IResolvers = {
       if (!ctx.auth) {
         return false;
       }
-      const review = await BuildReview.query()
-        .where("buildId", build.id)
-        .where("userId", ctx.auth.user.id)
-        .whereNot("state", "pending")
-        .whereNull("dismissedAt")
-        .resultSize();
-      return review > 0;
+      // Reuse the batched, non-pending reviews already loaded for `reviews`
+      // rather than issuing a separate count query.
+      const userId = ctx.auth.user.id;
+      const reviews = await ctx.loaders.BuildReviews.load(build.id);
+      return reviews.some(
+        (review) => review.userId === userId && !review.dismissedAt,
+      );
     },
     comments: async (build, _args, ctx) => {
       return ctx.loaders.BuildPublishedComments.load({

--- a/apps/backend/src/graphql/definitions/Build.ts
+++ b/apps/backend/src/graphql/definitions/Build.ts
@@ -3,7 +3,11 @@ import { invariant } from "@argos/util/invariant";
 import gqlTag from "graphql-tag";
 
 import { getPreviousDiffApprovalIds } from "@/build/approval";
-import { Build, BuildNotificationSubscription } from "@/database/models";
+import {
+  Build,
+  BuildNotificationSubscription,
+  BuildReview,
+} from "@/database/models";
 import { sortScreenshotDiffsForBuild } from "@/database/services/screenshot-diffs";
 import { getProjectMemberIds } from "@/project/members";
 
@@ -125,7 +129,9 @@ export const typeDefs = gql`
     baseBranchResolvedFrom: BaseBranchResolution
     "Submitted build reviews"
     reviews: [BuildReview!]!
-    "Comments posted on the build that are not part of a pending review"
+    "Whether the current user has already submitted a review on this build"
+    viewerHasSubmittedReview: Boolean!
+    "Comments visible to the current user (excludes other users' pending-review drafts)"
     comments: [Comment!]!
     "Previous approved diffs from a build with the same branch"
     branchApprovedDiffs: [ID!]!
@@ -320,8 +326,23 @@ export const resolvers: IResolvers = {
     reviews: async (build, _args, ctx) => {
       return ctx.loaders.BuildReviews.load(build.id);
     },
+    viewerHasSubmittedReview: async (build, _args, ctx) => {
+      if (!ctx.auth) {
+        return false;
+      }
+      const review = await BuildReview.query()
+        .where("buildId", build.id)
+        .where("userId", ctx.auth.user.id)
+        .whereNot("state", "pending")
+        .whereNull("dismissedAt")
+        .resultSize();
+      return review > 0;
+    },
     comments: async (build, _args, ctx) => {
-      return ctx.loaders.BuildPublishedComments.load(build.id);
+      return ctx.loaders.BuildPublishedComments.load({
+        buildId: build.id,
+        viewerUserId: ctx.auth?.user.id ?? null,
+      });
     },
     stats: (build) => {
       return build.getStats();

--- a/apps/backend/src/graphql/definitions/Comment.ts
+++ b/apps/backend/src/graphql/definitions/Comment.ts
@@ -1,3 +1,4 @@
+import type { BuildAggregatedStatus } from "@argos/schemas/build-status";
 import { invariant } from "@argos/util/invariant";
 import type { JSONContent } from "@tiptap/core";
 import gqlTag from "graphql-tag";
@@ -45,6 +46,19 @@ import { assertCanViewBuild } from "../buildAccess";
 import { badUserInput, forbidden, notFound, unauthenticated } from "../util";
 
 const { gql } = gqlTag;
+
+/**
+ * Whether a build is in a state where a review can be submitted. Mirrors the
+ * statuses the frontend offers "Submit review" for; outside these, attaching a
+ * comment to a pending review would strand it with no way to submit.
+ */
+function isReviewableBuildStatus(status: BuildAggregatedStatus): boolean {
+  return (
+    status === "accepted" ||
+    status === "rejected" ||
+    status === "changes-detected"
+  );
+}
 
 /**
  * Turn the comment-anchor input into the stored anchor shape, enforcing that
@@ -528,16 +542,22 @@ export const resolvers: IResolvers = {
 
       // A reply inherits its thread's review (so a reply to a draft comment
       // stays a draft); a root comment joins the user's pending review when
-      // `addToReview` is set, creating that review on first use.
+      // `addToReview` is set, creating that review on first use — but only when
+      // the build can actually be reviewed, otherwise the draft would attach to
+      // a review with no submit path and stay hidden forever. When it can't, we
+      // fall back to posting a standalone (immediately visible) comment.
       let buildReviewId: string | null = null;
       if (thread) {
         buildReviewId = thread.buildReviewId;
       } else if (input.addToReview) {
-        const pendingReview = await getOrCreatePendingBuildReview({
-          build,
-          userId: auth.user.id,
-        });
-        buildReviewId = pendingReview.id;
+        const status = await ctx.loaders.BuildAggregatedStatus.load(build);
+        if (isReviewableBuildStatus(status)) {
+          const pendingReview = await getOrCreatePendingBuildReview({
+            build,
+            userId: auth.user.id,
+          });
+          buildReviewId = pendingReview.id;
+        }
       }
 
       await createBuildComment({

--- a/apps/backend/src/graphql/definitions/Comment.ts
+++ b/apps/backend/src/graphql/definitions/Comment.ts
@@ -21,6 +21,7 @@ import {
 } from "@/comment/resolveCommentThread";
 import { updateBuildComment } from "@/comment/updateBuildComment";
 import { Build } from "@/database/models/Build";
+import { BuildReview } from "@/database/models/BuildReview";
 import {
   Comment,
   CommentAnchorSchema,
@@ -547,8 +548,15 @@ export const resolvers: IResolvers = {
       // a review with no submit path and stay hidden forever. When it can't, we
       // fall back to posting a standalone (immediately visible) comment.
       let buildReviewId: string | null = null;
+      let pending = false;
       if (thread) {
         buildReviewId = thread.buildReviewId;
+        if (buildReviewId) {
+          const review = await BuildReview.query()
+            .findById(buildReviewId)
+            .select("state");
+          pending = review?.state === "pending";
+        }
       } else if (input.addToReview) {
         const status = await ctx.loaders.BuildAggregatedStatus.load(build);
         if (isReviewableBuildStatus(status)) {
@@ -557,6 +565,7 @@ export const resolvers: IResolvers = {
             userId: auth.user.id,
           });
           buildReviewId = pendingReview.id;
+          pending = pendingReview.state === "pending";
         }
       }
 
@@ -568,6 +577,7 @@ export const resolvers: IResolvers = {
         screenshotDiffId,
         anchor,
         buildReviewId,
+        pending,
       });
 
       return build;

--- a/apps/backend/src/graphql/definitions/Comment.ts
+++ b/apps/backend/src/graphql/definitions/Comment.ts
@@ -2,6 +2,7 @@ import { invariant } from "@argos/util/invariant";
 import type { JSONContent } from "@tiptap/core";
 import gqlTag from "graphql-tag";
 
+import { getOrCreatePendingBuildReview } from "@/build/pendingReview";
 import { addCommentReaction } from "@/comment/addCommentReaction";
 import {
   subscribeToCommentChanges,
@@ -223,6 +224,8 @@ export const typeDefs = gql`
     anchor: CommentAnchor
     "Whether the current user is subscribed to this comment thread"
     threadSubscribed: Boolean!
+    "Whether the comment belongs to a pending (unsubmitted) review and is only visible to its author"
+    pending: Boolean!
     "Permissions of the current user on this comment"
     permissions: [CommentPermission!]!
     "Emoji reactions on the comment, grouped by emoji"
@@ -258,6 +261,8 @@ export const typeDefs = gql`
     anchor: CommentAnchorInput
     "Rich-text JSON content of the comment"
     body: JSONObject!
+    "Attach the comment to the current user's pending review (created if needed) instead of posting it immediately. Ignored for replies, which inherit their thread's review."
+    addToReview: Boolean
   }
 
   input UpdateCommentInput {
@@ -413,6 +418,13 @@ export const resolvers: IResolvers = {
         });
       return subscription?.isSubscribed() ?? false;
     },
+    pending: async (comment, _args, ctx) => {
+      if (!comment.buildReviewId) {
+        return false;
+      }
+      const review = await ctx.loaders.BuildReview.load(comment.buildReviewId);
+      return review?.state === "pending";
+    },
     permissions: (comment, _args, ctx) => {
       return getCommentPermissions(
         comment,
@@ -514,6 +526,20 @@ export const resolvers: IResolvers = {
 
       const anchor = input.anchor ? commentAnchorFromInput(input.anchor) : null;
 
+      // A reply inherits its thread's review (so a reply to a draft comment
+      // stays a draft); a root comment joins the user's pending review when
+      // `addToReview` is set, creating that review on first use.
+      let buildReviewId: string | null = null;
+      if (thread) {
+        buildReviewId = thread.buildReviewId;
+      } else if (input.addToReview) {
+        const pendingReview = await getOrCreatePendingBuildReview({
+          build,
+          userId: auth.user.id,
+        });
+        buildReviewId = pendingReview.id;
+      }
+
       await createBuildComment({
         build,
         userId: auth.user.id,
@@ -521,6 +547,7 @@ export const resolvers: IResolvers = {
         threadId: thread?.id ?? null,
         screenshotDiffId,
         anchor,
+        buildReviewId,
       });
 
       return build;

--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -732,31 +732,54 @@ function createGhApiInstallationLoader() {
   );
 }
 
+/**
+ * Loads the comments visible to a given viewer on a build. A comment is visible
+ * when it is standalone (no review), belongs to a submitted review, or belongs
+ * to the viewer's own pending (draft) review — draft comments stay hidden from
+ * everyone but their author until the review is submitted.
+ */
 function createBuildPublishedCommentsLoader() {
-  return new DataLoader<string, Comment[]>(async (inputs) => {
-    const comments = await Comment.query()
-      .whereIn("buildId", inputs as string[])
-      .whereNull("deletedAt")
-      .where((qb) => {
-        qb.whereNull("buildReviewId").orWhereExists(
-          BuildReview.query()
-            .select(1)
-            .whereColumn("build_reviews.id", "comments.buildReviewId")
-            .whereNot("build_reviews.state", "pending"),
-        );
-      })
-      .orderBy("createdAt", "asc");
-    const commentsMap = comments.reduce<Record<string, Comment[]>>(
-      (map, comment) => {
-        const array = map[comment.buildId] ?? [];
-        array.push(comment);
-        map[comment.buildId] = array;
-        return map;
-      },
-      {},
-    );
-    return inputs.map((id) => commentsMap[id] ?? []);
-  });
+  return new DataLoader<
+    { buildId: string; viewerUserId: string | null },
+    Comment[],
+    string
+  >(
+    async (inputs) => {
+      const buildIds = inputs.map((input) => input.buildId);
+      // A single request carries one viewer, so all inputs share it.
+      const viewerUserId = inputs[0]?.viewerUserId ?? null;
+      const comments = await Comment.query()
+        .whereIn("buildId", buildIds)
+        .whereNull("deletedAt")
+        .where((qb) => {
+          qb.whereNull("buildReviewId").orWhereExists(
+            BuildReview.query()
+              .select(1)
+              .whereColumn("build_reviews.id", "comments.buildReviewId")
+              .where((sub) => {
+                sub.whereNot("build_reviews.state", "pending");
+                if (viewerUserId) {
+                  sub.orWhere("build_reviews.userId", viewerUserId);
+                }
+              }),
+          );
+        })
+        .orderBy("createdAt", "asc");
+      const commentsMap = comments.reduce<Record<string, Comment[]>>(
+        (map, comment) => {
+          const array = map[comment.buildId] ?? [];
+          array.push(comment);
+          map[comment.buildId] = array;
+          return map;
+        },
+        {},
+      );
+      return inputs.map((input) => commentsMap[input.buildId] ?? []);
+    },
+    {
+      cacheKeyFn: (input) => `${input.buildId}:${input.viewerUserId ?? ""}`,
+    },
+  );
 }
 
 function createCommentReactionsLoader() {
@@ -1333,6 +1356,7 @@ export const createLoaders = () => ({
   BuildPublishedComments: createBuildPublishedCommentsLoader(),
   CommentReactions: createCommentReactionsLoader(),
   CommentMentionedUserIds: createCommentMentionedUserIdsLoader(),
+  BuildReview: createModelLoader(BuildReview),
   BuildReviews: createBuildReviewsLoader(),
   BuildRequestedReviewers: createBuildRequestedReviewersLoader(),
   DeploymentAliasesByDeploymentId:

--- a/apps/backend/src/graphql/tests/pendingReviewComment.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/pendingReviewComment.e2e.test.ts
@@ -1,0 +1,314 @@
+import { invariant } from "@argos/util/invariant";
+import request from "supertest";
+import { test as base, beforeEach, describe, expect, vi } from "vitest";
+
+import { concludeBuild } from "@/build/concludeBuild";
+import {
+  Account,
+  Build,
+  BuildReview,
+  Comment,
+  Project,
+  ScreenshotDiff,
+} from "@/database/models";
+import { factory, setupDatabase } from "@/database/testing";
+import { sendNotification } from "@/notification";
+
+import { apolloServer, createApolloMiddleware } from "../apollo";
+import { expectNoGraphQLError } from "../testing";
+import { createApolloServerApp } from "./util";
+
+vi.mock("@/notification", () => ({ sendNotification: vi.fn() }));
+const mockSendNotification = vi.mocked(sendNotification);
+
+const ADD_COMMENT = `
+  mutation AddBuildComment($input: AddBuildCommentInput!) {
+    addBuildComment(input: $input) {
+      id
+      comments {
+        id
+        pending
+      }
+    }
+  }
+`;
+
+const CREATE_REVIEW = `
+  mutation CreateBuildReview($input: CreateBuildReviewInput!) {
+    createBuildReview(input: $input) {
+      status
+    }
+  }
+`;
+
+const BUILD_COMMENTS = `
+  query BuildComments(
+    $accountSlug: String!
+    $projectName: String!
+    $buildNumber: Int!
+  ) {
+    project(accountSlug: $accountSlug, projectName: $projectName) {
+      build(number: $buildNumber) {
+        viewerHasSubmittedReview
+        comments {
+          id
+          pending
+        }
+      }
+    }
+  }
+`;
+
+function commentBody(text: string) {
+  return {
+    type: "doc",
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  };
+}
+
+function mentionBody(account: Account) {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "Hey " },
+          { type: "mention", attrs: { id: account.id, label: account.slug } },
+        ],
+      },
+    ],
+  };
+}
+
+type Fixtures = {
+  fixture: {
+    author: Account;
+    member: Account;
+    teamAccount: Account;
+    project: Project;
+    build: Build;
+    screenshotDiffs: ScreenshotDiff[];
+  };
+};
+
+const test = base.extend<Fixtures>({
+  fixture: async ({}, use) => {
+    await setupDatabase();
+    const [author, member, teamAccount] = await Promise.all([
+      factory.UserAccount.create(),
+      factory.UserAccount.create(),
+      factory.TeamAccount.create(),
+    ]);
+    invariant(teamAccount.teamId && author.userId && member.userId);
+    const [project] = await Promise.all([
+      factory.Project.create({ accountId: teamAccount.id }),
+      factory.TeamUser.create({
+        teamId: teamAccount.teamId,
+        userId: author.userId,
+        userLevel: "owner",
+      }),
+      factory.TeamUser.create({
+        teamId: teamAccount.teamId,
+        userId: member.userId,
+        userLevel: "member",
+      }),
+      author.$fetchGraph("user"),
+      member.$fetchGraph("user"),
+      teamAccount.$fetchGraph("team"),
+    ]);
+    const build = await factory.Build.create({
+      projectId: project.id,
+      conclusion: null,
+    });
+    const screenshots = await factory.Screenshot.createMany(2);
+    const screenshotDiffs = await factory.ScreenshotDiff.createMany(1, [
+      {
+        buildId: build.id,
+        baseScreenshotId: screenshots[0]!.id,
+        compareScreenshotId: screenshots[1]!.id,
+        score: 0.3,
+      },
+    ]);
+    await concludeBuild({ build, notify: false });
+    const freshBuild = await build.$query();
+    await use({
+      author,
+      member,
+      teamAccount,
+      project,
+      build: freshBuild,
+      screenshotDiffs,
+    });
+  },
+});
+
+describe("pending review comments", () => {
+  beforeEach(() => {
+    mockSendNotification.mockReset();
+  });
+
+  test("addToReview creates a pending review and a pending comment without notifying", async ({
+    fixture,
+  }) => {
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user: fixture.author.user!, account: fixture.author },
+    );
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: ADD_COMMENT,
+        variables: {
+          input: {
+            buildId: fixture.build.id,
+            body: commentBody("Drafting feedback"),
+            addToReview: true,
+          },
+        },
+      });
+    expectNoGraphQLError(res);
+    expect(res.body.data.addBuildComment.comments).toHaveLength(1);
+    expect(res.body.data.addBuildComment.comments[0].pending).toBe(true);
+
+    const review = await BuildReview.query().findOne({
+      buildId: fixture.build.id,
+      userId: fixture.author.userId,
+    });
+    invariant(review);
+    expect(review.state).toBe("pending");
+
+    const comment = await Comment.query().findOne({
+      buildId: fixture.build.id,
+    });
+    invariant(comment);
+    expect(comment.buildReviewId).toBe(review.id);
+
+    // Draft comments don't notify anyone.
+    expect(mockSendNotification).not.toHaveBeenCalled();
+  });
+
+  test("a pending comment is visible to its author but hidden from other members", async ({
+    fixture,
+  }) => {
+    const authorApp = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user: fixture.author.user!, account: fixture.author },
+    );
+    await request(authorApp)
+      .post("/graphql")
+      .send({
+        query: ADD_COMMENT,
+        variables: {
+          input: {
+            buildId: fixture.build.id,
+            body: commentBody("Only I should see this"),
+            addToReview: true,
+          },
+        },
+      });
+
+    const variables = {
+      accountSlug: fixture.teamAccount.slug,
+      projectName: fixture.project.name,
+      buildNumber: fixture.build.number,
+    };
+
+    const authorView = await request(authorApp)
+      .post("/graphql")
+      .send({ query: BUILD_COMMENTS, variables });
+    expectNoGraphQLError(authorView);
+    expect(authorView.body.data.project.build.comments).toHaveLength(1);
+    expect(authorView.body.data.project.build.comments[0].pending).toBe(true);
+    expect(authorView.body.data.project.build.viewerHasSubmittedReview).toBe(
+      false,
+    );
+
+    const memberApp = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user: fixture.member.user!, account: fixture.member },
+    );
+    const memberView = await request(memberApp)
+      .post("/graphql")
+      .send({ query: BUILD_COMMENTS, variables });
+    expectNoGraphQLError(memberView);
+    expect(memberView.body.data.project.build.comments).toHaveLength(0);
+  });
+
+  test("submitting the review reuses the pending review, makes its comments live and notifies mentions", async ({
+    fixture,
+  }) => {
+    const authorApp = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user: fixture.author.user!, account: fixture.author },
+    );
+    // Draft a comment that mentions another member.
+    await request(authorApp)
+      .post("/graphql")
+      .send({
+        query: ADD_COMMENT,
+        variables: {
+          input: {
+            buildId: fixture.build.id,
+            body: mentionBody(fixture.member),
+            addToReview: true,
+          },
+        },
+      });
+    // No notification while the comment is a draft.
+    expect(mockSendNotification).not.toHaveBeenCalled();
+
+    const submit = await request(authorApp)
+      .post("/graphql")
+      .send({
+        query: CREATE_REVIEW,
+        variables: {
+          input: {
+            buildId: fixture.build.id,
+            event: "COMMENT",
+            screenshotDiffReviews: [],
+          },
+        },
+      });
+    expectNoGraphQLError(submit);
+
+    // The pending review is reused (transitioned), not duplicated.
+    const reviews = await BuildReview.query().where({
+      buildId: fixture.build.id,
+      userId: fixture.author.userId,
+    });
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0]!.state).toBe("commented");
+
+    // The mention is now notified (deferred until the comment went live).
+    const mentionCalls = mockSendNotification.mock.calls.filter(
+      (call) => call[0]?.type === "comment_mention",
+    );
+    expect(mentionCalls).toHaveLength(1);
+    expect(mentionCalls[0]![0].recipients).toEqual([fixture.member.userId]);
+
+    // The comment is now visible to the other member.
+    const memberApp = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user: fixture.member.user!, account: fixture.member },
+    );
+    const memberView = await request(memberApp)
+      .post("/graphql")
+      .send({
+        query: BUILD_COMMENTS,
+        variables: {
+          accountSlug: fixture.teamAccount.slug,
+          projectName: fixture.project.name,
+          buildNumber: fixture.build.number,
+        },
+      });
+    expectNoGraphQLError(memberView);
+    expect(memberView.body.data.project.build.comments).toHaveLength(1);
+    expect(memberView.body.data.project.build.comments[0].pending).toBe(false);
+  });
+});

--- a/apps/backend/src/graphql/tests/pendingReviewComment.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/pendingReviewComment.e2e.test.ts
@@ -311,4 +311,45 @@ describe("pending review comments", () => {
     expect(memberView.body.data.project.build.comments).toHaveLength(1);
     expect(memberView.body.data.project.build.comments[0].pending).toBe(false);
   });
+
+  test("addToReview falls back to a standalone comment when the build is not reviewable", async ({
+    fixture,
+  }) => {
+    // A build with no diffs concludes as "no-changes" — there's nothing to
+    // review, so a draft would be stranded.
+    const unreviewable = await factory.Build.create({
+      projectId: fixture.project.id,
+      conclusion: null,
+    });
+    await concludeBuild({ build: unreviewable, notify: false });
+
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user: fixture.author.user!, account: fixture.author },
+    );
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: ADD_COMMENT,
+        variables: {
+          input: {
+            buildId: unreviewable.id,
+            body: commentBody("Heads up"),
+            addToReview: true,
+          },
+        },
+      });
+    expectNoGraphQLError(res);
+    // Posted immediately (not a draft), and no pending review was created.
+    expect(res.body.data.addBuildComment.comments).toHaveLength(1);
+    expect(res.body.data.addBuildComment.comments[0].pending).toBe(false);
+    const reviews = await BuildReview.query().where({
+      buildId: unreviewable.id,
+    });
+    expect(reviews).toHaveLength(0);
+    const comment = await Comment.query().findOne({ buildId: unreviewable.id });
+    invariant(comment);
+    expect(comment.buildReviewId).toBeNull();
+  });
 });

--- a/apps/frontend/src/pages/Build/BuildPage.tsx
+++ b/apps/frontend/src/pages/Build/BuildPage.tsx
@@ -14,6 +14,7 @@ import { BuildReviewStateProvider } from "./BuildReviewState";
 import { BuildWorkspace } from "./BuildWorkspace";
 import { BuildHeader } from "./header/BuildHeader";
 import { OvercapacityBanner } from "./OvercapacityBanner";
+import { RejectCommentDialogProvider } from "./RejectCommentDialog";
 
 const ProjectQuery = graphql(`
   query BuildPage_Project(
@@ -38,6 +39,7 @@ const ProjectQuery = graphql(`
         ...BuildHeader_Build
         ...BuildWorkspace_Build
         ...BuildDiffState_Build
+        ...RejectCommentDialog_Build
       }
     }
   }
@@ -87,31 +89,33 @@ export const BuildPage = ({ params }: { params: BuildParams }) => {
       >
         <BuildDiffProvider params={params} build={build}>
           <BuildReviewDialogProvider project={data?.project ?? null}>
-            <div className="flex h-screen min-h-0 flex-col">
-              {data?.project?.account && (
-                <>
-                  <PaymentBanner account={data.project.account} />
-                  <OvercapacityBanner
-                    account={data.project.account}
-                    accountSlug={params.accountSlug}
-                  />
-                </>
-              )}
-              <BuildHeader
-                buildNumber={params.buildNumber}
-                accountSlug={params.accountSlug}
-                projectName={params.projectName}
-                build={build}
-                project={data?.project ?? null}
-              />
-              {project && build ? (
-                <BuildWorkspace
-                  params={params}
+            <RejectCommentDialogProvider build={build}>
+              <div className="flex h-screen min-h-0 flex-col">
+                {data?.project?.account && (
+                  <>
+                    <PaymentBanner account={data.project.account} />
+                    <OvercapacityBanner
+                      account={data.project.account}
+                      accountSlug={params.accountSlug}
+                    />
+                  </>
+                )}
+                <BuildHeader
+                  buildNumber={params.buildNumber}
+                  accountSlug={params.accountSlug}
+                  projectName={params.projectName}
                   build={build}
-                  project={project}
+                  project={data?.project ?? null}
                 />
-              ) : null}
-            </div>
+                {project && build ? (
+                  <BuildWorkspace
+                    params={params}
+                    build={build}
+                    project={project}
+                  />
+                ) : null}
+              </div>
+            </RejectCommentDialogProvider>
           </BuildReviewDialogProvider>
         </BuildDiffProvider>
       </BuildReviewStateProvider>

--- a/apps/frontend/src/pages/Build/BuildReviewDialog.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewDialog.tsx
@@ -32,6 +32,7 @@ import { useCreateBuildReviewMutation } from "./BuildReviewAction";
 import { BUILD_REVIEW_EVENT_DEFINITIONS } from "./BuildReviewEvents";
 import { useBuildReviewSummary } from "./BuildReviewState";
 import { EvaluationStatus } from "./EvaluationStatus";
+import { PendingCommentsSection } from "./PendingCommentsSection";
 
 const _ProjectFragment = graphql(`
   fragment BuildReviewDialog_Project on Project {
@@ -42,6 +43,7 @@ const _ProjectFragment = graphql(`
         ...UserCard_user
       }
       ...BuildReviewAction_Build
+      ...PendingCommentsSection_Build
     }
   }
 `);
@@ -179,6 +181,7 @@ function BuildReviewDialog(props: {
               </>
             )}
           </DialogText>
+          <PendingCommentsSection build={build} />
           {allAccepted ? null : (
             <div>
               <Label>Comment</Label>

--- a/apps/frontend/src/pages/Build/BuildReviewForm.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewForm.tsx
@@ -26,6 +26,7 @@ import {
   BUILD_REVIEW_EVENT_DEFINITIONS,
   ReviewEventRadioVariant,
 } from "./BuildReviewEvents";
+import { PendingCommentsSection } from "./PendingCommentsSection";
 
 const _BuildFragment = graphql(`
   fragment BuildReviewForm_Build on Build {
@@ -34,6 +35,7 @@ const _BuildFragment = graphql(`
       ...UserCard_user
     }
     ...BuildReviewAction_Build
+    ...PendingCommentsSection_Build
   }
 `);
 
@@ -104,6 +106,7 @@ export function BuildReviewForm(props: {
       <DialogBody>
         <DialogTitle>Review changes</DialogTitle>
         <div className="flex flex-col gap-4">
+          <PendingCommentsSection build={build} />
           <div>
             <Label>
               Add a comment{" "}

--- a/apps/frontend/src/pages/Build/PendingCommentsSection.tsx
+++ b/apps/frontend/src/pages/Build/PendingCommentsSection.tsx
@@ -1,0 +1,55 @@
+import { ImageIcon } from "lucide-react";
+
+import { DocumentType, graphql } from "@/gql";
+import { ReadOnlyEditor } from "@/ui/Editor/ReadOnlyEditor";
+import { Label } from "@/ui/Label";
+
+export const PendingCommentsSection_Build = graphql(`
+  fragment PendingCommentsSection_Build on Build {
+    comments {
+      id
+      pending
+      content
+      screenshotDiff {
+        id
+        name
+      }
+    }
+  }
+`);
+
+/**
+ * Lists the comments the current user has drafted into their pending review,
+ * shown in the submit-review surfaces so they can see exactly what will become
+ * visible when they submit. Renders nothing when there are no pending comments.
+ */
+export function PendingCommentsSection(props: {
+  build: DocumentType<typeof PendingCommentsSection_Build>;
+}) {
+  const pending = props.build.comments.filter((comment) => comment.pending);
+  if (pending.length === 0) {
+    return null;
+  }
+  return (
+    <div>
+      <Label>
+        Pending comment{pending.length > 1 ? "s" : ""} ({pending.length})
+      </Label>
+      <div className="border-thin max-h-48 divide-y overflow-y-auto rounded-md">
+        {pending.map((comment) => (
+          <div key={comment.id} className="px-2.5 py-2">
+            {comment.screenshotDiff ? (
+              <div className="text-low mb-1 flex items-center gap-1 text-xs">
+                <ImageIcon className="size-3 shrink-0" />
+                <span className="min-w-0 truncate">
+                  {comment.screenshotDiff.name}
+                </span>
+              </div>
+            ) : null}
+            <ReadOnlyEditor content={comment.content} className="text-sm" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/Build/RejectCommentDialog.tsx
+++ b/apps/frontend/src/pages/Build/RejectCommentDialog.tsx
@@ -1,0 +1,182 @@
+import { createContext, use, useCallback, useMemo, useState } from "react";
+import { useMutation } from "@apollo/client/react";
+import { invariant } from "@argos/util/invariant";
+import { toast } from "sonner";
+
+import { DocumentType, graphql } from "@/gql";
+import { useProjectParams } from "@/pages/Project/ProjectParams";
+import {
+  Dialog,
+  DialogBody,
+  DialogDismiss,
+  DialogFooter,
+  DialogText,
+  DialogTitle,
+} from "@/ui/Dialog";
+import { type EditorValue } from "@/ui/Editor/Editor";
+import { StandaloneEditor } from "@/ui/Editor/StandaloneEditor";
+import { Modal } from "@/ui/Modal";
+import { getMentionUser } from "@/ui/UserCard";
+import { getErrorMessage } from "@/util/error";
+
+const _BuildFragment = graphql(`
+  fragment RejectCommentDialog_Build on Build {
+    id
+    members {
+      ...UserCard_user
+    }
+    comments {
+      id
+      pending
+      screenshotDiff {
+        id
+      }
+    }
+  }
+`);
+
+type Build = DocumentType<typeof _BuildFragment>;
+
+const AddBuildCommentMutation = graphql(`
+  mutation RejectCommentDialog_addBuildComment(
+    $input: AddBuildCommentInput!
+    $accountSlug: String!
+    $projectName: String!
+  ) {
+    addBuildComment(input: $input) {
+      id
+      comments {
+        ...CommentCard_Comment
+      }
+    }
+  }
+`);
+
+/**
+ * Returns a function to invite the user to comment on why they're rejecting a
+ * snapshot. It opens the dialog only when no pending comment already exists on
+ * that snapshot, returning whether it did so — callers use this to skip the
+ * usual auto-advance while the dialog is open. Null when no provider is mounted.
+ */
+type PromptRejectComment = (screenshotDiffId: string) => boolean;
+
+const RejectCommentDialogContext = createContext<PromptRejectComment | null>(
+  null,
+);
+
+export function useRejectCommentInvite(): PromptRejectComment | null {
+  return use(RejectCommentDialogContext);
+}
+
+export function RejectCommentDialogProvider(props: {
+  build: Build | null;
+  children: React.ReactNode;
+}) {
+  const { build, children } = props;
+  const [diffId, setDiffId] = useState<string | null>(null);
+
+  const comments = build?.comments;
+  const promptRejectComment = useCallback<PromptRejectComment>(
+    (screenshotDiffId) => {
+      const hasPendingComment = (comments ?? []).some(
+        (comment) =>
+          comment.pending && comment.screenshotDiff?.id === screenshotDiffId,
+      );
+      if (hasPendingComment) {
+        return false;
+      }
+      setDiffId(screenshotDiffId);
+      return true;
+    },
+    [comments],
+  );
+
+  return (
+    <RejectCommentDialogContext value={build ? promptRejectComment : null}>
+      {children}
+      {build ? (
+        <Modal
+          isOpen={diffId != null}
+          onOpenChange={(open) => {
+            if (!open) {
+              setDiffId(null);
+            }
+          }}
+          isDismissable
+        >
+          {diffId ? (
+            <RejectCommentDialog
+              build={build}
+              screenshotDiffId={diffId}
+              onClose={() => setDiffId(null)}
+            />
+          ) : (
+            <span />
+          )}
+        </Modal>
+      ) : null}
+    </RejectCommentDialogContext>
+  );
+}
+
+function RejectCommentDialog(props: {
+  build: Build;
+  screenshotDiffId: string;
+  onClose: () => void;
+}) {
+  const { build, screenshotDiffId, onClose } = props;
+  const projectParams = useProjectParams();
+  invariant(projectParams);
+  const mentions = useMemo(
+    () => build.members.map(getMentionUser),
+    [build.members],
+  );
+  const [addBuildComment] = useMutation(AddBuildCommentMutation);
+  const handleSubmit = async (body: EditorValue) => {
+    try {
+      await addBuildComment({
+        variables: {
+          input: {
+            buildId: build.id,
+            screenshotDiffId,
+            body,
+            addToReview: true,
+          },
+          accountSlug: projectParams.accountSlug,
+          projectName: projectParams.projectName,
+        },
+      });
+      onClose();
+    } catch (error) {
+      toast.error(getErrorMessage(error));
+      // Rethrow so the editor keeps the content and the user can retry.
+      throw error;
+    }
+  };
+  return (
+    <Dialog size="medium">
+      <DialogBody>
+        <DialogTitle>Add a note about this rejection</DialogTitle>
+        <DialogText>
+          Let your team know why you're rejecting this snapshot. Your comment is
+          added to your review and becomes visible once you submit it.
+        </DialogText>
+        <StandaloneEditor
+          onSubmit={handleSubmit}
+          mentions={mentions}
+          placeholder="Leave a comment…"
+          submitLabel="Add to review"
+          emptyMessage={{
+            title: "Comment required",
+            description: "Please add a comment before submitting.",
+          }}
+          autoFocus
+          aria-label="Rejection comment"
+        />
+      </DialogBody>
+      <DialogFooter>
+        <DialogDismiss>Skip</DialogDismiss>
+      </DialogFooter>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/pages/Build/ReviewCommentSubmitButton.tsx
+++ b/apps/frontend/src/pages/Build/ReviewCommentSubmitButton.tsx
@@ -1,0 +1,112 @@
+import { use } from "react";
+import { ArrowUpIcon, MessageSquarePlusIcon } from "lucide-react";
+
+import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
+import { DocumentType, graphql } from "@/gql";
+import { BuildStatus, ProjectPermission } from "@/gql/graphql";
+import { MOD } from "@/ui/Editor/EditorToolbar.shortcuts";
+import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
+import { IconButton } from "@/ui/IconButton";
+
+export const ReviewCommentSubmitButton_Build = graphql(`
+  fragment ReviewCommentSubmitButton_Build on Build {
+    id
+    status
+    viewerHasSubmittedReview
+  }
+`);
+
+// A build can be reviewed (and therefore drafted against) only once it has
+// changes to act on. Mirrors the visibility of the "Submit review" button so a
+// draft comment is never stranded on a build with no review surface.
+const REVIEWABLE_STATUSES: BuildStatus[] = [
+  BuildStatus.Accepted,
+  BuildStatus.Rejected,
+  BuildStatus.ChangesDetected,
+];
+
+/**
+ * Whether new comments on this build should default to being added to the
+ * current user's review draft. True only before the user has submitted a
+ * review, when they may review, and when the build is reviewable.
+ */
+export function useCanAddToReview(
+  build: DocumentType<typeof ReviewCommentSubmitButton_Build>,
+): boolean {
+  const permissions = use(ProjectPermissionsContext);
+  return (
+    !build.viewerHasSubmittedReview &&
+    REVIEWABLE_STATUSES.includes(build.status) &&
+    Boolean(permissions?.includes(ProjectPermission.Review))
+  );
+}
+
+/**
+ * The composer submit affordance for build comments. When the build can be
+ * drafted against, it defaults to "Add to review" (message-square-plus); while
+ * Alt is held it flips to "Post comment", which posts the comment immediately.
+ * Otherwise it is a plain send button.
+ */
+export function ReviewCommentSubmitButton(props: {
+  canAddToReview: boolean;
+  altHeld: boolean;
+  /** Label/tooltip used when the build can't be drafted against. */
+  fallbackLabel: string;
+  isEmpty: boolean;
+  isPending: boolean;
+  disabled?: boolean;
+  onPress: () => void;
+  className?: string;
+}) {
+  const {
+    canAddToReview,
+    altHeld,
+    fallbackLabel,
+    isEmpty,
+    isPending,
+    disabled,
+    onPress,
+    className,
+  } = props;
+  const reviewMode = canAddToReview && !altHeld;
+  const label = !canAddToReview
+    ? fallbackLabel
+    : reviewMode
+      ? "Add to review"
+      : "Post comment";
+  const Icon = reviewMode ? MessageSquarePlusIcon : ArrowUpIcon;
+  return (
+    <HotkeyTooltip
+      description={
+        canAddToReview ? (
+          <div className="flex flex-col">
+            <span>{label}</span>
+            <span className="text-low">
+              {reviewMode ? "Hold Alt to post now" : "Release Alt to draft"}
+            </span>
+          </div>
+        ) : (
+          label
+        )
+      }
+      keys={[MOD, "Enter"]}
+      placement="top"
+    >
+      <IconButton
+        variant="contained"
+        size="small"
+        rounded
+        aria-label={label}
+        // Truly disabled (not focusable/clickable) while submitting or when
+        // disabled by the parent. When merely empty it only *looks* disabled but
+        // stays clickable so the press can surface the "empty" toast.
+        isDisabled={disabled || isPending}
+        aria-disabled={isEmpty}
+        onPress={onPress}
+        className={className}
+      >
+        <Icon />
+      </IconButton>
+    </HotkeyTooltip>
+  );
+}

--- a/apps/frontend/src/pages/Build/TrackButtons.tsx
+++ b/apps/frontend/src/pages/Build/TrackButtons.tsx
@@ -15,6 +15,7 @@ import {
   useBuildDiffStatusState,
 } from "./BuildReviewState";
 import { EvaluationStatus } from "./EvaluationStatus";
+import { useRejectCommentInvite } from "./RejectCommentDialog";
 
 function useEvaluationToggle(props: {
   diffId: string;
@@ -23,6 +24,7 @@ function useEvaluationToggle(props: {
 }) {
   const { diffId, diffGroup, target } = props;
   const [checkIsPending, acknowledge] = useAcknowledgeMarkedDiff();
+  const promptRejectComment = useRejectCommentInvite();
   const [status, setStatus] = useBuildDiffStatusState({
     diffId,
     diffGroup,
@@ -35,6 +37,16 @@ function useEvaluationToggle(props: {
       status === EvaluationStatus.Pending ? target : EvaluationStatus.Pending;
     setStatus(nextStatus);
     if (nextStatus !== EvaluationStatus.Pending) {
+      // On a fresh rejection with no note yet, invite the reviewer to explain
+      // why. When the dialog opens we skip the usual auto-advance/review-dialog
+      // so it isn't buried; otherwise proceed as normal.
+      if (
+        target === EvaluationStatus.Rejected &&
+        !diffGroup &&
+        promptRejectComment?.(diffId)
+      ) {
+        return;
+      }
       acknowledge();
     }
   });

--- a/apps/frontend/src/pages/Build/TrackButtons.tsx
+++ b/apps/frontend/src/pages/Build/TrackButtons.tsx
@@ -9,7 +9,7 @@ import { IconButton } from "@/ui/IconButton";
 import { useEventCallback } from "@/ui/useEventCallback";
 import { useNonNullable } from "@/util/useNonNullable";
 
-import { Diff } from "./BuildDiffState";
+import { Diff, useBuildDiffState } from "./BuildDiffState";
 import {
   useAcknowledgeMarkedDiff,
   useBuildDiffStatusState,
@@ -25,6 +25,7 @@ function useEvaluationToggle(props: {
   const { diffId, diffGroup, target } = props;
   const [checkIsPending, acknowledge] = useAcknowledgeMarkedDiff();
   const promptRejectComment = useRejectCommentInvite();
+  const { diffs } = useBuildDiffState();
   const [status, setStatus] = useBuildDiffStatusState({
     diffId,
     diffGroup,
@@ -38,14 +39,16 @@ function useEvaluationToggle(props: {
     setStatus(nextStatus);
     if (nextStatus !== EvaluationStatus.Pending) {
       // On a fresh rejection with no note yet, invite the reviewer to explain
-      // why. When the dialog opens we skip the usual auto-advance/review-dialog
-      // so it isn't buried; otherwise proceed as normal.
-      if (
-        target === EvaluationStatus.Rejected &&
-        !diffGroup &&
-        promptRejectComment?.(diffId)
-      ) {
-        return;
+      // why. A whole-group rejection anchors the note to the group's first
+      // snapshot. When the dialog opens we skip the usual auto-advance/review
+      // dialog so it isn't buried; otherwise proceed as normal.
+      if (target === EvaluationStatus.Rejected) {
+        const rejectDiffId = diffGroup
+          ? (diffs.find((diff) => diff.group === diffGroup)?.id ?? diffId)
+          : diffId;
+        if (promptRejectComment?.(rejectDiffId)) {
+          return;
+        }
       }
       acknowledge();
     }

--- a/apps/frontend/src/pages/Build/diffComments/DiffCommentDraft.tsx
+++ b/apps/frontend/src/pages/Build/diffComments/DiffCommentDraft.tsx
@@ -1,12 +1,14 @@
 import { useId, useState } from "react";
+import { MessageSquarePlusIcon } from "lucide-react";
 import { toast } from "sonner";
 
 import { AccountAvatar } from "@/containers/AccountAvatar";
-import { Button } from "@/ui/Button";
+import { Button, ButtonIcon } from "@/ui/Button";
 import { Editor, type EditorValue } from "@/ui/Editor/Editor";
 import { MOD } from "@/ui/Editor/EditorToolbar.shortcuts";
 import { hasEditorContent } from "@/ui/Editor/util";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
+import { useAltKeyHeld } from "@/ui/useAltKeyHeld";
 
 import { useMentionableUsers } from "../sidebar/MentionableUsersContext";
 
@@ -22,15 +24,26 @@ type Avatar = React.ComponentProps<typeof AccountAvatar>["avatar"];
  */
 export function DiffCommentDraft(props: {
   avatar: Avatar | null;
-  onSubmit: (body: EditorValue) => Promise<void>;
+  canAddToReview: boolean;
+  onSubmit: (
+    body: EditorValue,
+    options: { addToReview: boolean },
+  ) => Promise<void>;
   onCancel: () => void;
 }) {
-  const { avatar, onSubmit, onCancel } = props;
+  const { avatar, canAddToReview, onSubmit, onCancel } = props;
   const mentions = useMentionableUsers();
+  const altHeld = useAltKeyHeld();
   const [value, setValue] = useState<EditorValue>(null);
   const [isPending, setIsPending] = useState(false);
   const emptyToastId = useId();
   const isEmpty = !hasEditorContent(value);
+  const reviewMode = canAddToReview && !altHeld;
+  const submitLabel = !canAddToReview
+    ? "Add comment"
+    : reviewMode
+      ? "Add to review"
+      : "Post comment";
 
   const submit = () => {
     if (isPending) {
@@ -44,7 +57,7 @@ export function DiffCommentDraft(props: {
       return;
     }
     setIsPending(true);
-    onSubmit(value)
+    onSubmit(value, { addToReview: canAddToReview && !altHeld })
       .catch(() => {
         // Keep the content so the user can retry.
       })
@@ -87,7 +100,20 @@ export function DiffCommentDraft(props: {
             Cancel
           </Button>
           <HotkeyTooltip
-            description="Add comment"
+            description={
+              canAddToReview ? (
+                <div className="flex flex-col">
+                  <span>{submitLabel}</span>
+                  <span className="text-low">
+                    {reviewMode
+                      ? "Hold Alt to post now"
+                      : "Release Alt to draft"}
+                  </span>
+                </div>
+              ) : (
+                submitLabel
+              )
+            }
             keys={[MOD, "Enter"]}
             placement="top"
           >
@@ -101,7 +127,12 @@ export function DiffCommentDraft(props: {
               isDisabled={isPending}
               aria-disabled={isEmpty}
             >
-              Add comment
+              {reviewMode ? (
+                <ButtonIcon>
+                  <MessageSquarePlusIcon />
+                </ButtonIcon>
+              ) : null}
+              {submitLabel}
             </Button>
           </HotkeyTooltip>
         </div>

--- a/apps/frontend/src/pages/Build/diffComments/DiffCommentLayer.tsx
+++ b/apps/frontend/src/pages/Build/diffComments/DiffCommentLayer.tsx
@@ -20,6 +20,7 @@ import { type EditorValue } from "@/ui/Editor/Editor";
 import { getMentionUser } from "@/ui/UserCard";
 import { getErrorMessage } from "@/util/error";
 
+import { useCanAddToReview } from "../ReviewCommentSubmitButton";
 import { CommentCard } from "../sidebar/CommentCard";
 import {
   getCommentThreads,
@@ -38,6 +39,7 @@ const _BuildFragment = graphql(`
     comments {
       ...CommentCard_Comment
     }
+    ...ReviewCommentSubmitButton_Build
   }
 `);
 
@@ -105,6 +107,7 @@ export function DiffCommentLayer(props: {
   const visible = useAtomValue(commentsVisibleAtom);
   const permissions = use(ProjectPermissionsContext);
   const canComment = permissions?.includes(ProjectPermission.Review) ?? false;
+  const canAddToReview = useCanAddToReview(build);
   const { accountSlug, projectName } = useProjectParams() ?? {};
   invariant(accountSlug && projectName, "Missing project route params");
   const accountId = useAuthTokenPayload()?.account.id;
@@ -200,7 +203,7 @@ export function DiffCommentLayer(props: {
   }, [threads, activeDraft, visible]);
 
   const handleCreate = useCallback(
-    async (body: EditorValue) => {
+    async (body: EditorValue, options: { addToReview: boolean }) => {
       if (!draft) {
         return;
       }
@@ -212,6 +215,7 @@ export function DiffCommentLayer(props: {
               screenshotDiffId,
               anchor: { lines: { from: draft.from, to: draft.to } },
               body,
+              addToReview: options.addToReview,
             },
             accountSlug,
             projectName,
@@ -263,6 +267,7 @@ export function DiffCommentLayer(props: {
           {draftRange ? (
             <DiffCommentDraft
               avatar={currentAvatar}
+              canAddToReview={canAddToReview}
               onSubmit={handleCreate}
               onCancel={closeDraft}
             />
@@ -270,7 +275,14 @@ export function DiffCommentLayer(props: {
         </div>
       );
     },
-    [build.id, canComment, currentAvatar, handleCreate, closeDraft],
+    [
+      build.id,
+      canComment,
+      canAddToReview,
+      currentAvatar,
+      handleCreate,
+      closeDraft,
+    ],
   );
 
   const onGutterUtilityClick = useCallback((range: SelectedLineRange) => {

--- a/apps/frontend/src/pages/Build/screenshotComments/CommentDraftPopover.tsx
+++ b/apps/frontend/src/pages/Build/screenshotComments/CommentDraftPopover.tsx
@@ -1,13 +1,11 @@
 import { useId, useState } from "react";
-import { ArrowUpIcon } from "lucide-react";
 import { toast } from "sonner";
 
 import { Editor, type EditorValue } from "@/ui/Editor/Editor";
-import { MOD } from "@/ui/Editor/EditorToolbar.shortcuts";
 import { hasEditorContent } from "@/ui/Editor/util";
-import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
-import { IconButton } from "@/ui/IconButton";
+import { useAltKeyHeld } from "@/ui/useAltKeyHeld";
 
+import { ReviewCommentSubmitButton } from "../ReviewCommentSubmitButton";
 import { useMentionableUsers } from "../sidebar/MentionableUsersContext";
 import { CommentPopoverFrame } from "./CommentPopoverFrame";
 import type { ScreenPoint } from "./geometry";
@@ -21,10 +19,15 @@ import type { ScreenPoint } from "./geometry";
  */
 export function CommentDraftPopover(props: {
   point: ScreenPoint;
-  onSubmit: (body: EditorValue) => Promise<void>;
+  canAddToReview: boolean;
+  onSubmit: (
+    body: EditorValue,
+    options: { addToReview: boolean },
+  ) => Promise<void>;
 }) {
-  const { point, onSubmit } = props;
+  const { point, canAddToReview, onSubmit } = props;
   const mentions = useMentionableUsers();
+  const altHeld = useAltKeyHeld();
   const [value, setValue] = useState<EditorValue>(null);
   // Remounts the editor to clear it after a successful submit.
   const [editorKey, setEditorKey] = useState(0);
@@ -44,7 +47,7 @@ export function CommentDraftPopover(props: {
       return;
     }
     setIsPending(true);
-    onSubmit(value)
+    onSubmit(value, { addToReview: canAddToReview && !altHeld })
       .then(() => {
         setValue(null);
         setEditorKey((key) => key + 1);
@@ -82,24 +85,15 @@ export function CommentDraftPopover(props: {
           className="min-w-0 flex-1 px-1.5 text-sm"
           contentClassName="max-h-32 min-h-6 overflow-y-auto py-0.5"
         />
-        <HotkeyTooltip
-          description="Submit the comment"
-          keys={[MOD, "Enter"]}
-          placement="top"
-        >
-          <IconButton
-            variant="contained"
-            size="small"
-            rounded
-            aria-label="Submit the comment"
-            aria-disabled={isEmpty}
-            isDisabled={isPending}
-            onPress={submit}
-            className="shrink-0"
-          >
-            <ArrowUpIcon />
-          </IconButton>
-        </HotkeyTooltip>
+        <ReviewCommentSubmitButton
+          canAddToReview={canAddToReview}
+          altHeld={altHeld}
+          fallbackLabel="Submit the comment"
+          isEmpty={isEmpty}
+          isPending={isPending}
+          onPress={submit}
+          className="shrink-0"
+        />
       </div>
     </CommentPopoverFrame>
   );

--- a/apps/frontend/src/pages/Build/screenshotComments/ScreenshotCommentLayer.tsx
+++ b/apps/frontend/src/pages/Build/screenshotComments/ScreenshotCommentLayer.tsx
@@ -30,6 +30,7 @@ import { type EditorValue } from "@/ui/Editor/Editor";
 import { getMentionUser } from "@/ui/UserCard";
 import { getErrorMessage } from "@/util/error";
 
+import { useCanAddToReview } from "../ReviewCommentSubmitButton";
 import { getCommentThreads } from "../sidebar/commentThreads";
 import { MentionableUsersProvider } from "../sidebar/MentionableUsersContext";
 import { CommentDraftPopover } from "./CommentDraftPopover";
@@ -53,6 +54,7 @@ const _BuildFragment = graphql(`
     comments {
       ...CommentCard_Comment
     }
+    ...ReviewCommentSubmitButton_Build
   }
 `);
 
@@ -121,6 +123,7 @@ export function ScreenshotCommentLayer(props: {
   const visible = useAtomValue(commentsVisibleAtom);
   const permissions = use(ProjectPermissionsContext);
   const canComment = permissions?.includes(ProjectPermission.Review) ?? false;
+  const canAddToReview = useCanAddToReview(build);
   const { accountSlug, projectName } = useProjectParams() ?? {};
   invariant(accountSlug && projectName, "Missing project route params");
   const accountId = useAuthTokenPayload()?.account.id;
@@ -312,7 +315,7 @@ export function ScreenshotCommentLayer(props: {
   };
 
   const handleCreate = useCallback(
-    async (body: EditorValue) => {
+    async (body: EditorValue, options: { addToReview: boolean }) => {
       if (!draft) {
         return;
       }
@@ -325,6 +328,7 @@ export function ScreenshotCommentLayer(props: {
               screenshotDiffId,
               anchor: { point: { x: draft.x, y: draft.y } },
               body,
+              addToReview: options.addToReview,
             },
             accountSlug,
             projectName,
@@ -424,6 +428,7 @@ export function ScreenshotCommentLayer(props: {
       {draftShown ? (
         <CommentDraftPopover
           point={toViewport(toScreen(draft))}
+          canAddToReview={canAddToReview}
           onSubmit={handleCreate}
         />
       ) : null}

--- a/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
@@ -11,15 +11,21 @@ import { useProjectParams } from "@/pages/Project/ProjectParams";
 import { type EditorValue } from "@/ui/Editor/Editor";
 import { StandaloneEditor } from "@/ui/Editor/StandaloneEditor";
 import { Tooltip } from "@/ui/Tooltip";
+import { useAltKeyHeld } from "@/ui/useAltKeyHeld";
 import { getErrorMessage } from "@/util/error";
 
 import { useBuildDiffState } from "../BuildDiffState";
+import {
+  ReviewCommentSubmitButton,
+  useCanAddToReview,
+} from "../ReviewCommentSubmitButton";
 import { useMentionableUsers } from "./MentionableUsersContext";
 import { ScreenshotDiffThumbnail } from "./ScreenshotDiffThumbnail";
 
 const _BuildFragment = graphql(`
   fragment AddCommentForm_Build on Build {
     id
+    ...ReviewCommentSubmitButton_Build
   }
 `);
 
@@ -102,6 +108,8 @@ export function AddCommentForm(props: {
   // the view.
   const [detached, setDetached] = useState(false);
   const attachedDiff = detached ? null : activeDiff;
+  const canAddToReview = useCanAddToReview(build);
+  const altHeld = useAltKeyHeld();
   const [addBuildComment] = useMutation(AddBuildCommentMutation);
   const handleSubmit = async (body: EditorValue) => {
     try {
@@ -110,6 +118,7 @@ export function AddCommentForm(props: {
           input: {
             buildId: build.id,
             body,
+            addToReview: canAddToReview && !altHeld,
             ...(attachedDiff ? { screenshotDiffId: attachedDiff.id } : null),
           },
           accountSlug: projectParams.accountSlug,
@@ -135,6 +144,17 @@ export function AddCommentForm(props: {
         description: "Please add a comment before submitting.",
       }}
       aria-label="Add a comment"
+      renderSubmit={({ submit, isEmpty, isPending, disabled }) => (
+        <ReviewCommentSubmitButton
+          canAddToReview={canAddToReview}
+          altHeld={altHeld}
+          fallbackLabel="Submit the comment"
+          isEmpty={isEmpty}
+          isPending={isPending}
+          disabled={disabled}
+          onPress={submit}
+        />
+      )}
       footerStart={
         activeDiff ? (
           <AttachedSnapshotToggle

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -69,6 +69,7 @@ const _CommentFragment = graphql(`
     content
     threadId
     threadSubscribed
+    pending
     permissions
     user {
       ...UserCard_user
@@ -581,9 +582,10 @@ function CommentMessage(props: {
                   {isEdited ? " (edited)" : null}
                 </Button>
               </Tooltip>
+              {comment.pending ? <PendingCommentBadge /> : null}
             </div>
           </div>
-          <div className="bg-app pointer-events-none absolute top-1 right-1 flex items-center rounded-md pl-1 opacity-0 transition group-focus-within/comment:pointer-events-auto group-focus-within/comment:opacity-100 group-hover/comment:pointer-events-auto group-hover/comment:opacity-100 has-[button[aria-expanded=true]]:pointer-events-auto has-[button[aria-expanded=true]]:opacity-100">
+          <div className="bg-app before:from-app pointer-events-none absolute top-1 right-1 flex items-center rounded-md pl-1 opacity-0 transition group-focus-within/comment:pointer-events-auto group-focus-within/comment:opacity-100 group-hover/comment:pointer-events-auto group-hover/comment:opacity-100 before:absolute before:inset-y-0 before:right-full before:w-8 before:bg-linear-to-l before:to-transparent before:content-[''] has-[button[aria-expanded=true]]:pointer-events-auto has-[button[aria-expanded=true]]:opacity-100">
             <CommentAddReactionButton comment={comment} />
             <CommentActionsMenu
               onCopyLink={copyLink}
@@ -631,6 +633,20 @@ function CommentMessage(props: {
         <DeleteCommentDialog commentId={comment.id} />
       </Modal>
     </>
+  );
+}
+
+/**
+ * Marks a comment that belongs to the current user's not-yet-submitted review.
+ * Such comments are visible only to their author until the review is submitted.
+ */
+function PendingCommentBadge() {
+  return (
+    <Tooltip content="Only you can see this. It becomes visible when you submit your review.">
+      <span className="border-thin text-low shrink-0 cursor-default rounded-full px-1.5 py-0.5 text-[10px] font-medium tracking-wide uppercase">
+        Pending
+      </span>
+    </Tooltip>
   );
 }
 

--- a/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
+++ b/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
@@ -58,6 +58,17 @@ export interface StandaloneEditorProps {
    */
   footerStart?: React.ReactNode;
   contentClassName?: string;
+  /**
+   * Render a custom submit control in place of the default send button (only in
+   * compose mode, i.e. when no `onCancel` is set). Receives the submit handler
+   * (which keeps the empty-check/toast behavior) and the current button state.
+   */
+  renderSubmit?: (args: {
+    submit: () => void;
+    isEmpty: boolean;
+    isPending: boolean;
+    disabled: boolean;
+  }) => React.ReactNode;
   /** Users that can be mentioned with `@`, forwarded to the {@link Editor}. */
   mentions?: MentionUser[];
   /** Users to resolve existing mentions against, forwarded to the {@link Editor}. */
@@ -92,6 +103,7 @@ export function StandaloneEditor(props: StandaloneEditorProps) {
     variant = "boxed",
     footerStart,
     contentClassName,
+    renderSubmit,
     mentions,
     mentionedUsers,
     draftKey,
@@ -192,28 +204,39 @@ export function StandaloneEditor(props: StandaloneEditorProps) {
                 {footerStart}
               </div>
             ) : null}
-            <HotkeyTooltip
-              description={submitLabel}
-              keys={[MOD, "Enter"]}
-              placement="top"
-            >
-              <IconButton
-                variant="contained"
-                size="small"
-                rounded
-                aria-label={submitLabel}
-                // Truly disabled (not focusable/clickable) while submitting or when
-                // disabled by the parent. When the editor is merely empty it only
-                // *looks* disabled but stays clickable, so the press can surface the
-                // "empty" toast.
-                isDisabled={disabled || isPending}
-                aria-disabled={isEmpty}
-                onPress={submit}
-                className="ml-auto"
+            {renderSubmit ? (
+              <div className="ml-auto flex items-center">
+                {renderSubmit({
+                  submit,
+                  isEmpty,
+                  isPending,
+                  disabled: Boolean(disabled),
+                })}
+              </div>
+            ) : (
+              <HotkeyTooltip
+                description={submitLabel}
+                keys={[MOD, "Enter"]}
+                placement="top"
               >
-                <ArrowUpIcon />
-              </IconButton>
-            </HotkeyTooltip>
+                <IconButton
+                  variant="contained"
+                  size="small"
+                  rounded
+                  aria-label={submitLabel}
+                  // Truly disabled (not focusable/clickable) while submitting or when
+                  // disabled by the parent. When the editor is merely empty it only
+                  // *looks* disabled but stays clickable, so the press can surface the
+                  // "empty" toast.
+                  isDisabled={disabled || isPending}
+                  aria-disabled={isEmpty}
+                  onPress={submit}
+                  className="ml-auto"
+                >
+                  <ArrowUpIcon />
+                </IconButton>
+              </HotkeyTooltip>
+            )}
           </div>
         )
       }

--- a/apps/frontend/src/ui/useAltKeyHeld.ts
+++ b/apps/frontend/src/ui/useAltKeyHeld.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Tracks whether the Alt/Option key is currently held down. Used to offer a
+ * modifier-driven secondary action on a button (e.g. flip "Add to review" to
+ * "Post comment"). Resets on window blur so a key-up missed while another window
+ * was focused doesn't leave it stuck on.
+ */
+export function useAltKeyHeld(): boolean {
+  const [altHeld, setAltHeld] = useState(false);
+  useEffect(() => {
+    const handleKeyChange = (event: KeyboardEvent) => {
+      setAltHeld(event.altKey);
+    };
+    const reset = () => setAltHeld(false);
+    window.addEventListener("keydown", handleKeyChange);
+    window.addEventListener("keyup", handleKeyChange);
+    window.addEventListener("blur", reset);
+    return () => {
+      window.removeEventListener("keydown", handleKeyChange);
+      window.removeEventListener("keyup", handleKeyChange);
+      window.removeEventListener("blur", reset);
+    };
+  }, []);
+  return altHeld;
+}


### PR DESCRIPTION
## Context

Today, comments on a build post immediately and publicly, and a `BuildReview` is a separate object created only from the submit-review UI. The two never interleave — you can't draft comments as part of a review the way GitHub lets you. This PR adds that flow.

## Behavior

- **Drafting**: Before a user has submitted their first review on a build, new comments default to **"Add to review"** (message-square-plus icon). Holding **Alt** flips the action to **"Post comment"** (standalone, immediate). After the user has submitted a review, comments default back to standalone.
- **Pending review**: The first drafted comment opens a `BuildReview` in `pending` state and attaches the comment to it. Pending comments are visible **only to their author**, shown with a **"Pending"** badge (tooltip: visible once the review is submitted).
- **Notifications**: Pending comments notify no one. When the review is submitted, its comments go **live** for everyone and any **@mentions** are notified *then* (not while pending). The submission still sends the usual `review_submitted` notification.
- **Submit dialog**: Both submit-review surfaces list the **Pending comments** that will be submitted (scrollable, hidden when empty).
- **Reject (N)**: Rejecting a snapshot with no pending comment on it opens an optional dialog inviting the reviewer to explain why; the note is added to their review.

This applies to comments from the activity feed, screenshots (point anchors), and text diffs (line anchors).

## Implementation notes

- New partial unique index guarantees one active pending review per (build, user); `getOrCreatePendingBuildReview` is race-safe against it.
- `createBuildReview` **reuses** the user's pending review (transitions its state) rather than creating a second one, then promotes its comments and fires deferred mention notifications.
- The build-comments loader is now **viewer-aware** so a pending comment surfaces only to its author. New `Comment.pending` and `Build.viewerHasSubmittedReview` fields drive the UI.

## Testing

- New e2e suite `pendingReviewComment.e2e.test.ts` covers: draft creation without notifications, author-only visibility, and go-live + mention notification on submit.
- Backend `tsc`, frontend `tsc`, eslint, and the comment/review test suites pass (124 tests). Migrations applied to dev + test DBs.
- ⚠️ Manual in-app E2E not yet performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)