### PR TITLE
feat(build): redesign the review dialog to be lighter

### DIFF
--- a/apps/frontend/src/containers/Build/BuildDiffDetailToolbar.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetailToolbar.tsx
@@ -67,10 +67,13 @@ export function BuildDiffDetailToolbar(props: BuildDiffDetailToolbarProps) {
 
   const permissions = use(ProjectPermissionsContext);
   const canComment = permissions?.includes(ProjectPermission.Review) ?? false;
-  const showCommentTools = canComment && checkCanCommentOnDiff(diff);
-  // Text diffs use the gutter "+" (no hand/comment tool switch), so they only
-  // get the show/hide toggle.
-  const showTextCommentTools = canComment && checkCanCommentOnTextDiff(diff);
+  // The hand/comment tool switch only makes sense on image diffs (point
+  // comments). Text diffs use the gutter "+" instead.
+  const showCommentTool = canComment && checkCanCommentOnDiff(diff);
+  // The show/hide toggle applies whenever comments can exist on the diff,
+  // whether image (point) or text (line) comments.
+  const showComments =
+    showCommentTool || (canComment && checkCanCommentOnTextDiff(diff));
 
   return (
     <div className="flex shrink-0 items-center gap-1.5">
@@ -90,16 +93,10 @@ export function BuildDiffDetailToolbar(props: BuildDiffDetailToolbarProps) {
           <SettingsButton />
         </>
       )}
-      {showCommentTools && (
+      {showComments && (
         <>
           <Separator orientation="vertical" className="mx-1 h-6" />
-          <CommentToolToggle />
-          <CommentsVisibilityToggle />
-        </>
-      )}
-      {showTextCommentTools && (
-        <>
-          <Separator orientation="vertical" className="mx-1 h-6" />
+          {showCommentTool && <CommentToolToggle />}
           <CommentsVisibilityToggle />
         </>
       )}

--- a/apps/frontend/src/containers/Build/BuildHotkeys.tsx
+++ b/apps/frontend/src/containers/Build/BuildHotkeys.tsx
@@ -346,8 +346,8 @@ function handleDocumentKeyDown(event: KeyboardEvent) {
   }
 
   const isTextInput =
-    event.target instanceof HTMLInputElement &&
-    (event.target.type === "text" || event.target.type === "textarea");
+    event.target instanceof HTMLTextAreaElement ||
+    (event.target instanceof HTMLInputElement && event.target.type === "text");
 
   for (const registration of hotkeyRegistry) {
     const { hotkey, ref } = registration;

--- a/apps/frontend/src/containers/Build/BuildHotkeys.tsx
+++ b/apps/frontend/src/containers/Build/BuildHotkeys.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef } from "react";
+import { memo, useEffect } from "react";
 import clsx from "clsx";
 import { XIcon } from "lucide-react";
 
@@ -264,6 +264,136 @@ function checkIsModifiedPressed(event: KeyboardEvent) {
   return event.ctrlKey;
 }
 
+type HotkeyOptions = {
+  preventDefault: boolean;
+  enabled: boolean;
+  allowInInput: boolean;
+};
+
+type HotkeyRegistration = {
+  hotkey: Hotkey;
+  /** Live ref so callback/options updates don't require re-registering. */
+  ref: React.RefObject<{
+    callback: (event: KeyboardEvent) => void;
+    options: HotkeyOptions;
+  }>;
+  /** Pending async dispatch, cleared on unregister. */
+  timeout: number;
+};
+
+/**
+ * Whether `event` matches `hotkey`'s key combination (modifiers included).
+ */
+function checkHotkeyMatches(hotkey: Hotkey, event: KeyboardEvent): boolean {
+  const modifierShouldBePressed = hotkey.keys.some((key) => key === "⌘");
+  const altShouldBePressed = hotkey.keys.some((key) => key === "⌥");
+  const hasDigits = hotkey.keys.some((key) => key.startsWith("Digit"));
+
+  if (hasDigits && altShouldBePressed !== event.altKey) {
+    return false;
+  }
+
+  if (modifierShouldBePressed !== checkIsModifiedPressed(event)) {
+    return false;
+  }
+
+  return hotkey.keys.every((key) => {
+    // Ignore modifier keys
+    if (key === "⌘") {
+      return true;
+    }
+    if (key.startsWith("Key")) {
+      const letter = key.slice(3);
+      return letter === event.key || letter.toLowerCase() === event.key;
+    }
+    return key === event.code || key === event.key;
+  });
+}
+
+/**
+ * Single source of truth for build hotkeys: every `useBuildHotkey` consumer
+ * registers here and we keep a single capture-phase `keydown` listener on the
+ * document, instead of one listener per hook.
+ */
+const hotkeyRegistry = new Set<HotkeyRegistration>();
+
+function handleDocumentKeyDown(event: KeyboardEvent) {
+  // Guards shared by all hotkeys, based solely on the event target.
+
+  // If the element has a modal as ancestor, it means a modal is open (because
+  // of focus trap). So by doing that we ignore all hotkeys when a modal is open.
+  if (
+    event.target instanceof HTMLElement &&
+    event.target.closest("[data-modal]")
+  ) {
+    return;
+  }
+
+  if (document.getElementById("root")?.getAttribute("aria-hidden") === "true") {
+    return;
+  }
+
+  // Ignore key events from menu, menuitem or textbox
+  if (
+    event.target instanceof HTMLElement &&
+    (event.target.role === "menu" ||
+      event.target.role?.startsWith("menuitem") ||
+      event.target.role === "textbox" ||
+      event.target.closest("[data-hotkeys-disabled]") ||
+      event.target.closest("[role=dialog]"))
+  ) {
+    return;
+  }
+
+  const isTextInput =
+    event.target instanceof HTMLInputElement &&
+    (event.target.type === "text" || event.target.type === "textarea");
+
+  for (const registration of hotkeyRegistry) {
+    const { hotkey, ref } = registration;
+    const { callback, options } = ref.current;
+
+    if (!options.enabled) {
+      continue;
+    }
+
+    if (!options.allowInInput && isTextInput) {
+      continue;
+    }
+
+    if (!checkHotkeyMatches(hotkey, event)) {
+      continue;
+    }
+
+    if (options.preventDefault) {
+      event.preventDefault();
+    }
+
+    // Make sure events are triggered asynchronously.
+    registration.timeout = window.setTimeout(() => {
+      callback(event);
+    });
+  }
+}
+
+function registerHotkey(registration: HotkeyRegistration) {
+  if (hotkeyRegistry.size === 0) {
+    document.addEventListener("keydown", handleDocumentKeyDown, {
+      capture: true,
+    });
+  }
+  hotkeyRegistry.add(registration);
+  return () => {
+    window.clearTimeout(registration.timeout);
+    hotkeyRegistry.delete(registration);
+    if (hotkeyRegistry.size === 0) {
+      document.removeEventListener("keydown", handleDocumentKeyDown, {
+        capture: true,
+      });
+    }
+  };
+}
+
 export function useBuildHotkey(
   name: HotkeyName,
   callback: (event: KeyboardEvent) => void,
@@ -279,96 +409,13 @@ export function useBuildHotkey(
     enabled = true,
     allowInInput = false,
   } = options ?? {};
-  const optionsWithDefaults = { preventDefault, enabled, allowInInput };
-  const refs = useLiveRef({ callback, options: optionsWithDefaults });
-  const timeoutRef = useRef(0);
+  const ref = useLiveRef({
+    callback,
+    options: { preventDefault, enabled, allowInInput },
+  });
   useEffect(() => {
-    const listener = (event: KeyboardEvent) => {
-      const { options, callback } = refs.current;
-
-      // If the element has a modal as ancestor, it means a modal is open (because of focus trap).
-      // So by doing that we ignore all hotkeys when a modal is open.
-      if (
-        event.target instanceof HTMLElement &&
-        event.target.closest("[data-modal]")
-      ) {
-        return;
-      }
-
-      if (!options.enabled) {
-        return;
-      }
-
-      if (
-        document.getElementById("root")?.getAttribute("aria-hidden") === "true"
-      ) {
-        return;
-      }
-
-      // Ignore key events from menu, menuitem or textbox
-      if (
-        event.target instanceof HTMLElement &&
-        (event.target.role === "menu" ||
-          event.target.role?.startsWith("menuitem") ||
-          event.target.role === "textbox" ||
-          event.target.closest("[data-hotkeys-disabled]") ||
-          event.target.closest("[role=dialog]"))
-      ) {
-        return;
-      }
-
-      if (!options.allowInInput && event.target instanceof HTMLInputElement) {
-        if (event.target.type === "text") {
-          return;
-        }
-        if (event.target.type === "textarea") {
-          return;
-        }
-      }
-
-      const modifierShouldBePressed = hotkey.keys.some((key) => key === "⌘");
-      const altShouldBePressed = hotkey.keys.some((key) => key === "⌥");
-      const hasDigits = hotkey.keys.some((key) => key.startsWith("Digit"));
-
-      if (hasDigits && altShouldBePressed !== event.altKey) {
-        return;
-      }
-
-      if (modifierShouldBePressed !== checkIsModifiedPressed(event)) {
-        return;
-      }
-
-      const matchKeys = hotkey.keys.every((key) => {
-        // Ignore modifier keys
-        if (key === "⌘") {
-          return true;
-        }
-        if (key.startsWith("Key")) {
-          const letter = key.slice(3);
-          return letter === event.key || letter.toLowerCase() === event.key;
-        }
-        return key === event.code || key === event.key;
-      });
-
-      if (!matchKeys) {
-        return;
-      }
-
-      if (options.preventDefault) {
-        event.preventDefault();
-      }
-
-      // Make sure events are triggered asynchronously.
-      timeoutRef.current = window.setTimeout(() => {
-        callback(event);
-      });
-    };
-    document.addEventListener("keydown", listener, { capture: true });
-    return () => {
-      document.removeEventListener("keydown", listener, { capture: true });
-    };
-  }, [hotkey, refs]);
-  useEffect(() => () => window.clearTimeout(timeoutRef.current), []);
+    return registerHotkey({ hotkey, ref, timeout: 0 });
+  }, [hotkey, ref]);
   return hotkey;
 }
 

--- a/apps/frontend/src/pages/Build/BuildDiffList.tsx
+++ b/apps/frontend/src/pages/Build/BuildDiffList.tsx
@@ -22,15 +22,14 @@ import {
   SquareStackIcon,
 } from "lucide-react";
 import memoize from "memoize";
+import { AnimatePresence, motion } from "motion/react";
 import {
   Heading,
   Button as RACButton,
   ButtonProps as RACButtonProps,
-  Tooltip as RACTooltip,
-  TooltipProps as RACTooltipProps,
   Text,
-  TooltipTrigger,
 } from "react-aria-components";
+import { createPortal } from "react-dom";
 
 import {
   checkIsDiffGroupName,
@@ -53,7 +52,7 @@ import { Badge } from "@/ui/Badge";
 import { Button, ButtonIcon, ButtonProps } from "@/ui/Button";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 import { EmptyState, EmptyStateIcon } from "@/ui/Layout";
-import { getTooltipAnimationClassName, Tooltip } from "@/ui/Tooltip";
+import { Tooltip } from "@/ui/Tooltip";
 import { useEventCallback } from "@/ui/useEventCallback";
 import { useLiveRef } from "@/ui/useLiveRef";
 
@@ -604,40 +603,82 @@ const ListItem = memo(function ListItem(props: {
           style={{ top: 8, left: 16 }}
         />
       )}
+      {button}
       {isEvaluated && item.diff ? (
-        <TooltipTrigger delay={0} closeDelay={0} isOpen={isHovered}>
-          {button}
-          <DiffTooltip status={status} diff={item.diff} triggerRef={ref} />
-        </TooltipTrigger>
-      ) : (
-        button
-      )}
+        <DiffPreview
+          status={status}
+          diff={item.diff}
+          triggerRef={ref}
+          open={isHovered}
+        />
+      ) : null}
     </div>
   );
 });
 
