### PR TITLE
feat(api): expose review and commenting actions in the REST API

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -78,6 +78,7 @@
     "jsonwebtoken": "^9.0.3",
     "knex": "^3.2.10",
     "lodash-es": "catalog:",
+    "marked": "^15.0.0",
     "mime": "^4.1.0",
     "minimatch": "catalog:",
     "moment": "^2.30.1",

--- a/apps/backend/src/api/auth/build.ts
+++ b/apps/backend/src/api/auth/build.ts
@@ -1,0 +1,111 @@
+import { invariant } from "@argos/util/invariant";
+import type { Request } from "express";
+
+import type { AuthPATPayload } from "@/auth/payload";
+import { getCommentThreadRoot } from "@/comment/thread";
+import { Build, Comment, type User } from "@/database/models";
+import { boom } from "@/util/error";
+
+import { assertProjectAccess, getAuthPayloadFromExpressReq } from "./project";
+
+/** Project permissions checked by the review/comment endpoints. */
+type BuildActionPermission = "view" | "review" | "review_dismiss";
+
+/**
+ * Load the build addressed by `{owner}/{project}/builds/{buildNumber}` and the
+ * authenticated caller, enforcing the rules shared by every review/comment
+ * endpoint: the caller must use a personal access token (these are user
+ * actions, and pending-draft visibility depends on the viewer's identity), the
+ * token must be scoped to the owner account, and the build must exist.
+ *
+ * Returns the build with `project.account` fetched so callers can check
+ * permissions and serialize without a second round-trip.
+ */
+export async function getPatAuthAndBuild(
+  request: Request,
+  params: { owner: string; project: string; buildNumber: number },
+): Promise<{ auth: AuthPATPayload; build: Build }> {
+  const [auth, build] = await Promise.all([
+    getAuthPayloadFromExpressReq(request),
+    Build.query()
+      .joinRelated("project.account")
+      .where("project:account.slug", params.owner)
+      .where("project.name", params.project)
+      .where("number", params.buildNumber)
+      .withGraphFetched("project.account")
+      .first(),
+  ]);
+
+  if (auth.type !== "pat") {
+    throw boom(
+      401,
+      "This action requires a personal access token. See https://argos-ci.com/docs for details.",
+    );
+  }
+
+  assertProjectAccess(auth, {
+    projectId: build?.projectId ?? null,
+    account: { slug: params.owner },
+  });
+
+  if (!build) {
+    throw boom(404, "Not found");
+  }
+
+  invariant(build.project?.account, "Build project account not found");
+
+  return { auth, build };
+}
+
+/**
+ * Assert the user holds a project permission on the build's project, throwing a
+ * 403 with the given message otherwise. The build must have `project` fetched
+ * (as returned by {@link getPatAuthAndBuild}).
+ */
+export async function assertBuildPermission(input: {
+  build: Build;
+  user: User;
+  permission: BuildActionPermission;
+  message: string;
+}): Promise<void> {
+  const { build, user, permission, message } = input;
+  invariant(build.project, "Build project not fetched");
+  const permissions = await build.project.$getPermissions(user);
+  if (!permissions.includes(permission)) {
+    throw boom(403, message);
+  }
+}
+
+/**
+ * Load a comment by id, scoped to a build: a comment whose id is unknown or
+ * belongs to a different build surfaces as a clean 404 rather than leaking
+ * across builds. Soft-deleted comments are returned as-is — callers decide
+ * whether a deleted comment is meaningful for their action (mirroring the
+ * GraphQL resolvers).
+ */
+export async function getBuildComment(input: {
+  commentId: string;
+  buildId: string;
+}): Promise<Comment> {
+  const comment = await Comment.query().findById(input.commentId);
+  if (!comment || comment.buildId !== input.buildId) {
+    throw boom(404, "Comment not found");
+  }
+  return comment;
+}
+
+/**
+ * Resolve the (non-deleted) root comment of the thread a comment belongs to,
+ * scoped to a build. Thread-level actions (resolve, subscribe) operate on the
+ * root regardless of which comment in the thread the caller referenced.
+ */
+export async function getBuildCommentThread(input: {
+  commentId: string;
+  buildId: string;
+}): Promise<Comment> {
+  const thread = await getCommentThreadRoot(input.commentId);
+  if (!thread || thread.buildId !== input.buildId) {
+    throw boom(404, "Thread not found");
+  }
+  return thread;
+}

--- a/apps/backend/src/api/handlers/addCommentReaction.ts
+++ b/apps/backend/src/api/handlers/addCommentReaction.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+import { ZodOpenApiOperationObject } from "zod-openapi";
+
+import { addCommentReaction as addCommentReactionService } from "@/comment/addCommentReaction";
+
+import {
+  assertBuildPermission,
+  getBuildComment,
+  getPatAuthAndBuild,
+} from "../auth/build";
+import { BuildNumber } from "../schema/primitives/build";
+import { CommentSchema, serializeComment } from "../schema/primitives/comment";
+import { AccountSlug, ProjectName } from "../schema/primitives/project";
+import {
+  forbidden,
+  invalidParameters,
+  notFound,
+  serverError,
+  unauthorized,
+} from "../schema/util/error";
+import { CreateAPIHandler } from "../util";
+
+const AddReactionBodySchema = z.object({
+  emoji: z.string().meta({ description: "The emoji to react with." }),
+});
+
+export const addCommentReactionOperation = {
+  operationId: "addCommentReaction",
+  summary: "Add an emoji reaction to a comment",
+  requestParams: {
+    path: z.object({
+      owner: AccountSlug,
+      project: ProjectName,
+      buildNumber: BuildNumber,
+      commentId: z.string().meta({ description: "The ID of the comment" }),
+    }),
+  },
+  requestBody: {
+    required: true,
+    content: {
+      "application/json": {
+        schema: AddReactionBodySchema,
+      },
+    },
+  },
+  responses: {
+    "200": {
+      description: "Reaction added — returns the comment",
+      content: {
+        "application/json": {
+          schema: CommentSchema,
+        },
+      },
+    },
+    "400": invalidParameters,
+    "401": unauthorized,
+    "403": forbidden,
+    "404": notFound,
+    "500": serverError,
+  },
+} satisfies ZodOpenApiOperationObject;
+
+export const addCommentReaction: CreateAPIHandler = ({ post }) => {
+  post(
+    "/projects/{owner}/{project}/builds/{buildNumber}/comments/{commentId}/reactions",
+    async (req, res) => {
+      const { params, body: input } = req.ctx;
+      const { auth, build } = await getPatAuthAndBuild(req, params);
+
+      await assertBuildPermission({
+        build,
+        user: auth.user,
+        permission: "review",
+        message: "You do not have permission to react to this comment",
+      });
+
+      const comment = await getBuildComment({
+        commentId: params.commentId,
+        buildId: build.id,
+      });
+
+      const updated = await addCommentReactionService({
+        comment,
+        userId: auth.user.id,
+        emoji: input.emoji,
+      });
+
+      res.send(await serializeComment(updated));
+    },
+  );
+};