-function DiffTooltip(props: {
+/**
+ * Hover preview of an evaluated (accepted/rejected) diff. These rows are
+ * collapsed in the list, so we float a full-size card to their right.
+ *
+ * We deliberately avoid react-aria's `Tooltip`: it registers a global
+ * capture-phase `keydown` listener that calls `stopPropagation()` on Escape to
+ * dismiss itself. Since this preview is controlled (`isOpen`), that close is a
+ * no-op but the `stopPropagation()` still fires, swallowing Escape for every
+ * open modal while a preview is shown.
+ *
+ * The preview is portaled to `document.body` because the list rows live inside
+ * an `overflow-y-auto` container with `translateY` transforms, which would both
+ * clip the card and break `position: fixed` positioning.
+ */
+function DiffPreview(props: {
   diff: Diff;
   status: EvaluationStatus;
-  triggerRef: RACTooltipProps["triggerRef"];
+  triggerRef: React.RefObject<HTMLElement | null>;
+  open: boolean;
 }) {
-  const { diff } = props;
-  return (
-    <RACTooltip
-      triggerRef={props.triggerRef}
-      placement="right top"
-      offset={8}
-      className={(props) =>
-        clsx(
-          "z-hover-card! pointer-events-none w-60",
-          getTooltipAnimationClassName(props),
-        )
-      }
-    >
-      <StatusDiffCard isActive={false} status={props.status}>
-        <DiffImage diff={diff} config={DIFF_IMAGE_CONFIG} />
-      </StatusDiffCard>
-    </RACTooltip>
+  const { diff, status, triggerRef, open } = props;
+  const [position, setPosition] = useState<{
+    top: number;
+    left: number;
+  } | null>(null);
+
+  // Anchor to the trigger when opening. We keep the last position during the
+  // exit animation, so the card fades out where it was shown.
+  useLayoutEffect(() => {
+    if (!open) {
+      return;
+    }
+    const trigger = triggerRef.current;
+    if (!trigger) {
+      return;
+    }
+    const rect = trigger.getBoundingClientRect();
+    setPosition({ top: rect.top, left: rect.right + 8 });
+  }, [open, triggerRef]);
+
+  return createPortal(
+    <AnimatePresence>
+      {open && position ? (
+        <motion.div
+          key="diff-preview"
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={{ opacity: 0, scale: 0.95 }}
+          transition={{ duration: 0.15, ease: "easeOut" }}
+          style={{
+            top: position.top,
+            left: position.left,
+            transformOrigin: "top left",
+          }}
+          className="z-hover-card pointer-events-none fixed w-60"
+        >
+          <StatusDiffCard isActive={false} status={status}>
+            <DiffImage diff={diff} config={DIFF_IMAGE_CONFIG} />
+          </StatusDiffCard>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>,
+    document.body,
   );
 }
 

--- a/apps/frontend/src/pages/Build/BuildDiffList.tsx
+++ b/apps/frontend/src/pages/Build/BuildDiffList.tsx
@@ -642,18 +642,30 @@ function DiffPreview(props: {
     left: number;
   } | null>(null);
 
-  // Anchor to the trigger when opening. We keep the last position during the
+  // Anchor to the trigger while open, and keep it anchored as the list scrolls
+  // or the window resizes (the card is `position: fixed`, so a moving trigger
+  // would otherwise leave it stranded). We keep the last position during the
   // exit animation, so the card fades out where it was shown.
   useLayoutEffect(() => {
     if (!open) {
       return;
     }
-    const trigger = triggerRef.current;
-    if (!trigger) {
-      return;
-    }
-    const rect = trigger.getBoundingClientRect();
-    setPosition({ top: rect.top, left: rect.right + 8 });
+    const update = () => {
+      const trigger = triggerRef.current;
+      if (!trigger) {
+        return;
+      }
+      const rect = trigger.getBoundingClientRect();
+      setPosition({ top: rect.top, left: rect.right + 8 });
+    };
+    update();
+    // Capture phase so scrolls on the ancestor list container are caught too.
+    window.addEventListener("scroll", update, true);
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", update, true);
+      window.removeEventListener("resize", update);
+    };
   }, [open, triggerRef]);
 
   return createPortal(

--- a/apps/frontend/src/pages/Build/BuildReviewDialog.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewDialog.tsx
@@ -1,49 +1,17 @@
 import { createContext, memo, use, useMemo, useState } from "react";
 import { invariant } from "@argos/util/invariant";
-import { ChevronDownIcon } from "lucide-react";
-import { useForm, type SubmitHandler } from "react-hook-form";
 
 import { DocumentType, graphql } from "@/gql";
-import { BuildReviewEvent } from "@/gql/graphql";
-import { Button, ButtonIcon } from "@/ui/Button";
-import { ButtonGroup } from "@/ui/ButtonGroup";
-import {
-  Dialog,
-  DialogBody,
-  DialogDismiss,
-  DialogFooter,
-  DialogText,
-  DialogTitle,
-} from "@/ui/Dialog";
-import { type EditorValue } from "@/ui/Editor/Editor";
-import { EditorField } from "@/ui/Editor/EditorField";
-import { hasEditorContent } from "@/ui/Editor/util";
-import { ErrorMessage } from "@/ui/ErrorMessage";
-import { Form } from "@/ui/Form";
-import { FormRootError } from "@/ui/FormRootError";
-import { FormSubmit } from "@/ui/FormSubmit";
-import { Label } from "@/ui/Label";
-import { Menu, MenuItem, MenuItemIcon, MenuTrigger } from "@/ui/Menu";
-import { Modal, ModalActionContext, ModalProps } from "@/ui/Modal";
-import { Popover } from "@/ui/Popover";
-import { getMentionUser } from "@/ui/UserCard";
+import { Dialog } from "@/ui/Dialog";
+import { Modal, ModalProps } from "@/ui/Modal";
 
-import { useCreateBuildReviewMutation } from "./BuildReviewAction";
-import { BUILD_REVIEW_EVENT_DEFINITIONS } from "./BuildReviewEvents";
-import { useBuildReviewSummary } from "./BuildReviewState";
-import { EvaluationStatus } from "./EvaluationStatus";
-import { PendingCommentsSection } from "./PendingCommentsSection";
+import { BuildReviewForm } from "./BuildReviewForm";
 
 const _ProjectFragment = graphql(`
   fragment BuildReviewDialog_Project on Project {
     build(number: $buildNumber) {
       id
-      status
-      members {
-        ...UserCard_user
-      }
-      ...BuildReviewAction_Build
-      ...PendingCommentsSection_Build
+      ...BuildReviewForm_Build
     }
   }
 `);
@@ -81,204 +49,17 @@ const BuildReviewModal = memo(function BuildReviewModal(props: {
   }
   return (
     <Modal isOpen={isOpen} onOpenChange={onOpenChange} isDismissable>
-      <BuildReviewDialog
-        build={project.build}
-        onClose={() => onOpenChange(false)}
-      />
+      {/* Same review surface as the header popover, just hosted in a modal. */}
+      <Dialog aria-label="Submit your review">
+        <BuildReviewForm
+          build={project.build}
+          onSubmitted={() => onOpenChange(false)}
+          size="large"
+        />
+      </Dialog>
     </Modal>
   );
 });
-
-type Inputs = {
-  body: EditorValue;
-};
-
-const MENU_EVENTS: BuildReviewEvent[] = [
-  BuildReviewEvent.Approve,
-  BuildReviewEvent.Reject,
-  BuildReviewEvent.Comment,
-];
-
-function BuildReviewDialog(props: {
-  build: NonNullable<DocumentType<typeof _ProjectFragment>["build"]>;
-  onClose: () => void;
-}) {
-  const { build, onClose } = props;
-  const mentions = useMemo(
-    () => build.members.map(getMentionUser),
-    [build.members],
-  );
-  const summary = useBuildReviewSummary();
-  invariant(summary, "BuildReviewDialog requires a summary");
-  const hasRejected = summary[EvaluationStatus.Rejected].length > 0;
-  const pendingCount = summary[EvaluationStatus.Pending].length;
-  const rejectedCount = summary[EvaluationStatus.Rejected].length;
-  const allAccepted = !hasRejected && pendingCount === 0;
-
-  const [event, setEvent] = useState<BuildReviewEvent>(
-    hasRejected ? BuildReviewEvent.Reject : BuildReviewEvent.Approve,
-  );
-
-  const form = useForm<Inputs>({
-    defaultValues: { body: null },
-  });
-
-  const [createReview] = useCreateBuildReviewMutation(build, {
-    onCompleted: () => onClose(),
-  });
-
-  const onSubmit: SubmitHandler<Inputs> = async (data) => {
-    if (event === BuildReviewEvent.Comment && !hasEditorContent(data.body)) {
-      form.setError("body", {
-        type: "validate",
-        message: "A comment is required when leaving a neutral review.",
-      });
-      return;
-    }
-    await createReview({
-      event,
-      body: hasEditorContent(data.body) ? data.body : undefined,
-    });
-    // The dialog closes itself once the mutation completes (see `onCompleted`).
-    // Never resolve so the form stays pending through the closing animation,
-    // instead of flashing back to its idle state before the dialog disappears.
-    await new Promise(() => {});
-  };
-
-  const bodyError = form.formState.errors.body;
-  const definition = BUILD_REVIEW_EVENT_DEFINITIONS[event];
-  const Icon = definition.icon;
-  const actionContext = use(ModalActionContext);
-
-  return (
-    <Dialog size="medium">
-      <Form form={form} onSubmit={onSubmit}>
-        <DialogBody>
-          <DialogTitle>Submit your review</DialogTitle>
-          <DialogText>
-            {hasRejected ? (
-              <>
-                During your review,{" "}
-                <strong>
-                  {rejectedCount === 1
-                    ? "1 change has been marked as rejected"
-                    : `${rejectedCount} changes have been marked as rejected`}
-                </strong>
-                .
-              </>
-            ) : pendingCount > 0 ? (
-              <>
-                <strong>
-                  {pendingCount === 1
-                    ? "1 change is still pending review"
-                    : `${pendingCount} changes are still pending review`}
-                </strong>
-                .
-              </>
-            ) : (
-              <>
-                <strong>All changes have been marked as accepted.</strong>
-              </>
-            )}
-          </DialogText>
-          <PendingCommentsSection build={build} />
-          {allAccepted ? null : (
-            <div>
-              <Label>Comment</Label>
-              <EditorField
-                control={form.control}
-                name="body"
-                mentions={mentions}
-                onChange={() => {
-                  if (bodyError) {
-                    form.clearErrors("body");
-                  }
-                }}
-                aria-label="Review comment"
-                placeholder="Leave a comment"
-                className="w-full"
-                autoFocus={hasRejected}
-                disabled={actionContext?.isPending}
-              />
-              {bodyError?.message ? (
-                <ErrorMessage className="mt-2">
-                  {String(bodyError.message)}
-                </ErrorMessage>
-              ) : null}
-            </div>
-          )}
-        </DialogBody>
-        <DialogFooter>
-          <FormRootError control={form.control} className="flex-1" />
-          <DialogDismiss>Cancel</DialogDismiss>
-          {allAccepted ? (
-            <FormSubmit
-              control={form.control}
-              variant={definition.variant}
-              autoFocus
-            >
-              <ButtonIcon>
-                <Icon />
-              </ButtonIcon>
-              {definition.label}
-            </FormSubmit>
-          ) : (
-            <ButtonGroup>
-              <FormSubmit
-                control={form.control}
-                variant={definition.variant}
-                autoFocus={!hasRejected}
-              >
-                <ButtonIcon>
-                  <Icon />
-                </ButtonIcon>
-                {definition.label}
-              </FormSubmit>
-              <MenuTrigger>
-                <Button
-                  variant={definition.variant}
-                  iconOnly
-                  aria-label="Change action"
-                  isDisabled={actionContext?.isPending}
-                >
-                  <ChevronDownIcon />
-                </Button>
-                <Popover placement="bottom end">
-                  <Menu
-                    selectionMode="single"
-                    disallowEmptySelection
-                    selectedKeys={[event]}
-                    onSelectionChange={(keys) => {
-                      if (keys && keys !== "all") {
-                        const [key] = keys;
-                        if (key) {
-                          setEvent(key as BuildReviewEvent);
-                        }
-                      }
-                    }}
-                  >
-                    {MENU_EVENTS.map((eventKey) => {
-                      const eventDef = BUILD_REVIEW_EVENT_DEFINITIONS[eventKey];
-                      const EventIcon = eventDef.icon;
-                      return (
-                        <MenuItem key={eventKey} id={eventKey}>
-                          <MenuItemIcon>
-                            <EventIcon />
-                          </MenuItemIcon>
-                          {eventDef.label}
-                        </MenuItem>
-                      );
-                    })}
-                  </Menu>
-                </Popover>
-              </MenuTrigger>
-            </ButtonGroup>
-          )}
-        </DialogFooter>
-      </Form>
-    </Dialog>
-  );
-}
 
 export function BuildReviewDialogProvider(props: {
   children: React.ReactNode;

--- a/apps/frontend/src/pages/Build/BuildReviewEvents.ts
+++ b/apps/frontend/src/pages/Build/BuildReviewEvents.ts
@@ -6,6 +6,7 @@ import {
 } from "lucide-react";
 
 import { BuildReviewEvent } from "@/gql/graphql";
+import type { UIColor } from "@/util/colors";
 
 export type ReviewEventRadioVariant = "primary" | "secondary" | "destructive";
 
@@ -14,6 +15,7 @@ export type BuildReviewEventDefinition = {
   description: string;
   variant: ReviewEventRadioVariant;
   icon: LucideIcon;
+  iconColor: UIColor | null;
 };
 
 export const BUILD_REVIEW_EVENT_DEFINITIONS: Record<
@@ -23,19 +25,22 @@ export const BUILD_REVIEW_EVENT_DEFINITIONS: Record<
   [BuildReviewEvent.Approve]: {
     label: "Approve",
     description: "Submit feedback and approve merging these changes.",
-    variant: "primary",
+    variant: "secondary",
     icon: ThumbsUpIcon,
+    iconColor: "success",
   },
   [BuildReviewEvent.Reject]: {
     label: "Reject",
     description: "Submit feedback about rejection.",
-    variant: "destructive",
+    variant: "secondary",
     icon: ThumbsDownIcon,
+    iconColor: "danger",
   },
   [BuildReviewEvent.Comment]: {
     label: "Comment",
     description: "Submit general feedback without explicit approval.",
     variant: "secondary",
     icon: MessageCircleIcon,
+    iconColor: null,
   },
 };

--- a/apps/frontend/src/pages/Build/BuildReviewEvents.ts
+++ b/apps/frontend/src/pages/Build/BuildReviewEvents.ts
@@ -8,12 +8,10 @@ import {
 import { BuildReviewEvent } from "@/gql/graphql";
 import type { UIColor } from "@/util/colors";
 
-export type ReviewEventRadioVariant = "primary" | "secondary" | "destructive";
-
 export type BuildReviewEventDefinition = {
   label: string;
   description: string;
-  variant: ReviewEventRadioVariant;
+  variant: "primary" | "secondary" | "destructive";
   icon: LucideIcon;
   iconColor: UIColor | null;
 };

--- a/apps/frontend/src/pages/Build/BuildReviewForm.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewForm.tsx
@@ -78,15 +78,19 @@ export function BuildReviewForm(props: {
   );
   const isSubmitting = pendingEvent !== null;
 
-  // Focus rules driven by the current review state:
-  // - at least one rejection → focus the comment field, a note is expected;
-  // - otherwise (all accepted, or nothing reviewed yet) → make Approve the
-  //   default so pressing Enter accepts the changes.
+  // The default action drives both focus and the implicit submit (Enter on the
+  // focused button, Cmd+Enter in the editor):
+  // - at least one rejection → Reject, and focus the comment field since a note
+  //   is expected;
+  // - otherwise (all accepted, or nothing reviewed yet) → Approve, so pressing
+  //   Enter accepts the changes.
   const summary = useBuildReviewSummary();
   const hasRejected = summary
     ? summary[EvaluationStatus.Rejected].length > 0
     : false;
-  const defaultApprove = !hasRejected;
+  const defaultEvent = hasRejected
+    ? BuildReviewEvent.Reject
+    : BuildReviewEvent.Approve;
 
   const submitReview = async (event: BuildReviewEvent) => {
     const { body } = form.getValues();
@@ -117,7 +121,7 @@ export function BuildReviewForm(props: {
   return (
     <Form
       form={form}
-      onSubmit={() => submitReview(BuildReviewEvent.Approve)}
+      onSubmit={() => submitReview(defaultEvent)}
       className={clsx("flex flex-col", size === "large" ? "w-lg" : "w-md")}
       onKeyDown={(event) => {
         if (event.key === "Escape" && !isSubmitting) {
@@ -155,7 +159,7 @@ export function BuildReviewForm(props: {
               form.clearErrors("body");
             }
           }}
-          onSubmit={() => submitReview(BuildReviewEvent.Approve)}
+          onSubmit={() => submitReview(defaultEvent)}
           aria-label="Review comment"
           placeholder="Add review summary…"
           className="text-sm"
@@ -174,9 +178,7 @@ export function BuildReviewForm(props: {
         {SUBMIT_EVENTS.map((event) => {
           const definition = BUILD_REVIEW_EVENT_DEFINITIONS[event];
           const Icon = definition.icon;
-          // Approve is the default action unless something was rejected.
-          const isDefault =
-            defaultApprove && event === BuildReviewEvent.Approve;
+          const isDefault = event === defaultEvent;
           return (
             <Button
               key={event}

--- a/apps/frontend/src/pages/Build/BuildReviewForm.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewForm.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { use, useMemo, useState } from "react";
 import { clsx } from "clsx";
 import { XIcon } from "lucide-react";
 import { useForm } from "react-hook-form";
@@ -14,6 +14,7 @@ import { ErrorMessage } from "@/ui/ErrorMessage";
 import { Form, handleFormError } from "@/ui/Form";
 import { FormRootError } from "@/ui/FormRootError";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
+import { ModalActionContext } from "@/ui/Modal";
 import { getMentionUser } from "@/ui/UserCard";
 import { lowTextColorClassNames } from "@/util/colors";
 
@@ -56,6 +57,10 @@ export function BuildReviewForm(props: {
   const { build, onSubmitted, size = "default" } = props;
 
   const state = useOverlayTriggerState();
+  // When hosted in a modal, lock dismissal (Escape/backdrop) while a review is
+  // in flight. Submitting through the buttons bypasses `Form`'s `onSubmit`
+  // wrapper, so we drive the pending state here instead.
+  const actionContext = use(ModalActionContext);
   const mentions = useMemo(
     () => build.members.map(getMentionUser),
     [build.members],
@@ -103,16 +108,19 @@ export function BuildReviewForm(props: {
     }
     form.clearErrors();
     setPendingEvent(event);
+    actionContext?.setIsPending(true);
     try {
       await createReview({
         event,
         body: hasEditorContent(body) ? body : undefined,
       });
       // The mutation closes the dialog through `onCompleted`; keep the pending
-      // state until then so the form doesn't flash back to idle.
+      // state until then so the form doesn't flash back to idle and the modal
+      // stays locked through the closing animation.
     } catch (error) {
       handleFormError(form, error);
       setPendingEvent(null);
+      actionContext?.setIsPending(false);
     }
   };
 

--- a/apps/frontend/src/pages/Build/BuildReviewForm.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewForm.tsx
@@ -23,7 +23,10 @@ import { BUILD_REVIEW_EVENT_DEFINITIONS } from "./BuildReviewEvents";
 import { useBuildReviewSummary } from "./BuildReviewState";
 import { EvaluationStatus } from "./EvaluationStatus";
 import { PendingCommentChip } from "./PendingCommentsSection";
-import { ReviewProgressBadge } from "./ReviewProgressBadge";
+import {
+  ReviewProgressBadge,
+  useBuildReviewProgression,
+} from "./ReviewProgressBadge";
 
 const _BuildFragment = graphql(`
   fragment BuildReviewForm_Build on Build {
@@ -89,6 +92,7 @@ export function BuildReviewForm(props: {
   //   is expected;
   // - otherwise (all accepted, or nothing reviewed yet) → Approve, so pressing
   //   Enter accepts the changes.
+  const progression = useBuildReviewProgression();
   const summary = useBuildReviewSummary();
   const hasRejected = summary
     ? summary[EvaluationStatus.Rejected].length > 0
@@ -139,7 +143,7 @@ export function BuildReviewForm(props: {
     >
       <div className="flex items-center justify-between gap-3 p-3">
         <div className="flex items-center gap-2">
-          <ReviewProgressBadge scale="sm" />
+          <ReviewProgressBadge scale="sm" progression={progression} />
           <PendingCommentChip build={build} />
         </div>
         <HotkeyTooltip keys={["Esc"]} description="Hide">

--- a/apps/frontend/src/pages/Build/BuildReviewForm.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewForm.tsx
@@ -1,32 +1,28 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { clsx } from "clsx";
-import { Text } from "react-aria-components";
-import { useForm, type SubmitHandler } from "react-hook-form";
+import { XIcon } from "lucide-react";
+import { useForm } from "react-hook-form";
 
 import { DocumentType, graphql } from "@/gql";
 import { BuildReviewEvent } from "@/gql/graphql";
-import {
-  DialogBody,
-  DialogDismiss,
-  DialogFooter,
-  DialogTitle,
-} from "@/ui/Dialog";
+import { Button, ButtonIcon } from "@/ui/Button";
+import { useOverlayTriggerState } from "@/ui/Dialog";
 import { type EditorValue } from "@/ui/Editor/Editor";
 import { EditorField } from "@/ui/Editor/EditorField";
 import { hasEditorContent } from "@/ui/Editor/util";
 import { ErrorMessage } from "@/ui/ErrorMessage";
-import { Form } from "@/ui/Form";
+import { Form, handleFormError } from "@/ui/Form";
 import { FormRootError } from "@/ui/FormRootError";
-import { FormSubmit } from "@/ui/FormSubmit";
-import { Label } from "@/ui/Label";
+import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 import { getMentionUser } from "@/ui/UserCard";
+import { lowTextColorClassNames } from "@/util/colors";
 
 import { useCreateBuildReviewMutation } from "./BuildReviewAction";
-import {
-  BUILD_REVIEW_EVENT_DEFINITIONS,
-  ReviewEventRadioVariant,
-} from "./BuildReviewEvents";
-import { PendingCommentsSection } from "./PendingCommentsSection";
+import { BUILD_REVIEW_EVENT_DEFINITIONS } from "./BuildReviewEvents";
+import { useBuildReviewSummary } from "./BuildReviewState";
+import { EvaluationStatus } from "./EvaluationStatus";
+import { PendingCommentChip } from "./PendingCommentsSection";
+import { ReviewProgressBadge } from "./ReviewProgressBadge";
 
 const _BuildFragment = graphql(`
   fragment BuildReviewForm_Build on Build {
@@ -40,39 +36,33 @@ const _BuildFragment = graphql(`
 `);
 
 type Inputs = {
-  event: BuildReviewEvent;
   body: EditorValue;
 };
 
+// Left-to-right order of the submit buttons: neutral, negative, then the
+// primary positive action on the right.
+const SUBMIT_EVENTS: BuildReviewEvent[] = [
+  BuildReviewEvent.Comment,
+  BuildReviewEvent.Reject,
+  BuildReviewEvent.Approve,
+];
+
 export function BuildReviewForm(props: {
   build: DocumentType<typeof _BuildFragment>;
-  defaultEvent?: BuildReviewEvent;
-  availableEvents?: BuildReviewEvent[];
   onSubmitted?: () => void;
-  cancel?: React.ReactNode;
+  /** Widen the form when hosted in a modal rather than the header popover. */
+  size?: "default" | "large";
 }) {
-  const {
-    build,
-    defaultEvent = BuildReviewEvent.Approve,
-    availableEvents = [
-      BuildReviewEvent.Comment,
-      BuildReviewEvent.Approve,
-      BuildReviewEvent.Reject,
-    ],
-    onSubmitted,
-    cancel,
-  } = props;
+  const { build, onSubmitted, size = "default" } = props;
 
+  const state = useOverlayTriggerState();
   const mentions = useMemo(
     () => build.members.map(getMentionUser),
     [build.members],
   );
 
   const form = useForm<Inputs>({
-    defaultValues: {
-      event: defaultEvent,
-      body: null,
-    },
+    defaultValues: { body: null },
   });
 
   const [createReview] = useCreateBuildReviewMutation(build, {
@@ -81,195 +71,140 @@ export function BuildReviewForm(props: {
     },
   });
 
-  const onSubmit: SubmitHandler<Inputs> = async (data) => {
-    if (
-      data.event === BuildReviewEvent.Comment &&
-      !hasEditorContent(data.body)
-    ) {
+  // Tracks the action currently being submitted: drives the per-button spinner
+  // and disables the rest of the form while the review is in flight.
+  const [pendingEvent, setPendingEvent] = useState<BuildReviewEvent | null>(
+    null,
+  );
+  const isSubmitting = pendingEvent !== null;
+
+  // Focus rules driven by the current review state:
+  // - at least one rejection → focus the comment field, a note is expected;
+  // - otherwise (all accepted, or nothing reviewed yet) → make Approve the
+  //   default so pressing Enter accepts the changes.
+  const summary = useBuildReviewSummary();
+  const hasRejected = summary
+    ? summary[EvaluationStatus.Rejected].length > 0
+    : false;
+  const defaultApprove = !hasRejected;
+
+  const submitReview = async (event: BuildReviewEvent) => {
+    const { body } = form.getValues();
+    if (event === BuildReviewEvent.Comment && !hasEditorContent(body)) {
       form.setError("body", {
         type: "validate",
         message: "A comment is required when leaving a neutral review.",
       });
       return;
     }
-    await createReview({
-      event: data.event,
-      body: hasEditorContent(data.body) ? data.body : undefined,
-    });
+    form.clearErrors();
+    setPendingEvent(event);
+    try {
+      await createReview({
+        event,
+        body: hasEditorContent(body) ? body : undefined,
+      });
+      // The mutation closes the dialog through `onCompleted`; keep the pending
+      // state until then so the form doesn't flash back to idle.
+    } catch (error) {
+      handleFormError(form, error);
+      setPendingEvent(null);
+    }
   };
 
-  const eventValue = form.watch("event");
   const bodyError = form.formState.errors.body;
 
   return (
-    <Form form={form} onSubmit={onSubmit}>
-      <DialogBody>
-        <DialogTitle>Review changes</DialogTitle>
-        <div className="flex flex-col gap-4">
-          <PendingCommentsSection build={build} />
-          <div>
-            <Label>
-              Add a comment{" "}
-              <Text className="text-low text-sm font-normal">(optional)</Text>
-            </Label>
-            <EditorField
-              control={form.control}
-              name="body"
-              mentions={mentions}
-              onChange={() => {
-                if (bodyError) {
-                  form.clearErrors("body");
-                }
-              }}
-              aria-label="Review comment"
-              placeholder="Share your feedback, ask a question, or leave a note..."
-              className="w-md"
-              disabled={form.formState.isSubmitting}
-            />
-            {bodyError?.message ? (
-              <ErrorMessage className="mt-2">
-                {String(bodyError.message)}
-              </ErrorMessage>
-            ) : null}
-          </div>
-          <ReviewEventRadioGroup
-            value={eventValue}
-            onChange={(value) => {
-              form.setValue("event", value, { shouldDirty: true });
-            }}
-            availableEvents={availableEvents}
-          />
-        </div>
-      </DialogBody>
-      <DialogFooter>
-        <FormRootError control={form.control} className="flex-1" />
-        {cancel}
-        <DialogDismiss>Cancel</DialogDismiss>
-        <FormSubmit control={form.control} autoFocus>
-          Submit review
-        </FormSubmit>
-      </DialogFooter>
-    </Form>
-  );
-}
-
-const RADIO_EVENT_ORDER: BuildReviewEvent[] = [
-  BuildReviewEvent.Comment,
-  BuildReviewEvent.Approve,
-  BuildReviewEvent.Reject,
-];
-
-function ReviewEventRadioGroup(props: {
-  value: BuildReviewEvent;
-  onChange: (value: BuildReviewEvent) => void;
-  availableEvents: BuildReviewEvent[];
-}) {
-  const { value, onChange, availableEvents } = props;
-  return (
-    <div role="radiogroup" className="flex flex-col gap-2">
-      {RADIO_EVENT_ORDER.filter((event) => availableEvents.includes(event)).map(
-        (event) => {
-          const definition = BUILD_REVIEW_EVENT_DEFINITIONS[event];
-          return (
-            <ReviewEventRadio
-              key={event}
-              value={event}
-              checked={value === event}
-              onChange={() => onChange(event)}
-              label={definition.label}
-              description={definition.description}
-              icon={definition.icon}
-              variant={definition.variant}
-            />
-          );
-        },
-      )}
-    </div>
-  );
-}
-
-const REVIEW_EVENT_THEME_BY_VARIANT: Record<
-  ReviewEventRadioVariant,
-  { checkedContainer: string; icon: string; iconChecked: string }
-> = {
-  primary: {
-    checkedContainer: "border-success bg-success-app",
-    icon: "bg-success-hover text-success-low",
-    iconChecked: "bg-success-active text-success-low",
-  },
-  destructive: {
-    checkedContainer: "border-danger bg-danger-app",
-    icon: "bg-danger-hover text-danger-low",
-    iconChecked: "bg-danger-active text-danger-low",
-  },
-  secondary: {
-    checkedContainer: "border-info bg-info-app",
-    icon: "bg-info-hover text-info-low",
-    iconChecked: "bg-info-active text-info-low",
-  },
-};
-
-function ReviewEventRadio(props: {
-  value: BuildReviewEvent;
-  checked: boolean;
-  onChange: () => void;
-  label: string;
-  description: string;
-  icon: React.ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
-  isDisabled?: boolean;
-  variant: ReviewEventRadioVariant;
-}) {
-  const {
-    value,
-    checked,
-    onChange,
-    label,
-    description,
-    icon: Icon,
-    isDisabled,
-    variant,
-  } = props;
-  const id = `review-event-${value}`;
-  const { checkedContainer, icon, iconChecked } =
-    REVIEW_EVENT_THEME_BY_VARIANT[variant];
-  return (
-    <label
-      htmlFor={id}
-      className={clsx(
-        "flex cursor-pointer items-center gap-2 rounded-md border p-2 transition-colors select-none",
-        !checked &&
-          "hover:bg-hover hover:border-low active:bg-active active:border-active",
-        "aria-disabled:cursor-not-allowed aria-disabled:opacity-50",
-        checked && checkedContainer,
-      )}
-      aria-disabled={isDisabled || undefined}
+    <Form
+      form={form}
+      onSubmit={() => submitReview(BuildReviewEvent.Approve)}
+      className={clsx("flex flex-col", size === "large" ? "w-lg" : "w-md")}
+      onKeyDown={(event) => {
+        if (event.key === "Escape" && !isSubmitting) {
+          state.close();
+        }
+      }}
     >
-      <input
-        id={id}
-        type="radio"
-        name="build-review-event"
-        value={value}
-        checked={checked}
-        onChange={onChange}
-        disabled={isDisabled}
-        className="focus-visible:ring-default focus-visible:ring-2"
-      />
-      <div className="flex items-center gap-1.5 text-sm font-medium">
-        <div
-          className={clsx(
-            "flex size-10 items-center justify-center rounded-sm",
-            checked ? iconChecked : icon,
-          )}
-        >
-          <Icon aria-hidden className="size-4" />
+      <div className="flex items-center justify-between gap-3 p-3">
+        <div className="flex items-center gap-2">
+          <ReviewProgressBadge />
+          <PendingCommentChip build={build} />
         </div>
-        <div>
-          <div className={clsx(checked && "text-default")}>{label}</div>
-          <span className={clsx("text-low text-xs", checked && "text-default")}>
-            {description}
-          </span>
-        </div>
+        <HotkeyTooltip keys={["Esc"]} description="Hide">
+          <Button
+            variant="ghost"
+            size="small"
+            iconOnly
+            aria-label="Close"
+            rounded
+            onPress={() => state.close()}
+            isDisabled={isSubmitting}
+          >
+            <XIcon />
+          </Button>
+        </HotkeyTooltip>
       </div>
-    </label>
+      <div className="px-4 pb-3">
+        <EditorField
+          control={form.control}
+          name="body"
+          variant="plain"
+          mentions={mentions}
+          onChange={() => {
+            if (bodyError) {
+              form.clearErrors("body");
+            }
+          }}
+          onSubmit={() => submitReview(BuildReviewEvent.Approve)}
+          aria-label="Review comment"
+          placeholder="Add review summary…"
+          className="text-sm"
+          contentClassName="max-h-64 min-h-16 overflow-y-auto"
+          autoFocus={hasRejected}
+          disabled={isSubmitting}
+        />
+        {bodyError?.message ? (
+          <ErrorMessage className="mt-2">
+            {String(bodyError.message)}
+          </ErrorMessage>
+        ) : null}
+      </div>
+      <div className="flex justify-end gap-2 p-3">
+        <FormRootError control={form.control} className="flex-1" />
+        {SUBMIT_EVENTS.map((event) => {
+          const definition = BUILD_REVIEW_EVENT_DEFINITIONS[event];
+          const Icon = definition.icon;
+          // Approve is the default action unless something was rejected.
+          const isDefault =
+            defaultApprove && event === BuildReviewEvent.Approve;
+          return (
+            <Button
+              key={event}
+              variant={definition.variant}
+              rounded
+              size="small"
+              isPending={pendingEvent === event}
+              isDisabled={isSubmitting && pendingEvent !== event}
+              autoFocus={isDefault}
+              // Keep the ring on the focused button (not only keyboard focus)
+              // so the default action Enter triggers stays visible.
+              showFocusRing
+              onAction={() => submitReview(event)}
+            >
+              <ButtonIcon>
+                <Icon
+                  className={
+                    definition.iconColor
+                      ? lowTextColorClassNames[definition.iconColor]
+                      : undefined
+                  }
+                />
+              </ButtonIcon>
+              {definition.label}
+            </Button>
+          );
+        })}
+      </div>
+    </Form>
   );
 }

--- a/apps/frontend/src/pages/Build/BuildReviewForm.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewForm.tsx
@@ -127,7 +127,7 @@ export function BuildReviewForm(props: {
     >
       <div className="flex items-center justify-between gap-3 p-3">
         <div className="flex items-center gap-2">
-          <ReviewProgressBadge />
+          <ReviewProgressBadge scale="sm" />
           <PendingCommentChip build={build} />
         </div>
         <HotkeyTooltip keys={["Esc"]} description="Hide">

--- a/apps/frontend/src/pages/Build/PendingCommentsSection.tsx
+++ b/apps/frontend/src/pages/Build/PendingCommentsSection.tsx
@@ -1,55 +1,37 @@
-import { ImageIcon } from "lucide-react";
+import { MessageSquareIcon } from "lucide-react";
 
 import { DocumentType, graphql } from "@/gql";
-import { ReadOnlyEditor } from "@/ui/Editor/ReadOnlyEditor";
-import { Label } from "@/ui/Label";
+import { Chip } from "@/ui/Chip";
 
 export const PendingCommentsSection_Build = graphql(`
   fragment PendingCommentsSection_Build on Build {
     comments {
       id
       pending
-      content
-      screenshotDiff {
-        id
-        name
-      }
     }
   }
 `);
 
 /**
- * Lists the comments the current user has drafted into their pending review,
- * shown in the submit-review surfaces so they can see exactly what will become
- * visible when they submit. Renders nothing when there are no pending comments.
+ * Compact status chip summarizing how many comments are drafted into the
+ * pending review, without expanding their content. Used in the lightweight
+ * review popover where the full list would be too heavy.
  */
-export function PendingCommentsSection(props: {
+export function PendingCommentChip(props: {
   build: DocumentType<typeof PendingCommentsSection_Build>;
 }) {
-  const pending = props.build.comments.filter((comment) => comment.pending);
-  if (pending.length === 0) {
-    return null;
-  }
+  const count = props.build.comments.filter(
+    (comment) => comment.pending,
+  ).length;
   return (
-    <div>
-      <Label>
-        Pending comment{pending.length > 1 ? "s" : ""} ({pending.length})
-      </Label>
-      <div className="border-thin max-h-48 divide-y overflow-y-auto rounded-md">
-        {pending.map((comment) => (
-          <div key={comment.id} className="px-2.5 py-2">
-            {comment.screenshotDiff ? (
-              <div className="text-low mb-1 flex items-center gap-1 text-xs">
-                <ImageIcon className="size-3 shrink-0" />
-                <span className="min-w-0 truncate">
-                  {comment.screenshotDiff.name}
-                </span>
-              </div>
-            ) : null}
-            <ReadOnlyEditor content={comment.content} className="text-sm" />
-          </div>
-        ))}
-      </div>
-    </div>
+    <Chip
+      scale="sm"
+      color="neutral"
+      icon={count > 0 ? MessageSquareIcon : undefined}
+    >
+      {count === 0
+        ? "No pending comments"
+        : `${count} pending comment${count > 1 ? "s" : ""}`}
+    </Chip>
   );
 }

--- a/apps/frontend/src/pages/Build/ReviewProgressBadge.tsx
+++ b/apps/frontend/src/pages/Build/ReviewProgressBadge.tsx
@@ -1,0 +1,89 @@
+import {
+  EllipsisIcon,
+  ThumbsDownIcon,
+  ThumbsUpIcon,
+  type LucideIcon,
+} from "lucide-react";
+
+import { Chip, type ChipColor } from "@/ui/Chip";
+import { Tooltip } from "@/ui/Tooltip";
+
+import { checkDiffCanBeReviewed, useBuildDiffState } from "./BuildDiffState";
+import { useGetDiffEvaluationStatus } from "./BuildReviewState";
+import { EvaluationStatus } from "./EvaluationStatus";
+
+/**
+ * Compute how many reviewable diffs the current user has evaluated, split by
+ * outcome. Returns `null` while the diff/review state is still initializing.
+ */
+export function useBuildReviewProgression() {
+  const diffState = useBuildDiffState();
+  const getDiffEvaluationStatus = useGetDiffEvaluationStatus();
+  if (diffState.ready && getDiffEvaluationStatus) {
+    const toReview = diffState.allDiffs.filter((diff) =>
+      checkDiffCanBeReviewed(diff.status, {
+        isSubsetBuild: diffState.isSubsetBuild,
+      }),
+    );
+    const reviewed = toReview.filter(
+      (diff) => getDiffEvaluationStatus(diff.id) !== EvaluationStatus.Pending,
+    );
+    const accepted = toReview.filter(
+      (diff) => getDiffEvaluationStatus(diff.id) === EvaluationStatus.Accepted,
+    );
+    const rejected = toReview.filter(
+      (diff) => getDiffEvaluationStatus(diff.id) === EvaluationStatus.Rejected,
+    );
+    return { toReview, reviewed, accepted, rejected };
+  }
+  return null;
+}
+
+export type BuildReviewProgression = NonNullable<
+  ReturnType<typeof useBuildReviewProgression>
+>;
+
+function getProgressionDisplay(progression: BuildReviewProgression): {
+  color: ChipColor;
+  tooltip: string;
+  icon: LucideIcon;
+} {
+  if (progression.rejected.length > 0) {
+    return {
+      color: "danger",
+      tooltip: "Some changes have been rejected",
+      icon: ThumbsDownIcon,
+    };
+  }
+  if (progression.reviewed.length === progression.toReview.length) {
+    return {
+      color: "success",
+      tooltip: "All changes have been accepted",
+      icon: ThumbsUpIcon,
+    };
+  }
+  return {
+    color: "neutral",
+    tooltip: "Track your review progress",
+    icon: EllipsisIcon,
+  };
+}
+
+/**
+ * Compact "X / Y reviewed" counter chip summarizing the viewer's review
+ * progress. Renders nothing until there is at least one diff to review.
+ */
+export function ReviewProgressBadge() {
+  const progression = useBuildReviewProgression();
+  if (!progression || progression.toReview.length === 0) {
+    return null;
+  }
+  const { color, tooltip, icon } = getProgressionDisplay(progression);
+  return (
+    <Tooltip content={tooltip}>
+      <Chip scale="sm" color={color} className="tabular-nums" icon={icon}>
+        {progression.reviewed.length} / {progression.toReview.length} reviewed
+      </Chip>
+    </Tooltip>
+  );
+}

--- a/apps/frontend/src/pages/Build/ReviewProgressBadge.tsx
+++ b/apps/frontend/src/pages/Build/ReviewProgressBadge.tsx
@@ -75,10 +75,15 @@ function getProgressionDisplay(progression: BuildReviewProgression): {
  *
  * The chip is sized to its host: `xs` in the build header, `sm` in the
  * review form.
+ *
+ * Hosts pass the already-computed `progression` (via `useBuildReviewProgression`)
+ * so it isn't recomputed per render. Renders nothing while it's still null.
  */
-export function ReviewProgressBadge(props: { scale?: "xs" | "sm" }) {
-  const { scale = "sm" } = props;
-  const progression = useBuildReviewProgression();
+export function ReviewProgressBadge(props: {
+  scale?: "xs" | "sm";
+  progression: BuildReviewProgression | null;
+}) {
+  const { scale = "sm", progression } = props;
   if (!progression || progression.toReview.length === 0) {
     return null;
   }

--- a/apps/frontend/src/pages/Build/ReviewProgressBadge.tsx
+++ b/apps/frontend/src/pages/Build/ReviewProgressBadge.tsx
@@ -72,8 +72,12 @@ function getProgressionDisplay(progression: BuildReviewProgression): {
 /**
  * Compact "X / Y reviewed" counter chip summarizing the viewer's review
  * progress. Renders nothing until there is at least one diff to review.
+ *
+ * The chip is sized to its host: `xs` in the build header, `sm` in the
+ * review form.
  */
-export function ReviewProgressBadge() {
+export function ReviewProgressBadge(props: { scale?: "xs" | "sm" }) {
+  const { scale = "sm" } = props;
   const progression = useBuildReviewProgression();
   if (!progression || progression.toReview.length === 0) {
     return null;
@@ -81,7 +85,7 @@ export function ReviewProgressBadge() {
   const { color, tooltip, icon } = getProgressionDisplay(progression);
   return (
     <Tooltip content={tooltip}>
-      <Chip scale="sm" color={color} className="tabular-nums" icon={icon}>
+      <Chip scale={scale} color={color} className="tabular-nums" icon={icon}>
         {progression.reviewed.length} / {progression.toReview.length} reviewed
       </Chip>
     </Tooltip>

--- a/apps/frontend/src/pages/Build/header/BuildHeader.tsx
+++ b/apps/frontend/src/pages/Build/header/BuildHeader.tsx
@@ -111,7 +111,7 @@ function LoggedReviewButton(props: {
   return (
     <div className="flex items-center gap-4">
       <div className="flex flex-col gap-1.5">
-        <ReviewProgressBadge scale="xs" />
+        <ReviewProgressBadge scale="xs" progression={progression} />
         <Progress
           scale="sm"
           value={progression.reviewed.length}

--- a/apps/frontend/src/pages/Build/header/BuildHeader.tsx
+++ b/apps/frontend/src/pages/Build/header/BuildHeader.tsx
@@ -111,7 +111,7 @@ function LoggedReviewButton(props: {
   return (
     <div className="flex items-center gap-4">
       <div className="flex flex-col gap-1.5">
-        <ReviewProgressBadge />
+        <ReviewProgressBadge scale="xs" />
         <Progress
           scale="sm"
           value={progression.reviewed.length}

--- a/apps/frontend/src/pages/Build/header/BuildHeader.tsx
+++ b/apps/frontend/src/pages/Build/header/BuildHeader.tsx
@@ -1,13 +1,6 @@
 import { ComponentProps, memo, useState } from "react";
 import clsx from "clsx";
-import {
-  CheckIcon,
-  EllipsisIcon,
-  RefreshCcwIcon,
-  SparklesIcon,
-  ThumbsDownIcon,
-  ThumbsUpIcon,
-} from "lucide-react";
+import { CheckIcon, RefreshCcwIcon, SparklesIcon } from "lucide-react";
 import { useClipboard } from "use-clipboard-copy";
 
 import { useIsLoggedIn } from "@/containers/Auth";
@@ -21,19 +14,20 @@ import { DocumentType, graphql } from "@/gql";
 import { BuildMode, BuildType } from "@/gql/graphql";
 import { getProjectURL } from "@/pages/Project/ProjectParams";
 import { BrandShield } from "@/ui/BrandShield";
-import { Chip } from "@/ui/Chip";
 import { HeadlessLink } from "@/ui/Link";
 import { Progress } from "@/ui/Progress";
 import { Tooltip } from "@/ui/Tooltip";
 
 import { IconButton } from "../../../ui/IconButton";
-import { checkDiffCanBeReviewed, useBuildDiffState } from "../BuildDiffState";
+import { useBuildDiffState } from "../BuildDiffState";
 import {
   BuildReviewButton,
   DisabledBuildReviewButton,
 } from "../BuildReviewButton";
-import { useGetDiffEvaluationStatus } from "../BuildReviewState";
-import { EvaluationStatus } from "../EvaluationStatus";
+import {
+  ReviewProgressBadge,
+  useBuildReviewProgression,
+} from "../ReviewProgressBadge";
 import { createBuildReviewPrompt } from "./BuildReviewPrompt";
 
 const _BuildFragment = graphql(`
@@ -95,29 +89,6 @@ const ProjectLink = memo(
   },
 );
 
-function useBuildReviewProgression() {
-  const diffState = useBuildDiffState();
-  const getDiffEvaluationStatus = useGetDiffEvaluationStatus();
-  if (diffState.ready && getDiffEvaluationStatus) {
-    const toReview = diffState.allDiffs.filter((diff) =>
-      checkDiffCanBeReviewed(diff.status, {
-        isSubsetBuild: diffState.isSubsetBuild,
-      }),
-    );
-    const reviewed = toReview.filter(
-      (diff) => getDiffEvaluationStatus(diff.id) !== EvaluationStatus.Pending,
-    );
-    const accepted = toReview.filter(
-      (diff) => getDiffEvaluationStatus(diff.id) === EvaluationStatus.Accepted,
-    );
-    const rejected = toReview.filter(
-      (diff) => getDiffEvaluationStatus(diff.id) === EvaluationStatus.Rejected,
-    );
-    return { toReview, reviewed, accepted, rejected };
-  }
-  return null;
-}
-
 function LoggedReviewButton(props: {
   project: ComponentProps<typeof BuildReviewButton>["project"];
   build: DocumentType<typeof _BuildFragment>;
@@ -137,46 +108,18 @@ function LoggedReviewButton(props: {
   if (progression.toReview.length === 0) {
     return <DisabledBuildReviewButton tooltip="No changes to review" />;
   }
-  const reviewComplete =
-    progression.reviewed.length === progression.toReview.length;
-  const { color, tooltip, icon } = (() => {
-    if (progression.rejected.length > 0) {
-      return {
-        color: "danger" as const,
-        tooltip: "Some changes have been rejected",
-        icon: ThumbsDownIcon,
-      };
-    }
-    if (reviewComplete) {
-      return {
-        color: "success" as const,
-        tooltip: "All changes have been accepted",
-        icon: ThumbsUpIcon,
-      };
-    }
-    return {
-      color: "neutral" as const,
-      tooltip: "Track your review progress",
-      icon: EllipsisIcon,
-    };
-  })();
   return (
     <div className="flex items-center gap-4">
-      <Tooltip content={tooltip}>
-        <div className="flex flex-col gap-1.5">
-          <Chip scale="xs" color={color} className="tabular-nums" icon={icon}>
-            {progression.reviewed.length} / {progression.toReview.length}{" "}
-            reviewed
-          </Chip>
-          <Progress
-            scale="sm"
-            value={progression.reviewed.length}
-            min={0}
-            max={progression.toReview.length}
-            className="w-full"
-          />
-        </div>
-      </Tooltip>
+      <div className="flex flex-col gap-1.5">
+        <ReviewProgressBadge />
+        <Progress
+          scale="sm"
+          value={progression.reviewed.length}
+          min={0}
+          max={progression.toReview.length}
+          className="w-full"
+        />
+      </div>
       <div className="flex items-center gap-1">
         <BuildReviewButton project={props.project} />
         <CopyBuildReviewPromptButton

--- a/apps/frontend/src/ui/Button.tsx
+++ b/apps/frontend/src/ui/Button.tsx
@@ -33,6 +33,12 @@ type ButtonOptions = {
   iconOnly?: boolean;
   /** Fully round the edges (pill shape) instead of the default rounded corners. */
   rounded?: boolean;
+  /**
+   * Show the focus ring whenever the button is focused, not only when it is
+   * `focus-visible`. Use it to make an autofocused default action visible even
+   * to pointer users, so they can see which button Enter will trigger.
+   */
+  showFocusRing?: boolean;
 };
 
 const variantClassNames: Record<ButtonVariant, string> = {
@@ -59,11 +65,26 @@ const sizeClassNames: Record<ButtonSize, string> = {
 };
 
 // Keep the same vertical padding as the regular sizes so an iconOnly button
-// matches the height of a text button (e.g. when placed in a ButtonGroup).
+// matches the height of a text button (e.g. when placed in a ButtonGroup), and
+// mirror it horizontally so the button stays a perfect square around the
+// `size-[1em]` icon.
 const iconOnlySizeClassNames: Record<ButtonSize, string> = {
-  small: "py-1 px-1.5 text-xs",
-  medium: "py-[calc(0.375rem-1px)] px-2 text-sm",
-  large: "py-3 px-4 text-base",
+  small: "py-1 px-1 text-xs",
+  medium: "py-[calc(0.375rem-1px)] px-[calc(0.375rem-1px)] text-sm",
+  large: "py-3 px-3 text-base",
+};
+
+// Ring color used by `highlight`, mirroring each variant's
+// `data-focus-visible:ring-*`. With `showFocusRing`, the ring is drawn on any
+// `data-focused` state (e.g. an autofocused button), not just keyboard focus.
+const focusedRingClassNames: Record<ButtonVariant, string> = {
+  primary: "data-focused:ring-4 data-focused:ring-primary",
+  secondary: "data-focused:ring-4 data-focused:ring-default",
+  ghost: "data-focused:ring-4 data-focused:ring-default",
+  destructive: "data-focused:ring-4 data-focused:ring-danger",
+  github: "data-focused:ring-4 data-focused:ring-default",
+  gitlab: "data-focused:ring-4 data-focused:ring-default",
+  google: "data-focused:ring-4 data-focused:ring-default",
 };
 
 // Default corner rounding per size (overridden by `rounded` for a pill shape).
@@ -78,8 +99,9 @@ function getButtonClassName(options: {
   size: ButtonSize;
   iconOnly: boolean;
   rounded: boolean;
+  showFocusRing: boolean;
 }) {
-  const { variant, size, iconOnly, rounded } = options;
+  const { variant, size, iconOnly, rounded, showFocusRing } = options;
   const variantClassName = variantClassNames[variant];
   const sizeClassName = (iconOnly ? iconOnlySizeClassNames : sizeClassNames)[
     size
@@ -88,6 +110,7 @@ function getButtonClassName(options: {
     "group/button",
     variantClassName,
     sizeClassName,
+    showFocusRing && focusedRingClassNames[variant],
     rounded ? "rounded-full" : roundingClassNames[size],
     // ButtonGroup integration: drop the inner rounded corners and overlap
     // adjacent borders so each variant's `border-l-*` acts as the separator.
@@ -108,9 +131,16 @@ function getButtonProps(options: ButtonOptions) {
     size = "medium",
     iconOnly = false,
     rounded = false,
+    showFocusRing = false,
   } = options;
   return {
-    className: getButtonClassName({ variant, size, iconOnly, rounded }),
+    className: getButtonClassName({
+      variant,
+      size,
+      iconOnly,
+      rounded,
+      showFocusRing,
+    }),
     "data-size": size ?? "medium",
     "data-icon-only": iconOnly ? "true" : undefined,
   };
@@ -143,12 +173,19 @@ export function Button({
   size,
   iconOnly,
   rounded,
+  showFocusRing,
   children,
   onAction,
   onPress,
   ...props
 }: ButtonProps) {
-  const buttonProps = getButtonProps({ variant, size, iconOnly, rounded });
+  const buttonProps = getButtonProps({
+    variant,
+    size,
+    iconOnly,
+    rounded,
+    showFocusRing,
+  });
   const [isPending, setIsPending] = useState(false);
   return (
     <RACButton
@@ -203,9 +240,16 @@ export function LinkButton({
   size,
   iconOnly,
   rounded,
+  showFocusRing,
   ...props
 }: LinkButtonProps) {
-  const buttonProps = getButtonProps({ variant, size, iconOnly, rounded });
+  const buttonProps = getButtonProps({
+    variant,
+    size,
+    iconOnly,
+    rounded,
+    showFocusRing,
+  });
   return (
     <RACLink
       ref={ref}

--- a/apps/frontend/src/ui/Button.tsx
+++ b/apps/frontend/src/ui/Button.tsx
@@ -43,19 +43,19 @@ type ButtonOptions = {
 
 const variantClassNames: Record<ButtonVariant, string> = {
   primary:
-    "data-focus-visible:ring-primary text-white border-transparent bg-primary-solid data-hovered:bg-primary-solid-hover data-pressed:bg-primary-solid-active aria-expanded:bg-primary-solid-active group-[*]/button-group:not-first:border-l-white/20",
+    "text-white border-transparent bg-primary-solid data-hovered:bg-primary-solid-hover data-pressed:bg-primary-solid-active aria-expanded:bg-primary-solid-active group-[*]/button-group:not-first:border-l-white/20",
   secondary:
-    "data-focus-visible:ring-default text-default border bg-transparent data-hovered:bg-hover data-hovered:border-hover data-pressed:bg-active",
+    "text-default border bg-transparent data-hovered:bg-hover data-hovered:border-hover data-pressed:bg-active",
   ghost:
-    "data-focus-visible:ring-default text-default border-transparent bg-transparent data-hovered:bg-hover data-pressed:bg-active aria-expanded:bg-active",
+    "text-default border-transparent bg-transparent data-hovered:bg-hover data-pressed:bg-active aria-expanded:bg-active",
   destructive:
-    "data-focus-visible:ring-danger text-white border-transparent bg-danger-solid data-hovered:bg-danger-solid-hover data-pressed:bg-danger-solid-active aria-expanded:bg-danger-solid-active group-[*]/button-group:not-first:border-l-white/20",
+    "text-white border-transparent bg-danger-solid data-hovered:bg-danger-solid-hover data-pressed:bg-danger-solid-active aria-expanded:bg-danger-solid-active group-[*]/button-group:not-first:border-l-white/20",
   github:
-    "data-focus-visible:ring-default text-white border-transparent bg-github data-hovered:bg-github-hover data-pressed:bg-github-active aria-expanded:bg-github-active group-[*]/button-group:not-first:border-l-white/20",
+    "text-white border-transparent bg-github data-hovered:bg-github-hover data-pressed:bg-github-active aria-expanded:bg-github-active group-[*]/button-group:not-first:border-l-white/20",
   gitlab:
-    "data-focus-visible:ring-default text-white border-transparent bg-gitlab data-hovered:bg-gitlab-hover data-pressed:bg-gitlab-active aria-expanded:bg-gitlab-active group-[*]/button-group:not-first:border-l-white/20",
+    "text-white border-transparent bg-gitlab data-hovered:bg-gitlab-hover data-pressed:bg-gitlab-active aria-expanded:bg-gitlab-active group-[*]/button-group:not-first:border-l-white/20",
   google:
-    "data-focus-visible:ring-default text-default border-transparent bg-google data-hovered:bg-google-hover data-pressed:bg-google-active aria-expanded:bg-google-active ring-1 ring-google group-[*]/button-group:not-first:border-l-black/15",
+    "text-default border-transparent bg-google data-hovered:bg-google-hover data-pressed:bg-google-active aria-expanded:bg-google-active ring-1 ring-google group-[*]/button-group:not-first:border-l-black/15",
 };
 
 const sizeClassNames: Record<ButtonSize, string> = {
@@ -74,17 +74,43 @@ const iconOnlySizeClassNames: Record<ButtonSize, string> = {
   large: "py-3 px-3 text-base",
 };
 
-// Ring color used by `highlight`, mirroring each variant's
-// `data-focus-visible:ring-*`. With `showFocusRing`, the ring is drawn on any
-// `data-focused` state (e.g. an autofocused button), not just keyboard focus.
-const focusedRingClassNames: Record<ButtonVariant, string> = {
-  primary: "data-focused:ring-4 data-focused:ring-primary",
-  secondary: "data-focused:ring-4 data-focused:ring-default",
-  ghost: "data-focused:ring-4 data-focused:ring-default",
-  destructive: "data-focused:ring-4 data-focused:ring-danger",
-  github: "data-focused:ring-4 data-focused:ring-default",
-  gitlab: "data-focused:ring-4 data-focused:ring-default",
-  google: "data-focused:ring-4 data-focused:ring-default",
+// Ring color per variant, the single source of truth for both the
+// keyboard-focus ring (`data-focus-visible`) and the always-on ring drawn by
+// `showFocusRing` (`data-focused`, e.g. an autofocused default action). Keeping
+// the two states side by side stops them from drifting apart; the values are
+// full literals so Tailwind keeps generating the classes.
+const ringClassNames: Record<
+  ButtonVariant,
+  { focusVisible: string; focused: string }
+> = {
+  primary: {
+    focusVisible: "data-focus-visible:ring-primary",
+    focused: "data-focused:ring-primary",
+  },
+  secondary: {
+    focusVisible: "data-focus-visible:ring-default",
+    focused: "data-focused:ring-default",
+  },
+  ghost: {
+    focusVisible: "data-focus-visible:ring-default",
+    focused: "data-focused:ring-default",
+  },
+  destructive: {
+    focusVisible: "data-focus-visible:ring-danger",
+    focused: "data-focused:ring-danger",
+  },
+  github: {
+    focusVisible: "data-focus-visible:ring-default",
+    focused: "data-focused:ring-default",
+  },
+  gitlab: {
+    focusVisible: "data-focus-visible:ring-default",
+    focused: "data-focused:ring-default",
+  },
+  google: {
+    focusVisible: "data-focus-visible:ring-default",
+    focused: "data-focused:ring-default",
+  },
 };
 
 // Default corner rounding per size (overridden by `rounded` for a pill shape).
@@ -103,6 +129,7 @@ function getButtonClassName(options: {
 }) {
   const { variant, size, iconOnly, rounded, showFocusRing } = options;
   const variantClassName = variantClassNames[variant];
+  const ring = ringClassNames[variant];
   const sizeClassName = (iconOnly ? iconOnlySizeClassNames : sizeClassNames)[
     size
   ];
@@ -110,7 +137,8 @@ function getButtonClassName(options: {
     "group/button",
     variantClassName,
     sizeClassName,
-    showFocusRing && focusedRingClassNames[variant],
+    ring.focusVisible,
+    showFocusRing && ["data-focused:ring-4", ring.focused],
     rounded ? "rounded-full" : roundingClassNames[size],
     // ButtonGroup integration: drop the inner rounded corners and overlap
     // adjacent borders so each variant's `border-l-*` acts as the separator.

--- a/apps/frontend/src/ui/Tooltip.tsx
+++ b/apps/frontend/src/ui/Tooltip.tsx
@@ -30,9 +30,7 @@ export type TooltipProps = {
   closeDelay?: TooltipTriggerComponentProps["closeDelay"];
 };
 
-export function getTooltipAnimationClassName(
-  props: TooltipRenderProps,
-): string {
+function getTooltipAnimationClassName(props: TooltipRenderProps): string {
   return clsx(
     "fill-mode-forwards",
     props.placement &&


### PR DESCRIPTION
## Summary

Reworks the **Review changes** surface into a lighter, more compact popover, plus a few fixes uncovered along the way.

### Review surface redesign

- **Removed the title** and the bordered comment box — the summary editor now renders as a plain, borderless field that blends seamlessly into the popover.
- **New top bar**: review progress badge + a pending-comments chip (counter only, no expanded list), with an `Esc`-bound close (**X**) button on the right.
- **Three direct-action buttons** (Comment / Reject / Approve) replace the review-event radio group. Each submits on press with its own spinner; the rest of the form disables while a submit is in flight. **Approve** is the default (Enter) action unless changes were rejected, in which case the comment field is focused instead.
- **Button fix**: `iconOnly` buttons now render as perfect squares by mirroring the vertical padding horizontally around the `size-[1em]` icon (they were previously wider than tall).

<img width="946" height="400" alt="CleanShot 2026-06-21 at 16 27 02@2x" src="https://github.com/user-attachments/assets/fc24d802-2323-4cbe-9525-38c2039cfaab" />

### Escape-key regression fix

- **Diff hover preview no longer swallows `Escape`.** The evaluated-diff hover preview used a _controlled_ react-aria `Tooltip`, which registers a global capture-phase `keydown` listener that calls `stopPropagation()` on `Escape` to dismiss itself. Because the tooltip was controlled, the dismiss was a no-op but the `stopPropagation()` still fired — so while a preview was shown, `Escape` was intercepted before it could reach any open overlay (most visibly: it stopped the review modal, and every other modal, from closing).
- Replaced it with a custom `DiffPreview` portaled to `document.body`, positioned from the trigger's bounding rect, and animated in/out with motion's `AnimatePresence`. No global key listener, so `Escape` is no longer intercepted.
- Follow-up: `getTooltipAnimationClassName` is no longer exported (its only external consumer is gone).

### Other changes

- **Build hotkeys share a single DOM listener.** `useBuildHotkey` previously attached its own capture-phase `document` `keydown` listener per call (dozens per build page). Consolidated into a module-level registry with one shared listener, attached on the first registration and removed with the last. Target-based guards run once per event; per-hotkey concerns (enabled, allowInInput, matching, preventDefault, async dispatch) run per registration. Behavior unchanged.
- **Review progress chip sizing**: sized to its host via a new `scale` prop — `xs` in the build header, `sm` in the review form.
- Inlined the single-use `ReviewEventRadioVariant` union into its definition type.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `eslint` passes on changed files
- [x] Visually verify the review popover from the build header (approve / reject / comment-requires-body flows)
- [x] Verify icon-only buttons are square across sizes
- [x] Verify `Escape` closes the review modal while hovering an accepted/rejected diff, and still closes other modals
- [x] Verify build hotkeys still fire (and stay disabled inside modals / inputs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