--- a/apps/backend/src/api/handlers/comments.e2e.test.ts
+++ b/apps/backend/src/api/handlers/comments.e2e.test.ts
@@ -4,6 +4,7 @@ import z from "zod";
 
 import { concludeBuild } from "@/build/concludeBuild";
 import {
+  Account,
   Build,
   Comment,
   CommentNotificationSubscription,
@@ -495,8 +496,15 @@ describe("reactions", () => {
       .send({ emoji: "👍" })
       .expect(200);
 
+    const account = await Account.query().findOne({ userId: user.id });
     expect(added.body.reactions).toEqual([
-      { emoji: "👍", count: 1, userIds: [user.id] },
+      {
+        emoji: "👍",
+        count: 1,
+        users: [
+          { id: account!.id, slug: account!.slug, name: account!.displayName },
+        ],
+      },
     ]);
 
     const removed = await request(app)

--- a/apps/backend/src/api/handlers/comments.e2e.test.ts
+++ b/apps/backend/src/api/handlers/comments.e2e.test.ts
@@ -1,0 +1,603 @@
+import request from "supertest";
+import { test as base, beforeAll, describe, expect } from "vitest";
+import z from "zod";
+
+import { concludeBuild } from "@/build/concludeBuild";
+import {
+  Build,
+  Comment,
+  CommentNotificationSubscription,
+  Project,
+  ScreenshotBucket,
+  ScreenshotDiff,
+  User,
+  UserAccessTokenScope,
+} from "@/database/models";
+import { hashToken } from "@/database/services/crypto";
+import { factory, setupDatabase } from "@/database/testing";
+
+import { createTestHandlerApp } from "../test-util";
+import { addCommentReaction } from "./addCommentReaction";
+import { createComment } from "./createComment";
+import { deleteComment } from "./deleteComment";
+import { getComment } from "./getComment";
+import { listComments } from "./listComments";
+import { removeCommentReaction } from "./removeCommentReaction";
+import {
+  resolveCommentThread,
+  unresolveCommentThread,
+} from "./resolveCommentThread";
+import {
+  subscribeCommentThread,
+  unsubscribeCommentThread,
+} from "./subscribeCommentThread";
+import { updateComment } from "./updateComment";
+
+const app = createTestHandlerApp((ctx) => {
+  createComment(ctx);
+  listComments(ctx);
+  getComment(ctx);
+  updateComment(ctx);
+  deleteComment(ctx);
+  addCommentReaction(ctx);
+  removeCommentReaction(ctx);
+  resolveCommentThread(ctx);
+  unresolveCommentThread(ctx);
+  subscribeCommentThread(ctx);
+  unsubscribeCommentThread(ctx);
+});
+
+const DOC = (text: string) => ({
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+});
+
+const test = base.extend<{
+  user: User;
+  otherUser: User;
+  project: Project;
+  compareBucket: ScreenshotBucket;
+  build: Build;
+  screenshotDiffs: ScreenshotDiff[];
+  scopedPatToken: string;
+}>({
+  user: async ({}, use) => {
+    await setupDatabase();
+    const user = await factory.User.create();
+    await use(user);
+  },
+  otherUser: async ({ user }, use) => {
+    const otherUser = await factory.User.create();
+    await use(otherUser);
+    void user;
+  },
+  project: async ({ user }, use) => {
+    const [userAccount, teamAccount] = await Promise.all([
+      factory.UserAccount.create({ userId: user.id }),
+      factory.TeamAccount.create({ slug: "acme" }),
+    ]);
+    const project = await factory.Project.create({
+      accountId: teamAccount.id,
+      name: "web",
+      token: "the-awesome-token",
+    });
+    await factory.TeamUser.create({
+      teamId: teamAccount.teamId,
+      userId: user.id,
+      userLevel: "owner",
+    });
+    await use(project);
+    void userAccount;
+  },
+  compareBucket: async ({ project }, use) => {
+    const compareBucket = await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      branch: "feature/comment-api",
+      commit: "b".repeat(40),
+    });
+    await use(compareBucket);
+  },
+  build: async ({ project, compareBucket }, use) => {
+    const build = await factory.Build.create({
+      projectId: project.id,
+      compareScreenshotBucketId: compareBucket.id,
+      conclusion: null,
+    });
+    await use(build);
+  },
+  screenshotDiffs: async ({ build }, use) => {
+    const screenshots = await factory.Screenshot.createMany(3);
+    const screenshotDiffs = await factory.ScreenshotDiff.createMany(2, [
+      {
+        buildId: build.id,
+        baseScreenshotId: screenshots[0]!.id,
+        compareScreenshotId: screenshots[1]!.id,
+        score: 0.2,
+      },
+      {
+        buildId: build.id,
+        baseScreenshotId: screenshots[0]!.id,
+        compareScreenshotId: screenshots[2]!.id,
+        score: 0.4,
+      },
+    ]);
+    await concludeBuild({ build, notify: false });
+    await use(screenshotDiffs);
+  },
+  scopedPatToken: async ({ user, project }, use) => {
+    const token = `arp_${"e".repeat(36)}`;
+    const userAccessToken = await factory.UserAccessToken.create({
+      userId: user.id,
+      token: hashToken(token),
+    });
+    await UserAccessTokenScope.query().insert({
+      userAccessTokenId: userAccessToken.id,
+      accountId: project.accountId,
+    });
+    await use(token);
+  },
+});
+
+const auth = (token: string) => ({ Authorization: `Bearer ${token}` });
+
+describe("createComment", () => {
+  beforeAll(() => {
+    z.globalRegistry.clear();
+  });
+
+  test("posts a comment from Markdown", async ({
+    user,
+    build,
+    scopedPatToken,
+  }) => {
+    const res = await request(app)
+      .post(`/projects/acme/web/builds/${build.number}/comments`)
+      .set(auth(scopedPatToken))
+      .send({ body: "Looks **broken** on mobile" })
+      .expect(201);
+
+    expect(res.body).toMatchObject({
+      buildId: build.id,
+      threadId: null,
+      pending: false,
+      author: { id: expect.any(String) },
+    });
+    expect(res.body.text).toContain("Looks broken on mobile");
+    expect(JSON.stringify(res.body.body)).toContain("bold");
+
+    const comment = await Comment.query().findById(res.body.id);
+    expect(comment?.userId).toBe(user.id);
+  });
+
+  test("posts a comment from raw rich-text JSON", async ({
+    build,
+    scopedPatToken,
+  }) => {
+    const res = await request(app)
+      .post(`/projects/acme/web/builds/${build.number}/comments`)
+      .set(auth(scopedPatToken))
+      .send({ body: DOC("Hello world") })
+      .expect(201);
+
+    expect(res.body.text).toBe("Hello world");
+  });
+
+  test("replies to a thread", async ({ user, build, scopedPatToken }) => {
+    const root = await factory.Comment.create({
+      buildId: build.id,
+      userId: user.id,
+      content: DOC("Root"),
+    });
+
+    const res = await request(app)
+      .post(`/projects/acme/web/builds/${build.number}/comments`)
+      .set(auth(scopedPatToken))
+      .send({ body: "A reply", threadId: root.id })
+      .expect(201);
+
+    expect(res.body.threadId).toBe(root.id);
+  });
+
+  test("attaches to a pending review with addToReview", async ({
+    build,
+    screenshotDiffs,
+    scopedPatToken,
+  }) => {
+    void screenshotDiffs;
+    const res = await request(app)
+      .post(`/projects/acme/web/builds/${build.number}/comments`)
+      .set(auth(scopedPatToken))
+      .send({ body: "Draft note", addToReview: true })
+      .expect(201);
+
+    expect(res.body.pending).toBe(true);
+    const comment = await Comment.query().findById(res.body.id);
+    expect(comment?.buildReviewId).not.toBeNull();
+  });
+
+  test("anchors a comment to a screenshot diff", async ({
+    build,
+    screenshotDiffs,
+    scopedPatToken,
+  }) => {
+    const res = await request(app)
+      .post(`/projects/acme/web/builds/${build.number}/comments`)
+      .set(auth(scopedPatToken))
+      .send({
+        body: "Off by a pixel",
+        screenshotDiffId: screenshotDiffs[0]!.id,
+        anchor: { point: { x: 0.5, y: 0.5 } },
+      })
+      .expect(201);
+
+    expect(res.body.screenshotDiffId).toBe(screenshotDiffs[0]!.id);
+    expect(res.body.anchor).toEqual({ type: "point", x: 0.5, y: 0.5 });
+  });
+
+  test("rejects an anchor without a screenshot diff", async ({
+    build,
+    scopedPatToken,
+  }) => {
+    await request(app)
+      .post(`/projects/acme/web/builds/${build.number}/comments`)
+      .set(auth(scopedPatToken))
+      .send({ body: "x", anchor: { point: { x: 0.5, y: 0.5 } } })
+      .expect(400)
+      .expect((res) => {
+        expect(res.body.error).toEqual(expect.any(String));
+      });
+  });
+
+  test("rejects an anchored reply", async ({
+    user,
+    build,
+    screenshotDiffs,
+    scopedPatToken,
+  }) => {
+    const root = await factory.Comment.create({
+      buildId: build.id,
+      userId: user.id,
+      content: DOC("Root"),
+    });
+    await request(app)
+      .post(`/projects/acme/web/builds/${build.number}/comments`)
+      .set(auth(scopedPatToken))
+      .send({
+        body: "reply",
+        threadId: root.id,
+        screenshotDiffId: screenshotDiffs[0]!.id,
+      })
+      .expect(400)
+      .expect((res) => {
+        expect(res.body.error).toEqual(expect.any(String));
+      });
+  });
+
+  test("rejects project tokens", async ({ build }) => {
+    const res = await request(app)
+      .post(`/projects/acme/web/builds/${build.number}/comments`)
+      .set(auth("the-awesome-token"))
+      .send({ body: "nope" })
+      .expect(401);
+    expect(res.body.error).toEqual(expect.any(String));
+  });
+});
+
+describe("listComments / getComment", () => {
+  beforeAll(() => {
+    z.globalRegistry.clear();
+  });
+
+  test("lists visible comments and hides others' drafts", async ({
+    user,
+    otherUser,
+    build,
+    scopedPatToken,
+  }) => {
+    await factory.Comment.create({
+      buildId: build.id,
+      userId: user.id,
+      content: DOC("Visible"),
+    });
+    const otherPending = await factory.BuildReview.create({
+      buildId: build.id,
+      userId: otherUser.id,
+      state: "pending",
+    });
+    await factory.Comment.create({
+      buildId: build.id,
+      userId: otherUser.id,
+      buildReviewId: otherPending.id,
+      content: DOC("Hidden draft"),
+    });
+
+    const res = await request(app)
+      .get(`/projects/acme/web/builds/${build.number}/comments`)
+      .set(auth(scopedPatToken))
+      .expect(200);
+
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].text).toBe("Visible");
+  });
+
+  test("gets a single comment", async ({ user, build, scopedPatToken }) => {
+    const comment = await factory.Comment.create({
+      buildId: build.id,
+      userId: user.id,
+      content: DOC("One comment"),
+    });
+
+    const res = await request(app)
+      .get(`/projects/acme/web/builds/${build.number}/comments/${comment.id}`)
+      .set(auth(scopedPatToken))
+      .expect(200);
+
+    expect(res.body).toMatchObject({ id: comment.id, text: "One comment" });
+  });
+
+  test("returns 404 for a deleted comment", async ({
+    user,
+    build,
+    scopedPatToken,
+  }) => {
+    const comment = await factory.Comment.create({
+      buildId: build.id,
+      userId: user.id,
+      content: DOC("Gone"),
+      deletedAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .get(`/projects/acme/web/builds/${build.number}/comments/${comment.id}`)
+      .set(auth(scopedPatToken))
+      .expect(404);
+    expect(res.body.error).toEqual(expect.any(String));
+  });
+
+  test("returns 404 for another user's draft comment", async ({
+    otherUser,
+    build,
+    scopedPatToken,
+  }) => {
+    const pending = await factory.BuildReview.create({
+      buildId: build.id,
+      userId: otherUser.id,
+      state: "pending",
+    });
+    const comment = await factory.Comment.create({
+      buildId: build.id,
+      userId: otherUser.id,
+      buildReviewId: pending.id,
+      content: DOC("Secret"),
+    });
+
+    const res = await request(app)
+      .get(`/projects/acme/web/builds/${build.number}/comments/${comment.id}`)
+      .set(auth(scopedPatToken))
+      .expect(404);
+    expect(res.body.error).toEqual(expect.any(String));
+  });
+});
+
+describe("updateComment / deleteComment", () => {
+  beforeAll(() => {
+    z.globalRegistry.clear();
+  });
+
+  test("author can edit their comment", async ({
+    user,
+    build,
+    scopedPatToken,
+  }) => {
+    const comment = await factory.Comment.create({
+      buildId: build.id,
+      userId: user.id,
+      content: DOC("Before"),
+    });
+
+    const res = await request(app)
+      .patch(`/projects/acme/web/builds/${build.number}/comments/${comment.id}`)
+      .set(auth(scopedPatToken))
+      .send({ body: "After" })
+      .expect(200);
+
+    expect(res.body.text).toBe("After");
+    expect(res.body.editedAt).toEqual(expect.any(String));
+  });
+
+  test("non-author cannot edit", async ({
+    otherUser,
+    build,
+    scopedPatToken,
+  }) => {
+    const comment = await factory.Comment.create({
+      buildId: build.id,
+      userId: otherUser.id,
+      content: DOC("Theirs"),
+    });
+
+    await request(app)
+      .patch(`/projects/acme/web/builds/${build.number}/comments/${comment.id}`)
+      .set(auth(scopedPatToken))
+      .send({ body: "hijack" })
+      .expect(403)
+      .expect((res) => {
+        expect(res.body.error).toEqual(expect.any(String));
+      });
+  });
+
+  test("author can delete their comment", async ({
+    user,
+    build,
+    scopedPatToken,
+  }) => {
+    const comment = await factory.Comment.create({
+      buildId: build.id,
+      userId: user.id,
+      content: DOC("Delete me"),
+    });
+
+    await request(app)
+      .delete(
+        `/projects/acme/web/builds/${build.number}/comments/${comment.id}`,
+      )
+      .set(auth(scopedPatToken))
+      .expect(200);
+
+    const reloaded = await Comment.query().findById(comment.id);
+    expect(reloaded?.deletedAt).not.toBeNull();
+  });
+
+  test("non-author cannot delete", async ({
+    otherUser,
+    build,
+    scopedPatToken,
+  }) => {
+    const comment = await factory.Comment.create({
+      buildId: build.id,
+      userId: otherUser.id,
+      content: DOC("Theirs"),
+    });
+
+    await request(app)
+      .delete(
+        `/projects/acme/web/builds/${build.number}/comments/${comment.id}`,
+      )
+      .set(auth(scopedPatToken))
+      .expect(403)
+      .expect((res) => {
+        expect(res.body.error).toEqual(expect.any(String));
+      });
+  });
+});
+
+describe("reactions", () => {
+  beforeAll(() => {
+    z.globalRegistry.clear();
+  });
+
+  test("adds and removes a reaction", async ({
+    user,
+    build,
+    scopedPatToken,
+  }) => {
+    const comment = await factory.Comment.create({
+      buildId: build.id,
+      userId: user.id,
+      content: DOC("React to me"),
+    });
+
+    const added = await request(app)
+      .post(
+        `/projects/acme/web/builds/${build.number}/comments/${comment.id}/reactions`,
+      )
+      .set(auth(scopedPatToken))
+      .send({ emoji: "👍" })
+      .expect(200);
+
+    expect(added.body.reactions).toEqual([
+      { emoji: "👍", count: 1, userIds: [user.id] },
+    ]);
+
+    const removed = await request(app)
+      .delete(
+        `/projects/acme/web/builds/${build.number}/comments/${comment.id}/reactions`,
+      )
+      .query({ emoji: "👍" })
+      .set(auth(scopedPatToken))
+      .expect(200);
+
+    expect(removed.body.reactions).toEqual([]);
+  });
+
+  test("rejects an invalid emoji", async ({ user, build, scopedPatToken }) => {
+    const comment = await factory.Comment.create({
+      buildId: build.id,
+      userId: user.id,
+      content: DOC("React to me"),
+    });
+
+    await request(app)
+      .post(
+        `/projects/acme/web/builds/${build.number}/comments/${comment.id}/reactions`,
+      )
+      .set(auth(scopedPatToken))
+      .send({ emoji: "not-an-emoji" })
+      .expect(400)
+      .expect((res) => {
+        expect(res.body.error).toEqual(expect.any(String));
+      });
+  });
+});
+
+describe("thread resolve / subscription", () => {
+  beforeAll(() => {
+    z.globalRegistry.clear();
+  });
+
+  test("resolves and reopens a thread", async ({
+    user,
+    build,
+    scopedPatToken,
+  }) => {
+    const comment = await factory.Comment.create({
+      buildId: build.id,
+      userId: user.id,
+      content: DOC("Thread"),
+    });
+
+    const resolved = await request(app)
+      .post(
+        `/projects/acme/web/builds/${build.number}/comments/${comment.id}/resolve`,
+      )
+      .set(auth(scopedPatToken))
+      .expect(200);
+    expect(resolved.body.resolvedAt).toEqual(expect.any(String));
+
+    const reopened = await request(app)
+      .post(
+        `/projects/acme/web/builds/${build.number}/comments/${comment.id}/unresolve`,
+      )
+      .set(auth(scopedPatToken))
+      .expect(200);
+    expect(reopened.body.resolvedAt).toBeNull();
+  });
+
+  test("subscribes and unsubscribes from a thread", async ({
+    user,
+    build,
+    scopedPatToken,
+  }) => {
+    const comment = await factory.Comment.create({
+      buildId: build.id,
+      userId: user.id,
+      content: DOC("Thread"),
+    });
+
+    await request(app)
+      .post(
+        `/projects/acme/web/builds/${build.number}/comments/${comment.id}/subscription`,
+      )
+      .set(auth(scopedPatToken))
+      .expect(200);
+
+    let subscription = await CommentNotificationSubscription.query().findOne({
+      commentId: comment.id,
+      userId: user.id,
+    });
+    expect(subscription?.isSubscribed()).toBe(true);
+
+    await request(app)
+      .delete(
+        `/projects/acme/web/builds/${build.number}/comments/${comment.id}/subscription`,
+      )
+      .set(auth(scopedPatToken))
+      .expect(200);
+
+    subscription = await CommentNotificationSubscription.query().findOne({
+      commentId: comment.id,
+      userId: user.id,
+    });
+    expect(subscription?.isSubscribed()).toBe(false);
+  });
+});

--- a/apps/backend/src/api/handlers/comments.e2e.test.ts
+++ b/apps/backend/src/api/handlers/comments.e2e.test.ts
@@ -227,12 +227,49 @@ describe("createComment", () => {
       .send({
         body: "Off by a pixel",
         screenshotDiffId: screenshotDiffs[0]!.id,
-        anchor: { point: { x: 0.5, y: 0.5 } },
+        anchor: { type: "point", x: 0.5, y: 0.5 },
       })
       .expect(201);
 
     expect(res.body.screenshotDiffId).toBe(screenshotDiffs[0]!.id);
     expect(res.body.anchor).toEqual({ type: "point", x: 0.5, y: 0.5 });
+  });
+
+  test("anchors a comment to a line range", async ({
+    build,
+    screenshotDiffs,
+    scopedPatToken,
+  }) => {
+    const res = await request(app)
+      .post(`/projects/acme/web/builds/${build.number}/comments`)
+      .set(auth(scopedPatToken))
+      .send({
+        body: "These lines regressed",
+        screenshotDiffId: screenshotDiffs[0]!.id,
+        anchor: { type: "lines", from: 2, to: 5 },
+      })
+      .expect(201);
+
+    expect(res.body.anchor).toEqual({ type: "lines", from: 2, to: 5 });
+  });
+
+  test("rejects an inverted line range", async ({
+    build,
+    screenshotDiffs,
+    scopedPatToken,
+  }) => {
+    await request(app)
+      .post(`/projects/acme/web/builds/${build.number}/comments`)
+      .set(auth(scopedPatToken))
+      .send({
+        body: "bad range",
+        screenshotDiffId: screenshotDiffs[0]!.id,
+        anchor: { type: "lines", from: 5, to: 2 },
+      })
+      .expect(400)
+      .expect((res) => {
+        expect(res.body.error).toEqual(expect.any(String));
+      });
   });
 
   test("rejects an anchor without a screenshot diff", async ({
@@ -242,7 +279,7 @@ describe("createComment", () => {
     await request(app)
       .post(`/projects/acme/web/builds/${build.number}/comments`)
       .set(auth(scopedPatToken))
-      .send({ body: "x", anchor: { point: { x: 0.5, y: 0.5 } } })
+      .send({ body: "x", anchor: { type: "point", x: 0.5, y: 0.5 } })
       .expect(400)
       .expect((res) => {
         expect(res.body.error).toEqual(expect.any(String));

--- a/apps/backend/src/api/handlers/createComment.ts
+++ b/apps/backend/src/api/handlers/createComment.ts
@@ -1,0 +1,214 @@
+import { z } from "zod";
+import { ZodOpenApiOperationObject } from "zod-openapi";
+
+import { getOrCreatePendingBuildReview } from "@/build/pendingReview";
+import { isReviewableBuildStatus } from "@/build/reviewableStatus";
+import { resolveCommentBody } from "@/comment/body";
+import { createBuildComment } from "@/comment/createBuildComment";
+import { Build, BuildReview, ScreenshotDiff } from "@/database/models";
+import {
+  CommentAnchorSchema,
+  type CommentAnchor,
+} from "@/database/models/Comment";
+import { boom } from "@/util/error";
+
+import {
+  assertBuildPermission,
+  getBuildCommentThread,
+  getPatAuthAndBuild,
+} from "../auth/build";
+import { BuildNumber } from "../schema/primitives/build";
+import {
+  CommentBodyInputSchema,
+  CommentSchema,
+  serializeComment,
+} from "../schema/primitives/comment";
+import { AccountSlug, ProjectName } from "../schema/primitives/project";
+import {
+  forbidden,
+  invalidParameters,
+  notFound,
+  serverError,
+  unauthorized,
+} from "../schema/util/error";
+import { CreateAPIHandler } from "../util";
+
+const AnchorInputSchema = z
+  .object({
+    point: z.object({ x: z.number(), y: z.number() }).optional().meta({
+      description: "A point on the diff, in normalized (0–1) coordinates.",
+    }),
+    lines: z
+      .object({ from: z.number().int(), to: z.number().int() })
+      .optional()
+      .meta({ description: "A 1-based inclusive line range on a text diff." }),
+  })
+  .meta({
+    description:
+      "Where on the screenshot diff the comment points. Provide exactly one of point or lines.",
+  });
+
+const CreateCommentBodySchema = z.object({
+  body: CommentBodyInputSchema,
+  threadId: z
+    .string()
+    .optional()
+    .meta({ description: "Root comment ID to reply to." }),
+  screenshotDiffId: z.string().optional().meta({
+    description:
+      "Screenshot diff to anchor the comment to. Required when anchor is set.",
+  }),
+  anchor: AnchorInputSchema.optional(),
+  addToReview: z.boolean().optional().meta({
+    description:
+      "Attach the comment to your pending review (created if needed) instead of posting it immediately. Ignored for replies, which inherit their thread's review.",
+  }),
+});
+
+export const createCommentOperation = {
+  operationId: "createComment",
+  summary: "Post a comment (or reply) on a build",
+  requestParams: {
+    path: z.object({
+      owner: AccountSlug,
+      project: ProjectName,
+      buildNumber: BuildNumber,
+    }),
+  },
+  requestBody: {
+    required: true,
+    content: {
+      "application/json": {
+        schema: CreateCommentBodySchema,
+      },
+    },
+  },
+  responses: {
+    "201": {
+      description: "Comment created successfully — returns the comment",
+      content: {
+        "application/json": {
+          schema: CommentSchema,
+        },
+      },
+    },
+    "400": invalidParameters,
+    "401": unauthorized,
+    "403": forbidden,
+    "404": notFound,
+    "500": serverError,
+  },
+} satisfies ZodOpenApiOperationObject;
+
+/**
+ * Turn the comment-anchor input into the stored anchor shape, enforcing that
+ * exactly one positioning is given. Bounds and shape are validated by the
+ * model's {@link CommentAnchorSchema}.
+ */
+function commentAnchorFromInput(
+  input: z.infer<typeof AnchorInputSchema>,
+): CommentAnchor {
+  const { point, lines } = input;
+  if (Number(point != null) + Number(lines != null) !== 1) {
+    throw boom(400, "A comment anchor must set exactly one of point or lines");
+  }
+  const candidate = point
+    ? { type: "point", x: point.x, y: point.y }
+    : { type: "lines", from: lines!.from, to: lines!.to };
+  const result = CommentAnchorSchema.safeParse(candidate);
+  if (!result.success) {
+    throw boom(
+      400,
+      result.error.issues[0]?.message ?? "Invalid comment anchor",
+    );
+  }
+  return result.data;
+}
+
+export const createComment: CreateAPIHandler = ({ post }) => {
+  post(
+    "/projects/{owner}/{project}/builds/{buildNumber}/comments",
+    async (req, res) => {
+      const { params, body: input } = req.ctx;
+      const { auth, build } = await getPatAuthAndBuild(req, params);
+
+      await assertBuildPermission({
+        build,
+        user: auth.user,
+        permission: "review",
+        message: "You do not have permission to comment on this build",
+      });
+
+      const thread = input.threadId
+        ? await getBuildCommentThread({
+            commentId: input.threadId,
+            buildId: build.id,
+          })
+        : null;
+
+      // A reply inherits its thread's anchor, so it can't carry its own.
+      if (thread && (input.screenshotDiffId || input.anchor)) {
+        throw boom(400, "A reply cannot be anchored to a screenshot diff");
+      }
+
+      // An anchor only makes sense against a diff to resolve it on.
+      if (input.anchor && !input.screenshotDiffId) {
+        throw boom(400, "A screenshot diff is required to anchor a comment");
+      }
+
+      let screenshotDiffId: string | null = null;
+      if (input.screenshotDiffId) {
+        const diff = await ScreenshotDiff.query().findOne({
+          id: input.screenshotDiffId,
+          buildId: build.id,
+        });
+        if (!diff) {
+          throw boom(404, "Screenshot diff not found");
+        }
+        screenshotDiffId = diff.id;
+      }
+
+      const anchor = input.anchor ? commentAnchorFromInput(input.anchor) : null;
+
+      // A reply inherits its thread's review (so a reply to a draft comment
+      // stays a draft); a root comment joins the user's pending review when
+      // `addToReview` is set, creating that review on first use — but only when
+      // the build can actually be reviewed, otherwise the draft would attach to
+      // a review with no submit path and stay hidden forever.
+      let buildReviewId: string | null = null;
+      let pending = false;
+      if (thread) {
+        buildReviewId = thread.buildReviewId;
+        if (buildReviewId) {
+          const review = await BuildReview.query()
+            .findById(buildReviewId)
+            .select("state");
+          pending = review?.state === "pending";
+        }
+      } else if (input.addToReview) {
+        const [status] = await Build.getAggregatedBuildStatuses([build]);
+        if (status && isReviewableBuildStatus(status)) {
+          const pendingReview = await getOrCreatePendingBuildReview({
+            build,
+            userId: auth.user.id,
+          });
+          buildReviewId = pendingReview.id;
+          pending = pendingReview.state === "pending";
+        }
+      }
+
+      const comment = await createBuildComment({
+        build,
+        userId: auth.user.id,
+        body: resolveCommentBody(input.body),
+        threadId: thread?.id ?? null,
+        screenshotDiffId,
+        anchor,
+        buildReviewId,
+        pending,
+      });
+
+      res.status(201).send(await serializeComment(comment));
+    },
+  );
+};

--- a/apps/backend/src/api/handlers/createComment.ts
+++ b/apps/backend/src/api/handlers/createComment.ts
@@ -7,7 +7,7 @@ import { resolveCommentBody } from "@/comment/body";
 import { createBuildComment } from "@/comment/createBuildComment";
 import { Build, BuildReview, ScreenshotDiff } from "@/database/models";
 import {
-  CommentAnchorSchema,
+  CommentAnchorSchema as StoredCommentAnchorSchema,
   type CommentAnchor,
 } from "@/database/models/Comment";
 import { boom } from "@/util/error";
@@ -19,6 +19,7 @@ import {
 } from "../auth/build";
 import { BuildNumber } from "../schema/primitives/build";
 import {
+  CommentAnchorSchema,
   CommentBodyInputSchema,
   CommentSchema,
   serializeComment,
@@ -33,21 +34,6 @@ import {
 } from "../schema/util/error";
 import { CreateAPIHandler } from "../util";
 
-const AnchorInputSchema = z
-  .object({
-    point: z.object({ x: z.number(), y: z.number() }).optional().meta({
-      description: "A point on the diff, in normalized (0–1) coordinates.",
-    }),
-    lines: z
-      .object({ from: z.number().int(), to: z.number().int() })
-      .optional()
-      .meta({ description: "A 1-based inclusive line range on a text diff." }),
-  })
-  .meta({
-    description:
-      "Where on the screenshot diff the comment points. Provide exactly one of point or lines.",
-  });
-
 const CreateCommentBodySchema = z.object({
   body: CommentBodyInputSchema,
   threadId: z
@@ -58,7 +44,7 @@ const CreateCommentBodySchema = z.object({
     description:
       "Screenshot diff to anchor the comment to. Required when anchor is set.",
   }),
-  anchor: AnchorInputSchema.optional(),
+  anchor: CommentAnchorSchema.optional(),
   addToReview: z.boolean().optional().meta({
     description:
       "Attach the comment to your pending review (created if needed) instead of posting it immediately. Ignored for replies, which inherit their thread's review.",
@@ -101,21 +87,12 @@ export const createCommentOperation = {
 } satisfies ZodOpenApiOperationObject;
 
 /**
- * Turn the comment-anchor input into the stored anchor shape, enforcing that
- * exactly one positioning is given. Bounds and shape are validated by the
- * model's {@link CommentAnchorSchema}.
+ * Validate a comment anchor against the model's bounds and inverted-range rules,
+ * turning a failure into a clean 400. The input already has the stored shape,
+ * so this only enforces the constraints the request schema can't express.
  */
-function commentAnchorFromInput(
-  input: z.infer<typeof AnchorInputSchema>,
-): CommentAnchor {
-  const { point, lines } = input;
-  if (Number(point != null) + Number(lines != null) !== 1) {
-    throw boom(400, "A comment anchor must set exactly one of point or lines");
-  }
-  const candidate = point
-    ? { type: "point", x: point.x, y: point.y }
-    : { type: "lines", from: lines!.from, to: lines!.to };
-  const result = CommentAnchorSchema.safeParse(candidate);
+function parseCommentAnchor(input: CommentAnchor): CommentAnchor {
+  const result = StoredCommentAnchorSchema.safeParse(input);
   if (!result.success) {
     throw boom(
       400,
@@ -168,7 +145,7 @@ export const createComment: CreateAPIHandler = ({ post }) => {
         screenshotDiffId = diff.id;
       }
 
-      const anchor = input.anchor ? commentAnchorFromInput(input.anchor) : null;
+      const anchor = input.anchor ? parseCommentAnchor(input.anchor) : null;
 
       // A reply inherits its thread's review (so a reply to a draft comment
       // stays a draft); a root comment joins the user's pending review when

--- a/apps/backend/src/api/handlers/createComment.ts
+++ b/apps/backend/src/api/handlers/createComment.ts
@@ -177,7 +177,7 @@ export const createComment: CreateAPIHandler = ({ post }) => {
       const comment = await createBuildComment({
         build,
         userId: auth.user.id,
-        body: resolveCommentBody(input.body),
+        body: await resolveCommentBody(input.body),
         threadId: thread?.id ?? null,
         screenshotDiffId,
         anchor,

--- a/apps/backend/src/api/handlers/createReview.e2e.test.ts
+++ b/apps/backend/src/api/handlers/createReview.e2e.test.ts
@@ -4,6 +4,7 @@ import z from "zod";
 
 import { concludeBuild } from "@/build/concludeBuild";
 import {
+  Account,
   Build,
   BuildReview,
   Comment,
@@ -127,11 +128,12 @@ describe("createReview", () => {
       })
       .expect(200);
 
+    const userAccount = await Account.query().findOne({ userId: user.id });
     expect(res.body).toMatchObject({
       id: expect.any(String),
       buildId: build.id,
       state: "rejected",
-      userId: user.id,
+      user: { id: userAccount!.id, slug: userAccount!.slug },
     });
 
     const review = await BuildReview.query()

--- a/apps/backend/src/api/handlers/createReview.ts
+++ b/apps/backend/src/api/handlers/createReview.ts
@@ -221,7 +221,7 @@ export const createReview: CreateAPIHandler = ({ post }) => {
         })),
       });
 
-      res.send(serializeBuildReview(buildReview));
+      res.send(await serializeBuildReview(buildReview));
     },
   );
 };

--- a/apps/backend/src/api/handlers/createReview.ts
+++ b/apps/backend/src/api/handlers/createReview.ts
@@ -4,7 +4,6 @@ import {
 } from "@argos/schemas/build-review";
 import { assertNever } from "@argos/util/assertNever";
 import { invariant } from "@argos/util/invariant";
-import type { JSONContent } from "@tiptap/core";
 import { z } from "zod";
 import { ZodOpenApiOperationObject } from "zod-openapi";
 
@@ -12,6 +11,7 @@ import {
   createBuildReview,
   ScreenshotDiffReviewState,
 } from "@/build/createBuildReview";
+import { resolveCommentBody } from "@/comment/body";
 import { isCommentTooLarge, validateCommentJson } from "@/comment/validate";
 import { Build } from "@/database/models/Build";
 import { boom } from "@/util/error";
@@ -21,6 +21,10 @@ import {
   getAuthPayloadFromExpressReq,
 } from "../auth/project";
 import { BuildNumber } from "../schema/primitives/build";
+import {
+  BuildReviewSchema,
+  serializeBuildReview,
+} from "../schema/primitives/buildReview";
 import { AccountSlug, ProjectName } from "../schema/primitives/project";
 import {
   forbidden,
@@ -51,20 +55,27 @@ const CreateReviewBodySchema = z.object({
   body: z
     .unknown()
     .optional()
-    .refine((value) => value === undefined || validateCommentJson(value), {
-      message:
-        "Invalid comment body. Expected a valid rich-text JSON document.",
-    })
     .refine(
       (value) =>
         value === undefined ||
+        typeof value === "string" ||
+        validateCommentJson(value),
+      {
+        message:
+          "Invalid comment body. Expected Markdown text or a valid rich-text JSON document.",
+      },
+    )
+    .refine(
+      (value) =>
+        value === undefined ||
+        typeof value === "string" ||
         !validateCommentJson(value) ||
         !isCommentTooLarge(value),
       { message: "Comment is too large." },
     )
     .meta({
       description:
-        "Optional comment to attach to the review. Expected as the JSON representation of a rich-text document.",
+        "Optional comment to attach to the review. Either Markdown text or the JSON representation of a rich-text document.",
     }),
   snapshots: z
     .array(
@@ -85,13 +96,6 @@ const CreateReviewBodySchema = z.object({
         "Optional per-snapshot review decisions. When omitted, only the build-level review is recorded.",
     }),
 });
-
-const BuildReviewSchema = z
-  .object({
-    id: z.string(),
-    state: z.enum(["approved", "rejected", "commented", "pending"]),
-  })
-  .meta({ description: "Build review" });
 
 export const createReviewOperation = {
   operationId: "createReview",
@@ -209,14 +213,15 @@ export const createReview: CreateAPIHandler = ({ post }) => {
         build,
         userId: auth.user.id,
         event,
-        body: body.body as JSONContent | undefined,
+        body:
+          body.body !== undefined ? resolveCommentBody(body.body) : undefined,
         snapshotReviews: body.snapshots.map((snapshotReview) => ({
           screenshotDiffId: snapshotReview.id,
           state: getScreenshotReviewState(snapshotReview.conclusion),
         })),
       });
 
-      res.send(buildReview);
+      res.send(serializeBuildReview(buildReview));
     },
   );
 };

--- a/apps/backend/src/api/handlers/createReview.ts
+++ b/apps/backend/src/api/handlers/createReview.ts
@@ -214,7 +214,9 @@ export const createReview: CreateAPIHandler = ({ post }) => {
         userId: auth.user.id,
         event,
         body:
-          body.body !== undefined ? resolveCommentBody(body.body) : undefined,
+          body.body !== undefined
+            ? await resolveCommentBody(body.body)
+            : undefined,
         snapshotReviews: body.snapshots.map((snapshotReview) => ({
           screenshotDiffId: snapshotReview.id,
           state: getScreenshotReviewState(snapshotReview.conclusion),

--- a/apps/backend/src/api/handlers/deleteComment.ts
+++ b/apps/backend/src/api/handlers/deleteComment.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+import { ZodOpenApiOperationObject } from "zod-openapi";
+
+import { deleteBuildComment } from "@/comment/deleteBuildComment";
+import { getCommentPermissions } from "@/comment/permissions";
+import { boom } from "@/util/error";
+
+import { getBuildComment, getPatAuthAndBuild } from "../auth/build";
+import { BuildNumber } from "../schema/primitives/build";
+import { CommentSchema, serializeComment } from "../schema/primitives/comment";
+import { AccountSlug, ProjectName } from "../schema/primitives/project";
+import {
+  forbidden,
+  invalidParameters,
+  notFound,
+  serverError,
+  unauthorized,
+} from "../schema/util/error";
+import { CreateAPIHandler } from "../util";
+
+export const deleteCommentOperation = {
+  operationId: "deleteComment",
+  summary: "Delete a comment on a build",
+  requestParams: {
+    path: z.object({
+      owner: AccountSlug,
+      project: ProjectName,
+      buildNumber: BuildNumber,
+      commentId: z.string().meta({ description: "The ID of the comment" }),
+    }),
+  },
+  responses: {
+    "200": {
+      description: "Comment deleted successfully — returns the comment",
+      content: {
+        "application/json": {
+          schema: CommentSchema,
+        },
+      },
+    },
+    "400": invalidParameters,
+    "401": unauthorized,
+    "403": forbidden,
+    "404": notFound,
+    "500": serverError,
+  },
+} satisfies ZodOpenApiOperationObject;
+
+export const deleteComment: CreateAPIHandler = ({ delete: del }) => {
+  del(
+    "/projects/{owner}/{project}/builds/{buildNumber}/comments/{commentId}",
+    async (req, res) => {
+      const { params } = req.ctx;
+      const { auth, build } = await getPatAuthAndBuild(req, params);
+
+      const comment = await getBuildComment({
+        commentId: params.commentId,
+        buildId: build.id,
+      });
+
+      const permissions = getCommentPermissions(comment, auth.user);
+      if (!permissions.includes("delete")) {
+        throw boom(403, "You do not have permission to delete this comment");
+      }
+
+      const deleted = await deleteBuildComment({ comment });
+
+      res.send(await serializeComment(deleted));
+    },
+  );
+};

--- a/apps/backend/src/api/handlers/dismissReview.ts
+++ b/apps/backend/src/api/handlers/dismissReview.ts
@@ -82,7 +82,7 @@ export const dismissReview: CreateAPIHandler = ({ post }) => {
         dismissedById: auth.user.id,
       });
 
-      res.send(serializeBuildReview(dismissedReview));
+      res.send(await serializeBuildReview(dismissedReview));
     },
   );
 };

--- a/apps/backend/src/api/handlers/dismissReview.ts
+++ b/apps/backend/src/api/handlers/dismissReview.ts
@@ -1,0 +1,88 @@
+import { z } from "zod";
+import { ZodOpenApiOperationObject } from "zod-openapi";
+
+import { dismissBuildReview } from "@/build/dismissBuildReview";
+import { BuildReview } from "@/database/models";
+import { boom } from "@/util/error";
+
+import { assertBuildPermission, getPatAuthAndBuild } from "../auth/build";
+import { BuildNumber } from "../schema/primitives/build";
+import {
+  BuildReviewSchema,
+  serializeBuildReview,
+} from "../schema/primitives/buildReview";
+import { AccountSlug, ProjectName } from "../schema/primitives/project";
+import {
+  forbidden,
+  invalidParameters,
+  notFound,
+  serverError,
+  unauthorized,
+} from "../schema/util/error";
+import { CreateAPIHandler } from "../util";
+
+export const dismissReviewOperation = {
+  operationId: "dismissReview",
+  summary: "Dismiss a submitted review on a build",
+  requestParams: {
+    path: z.object({
+      owner: AccountSlug,
+      project: ProjectName,
+      buildNumber: BuildNumber,
+      reviewId: z.string().meta({ description: "The ID of the review" }),
+    }),
+  },
+  responses: {
+    "200": {
+      description: "Review dismissed successfully — returns the review",
+      content: {
+        "application/json": {
+          schema: BuildReviewSchema,
+        },
+      },
+    },
+    "400": invalidParameters,
+    "401": unauthorized,
+    "403": forbidden,
+    "404": notFound,
+    "500": serverError,
+  },
+} satisfies ZodOpenApiOperationObject;
+
+export const dismissReview: CreateAPIHandler = ({ post }) => {
+  post(
+    "/projects/{owner}/{project}/builds/{buildNumber}/reviews/{reviewId}/dismiss",
+    async (req, res) => {
+      const { params } = req.ctx;
+      const { auth, build } = await getPatAuthAndBuild(req, params);
+
+      await assertBuildPermission({
+        build,
+        user: auth.user,
+        permission: "review_dismiss",
+        message: "You do not have permission to dismiss this review",
+      });
+
+      const review = await BuildReview.query().findById(params.reviewId);
+      if (!review || review.buildId !== build.id) {
+        throw boom(404, "Review not found");
+      }
+
+      if (review.state === "pending") {
+        throw boom(400, "You cannot dismiss a pending review");
+      }
+
+      if (review.dismissedAt) {
+        throw boom(400, "Review already dismissed");
+      }
+
+      const dismissedReview = await dismissBuildReview({
+        review,
+        build,
+        dismissedById: auth.user.id,
+      });
+
+      res.send(serializeBuildReview(dismissedReview));
+    },
+  );
+};

--- a/apps/backend/src/api/handlers/getComment.ts
+++ b/apps/backend/src/api/handlers/getComment.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+import { ZodOpenApiOperationObject } from "zod-openapi";
+
+import { BuildReview } from "@/database/models";
+import { boom } from "@/util/error";
+
+import {
+  assertBuildPermission,
+  getBuildComment,
+  getPatAuthAndBuild,
+} from "../auth/build";
+import { BuildNumber } from "../schema/primitives/build";
+import { CommentSchema, serializeComment } from "../schema/primitives/comment";
+import { AccountSlug, ProjectName } from "../schema/primitives/project";
+import {
+  forbidden,
+  invalidParameters,
+  notFound,
+  serverError,
+  unauthorized,
+} from "../schema/util/error";
+import { CreateAPIHandler } from "../util";
+
+export const getCommentOperation = {
+  operationId: "getComment",
+  summary: "Get a single comment on a build",
+  requestParams: {
+    path: z.object({
+      owner: AccountSlug,
+      project: ProjectName,
+      buildNumber: BuildNumber,
+      commentId: z.string().meta({ description: "The ID of the comment" }),
+    }),
+  },
+  responses: {
+    "200": {
+      description: "Comment",
+      content: {
+        "application/json": {
+          schema: CommentSchema,
+        },
+      },
+    },
+    "400": invalidParameters,
+    "401": unauthorized,
+    "403": forbidden,
+    "404": notFound,
+    "500": serverError,
+  },
+} satisfies ZodOpenApiOperationObject;
+
+export const getComment: CreateAPIHandler = ({ get }) => {
+  get(
+    "/projects/{owner}/{project}/builds/{buildNumber}/comments/{commentId}",
+    async (req, res) => {
+      const { params } = req.ctx;
+      const { auth, build } = await getPatAuthAndBuild(req, params);
+
+      await assertBuildPermission({
+        build,
+        user: auth.user,
+        permission: "view",
+        message: "You do not have permission to view this build",
+      });
+
+      const comment = await getBuildComment({
+        commentId: params.commentId,
+        buildId: build.id,
+      });
+
+      // Deleted comments are no longer visible.
+      if (comment.deletedAt) {
+        throw boom(404, "Comment not found");
+      }
+
+      // A draft comment on a pending review is visible only to its author.
+      if (comment.buildReviewId) {
+        const review = await BuildReview.query()
+          .findById(comment.buildReviewId)
+          .select("state", "userId");
+        if (review?.state === "pending" && review.userId !== auth.user.id) {
+          throw boom(404, "Comment not found");
+        }
+      }
+
+      res.send(await serializeComment(comment));
+    },
+  );
+};

--- a/apps/backend/src/api/handlers/listComments.ts
+++ b/apps/backend/src/api/handlers/listComments.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+import { ZodOpenApiOperationObject } from "zod-openapi";
+
+import { getVisibleBuildComments } from "@/comment/getVisibleBuildComments";
+
+import { assertBuildPermission, getPatAuthAndBuild } from "../auth/build";
+import { BuildNumber } from "../schema/primitives/build";
+import { CommentSchema, serializeComments } from "../schema/primitives/comment";
+import { AccountSlug, ProjectName } from "../schema/primitives/project";
+import {
+  forbidden,
+  invalidParameters,
+  notFound,
+  serverError,
+  unauthorized,
+} from "../schema/util/error";
+import { CreateAPIHandler } from "../util";
+
+export const listCommentsOperation = {
+  operationId: "listComments",
+  summary: "List the comments on a build",
+  requestParams: {
+    path: z.object({
+      owner: AccountSlug,
+      project: ProjectName,
+      buildNumber: BuildNumber,
+    }),
+  },
+  responses: {
+    "200": {
+      description:
+        "Build comments, oldest first. Replies carry a threadId pointing at their root comment.",
+      content: {
+        "application/json": {
+          schema: z.array(CommentSchema),
+        },
+      },
+    },
+    "400": invalidParameters,
+    "401": unauthorized,
+    "403": forbidden,
+    "404": notFound,
+    "500": serverError,
+  },
+} satisfies ZodOpenApiOperationObject;
+
+export const listComments: CreateAPIHandler = ({ get }) => {
+  get(
+    "/projects/{owner}/{project}/builds/{buildNumber}/comments",
+    async (req, res) => {
+      const { auth, build } = await getPatAuthAndBuild(req, req.ctx.params);
+
+      await assertBuildPermission({
+        build,
+        user: auth.user,
+        permission: "view",
+        message: "You do not have permission to view this build",
+      });
+
+      const comments = await getVisibleBuildComments({
+        buildId: build.id,
+        viewerUserId: auth.user.id,
+      });
+
+      res.send(await serializeComments(comments));
+    },
+  );
+};

--- a/apps/backend/src/api/handlers/listReviews.ts
+++ b/apps/backend/src/api/handlers/listReviews.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+import { ZodOpenApiOperationObject } from "zod-openapi";
+
+import { BuildReview } from "@/database/models";
+
+import { assertBuildPermission, getPatAuthAndBuild } from "../auth/build";
+import { BuildNumber } from "../schema/primitives/build";
+import {
+  BuildReviewSchema,
+  serializeBuildReviews,
+} from "../schema/primitives/buildReview";
+import { AccountSlug, ProjectName } from "../schema/primitives/project";
+import {
+  forbidden,
+  invalidParameters,
+  notFound,
+  serverError,
+  unauthorized,
+} from "../schema/util/error";
+import { CreateAPIHandler } from "../util";
+
+export const listReviewsOperation = {
+  operationId: "listReviews",
+  summary: "List the reviews submitted on a build",
+  requestParams: {
+    path: z.object({
+      owner: AccountSlug,
+      project: ProjectName,
+      buildNumber: BuildNumber,
+    }),
+  },
+  responses: {
+    "200": {
+      description: "Build reviews",
+      content: {
+        "application/json": {
+          schema: z.array(BuildReviewSchema),
+        },
+      },
+    },
+    "400": invalidParameters,
+    "401": unauthorized,
+    "403": forbidden,
+    "404": notFound,
+    "500": serverError,
+  },
+} satisfies ZodOpenApiOperationObject;
+
+export const listReviews: CreateAPIHandler = ({ get }) => {
+  get(
+    "/projects/{owner}/{project}/builds/{buildNumber}/reviews",
+    async (req, res) => {
+      const { auth, build } = await getPatAuthAndBuild(req, req.ctx.params);
+
+      await assertBuildPermission({
+        build,
+        user: auth.user,
+        permission: "view",
+        message: "You do not have permission to view this build",
+      });
+
+      // Submitted reviews are visible to everyone with access; pending reviews
+      // are drafts visible only to their author.
+      const reviews = await BuildReview.query()
+        .where("buildId", build.id)
+        .where((qb) =>
+          qb.whereNot("state", "pending").orWhere("userId", auth.user.id),
+        )
+        .orderBy("createdAt", "asc");
+
+      res.send(serializeBuildReviews(reviews));
+    },
+  );
+};

--- a/apps/backend/src/api/handlers/listReviews.ts
+++ b/apps/backend/src/api/handlers/listReviews.ts
@@ -68,7 +68,7 @@ export const listReviews: CreateAPIHandler = ({ get }) => {
         )
         .orderBy("createdAt", "asc");
 
-      res.send(serializeBuildReviews(reviews));
+      res.send(await serializeBuildReviews(reviews));
     },
   );
 };

--- a/apps/backend/src/api/handlers/removeCommentReaction.ts
+++ b/apps/backend/src/api/handlers/removeCommentReaction.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+import { ZodOpenApiOperationObject } from "zod-openapi";
+
+import { removeCommentReaction as removeCommentReactionService } from "@/comment/removeCommentReaction";
+
+import {
+  assertBuildPermission,
+  getBuildComment,
+  getPatAuthAndBuild,
+} from "../auth/build";
+import { BuildNumber } from "../schema/primitives/build";
+import { CommentSchema, serializeComment } from "../schema/primitives/comment";
+import { AccountSlug, ProjectName } from "../schema/primitives/project";
+import {
+  forbidden,
+  invalidParameters,
+  notFound,
+  serverError,
+  unauthorized,
+} from "../schema/util/error";
+import { CreateAPIHandler } from "../util";
+
+export const removeCommentReactionOperation = {
+  operationId: "removeCommentReaction",
+  summary: "Remove an emoji reaction from a comment",
+  requestParams: {
+    path: z.object({
+      owner: AccountSlug,
+      project: ProjectName,
+      buildNumber: BuildNumber,
+      commentId: z.string().meta({ description: "The ID of the comment" }),
+    }),
+    query: z.object({
+      emoji: z.string().meta({ description: "The emoji reaction to remove." }),
+    }),
+  },
+  responses: {
+    "200": {
+      description: "Reaction removed — returns the comment",
+      content: {
+        "application/json": {
+          schema: CommentSchema,
+        },
+      },
+    },
+    "400": invalidParameters,
+    "401": unauthorized,
+    "403": forbidden,
+    "404": notFound,
+    "500": serverError,
+  },
+} satisfies ZodOpenApiOperationObject;
+
+export const removeCommentReaction: CreateAPIHandler = ({ delete: del }) => {
+  del(
+    "/projects/{owner}/{project}/builds/{buildNumber}/comments/{commentId}/reactions",
+    async (req, res) => {
+      const { params, query } = req.ctx;
+      const { auth, build } = await getPatAuthAndBuild(req, params);
+
+      await assertBuildPermission({
+        build,
+        user: auth.user,
+        permission: "review",
+        message: "You do not have permission to react to this comment",
+      });
+
+      const comment = await getBuildComment({
+        commentId: params.commentId,
+        buildId: build.id,
+      });
+
+      const updated = await removeCommentReactionService({
+        comment,
+        userId: auth.user.id,
+        emoji: query.emoji,
+      });
+
+      res.send(await serializeComment(updated));
+    },
+  );
+};

--- a/apps/backend/src/api/handlers/resolveCommentThread.ts
+++ b/apps/backend/src/api/handlers/resolveCommentThread.ts
@@ -1,0 +1,127 @@
+import { z } from "zod";
+import { ZodOpenApiOperationObject } from "zod-openapi";
+
+import {
+  resolveCommentThread as resolveCommentThreadService,
+  unresolveCommentThread as unresolveCommentThreadService,
+} from "@/comment/resolveCommentThread";
+
+import {
+  assertBuildPermission,
+  getBuildCommentThread,
+  getPatAuthAndBuild,
+} from "../auth/build";
+import { BuildNumber } from "../schema/primitives/build";
+import { CommentSchema, serializeComment } from "../schema/primitives/comment";
+import { AccountSlug, ProjectName } from "../schema/primitives/project";
+import {
+  forbidden,
+  invalidParameters,
+  notFound,
+  serverError,
+  unauthorized,
+} from "../schema/util/error";
+import { CreateAPIHandler } from "../util";
+
+const PathParams = z.object({
+  owner: AccountSlug,
+  project: ProjectName,
+  buildNumber: BuildNumber,
+  commentId: z
+    .string()
+    .meta({ description: "ID of any comment in the thread" }),
+});
+
+export const resolveCommentThreadOperation = {
+  operationId: "resolveCommentThread",
+  summary: "Mark a comment thread as resolved",
+  requestParams: { path: PathParams },
+  responses: {
+    "200": {
+      description: "Thread resolved — returns the root comment",
+      content: {
+        "application/json": {
+          schema: CommentSchema,
+        },
+      },
+    },
+    "400": invalidParameters,
+    "401": unauthorized,
+    "403": forbidden,
+    "404": notFound,
+    "500": serverError,
+  },
+} satisfies ZodOpenApiOperationObject;
+
+export const unresolveCommentThreadOperation = {
+  operationId: "unresolveCommentThread",
+  summary: "Reopen a resolved comment thread",
+  requestParams: { path: PathParams },
+  responses: {
+    "200": {
+      description: "Thread reopened — returns the root comment",
+      content: {
+        "application/json": {
+          schema: CommentSchema,
+        },
+      },
+    },
+    "400": invalidParameters,
+    "401": unauthorized,
+    "403": forbidden,
+    "404": notFound,
+    "500": serverError,
+  },
+} satisfies ZodOpenApiOperationObject;
+
+export const resolveCommentThread: CreateAPIHandler = ({ post }) => {
+  post(
+    "/projects/{owner}/{project}/builds/{buildNumber}/comments/{commentId}/resolve",
+    async (req, res) => {
+      const { params } = req.ctx;
+      const { auth, build } = await getPatAuthAndBuild(req, params);
+
+      await assertBuildPermission({
+        build,
+        user: auth.user,
+        permission: "review",
+        message: "You do not have permission to resolve this thread",
+      });
+
+      const thread = await getBuildCommentThread({
+        commentId: params.commentId,
+        buildId: build.id,
+      });
+
+      const resolved = await resolveCommentThreadService({ thread });
+
+      res.send(await serializeComment(resolved));
+    },
+  );
+};
+
+export const unresolveCommentThread: CreateAPIHandler = ({ post }) => {
+  post(
+    "/projects/{owner}/{project}/builds/{buildNumber}/comments/{commentId}/unresolve",
+    async (req, res) => {
+      const { params } = req.ctx;
+      const { auth, build } = await getPatAuthAndBuild(req, params);
+
+      await assertBuildPermission({
+        build,
+        user: auth.user,
+        permission: "review",
+        message: "You do not have permission to reopen this thread",
+      });
+
+      const thread = await getBuildCommentThread({
+        commentId: params.commentId,
+        buildId: build.id,
+      });
+
+      const reopened = await unresolveCommentThreadService({ thread });
+
+      res.send(await serializeComment(reopened));
+    },
+  );
+};

--- a/apps/backend/src/api/handlers/reviews.e2e.test.ts
+++ b/apps/backend/src/api/handlers/reviews.e2e.test.ts
@@ -1,0 +1,275 @@
+import request from "supertest";
+import { test as base, beforeAll, describe, expect } from "vitest";
+import z from "zod";
+
+import { concludeBuild } from "@/build/concludeBuild";
+import {
+  Build,
+  BuildReview,
+  Project,
+  ScreenshotBucket,
+  ScreenshotDiff,
+  User,
+  UserAccessTokenScope,
+} from "@/database/models";
+import { hashToken } from "@/database/services/crypto";
+import { factory, setupDatabase } from "@/database/testing";
+
+import { createTestHandlerApp } from "../test-util";
+import { dismissReview } from "./dismissReview";
+import { listReviews } from "./listReviews";
+
+const app = createTestHandlerApp((ctx) => {
+  listReviews(ctx);
+  dismissReview(ctx);
+});
+
+const test = base.extend<{
+  user: User;
+  otherUser: User;
+  project: Project;
+  compareBucket: ScreenshotBucket;
+  build: Build;
+  screenshotDiffs: ScreenshotDiff[];
+  scopedPatToken: string;
+}>({
+  user: async ({}, use) => {
+    await setupDatabase();
+    const user = await factory.User.create();
+    await use(user);
+  },
+  otherUser: async ({ user }, use) => {
+    const otherUser = await factory.User.create();
+    await use(otherUser);
+    void user;
+  },
+  project: async ({ user }, use) => {
+    const [userAccount, teamAccount] = await Promise.all([
+      factory.UserAccount.create({ userId: user.id }),
+      factory.TeamAccount.create({ slug: "acme" }),
+    ]);
+    const project = await factory.Project.create({
+      accountId: teamAccount.id,
+      name: "web",
+      token: "the-awesome-token",
+    });
+    await factory.TeamUser.create({
+      teamId: teamAccount.teamId,
+      userId: user.id,
+      userLevel: "owner",
+    });
+    await use(project);
+    void userAccount;
+  },
+  compareBucket: async ({ project }, use) => {
+    const compareBucket = await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      branch: "feature/review-api",
+      commit: "b".repeat(40),
+    });
+    await use(compareBucket);
+  },
+  build: async ({ project, compareBucket }, use) => {
+    const build = await factory.Build.create({
+      projectId: project.id,
+      compareScreenshotBucketId: compareBucket.id,
+      conclusion: null,
+    });
+    await use(build);
+  },
+  screenshotDiffs: async ({ build }, use) => {
+    const screenshots = await factory.Screenshot.createMany(3);
+    const screenshotDiffs = await factory.ScreenshotDiff.createMany(2, [
+      {
+        buildId: build.id,
+        baseScreenshotId: screenshots[0]!.id,
+        compareScreenshotId: screenshots[1]!.id,
+        score: 0.2,
+      },
+      {
+        buildId: build.id,
+        baseScreenshotId: screenshots[0]!.id,
+        compareScreenshotId: screenshots[2]!.id,
+        score: 0.4,
+      },
+    ]);
+    await concludeBuild({ build, notify: false });
+    await use(screenshotDiffs);
+  },
+  scopedPatToken: async ({ user, project }, use) => {
+    const token = `arp_${"e".repeat(36)}`;
+    const userAccessToken = await factory.UserAccessToken.create({
+      userId: user.id,
+      token: hashToken(token),
+    });
+    await UserAccessTokenScope.query().insert({
+      userAccessTokenId: userAccessToken.id,
+      accountId: project.accountId,
+    });
+    await use(token);
+  },
+});
+
+describe("listReviews", () => {
+  beforeAll(() => {
+    z.globalRegistry.clear();
+  });
+
+  test("lists submitted reviews and the viewer's own pending review", async ({
+    user,
+    otherUser,
+    build,
+    scopedPatToken,
+  }) => {
+    const [approved] = await Promise.all([
+      factory.BuildReview.create({
+        buildId: build.id,
+        userId: otherUser.id,
+        state: "approved",
+      }),
+      // Hidden: another user's pending draft.
+      factory.BuildReview.create({
+        buildId: build.id,
+        userId: otherUser.id,
+        state: "pending",
+      }),
+      // Visible: the viewer's own pending draft.
+      factory.BuildReview.create({
+        buildId: build.id,
+        userId: user.id,
+        state: "pending",
+      }),
+    ]);
+
+    const res = await request(app)
+      .get(`/projects/acme/web/builds/${build.number}/reviews`)
+      .set("Authorization", `Bearer ${scopedPatToken}`)
+      .expect(200);
+
+    expect(res.body).toHaveLength(2);
+    const states = res.body.map((r: { state: string }) => r.state).sort();
+    expect(states).toEqual(["approved", "pending"]);
+    expect(res.body).toContainEqual(
+      expect.objectContaining({ id: approved.id, state: "approved" }),
+    );
+  });
+
+  test("rejects project tokens", async ({ build }) => {
+    const res = await request(app)
+      .get(`/projects/acme/web/builds/${build.number}/reviews`)
+      .set("Authorization", "Bearer the-awesome-token")
+      .expect(401);
+    expect(res.body.error).toEqual(expect.any(String));
+  });
+});
+
+describe("dismissReview", () => {
+  beforeAll(() => {
+    z.globalRegistry.clear();
+  });
+
+  test("dismisses a submitted review and returns it", async ({
+    user,
+    otherUser,
+    build,
+    scopedPatToken,
+  }) => {
+    const review = await factory.BuildReview.create({
+      buildId: build.id,
+      userId: otherUser.id,
+      state: "approved",
+    });
+
+    const res = await request(app)
+      .post(
+        `/projects/acme/web/builds/${build.number}/reviews/${review.id}/dismiss`,
+      )
+      .set("Authorization", `Bearer ${scopedPatToken}`)
+      .expect(200);
+
+    expect(res.body).toMatchObject({
+      id: review.id,
+      state: "approved",
+      dismissedById: user.id,
+    });
+    expect(res.body.dismissedAt).toEqual(expect.any(String));
+
+    const reloaded = await BuildReview.query().findById(review.id);
+    expect(reloaded?.dismissedById).toBe(user.id);
+    expect(reloaded?.dismissedAt).not.toBeNull();
+  });
+
+  test("returns 400 for a pending review", async ({
+    otherUser,
+    build,
+    scopedPatToken,
+  }) => {
+    const review = await factory.BuildReview.create({
+      buildId: build.id,
+      userId: otherUser.id,
+      state: "pending",
+    });
+
+    await request(app)
+      .post(
+        `/projects/acme/web/builds/${build.number}/reviews/${review.id}/dismiss`,
+      )
+      .set("Authorization", `Bearer ${scopedPatToken}`)
+      .expect(400)
+      .expect((res) => {
+        expect(res.body.error).toContain("pending");
+      });
+  });
+
+  test("returns 400 when already dismissed", async ({
+    otherUser,
+    build,
+    scopedPatToken,
+  }) => {
+    const review = await factory.BuildReview.create({
+      buildId: build.id,
+      userId: otherUser.id,
+      state: "approved",
+      dismissedAt: new Date().toISOString(),
+      dismissedById: otherUser.id,
+    });
+
+    await request(app)
+      .post(
+        `/projects/acme/web/builds/${build.number}/reviews/${review.id}/dismiss`,
+      )
+      .set("Authorization", `Bearer ${scopedPatToken}`)
+      .expect(400)
+      .expect((res) => {
+        expect(res.body.error).toContain("already dismissed");
+      });
+  });
+
+  test("returns 404 for a review on another build", async ({
+    otherUser,
+    project,
+    build,
+    scopedPatToken,
+  }) => {
+    const otherBucket = await factory.ScreenshotBucket.create({
+      projectId: project.id,
+    });
+    const otherBuild = await factory.Build.create({
+      projectId: project.id,
+      compareScreenshotBucketId: otherBucket.id,
+    });
+    const review = await factory.BuildReview.create({
+      buildId: otherBuild.id,
+      userId: otherUser.id,
+      state: "approved",
+    });
+
+    const res = await request(app)
+      .post(
+        `/projects/acme/web/builds/${build.number}/reviews/${review.id}/dismiss`,
+      )
+      .set("Authorization", `Bearer ${scopedPatToken}`)
+      .expect(404);
+    expect(res.body.error).toEqual(expect.any(String));
+  });
+});

--- a/apps/backend/src/api/handlers/reviews.e2e.test.ts
+++ b/apps/backend/src/api/handlers/reviews.e2e.test.ts
@@ -4,6 +4,7 @@ import z from "zod";
 
 import { concludeBuild } from "@/build/concludeBuild";
 import {
+  Account,
   Build,
   BuildReview,
   Project,
@@ -152,6 +153,16 @@ describe("listReviews", () => {
     expect(res.body).toContainEqual(
       expect.objectContaining({ id: approved.id, state: "approved" }),
     );
+
+    // The viewer's own pending review exposes the resolved user object.
+    const userAccount = await Account.query().findOne({ userId: user.id });
+    const pending = res.body.find(
+      (r: { state: string }) => r.state === "pending",
+    );
+    expect(pending.user).toMatchObject({
+      id: userAccount!.id,
+      slug: userAccount!.slug,
+    });
   });
 
   test("rejects project tokens", async ({ build }) => {
@@ -187,10 +198,11 @@ describe("dismissReview", () => {
       .set("Authorization", `Bearer ${scopedPatToken}`)
       .expect(200);
 
+    const userAccount = await Account.query().findOne({ userId: user.id });
     expect(res.body).toMatchObject({
       id: review.id,
       state: "approved",
-      dismissedById: user.id,
+      dismissedBy: { id: userAccount!.id, slug: userAccount!.slug },
     });
     expect(res.body.dismissedAt).toEqual(expect.any(String));
 

--- a/apps/backend/src/api/handlers/subscribeCommentThread.ts
+++ b/apps/backend/src/api/handlers/subscribeCommentThread.ts
@@ -1,0 +1,133 @@
+import { z } from "zod";
+import { ZodOpenApiOperationObject } from "zod-openapi";
+
+import {
+  subscribeUserToCommentThread,
+  unsubscribeUserFromCommentThread,
+} from "@/database/services/comment-notification-subscription";
+
+import {
+  assertBuildPermission,
+  getBuildCommentThread,
+  getPatAuthAndBuild,
+} from "../auth/build";
+import { BuildNumber } from "../schema/primitives/build";
+import { CommentSchema, serializeComment } from "../schema/primitives/comment";
+import { AccountSlug, ProjectName } from "../schema/primitives/project";
+import {
+  forbidden,
+  invalidParameters,
+  notFound,
+  serverError,
+  unauthorized,
+} from "../schema/util/error";
+import { CreateAPIHandler } from "../util";
+
+const PathParams = z.object({
+  owner: AccountSlug,
+  project: ProjectName,
+  buildNumber: BuildNumber,
+  commentId: z
+    .string()
+    .meta({ description: "ID of any comment in the thread" }),
+});
+
+export const subscribeCommentThreadOperation = {
+  operationId: "subscribeCommentThread",
+  summary: "Subscribe to a comment thread's notifications",
+  requestParams: { path: PathParams },
+  responses: {
+    "200": {
+      description: "Subscribed — returns the root comment",
+      content: {
+        "application/json": {
+          schema: CommentSchema,
+        },
+      },
+    },
+    "400": invalidParameters,
+    "401": unauthorized,
+    "403": forbidden,
+    "404": notFound,
+    "500": serverError,
+  },
+} satisfies ZodOpenApiOperationObject;
+
+export const unsubscribeCommentThreadOperation = {
+  operationId: "unsubscribeCommentThread",
+  summary: "Unsubscribe from a comment thread's notifications",
+  requestParams: { path: PathParams },
+  responses: {
+    "200": {
+      description: "Unsubscribed — returns the root comment",
+      content: {
+        "application/json": {
+          schema: CommentSchema,
+        },
+      },
+    },
+    "400": invalidParameters,
+    "401": unauthorized,
+    "403": forbidden,
+    "404": notFound,
+    "500": serverError,
+  },
+} satisfies ZodOpenApiOperationObject;
+
+export const subscribeCommentThread: CreateAPIHandler = ({ post }) => {
+  post(
+    "/projects/{owner}/{project}/builds/{buildNumber}/comments/{commentId}/subscription",
+    async (req, res) => {
+      const { params } = req.ctx;
+      const { auth, build } = await getPatAuthAndBuild(req, params);
+
+      await assertBuildPermission({
+        build,
+        user: auth.user,
+        permission: "view",
+        message: "You do not have permission to access this thread",
+      });
+
+      const thread = await getBuildCommentThread({
+        commentId: params.commentId,
+        buildId: build.id,
+      });
+
+      await subscribeUserToCommentThread({
+        commentId: thread.id,
+        userId: auth.user.id,
+      });
+
+      res.send(await serializeComment(thread));
+    },
+  );
+};
+
+export const unsubscribeCommentThread: CreateAPIHandler = ({ delete: del }) => {
+  del(
+    "/projects/{owner}/{project}/builds/{buildNumber}/comments/{commentId}/subscription",
+    async (req, res) => {
+      const { params } = req.ctx;
+      const { auth, build } = await getPatAuthAndBuild(req, params);
+
+      await assertBuildPermission({
+        build,
+        user: auth.user,
+        permission: "view",
+        message: "You do not have permission to access this thread",
+      });
+
+      const thread = await getBuildCommentThread({
+        commentId: params.commentId,
+        buildId: build.id,
+      });
+
+      await unsubscribeUserFromCommentThread({
+        commentId: thread.id,
+        userId: auth.user.id,
+      });
+
+      res.send(await serializeComment(thread));
+    },
+  );
+};

--- a/apps/backend/src/api/handlers/updateComment.ts
+++ b/apps/backend/src/api/handlers/updateComment.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+import { ZodOpenApiOperationObject } from "zod-openapi";
+
+import { resolveCommentBody } from "@/comment/body";
+import { getCommentPermissions } from "@/comment/permissions";
+import { updateBuildComment } from "@/comment/updateBuildComment";
+import { boom } from "@/util/error";
+
+import { getBuildComment, getPatAuthAndBuild } from "../auth/build";
+import { BuildNumber } from "../schema/primitives/build";
+import {
+  CommentBodyInputSchema,
+  CommentSchema,
+  serializeComment,
+} from "../schema/primitives/comment";
+import { AccountSlug, ProjectName } from "../schema/primitives/project";
+import {
+  forbidden,
+  invalidParameters,
+  notFound,
+  serverError,
+  unauthorized,
+} from "../schema/util/error";
+import { CreateAPIHandler } from "../util";
+
+const UpdateCommentBodySchema = z.object({
+  body: CommentBodyInputSchema,
+});
+
+export const updateCommentOperation = {
+  operationId: "updateComment",
+  summary: "Update a comment on a build",
+  requestParams: {
+    path: z.object({
+      owner: AccountSlug,
+      project: ProjectName,
+      buildNumber: BuildNumber,
+      commentId: z.string().meta({ description: "The ID of the comment" }),
+    }),
+  },
+  requestBody: {
+    required: true,
+    content: {
+      "application/json": {
+        schema: UpdateCommentBodySchema,
+      },
+    },
+  },
+  responses: {
+    "200": {
+      description: "Comment updated successfully — returns the comment",
+      content: {
+        "application/json": {
+          schema: CommentSchema,
+        },
+      },
+    },
+    "400": invalidParameters,
+    "401": unauthorized,
+    "403": forbidden,
+    "404": notFound,
+    "500": serverError,
+  },
+} satisfies ZodOpenApiOperationObject;
+
+export const updateComment: CreateAPIHandler = ({ patch }) => {
+  patch(
+    "/projects/{owner}/{project}/builds/{buildNumber}/comments/{commentId}",
+    async (req, res) => {
+      const { params, body: input } = req.ctx;
+      const { auth, build } = await getPatAuthAndBuild(req, params);
+
+      const comment = await getBuildComment({
+        commentId: params.commentId,
+        buildId: build.id,
+      });
+
+      const permissions = getCommentPermissions(comment, auth.user);
+      if (!permissions.includes("edit")) {
+        throw boom(403, "You do not have permission to edit this comment");
+      }
+
+      const updated = await updateBuildComment({
+        comment,
+        body: resolveCommentBody(input.body),
+      });
+
+      res.send(await serializeComment(updated));
+    },
+  );
+};

--- a/apps/backend/src/api/handlers/updateComment.ts
+++ b/apps/backend/src/api/handlers/updateComment.ts
@@ -82,7 +82,7 @@ export const updateComment: CreateAPIHandler = ({ patch }) => {
 
       const updated = await updateBuildComment({
         comment,
-        body: resolveCommentBody(input.body),
+        body: await resolveCommentBody(input.body),
       });
 
       res.send(await serializeComment(updated));

--- a/apps/backend/src/api/index.ts
+++ b/apps/backend/src/api/index.ts
@@ -3,9 +3,13 @@ import cors from "cors";
 import { Router } from "express";
 import { stringify } from "yaml";
 
+import { addCommentReaction } from "./handlers/addCommentReaction";
 import { createBuild } from "./handlers/createBuild";
+import { createComment } from "./handlers/createComment";
 import { createDeployment } from "./handlers/createDeployment";
 import { createReview } from "./handlers/createReview";
+import { deleteComment } from "./handlers/deleteComment";
+import { dismissReview } from "./handlers/dismissReview";
 import { exchangeCliToken } from "./handlers/exchangeCliToken";
 import { exchangeGitHubActionsOidcToken } from "./handlers/exchangeGitHubActionsOidcToken";
 import { exchangeGitHubActionsTokenlessToken } from "./handlers/exchangeGitHubActionsTokenlessToken";
@@ -14,11 +18,24 @@ import { finalizeDeployment } from "./handlers/finalizeDeployment";
 import { getAuthProject } from "./handlers/getAuthProject";
 import { getBuild } from "./handlers/getBuild";
 import { getBuildDiffs } from "./handlers/getBuildDiffs";
+import { getComment } from "./handlers/getComment";
 import { getDeployment } from "./handlers/getDeployment";
 import { getProject } from "./handlers/getProject";
 import { getProjectBuilds } from "./handlers/getProjectBuilds";
+import { listComments } from "./handlers/listComments";
+import { listReviews } from "./handlers/listReviews";
+import { removeCommentReaction } from "./handlers/removeCommentReaction";
+import {
+  resolveCommentThread,
+  unresolveCommentThread,
+} from "./handlers/resolveCommentThread";
 import { resolveDeploymentDomain } from "./handlers/resolveDeploymentDomain";
+import {
+  subscribeCommentThread,
+  unsubscribeCommentThread,
+} from "./handlers/subscribeCommentThread";
 import { updateBuild } from "./handlers/updateBuild";
+import { updateComment } from "./handlers/updateComment";
 import { schema } from "./schema";
 import { errorHandler, registerHandler } from "./util";
 
@@ -49,6 +66,19 @@ router.get(
 // Register the handlers.
 registerHandler(router, createBuild);
 registerHandler(router, createReview);
+registerHandler(router, listReviews);
+registerHandler(router, dismissReview);
+registerHandler(router, listComments);
+registerHandler(router, createComment);
+registerHandler(router, getComment);
+registerHandler(router, updateComment);
+registerHandler(router, deleteComment);
+registerHandler(router, addCommentReaction);
+registerHandler(router, removeCommentReaction);
+registerHandler(router, resolveCommentThread);
+registerHandler(router, unresolveCommentThread);
+registerHandler(router, subscribeCommentThread);
+registerHandler(router, unsubscribeCommentThread);
 registerHandler(router, exchangeCliToken);
 registerHandler(router, exchangeGitHubActionsOidcToken);
 registerHandler(router, exchangeGitHubActionsTokenlessToken);

--- a/apps/backend/src/api/schema.ts
+++ b/apps/backend/src/api/schema.ts
@@ -3,9 +3,13 @@ import { createDocument, ZodOpenApiObject } from "zod-openapi";
 
 import config from "@/config";
 
+import { addCommentReactionOperation } from "./handlers/addCommentReaction";
 import { createBuildOperation } from "./handlers/createBuild";
+import { createCommentOperation } from "./handlers/createComment";
 import { createDeploymentOperation } from "./handlers/createDeployment";
 import { createReviewOperation } from "./handlers/createReview";
+import { deleteCommentOperation } from "./handlers/deleteComment";
+import { dismissReviewOperation } from "./handlers/dismissReview";
 import { exchangeCliTokenOperation } from "./handlers/exchangeCliToken";
 import { exchangeGitHubActionsOidcTokenOperation } from "./handlers/exchangeGitHubActionsOidcToken";
 import { exchangeGitHubActionsTokenlessTokenOperation } from "./handlers/exchangeGitHubActionsTokenlessToken";
@@ -14,11 +18,24 @@ import { finalizeDeploymentOperation } from "./handlers/finalizeDeployment";
 import { getAuthProjectOperation } from "./handlers/getAuthProject";
 import { getBuildOperation } from "./handlers/getBuild";
 import { getBuildDiffsOperation } from "./handlers/getBuildDiffs";
+import { getCommentOperation } from "./handlers/getComment";
 import { getDeploymentOperation } from "./handlers/getDeployment";
 import { getProjectOperation } from "./handlers/getProject";
 import { getProjectBuildsOperation } from "./handlers/getProjectBuilds";
+import { listCommentsOperation } from "./handlers/listComments";
+import { listReviewsOperation } from "./handlers/listReviews";
+import { removeCommentReactionOperation } from "./handlers/removeCommentReaction";
+import {
+  resolveCommentThreadOperation,
+  unresolveCommentThreadOperation,
+} from "./handlers/resolveCommentThread";
 import { resolveDeploymentDomainOperation } from "./handlers/resolveDeploymentDomain";
+import {
+  subscribeCommentThreadOperation,
+  unsubscribeCommentThreadOperation,
+} from "./handlers/subscribeCommentThread";
 import { updateBuildOperation } from "./handlers/updateBuild";
+import { updateCommentOperation } from "./handlers/updateComment";
 
 export const zodSchema = {
   openapi: "3.1.1",
@@ -90,8 +107,40 @@ export const zodSchema = {
       get: getBuildDiffsOperation,
     },
     "/projects/{owner}/{project}/builds/{buildNumber}/reviews": {
+      get: listReviewsOperation,
       post: createReviewOperation,
     },
+    "/projects/{owner}/{project}/builds/{buildNumber}/reviews/{reviewId}/dismiss":
+      {
+        post: dismissReviewOperation,
+      },
+    "/projects/{owner}/{project}/builds/{buildNumber}/comments": {
+      get: listCommentsOperation,
+      post: createCommentOperation,
+    },
+    "/projects/{owner}/{project}/builds/{buildNumber}/comments/{commentId}": {
+      get: getCommentOperation,
+      patch: updateCommentOperation,
+      delete: deleteCommentOperation,
+    },
+    "/projects/{owner}/{project}/builds/{buildNumber}/comments/{commentId}/reactions":
+      {
+        post: addCommentReactionOperation,
+        delete: removeCommentReactionOperation,
+      },
+    "/projects/{owner}/{project}/builds/{buildNumber}/comments/{commentId}/resolve":
+      {
+        post: resolveCommentThreadOperation,
+      },
+    "/projects/{owner}/{project}/builds/{buildNumber}/comments/{commentId}/unresolve":
+      {
+        post: unresolveCommentThreadOperation,
+      },
+    "/projects/{owner}/{project}/builds/{buildNumber}/comments/{commentId}/subscription":
+      {
+        post: subscribeCommentThreadOperation,
+        delete: unsubscribeCommentThreadOperation,
+      },
   },
 } satisfies ZodOpenApiObject;
 

--- a/apps/backend/src/api/schema/primitives/buildReview.ts
+++ b/apps/backend/src/api/schema/primitives/buildReview.ts
@@ -5,7 +5,7 @@ import type { BuildReview } from "@/database/models";
 
 import { getUserAccountsByUserId, serializeUser, UserSchema } from "./user";
 
-export const ReviewStateSchema = z
+const ReviewStateSchema = z
   .enum(["approved", "rejected", "commented", "pending"])
   .meta({
     description:

--- a/apps/backend/src/api/schema/primitives/buildReview.ts
+++ b/apps/backend/src/api/schema/primitives/buildReview.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+import type { BuildReview } from "@/database/models";
+
+export const ReviewStateSchema = z
+  .enum(["approved", "rejected", "commented", "pending"])
+  .meta({
+    description:
+      "State of a build review: approved, rejected, commented (neutral) or pending (an unsubmitted draft).",
+  });
+
+export const BuildReviewSchema = z
+  .object({
+    id: z.string(),
+    buildId: z.string(),
+    state: ReviewStateSchema,
+    userId: z.string().nullable().meta({
+      description: "ID of the user who submitted the review.",
+    }),
+    dismissedAt: z.string().nullable().meta({
+      description: "Date the review was dismissed, null if not dismissed.",
+    }),
+    dismissedById: z.string().nullable().meta({
+      description: "ID of the user who dismissed the review, if any.",
+    }),
+    date: z.string().meta({ description: "Date the review was created." }),
+  })
+  .meta({ description: "Build review", id: "BuildReview" });
+
+export function serializeBuildReview(
+  review: BuildReview,
+): z.infer<typeof BuildReviewSchema> {
+  return {
+    id: review.id,
+    buildId: review.buildId,
+    state: review.state,
+    userId: review.userId,
+    dismissedAt: review.dismissedAt,
+    dismissedById: review.dismissedById,
+    date: review.createdAt,
+  };
+}
+
+export function serializeBuildReviews(
+  reviews: BuildReview[],
+): z.infer<typeof BuildReviewSchema>[] {
+  return reviews.map(serializeBuildReview);
+}

--- a/apps/backend/src/api/schema/primitives/buildReview.ts
+++ b/apps/backend/src/api/schema/primitives/buildReview.ts
@@ -1,6 +1,9 @@
+import { invariant } from "@argos/util/invariant";
 import { z } from "zod";
 
 import type { BuildReview } from "@/database/models";
+
+import { getUserAccountsByUserId, serializeUser, UserSchema } from "./user";
 
 export const ReviewStateSchema = z
   .enum(["approved", "rejected", "commented", "pending"])
@@ -14,35 +17,49 @@ export const BuildReviewSchema = z
     id: z.string(),
     buildId: z.string(),
     state: ReviewStateSchema,
-    userId: z.string().nullable().meta({
-      description: "ID of the user who submitted the review.",
+    user: UserSchema.nullable().meta({
+      description: "The user who submitted the review.",
     }),
     dismissedAt: z.string().nullable().meta({
       description: "Date the review was dismissed, null if not dismissed.",
     }),
-    dismissedById: z.string().nullable().meta({
-      description: "ID of the user who dismissed the review, if any.",
+    dismissedBy: UserSchema.nullable().meta({
+      description: "The user who dismissed the review, if any.",
     }),
     date: z.string().meta({ description: "Date the review was created." }),
   })
   .meta({ description: "Build review", id: "BuildReview" });
 
-export function serializeBuildReview(
-  review: BuildReview,
-): z.infer<typeof BuildReviewSchema> {
-  return {
-    id: review.id,
-    buildId: review.buildId,
-    state: review.state,
-    userId: review.userId,
-    dismissedAt: review.dismissedAt,
-    dismissedById: review.dismissedById,
-    date: review.createdAt,
-  };
+export async function serializeBuildReviews(
+  reviews: BuildReview[],
+): Promise<z.infer<typeof BuildReviewSchema>[]> {
+  const accountByUserId = await getUserAccountsByUserId(
+    reviews.flatMap((review) => [review.userId, review.dismissedById]),
+  );
+
+  return reviews.map((review) => {
+    const user = review.userId
+      ? (accountByUserId.get(review.userId) ?? null)
+      : null;
+    const dismissedBy = review.dismissedById
+      ? (accountByUserId.get(review.dismissedById) ?? null)
+      : null;
+    return {
+      id: review.id,
+      buildId: review.buildId,
+      state: review.state,
+      user: user ? serializeUser(user) : null,
+      dismissedAt: review.dismissedAt,
+      dismissedBy: dismissedBy ? serializeUser(dismissedBy) : null,
+      date: review.createdAt,
+    };
+  });
 }
 
-export function serializeBuildReviews(
-  reviews: BuildReview[],
-): z.infer<typeof BuildReviewSchema>[] {
-  return reviews.map(serializeBuildReview);
+export async function serializeBuildReview(
+  review: BuildReview,
+): Promise<z.infer<typeof BuildReviewSchema>> {
+  const [serialized] = await serializeBuildReviews([review]);
+  invariant(serialized, "Failed to serialize build review");
+  return serialized;
 }

--- a/apps/backend/src/api/schema/primitives/comment.ts
+++ b/apps/backend/src/api/schema/primitives/comment.ts
@@ -1,0 +1,206 @@
+import { z } from "zod";
+
+import { schema as proseMirrorSchema } from "@/comment/schema";
+import {
+  Account,
+  BuildReview,
+  Comment,
+  CommentReaction,
+} from "@/database/models";
+
+/**
+ * Body of a comment as accepted by the write endpoints: either Markdown text or
+ * the JSON representation of a rich-text document. See `resolveCommentBody`.
+ */
+export const CommentBodyInputSchema = z
+  .union([z.string(), z.record(z.string(), z.unknown())])
+  .meta({
+    description:
+      "Comment content. Either Markdown text or the JSON representation of a rich-text document.",
+  });
+
+const CommentReactionGroupSchema = z
+  .object({
+    emoji: z.string().meta({ description: "The emoji used for the reaction." }),
+    count: z
+      .number()
+      .meta({ description: "Number of users who reacted with this emoji." }),
+    userIds: z
+      .array(z.string())
+      .meta({ description: "IDs of the users who reacted with this emoji." }),
+  })
+  .meta({ description: "Reactions of a single emoji on a comment." });
+
+const CommentAuthorSchema = z
+  .object({
+    id: z.string(),
+    slug: z.string(),
+    name: z.string().nullable(),
+  })
+  .meta({ description: "Author of a comment.", id: "CommentAuthor" });
+
+const CommentAnchorSchema = z
+  .discriminatedUnion("type", [
+    z.object({
+      type: z.literal("point"),
+      x: z.number(),
+      y: z.number(),
+    }),
+    z.object({
+      type: z.literal("lines"),
+      from: z.number().int(),
+      to: z.number().int(),
+    }),
+  ])
+  .nullable()
+  .meta({
+    description:
+      "Where on the referenced screenshot diff the comment points. A point uses normalized (0–1) coordinates; lines is a 1-based inclusive range. Null means the whole diff.",
+  });
+
+export const CommentSchema = z
+  .object({
+    id: z.string(),
+    buildId: z.string(),
+    threadId: z
+      .string()
+      .nullable()
+      .meta({ description: "Root comment ID when this comment is a reply." }),
+    body: z
+      .unknown()
+      .meta({ description: "Rich-text JSON content of the comment." }),
+    text: z
+      .string()
+      .meta({ description: "Plain-text rendering of the comment content." }),
+    author: CommentAuthorSchema.nullable(),
+    screenshotDiffId: z.string().nullable().meta({
+      description: "Screenshot diff this comment is anchored to, if any.",
+    }),
+    anchor: CommentAnchorSchema,
+    pending: z.boolean().meta({
+      description:
+        "Whether the comment belongs to a pending (unsubmitted) review and is only visible to its author.",
+    }),
+    resolvedAt: z.string().nullable().meta({
+      description:
+        "Date the thread was resolved, null if not resolved. Only set on a root comment.",
+    }),
+    editedAt: z.string().nullable().meta({
+      description: "Date the comment was last edited, null if never edited.",
+    }),
+    createdAt: z.string().meta({ description: "Date the comment was posted." }),
+    reactions: z.array(CommentReactionGroupSchema),
+  })
+  .meta({ description: "A comment posted on a build.", id: "Comment" });
+
+/** Best-effort plain-text rendering of a stored rich-text comment. */
+function commentText(content: unknown): string {
+  try {
+    return proseMirrorSchema.nodeFromJSON(content).textContent;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Serialize comments into the public API shape, batching the relations (author
+ * accounts, reactions, owning reviews) to avoid N+1 queries.
+ */
+export async function serializeComments(
+  comments: Comment[],
+): Promise<z.infer<typeof CommentSchema>[]> {
+  const commentIds = comments.map((comment) => comment.id);
+  const reviewIds = [
+    ...new Set(
+      comments
+        .map((comment) => comment.buildReviewId)
+        .filter((id): id is string => id !== null),
+    ),
+  ];
+  const userIds = [
+    ...new Set(
+      comments
+        .map((comment) => comment.userId)
+        .filter((id): id is string => id !== null),
+    ),
+  ];
+
+  const [reactions, reviews, accounts] = await Promise.all([
+    commentIds.length > 0
+      ? CommentReaction.query()
+          .whereIn("commentId", commentIds)
+          .orderBy("createdAt", "asc")
+      : [],
+    reviewIds.length > 0
+      ? BuildReview.query().findByIds(reviewIds)
+      : ([] as BuildReview[]),
+    userIds.length > 0
+      ? Account.query().whereIn("userId", userIds)
+      : ([] as Account[]),
+  ]);
+
+  // Group reactions per comment, preserving insertion order so the emoji groups
+  // come out oldest-first.
+  const reactionsByComment = new Map<string, CommentReaction[]>();
+  for (const reaction of reactions) {
+    const list = reactionsByComment.get(reaction.commentId) ?? [];
+    list.push(reaction);
+    reactionsByComment.set(reaction.commentId, list);
+  }
+
+  const reviewById = new Map(reviews.map((review) => [review.id, review]));
+  const accountByUserId = new Map(
+    accounts.flatMap((account) =>
+      account.userId ? [[account.userId, account] as const] : [],
+    ),
+  );
+
+  return comments.map((comment) => {
+    const account = comment.userId
+      ? (accountByUserId.get(comment.userId) ?? null)
+      : null;
+
+    const groups = new Map<string, string[]>();
+    for (const reaction of reactionsByComment.get(comment.id) ?? []) {
+      const list = groups.get(reaction.emoji) ?? [];
+      list.push(reaction.userId);
+      groups.set(reaction.emoji, list);
+    }
+
+    const pending = comment.buildReviewId
+      ? reviewById.get(comment.buildReviewId)?.state === "pending"
+      : false;
+
+    return {
+      id: comment.id,
+      buildId: comment.buildId,
+      threadId: comment.threadId,
+      body: comment.content,
+      text: commentText(comment.content),
+      author: account
+        ? { id: account.id, slug: account.slug, name: account.displayName }
+        : null,
+      screenshotDiffId: comment.screenshotDiffId,
+      anchor: comment.anchor,
+      pending,
+      resolvedAt: comment.resolvedAt,
+      editedAt: comment.editedAt,
+      createdAt: comment.createdAt,
+      reactions: Array.from(groups.entries()).map(([emoji, ids]) => ({
+        emoji,
+        count: ids.length,
+        userIds: ids,
+      })),
+    };
+  });
+}
+
+export async function serializeComment(
+  comment: Comment,
+): Promise<z.infer<typeof CommentSchema>> {
+  const [serialized] = await serializeComments([comment]);
+  if (!serialized) {
+    throw new Error("Failed to serialize comment");
+  }
+  return serialized;
+}

--- a/apps/backend/src/api/schema/primitives/comment.ts
+++ b/apps/backend/src/api/schema/primitives/comment.ts
@@ -1,12 +1,9 @@
 import { z } from "zod";
 
 import { schema as proseMirrorSchema } from "@/comment/schema";
-import {
-  Account,
-  BuildReview,
-  Comment,
-  CommentReaction,
-} from "@/database/models";
+import { BuildReview, Comment, CommentReaction } from "@/database/models";
+
+import { getUserAccountsByUserId, serializeUser, UserSchema } from "./user";
 
 /**
  * Body of a comment as accepted by the write endpoints: either Markdown text or
@@ -25,19 +22,11 @@ const CommentReactionGroupSchema = z
     count: z
       .number()
       .meta({ description: "Number of users who reacted with this emoji." }),
-    userIds: z
-      .array(z.string())
-      .meta({ description: "IDs of the users who reacted with this emoji." }),
+    users: z
+      .array(UserSchema)
+      .meta({ description: "The users who reacted with this emoji." }),
   })
   .meta({ description: "Reactions of a single emoji on a comment." });
-
-const CommentAuthorSchema = z
-  .object({
-    id: z.string(),
-    slug: z.string(),
-    name: z.string().nullable(),
-  })
-  .meta({ description: "Author of a comment.", id: "CommentAuthor" });
 
 const CommentAnchorSchema = z
   .discriminatedUnion("type", [
@@ -72,7 +61,7 @@ export const CommentSchema = z
     text: z
       .string()
       .meta({ description: "Plain-text rendering of the comment content." }),
-    author: CommentAuthorSchema.nullable(),
+    author: UserSchema.nullable(),
     screenshotDiffId: z.string().nullable().meta({
       description: "Screenshot diff this comment is anchored to, if any.",
     }),
@@ -104,7 +93,7 @@ function commentText(content: unknown): string {
 
 /**
  * Serialize comments into the public API shape, batching the relations (author
- * accounts, reactions, owning reviews) to avoid N+1 queries.
+ * and reaction accounts, reactions, owning reviews) to avoid N+1 queries.
  */
 export async function serializeComments(
   comments: Comment[],
@@ -117,15 +106,8 @@ export async function serializeComments(
         .filter((id): id is string => id !== null),
     ),
   ];
-  const userIds = [
-    ...new Set(
-      comments
-        .map((comment) => comment.userId)
-        .filter((id): id is string => id !== null),
-    ),
-  ];
 
-  const [reactions, reviews, accounts] = await Promise.all([
+  const [reactions, reviews] = await Promise.all([
     commentIds.length > 0
       ? CommentReaction.query()
           .whereIn("commentId", commentIds)
@@ -134,9 +116,13 @@ export async function serializeComments(
     reviewIds.length > 0
       ? BuildReview.query().findByIds(reviewIds)
       : ([] as BuildReview[]),
-    userIds.length > 0
-      ? Account.query().whereIn("userId", userIds)
-      : ([] as Account[]),
+  ]);
+
+  // Resolve the accounts for both comment authors and everyone who reacted in a
+  // single batched query.
+  const accountByUserId = await getUserAccountsByUserId([
+    ...comments.map((comment) => comment.userId),
+    ...reactions.map((reaction) => reaction.userId),
   ]);
 
   // Group reactions per comment, preserving insertion order so the emoji groups
@@ -149,21 +135,16 @@ export async function serializeComments(
   }
 
   const reviewById = new Map(reviews.map((review) => [review.id, review]));
-  const accountByUserId = new Map(
-    accounts.flatMap((account) =>
-      account.userId ? [[account.userId, account] as const] : [],
-    ),
-  );
 
   return comments.map((comment) => {
     const account = comment.userId
       ? (accountByUserId.get(comment.userId) ?? null)
       : null;
 
-    const groups = new Map<string, string[]>();
+    const groups = new Map<string, CommentReaction[]>();
     for (const reaction of reactionsByComment.get(comment.id) ?? []) {
       const list = groups.get(reaction.emoji) ?? [];
-      list.push(reaction.userId);
+      list.push(reaction);
       groups.set(reaction.emoji, list);
     }
 
@@ -177,19 +158,20 @@ export async function serializeComments(
       threadId: comment.threadId,
       body: comment.content,
       text: commentText(comment.content),
-      author: account
-        ? { id: account.id, slug: account.slug, name: account.displayName }
-        : null,
+      author: account ? serializeUser(account) : null,
       screenshotDiffId: comment.screenshotDiffId,
       anchor: comment.anchor,
       pending,
       resolvedAt: comment.resolvedAt,
       editedAt: comment.editedAt,
       createdAt: comment.createdAt,
-      reactions: Array.from(groups.entries()).map(([emoji, ids]) => ({
+      reactions: Array.from(groups.entries()).map(([emoji, list]) => ({
         emoji,
-        count: ids.length,
-        userIds: ids,
+        count: list.length,
+        users: list.flatMap((reaction) => {
+          const reactionAccount = accountByUserId.get(reaction.userId);
+          return reactionAccount ? [serializeUser(reactionAccount)] : [];
+        }),
       })),
     };
   });

--- a/apps/backend/src/api/schema/primitives/comment.ts
+++ b/apps/backend/src/api/schema/primitives/comment.ts
@@ -28,7 +28,13 @@ const CommentReactionGroupSchema = z
   })
   .meta({ description: "Reactions of a single emoji on a comment." });
 
-const CommentAnchorSchema = z
+/**
+ * Where on the referenced screenshot diff a comment points. A point uses
+ * normalized (0–1) coordinates; lines is a 1-based inclusive range. Shared by
+ * the comment output and the comment-creation input so both speak the same
+ * anchor shape.
+ */
+export const CommentAnchorSchema = z
   .discriminatedUnion("type", [
     z.object({
       type: z.literal("point"),
@@ -41,10 +47,9 @@ const CommentAnchorSchema = z
       to: z.number().int(),
     }),
   ])
-  .nullable()
   .meta({
     description:
-      "Where on the referenced screenshot diff the comment points. A point uses normalized (0–1) coordinates; lines is a 1-based inclusive range. Null means the whole diff.",
+      "Where on the referenced screenshot diff the comment points. A point uses normalized (0–1) coordinates; lines is a 1-based inclusive range.",
   });
 
 export const CommentSchema = z
@@ -65,7 +70,10 @@ export const CommentSchema = z
     screenshotDiffId: z.string().nullable().meta({
       description: "Screenshot diff this comment is anchored to, if any.",
     }),
-    anchor: CommentAnchorSchema,
+    anchor: CommentAnchorSchema.nullable().meta({
+      description:
+        "Where the comment points on its screenshot diff. Null means the whole diff.",
+    }),
     pending: z.boolean().meta({
       description:
         "Whether the comment belongs to a pending (unsubmitted) review and is only visible to its author.",

--- a/apps/backend/src/api/schema/primitives/user.ts
+++ b/apps/backend/src/api/schema/primitives/user.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+import { Account } from "@/database/models";
+
+export const UserSchema = z
+  .object({
+    id: z.string(),
+    slug: z.string(),
+    name: z.string().nullable(),
+  })
+  .meta({ description: "A user.", id: "User" });
+
+/** Serialize a user's personal account into the public API user shape. */
+export function serializeUser(account: Account): z.infer<typeof UserSchema> {
+  return { id: account.id, slug: account.slug, name: account.displayName };
+}
+
+/**
+ * Resolve the personal accounts backing a set of user ids, keyed by user id, so
+ * serializers can expose `user`/`dismissedBy`/reaction users without N+1
+ * queries. Null/undefined ids are ignored.
+ */
+export async function getUserAccountsByUserId(
+  userIds: (string | null | undefined)[],
+): Promise<Map<string, Account>> {
+  const ids = [...new Set(userIds.filter((id): id is string => id != null))];
+  if (ids.length === 0) {
+    return new Map();
+  }
+  const accounts = await Account.query().whereIn("userId", ids);
+  return new Map(
+    accounts.flatMap((account) =>
+      account.userId ? [[account.userId, account] as const] : [],
+    ),
+  );
+}

--- a/apps/backend/src/api/util.ts
+++ b/apps/backend/src/api/util.ts
@@ -90,6 +90,18 @@ type PutOperationHandler<TPath extends Path> = OperationRequestHandler<
     : never
 >;
 
+type PatchOperationHandler<TPath extends Path> = OperationRequestHandler<
+  paths[TPath] extends { patch: ZodOpenApiOperationObject }
+    ? paths[TPath]["patch"]
+    : never
+>;
+
+type DeleteOperationHandler<TPath extends Path> = OperationRequestHandler<
+  paths[TPath] extends { delete: ZodOpenApiOperationObject }
+    ? paths[TPath]["delete"]
+    : never
+>;
+
 /**
  * Convert OpenAPI path to Express path
  */
@@ -145,12 +157,20 @@ type Context = {
     path: TPath,
     ...handlers: HandlerParams<PutOperationHandler<TPath>>
   ): void;
+  patch<TPath extends Path>(
+    path: TPath,
+    ...handlers: HandlerParams<PatchOperationHandler<TPath>>
+  ): void;
+  delete<TPath extends Path>(
+    path: TPath,
+    ...handlers: HandlerParams<DeleteOperationHandler<TPath>>
+  ): void;
 };
 
 /**
- * Register a GET handler.
+ * Register a handler for the given HTTP method.
  */
-function handler<TMethod extends "get" | "post" | "put">(
+function handler<TMethod extends "get" | "post" | "put" | "patch" | "delete">(
   router: Router,
   method: TMethod,
 ) {
@@ -249,6 +269,8 @@ export function registerHandler(router: Router, create: CreateAPIHandler) {
     get: handler(router, "get"),
     post: handler(router, "post"),
     put: handler(router, "put"),
+    patch: handler(router, "patch"),
+    delete: handler(router, "delete"),
   };
   return create(context);
 }

--- a/apps/backend/src/build/dismissBuildReview.ts
+++ b/apps/backend/src/build/dismissBuildReview.ts
@@ -1,0 +1,75 @@
+import { invariant } from "@argos/util/invariant";
+
+import { Build, BuildReview, User } from "@/database/models";
+import { sendNotification } from "@/notification";
+
+import { publishReviewChange } from "./reviewEvents";
+
+/**
+ * Dismiss a submitted build review: stamp who dismissed it and when, notify the
+ * original reviewer, and broadcast the change so watching clients update live.
+ *
+ * The caller is responsible for authorization and for rejecting pending or
+ * already-dismissed reviews; this performs the dismissal and its side effects
+ * only. Shared by the GraphQL `dismissReview` mutation and the REST API.
+ */
+export async function dismissBuildReview(input: {
+  /** The review to dismiss, with `build.project.account` fetched. */
+  review: BuildReview;
+  build: Build;
+  dismissedById: string;
+}): Promise<BuildReview> {
+  const { review, build, dismissedById } = input;
+
+  const dismissedReview = await review.$query().patchAndFetch({
+    dismissedAt: new Date().toISOString(),
+    dismissedById,
+  });
+
+  await Promise.all([
+    notifyReviewDismissed({ review, build, dismissedById }),
+    // Notify clients watching this build so the dismissal appears live.
+    publishReviewChange({
+      buildId: build.id,
+      type: "DISMISSED",
+      review: dismissedReview,
+    }),
+  ]);
+
+  return dismissedReview;
+}
+
+async function notifyReviewDismissed(input: {
+  review: BuildReview;
+  build: Build;
+  dismissedById: string;
+}): Promise<void> {
+  const { review, build, dismissedById } = input;
+  const { state } = review;
+  if (state !== "approved" && state !== "rejected" && state !== "commented") {
+    return;
+  }
+  if (!review.userId || review.userId === dismissedById) {
+    return;
+  }
+  const project = build.project;
+  invariant(project?.account, "project account not found");
+  const [dismissedBy, buildUrl] = await Promise.all([
+    User.query().findById(dismissedById).withGraphFetched("account"),
+    build.getUrl(),
+  ]);
+  const dismissedByName = dismissedBy?.account?.displayName ?? null;
+  await sendNotification({
+    type: "review_dismissed",
+    data: {
+      accountSlug: project.account.slug,
+      projectName: project.name,
+      buildNumber: build.number,
+      buildName: build.name,
+      buildUrl,
+      dismissedByName,
+      state,
+    },
+    recipients: [review.userId],
+  });
+}

--- a/apps/backend/src/build/reviewableStatus.ts
+++ b/apps/backend/src/build/reviewableStatus.ts
@@ -1,0 +1,16 @@
+import type { BuildAggregatedStatus } from "@argos/schemas/build-status";
+
+/**
+ * Whether a build is in a state where a review can be submitted. Mirrors the
+ * statuses the frontend offers "Submit review" for; outside these, attaching a
+ * comment to a pending review would strand it with no way to submit.
+ */
+export function isReviewableBuildStatus(
+  status: BuildAggregatedStatus,
+): boolean {
+  return (
+    status === "accepted" ||
+    status === "rejected" ||
+    status === "changes-detected"
+  );
+}

--- a/apps/backend/src/comment/body.ts
+++ b/apps/backend/src/comment/body.ts
@@ -1,0 +1,47 @@
+import type { JSONContent } from "@tiptap/core";
+import { generateJSON } from "@tiptap/html/server";
+import { marked } from "marked";
+
+import { boom } from "@/util/error";
+
+import { getExtensions } from "./schema";
+import { validateCommentJson } from "./validate";
+
+/**
+ * Resolve a comment/review body submitted through the public API into the
+ * rich-text (TipTap/ProseMirror) JSON the rest of the system stores.
+ *
+ * The API accepts two forms so a CLI can stay ergonomic while power users keep
+ * full control:
+ * - a **string**, interpreted as Markdown and converted to rich-text JSON using
+ *   the same schema the editor uses, so headings, lists, emphasis, links, etc.
+ *   are preserved;
+ * - an **object**, treated as raw rich-text JSON (the form the web app sends),
+ *   validated against the comment schema.
+ *
+ * Note: `@mentions` are stored by user id and therefore can't be expressed in
+ * Markdown — use the raw-JSON form to mention users.
+ *
+ * Length/empty/sanitize limits are enforced downstream by `createBuildComment`,
+ * `updateBuildComment` and `createBuildReview`; this only produces the document.
+ */
+export function resolveCommentBody(input: string | object): JSONContent {
+  if (typeof input === "string") {
+    // marked is synchronous unless async extensions are registered; force the
+    // sync return so the type is a plain string rather than a promise.
+    const html = marked.parse(input, { async: false });
+    // generateJSON builds the doc against the comment schema, so the output is
+    // structurally valid by construction; nodes Markdown can produce that the
+    // schema doesn't allow are simply dropped.
+    return generateJSON(html, getExtensions()) as JSONContent;
+  }
+
+  if (!validateCommentJson(input)) {
+    throw boom(
+      400,
+      "Invalid comment body. Expected Markdown text or a valid rich-text JSON document.",
+    );
+  }
+
+  return input;
+}

--- a/apps/backend/src/comment/body.ts
+++ b/apps/backend/src/comment/body.ts
@@ -25,11 +25,13 @@ import { validateCommentJson } from "./validate";
  * Length/empty/sanitize limits are enforced downstream by `createBuildComment`,
  * `updateBuildComment` and `createBuildReview`; this only produces the document.
  */
-export function resolveCommentBody(input: string | object): JSONContent {
+export async function resolveCommentBody(
+  input: string | object,
+): Promise<JSONContent> {
   if (typeof input === "string") {
-    // marked is synchronous unless async extensions are registered; force the
-    // sync return so the type is a plain string rather than a promise.
-    const html = marked.parse(input, { async: false });
+    // `marked` may run async extensions, so await covers both the sync and the
+    // async cases without forcing a particular return type.
+    const html = await marked.parse(input);
     // generateJSON builds the doc against the comment schema, so the output is
     // structurally valid by construction; nodes Markdown can produce that the
     // schema doesn't allow are simply dropped.

--- a/apps/backend/src/comment/getVisibleBuildComments.ts
+++ b/apps/backend/src/comment/getVisibleBuildComments.ts
@@ -1,0 +1,47 @@
+import type { QueryBuilder } from "objection";
+
+import { BuildReview, Comment } from "@/database/models";
+
+/**
+ * Restrict a `Comment` query to the rows visible to a given viewer: standalone
+ * comments (no review), comments on a submitted review, or comments on the
+ * viewer's own pending (draft) review — draft comments stay hidden from everyone
+ * but their author until the review is submitted. Soft-deleted comments are
+ * always excluded.
+ *
+ * This is the single source of truth for comment visibility, shared by the
+ * GraphQL `BuildPublishedComments` loader (which batches across many builds) and
+ * the REST API (which scopes to one build).
+ */
+export function filterVisibleComments<QB extends QueryBuilder<Comment, any>>(
+  query: QB,
+  viewerUserId: string | null,
+): QB {
+  return query.whereNull("deletedAt").where((qb) => {
+    qb.whereNull("buildReviewId").orWhereExists(
+      BuildReview.query()
+        .select(1)
+        .whereColumn("build_reviews.id", "comments.buildReviewId")
+        .where((sub) => {
+          sub.whereNot("build_reviews.state", "pending");
+          if (viewerUserId) {
+            sub.orWhere("build_reviews.userId", viewerUserId);
+          }
+        }),
+    );
+  }) as QB;
+}
+
+/**
+ * Load the comments visible to a given viewer on a single build, oldest first.
+ */
+export async function getVisibleBuildComments(input: {
+  buildId: string;
+  viewerUserId: string | null;
+}): Promise<Comment[]> {
+  const { buildId, viewerUserId } = input;
+  return filterVisibleComments(
+    Comment.query().where("buildId", buildId),
+    viewerUserId,
+  ).orderBy("createdAt", "asc");
+}

--- a/apps/backend/src/comment/thread.ts
+++ b/apps/backend/src/comment/thread.ts
@@ -1,0 +1,28 @@
+import { Comment } from "@/database/models";
+
+/**
+ * Resolve the non-deleted root comment of the thread a comment belongs to.
+ *
+ * A standalone/root comment is its own thread; a reply points at the root via
+ * `threadId`. Thread-level state (resolution, subscriptions) always lives on the
+ * root, so callers operating on "the thread" go through this. Returns `null`
+ * when the comment — or the thread root it points at — is missing or
+ * soft-deleted.
+ */
+export async function getCommentThreadRoot(
+  commentId: string,
+): Promise<Comment | null> {
+  const comment = await Comment.query().findById(commentId);
+  if (!comment || comment.deletedAt) {
+    return null;
+  }
+  const threadId = comment.threadId ?? comment.id;
+  if (threadId === comment.id) {
+    return comment;
+  }
+  const thread = await Comment.query().findById(threadId);
+  if (!thread || thread.deletedAt) {
+    return null;
+  }
+  return thread;
+}

--- a/apps/backend/src/graphql/definitions/BuildReview.ts
+++ b/apps/backend/src/graphql/definitions/BuildReview.ts
@@ -9,15 +9,13 @@ import {
   ReviewState,
   ScreenshotDiffReviewState,
 } from "@/build/createBuildReview";
+import { dismissBuildReview } from "@/build/dismissBuildReview";
 import {
-  publishReviewChange,
   subscribeToReviewChanges,
   type ReviewChangeType,
 } from "@/build/reviewEvents";
 import { Build } from "@/database/models/Build";
 import { BuildReview } from "@/database/models/BuildReview";
-import { User } from "@/database/models/User";
-import { sendNotification } from "@/notification";
 
 import {
   IBuildReviewEvent,
@@ -233,24 +231,7 @@ export const resolvers: IResolvers = {
         throw badUserInput("Review already dismissed");
       }
 
-      const dismissedReview = await review.$query().patchAndFetch({
-        dismissedAt: new Date().toISOString(),
-        dismissedById: auth.user.id,
-      });
-
-      await Promise.all([
-        notifyReviewDismissed({
-          review,
-          build,
-          dismissedById: auth.user.id,
-        }),
-        // Notify clients watching this build so the dismissal appears live.
-        publishReviewChange({
-          buildId: build.id,
-          type: "DISMISSED",
-          review: dismissedReview,
-        }),
-      ]);
+      await dismissBuildReview({ review, build, dismissedById: auth.user.id });
 
       return build;
     },
@@ -315,39 +296,4 @@ function parseScreenshotDiffReviewState(
     default:
       assertNever(state);
   }
-}
-
-async function notifyReviewDismissed(input: {
-  review: BuildReview;
-  build: Build;
-  dismissedById: string;
-}): Promise<void> {
-  const { review, build, dismissedById } = input;
-  const { state } = review;
-  if (state !== "approved" && state !== "rejected" && state !== "commented") {
-    return;
-  }
-  if (!review.userId || review.userId === dismissedById) {
-    return;
-  }
-  const project = build.project;
-  invariant(project?.account, "project account not found");
-  const [dismissedBy, buildUrl] = await Promise.all([
-    User.query().findById(dismissedById).withGraphFetched("account"),
-    build.getUrl(),
-  ]);
-  const dismissedByName = dismissedBy?.account?.displayName ?? null;
-  await sendNotification({
-    type: "review_dismissed",
-    data: {
-      accountSlug: project.account.slug,
-      projectName: project.name,
-      buildNumber: build.number,
-      buildName: build.name,
-      buildUrl,
-      dismissedByName,
-      state,
-    },
-    recipients: [review.userId],
-  });
 }

--- a/apps/backend/src/graphql/definitions/Comment.ts
+++ b/apps/backend/src/graphql/definitions/Comment.ts
@@ -1,9 +1,9 @@
-import type { BuildAggregatedStatus } from "@argos/schemas/build-status";
 import { invariant } from "@argos/util/invariant";
 import type { JSONContent } from "@tiptap/core";
 import gqlTag from "graphql-tag";
 
 import { getOrCreatePendingBuildReview } from "@/build/pendingReview";
+import { isReviewableBuildStatus } from "@/build/reviewableStatus";
 import { addCommentReaction } from "@/comment/addCommentReaction";
 import {
   subscribeToCommentChanges,
@@ -19,6 +19,7 @@ import {
   resolveCommentThread,
   unresolveCommentThread,
 } from "@/comment/resolveCommentThread";
+import { getCommentThreadRoot } from "@/comment/thread";
 import { updateBuildComment } from "@/comment/updateBuildComment";
 import { Build } from "@/database/models/Build";
 import { BuildReview } from "@/database/models/BuildReview";
@@ -47,19 +48,6 @@ import { assertCanViewBuild } from "../buildAccess";
 import { badUserInput, forbidden, notFound, unauthenticated } from "../util";
 
 const { gql } = gqlTag;
-
-/**
- * Whether a build is in a state where a review can be submitted. Mirrors the
- * statuses the frontend offers "Submit review" for; outside these, attaching a
- * comment to a pending review would strand it with no way to submit.
- */
-function isReviewableBuildStatus(status: BuildAggregatedStatus): boolean {
-  return (
-    status === "accepted" ||
-    status === "rejected" ||
-    status === "changes-detected"
-  );
-}
 
 /**
  * Turn the comment-anchor input into the stored anchor shape, enforcing that
@@ -123,16 +111,14 @@ async function assertCanReactToComment(
 }
 
 async function getCommentThreadByGraphqlId(id: string): Promise<Comment> {
-  const comment = await getCommentByGraphqlId(id);
-  if (comment.deletedAt) {
+  let commentId: string;
+  try {
+    commentId = parseCommentId(id);
+  } catch {
     throw notFound("Thread not found");
   }
-  const threadId = comment.threadId ?? comment.id;
-  const thread =
-    threadId === comment.id
-      ? comment
-      : await Comment.query().findById(threadId);
-  if (!thread || thread.deletedAt) {
+  const thread = await getCommentThreadRoot(commentId);
+  if (!thread) {
     throw notFound("Thread not found");
   }
   return thread;

--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -5,6 +5,7 @@ import { memoize } from "lodash-es";
 import type { ModelClass } from "objection";
 
 import { getPresences, type UserPresence } from "@/auth/presence";
+import { filterVisibleComments } from "@/comment/getVisibleBuildComments";
 import { knex } from "@/database";
 import {
   Account,
@@ -748,23 +749,10 @@ function createBuildPublishedCommentsLoader() {
       const buildIds = inputs.map((input) => input.buildId);
       // A single request carries one viewer, so all inputs share it.
       const viewerUserId = inputs[0]?.viewerUserId ?? null;
-      const comments = await Comment.query()
-        .whereIn("buildId", buildIds)
-        .whereNull("deletedAt")
-        .where((qb) => {
-          qb.whereNull("buildReviewId").orWhereExists(
-            BuildReview.query()
-              .select(1)
-              .whereColumn("build_reviews.id", "comments.buildReviewId")
-              .where((sub) => {
-                sub.whereNot("build_reviews.state", "pending");
-                if (viewerUserId) {
-                  sub.orWhere("build_reviews.userId", viewerUserId);
-                }
-              }),
-          );
-        })
-        .orderBy("createdAt", "asc");
+      const comments = await filterVisibleComments(
+        Comment.query().whereIn("buildId", buildIds),
+        viewerUserId,
+      ).orderBy("createdAt", "asc");
       const commentsMap = comments.reduce<Record<string, Comment[]>>(
         (map, comment) => {
           const array = map[comment.buildId] ?? [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,9 @@ importers:
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
+      marked:
+        specifier: ^15.0.0
+        version: 15.0.12
       mime:
         specifier: ^4.1.0
         version: 4.1.0


### PR DESCRIPTION
## What

Exposes the full review + commenting surface — previously available only in GraphQL — through the public **v2 REST API**, so it can be driven from the `@argos-ci/cli`. Only `POST .../reviews` (`createReview`) existed before.

### New endpoints (nested under the build path, PAT-only)

**Reviews**
- `GET  .../builds/{n}/reviews` — list reviews (submitted + the caller's own draft)
- `POST .../builds/{n}/reviews/{reviewId}/dismiss`
- `createReview` body extended to accept Markdown

**Comments**
- `GET  .../comments` · `POST .../comments` — list / create (reply via `threadId`, anchor to a diff, `addToReview` draft)
- `GET .../comments/{id}` · `PATCH .../comments/{id}` · `DELETE .../comments/{id}`
- `POST .../comments/{id}/reactions` · `DELETE .../comments/{id}/reactions?emoji=…`
- `POST .../comments/{id}/resolve` · `POST .../comments/{id}/unresolve`
- `POST .../comments/{id}/subscription` · `DELETE .../comments/{id}/subscription`

## Design

- **Body = Markdown _or_ rich-text JSON.** `resolveCommentBody` converts Markdown → HTML (`marked`) → ProseMirror JSON via the existing comment schema; objects are validated as raw JSON. `createReview`'s `body` now accepts both, backward-compatibly. (Limitation: `@mentions` need user ids and aren't expressible in Markdown — use the raw-JSON form.)
- **Reuses GraphQL services, no duplication.** Handlers call the same service functions; shared logic — review dismissal, comment visibility, thread resolution, reviewable-status — is extracted into modules consumed by both REST and the GraphQL resolvers/loader, preserving GraphQL's typed errors.
- **Conventions:** PAT-only (these are user actions and pending-draft visibility depends on the viewer); raw DB ids like the rest of v2; draft comments on pending reviews stay visible only to their author; deleted comments hidden. Comments serialize both the rich-text `body` and a plain-text `text` (batched to avoid N+1).
- Added `patch`/`delete` support to the API handler layer; new serializers and a shared build/comment auth helper.

The OpenAPI spec (`/v2/openapi.yaml`) regenerates automatically from `schema.ts`.

## Testing

- New e2e suites cover every handler: Markdown/raw-JSON bodies, replies, anchors, `addToReview` drafts, reactions, resolve/unresolve, subscriptions, and auth/permission/visibility failure paths (401/403/404/400).
- Full backend suite green for the touched areas (283 e2e + 81 unit, incl. 26 new). Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)