### PR TITLE
feat: allow creating a project without a Git provider

### DIFF
--- a/apps/backend/src/graphql/definitions/Project.ts
+++ b/apps/backend/src/graphql/definitions/Project.ts
@@ -217,6 +217,11 @@ export const typeDefs = gql`
     edges: [Project!]!
   }
 
+  input CreateProjectInput {
+    name: String!
+    accountSlug: String!
+  }
+
   input ImportGithubProjectInput {
     repo: String!
     owner: String!
@@ -297,6 +302,8 @@ export const typeDefs = gql`
   }
 
   extend type Mutation {
+    "Create a project without connecting a Git provider"
+    createProject(input: CreateProjectInput!): Project!
     "Import a project from GitHub"
     importGithubProject(input: ImportGithubProjectInput!): Project!
     "Import a project from GitLab"
@@ -348,13 +355,15 @@ async function notifyProjectCreation(input: {
   project: Project;
   account: Account;
   email: string | null;
-  source: "GitHub" | "GitLab";
+  source: "GitHub" | "GitLab" | null;
 }) {
   await notifyDiscord({
     content: `
-New project from ${input.account.name} (${
-      input.email ?? "unknown email"
-    }) imported from ${input.source}:
+New project from ${input.account.name} (${input.email ?? "unknown email"}) ${
+      input.source
+        ? `imported from ${input.source}`
+        : "created without a Git provider"
+    }:
 ${input.account.slug} / ${input.project.name}
 `.trim(),
   }).catch((error) => {
@@ -976,6 +985,34 @@ export const resolvers: IResolvers = {
     level: (projectUser) => projectUser.userLevel as IProjectUserLevel,
   },
   Mutation: {
+    createProject: async (_root, args, ctx) => {
+      if (!ctx.auth) {
+        throw unauthenticated();
+      }
+
+      const account = await Account.query()
+        .findOne({ slug: args.input.accountSlug })
+        .throwIfNotFound();
+
+      const permissions = await account.$getPermissions(ctx.auth.user);
+      if (!permissions.includes("admin")) {
+        throw forbidden();
+      }
+
+      const name = args.input.name.trim();
+      await checkGqlProjectName({ name, accountId: account.id });
+
+      const project = await createProject({ name, accountId: account.id });
+
+      await notifyProjectCreation({
+        project,
+        email: ctx.auth.user.email,
+        account,
+        source: null,
+      });
+
+      return project;
+    },
     importGithubProject: async (_root, args, ctx) => {
       if (!ctx.auth) {
         throw unauthenticated();

--- a/apps/backend/src/graphql/tests/createProject.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/createProject.e2e.test.ts
@@ -1,0 +1,168 @@
+import { invariant } from "@argos/util/invariant";
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Project } from "@/database/models";
+import { factory, setupDatabase } from "@/database/testing";
+
+import { apolloServer, createApolloMiddleware } from "../apollo";
+import { expectNoGraphQLError } from "../testing";
+import { createApolloServerApp } from "./util";
+
+const CreateProjectMutation = `
+  mutation CreateProject($input: CreateProjectInput!) {
+    createProject(input: $input) {
+      id
+      name
+      slug
+    }
+  }
+`;
+
+async function createTeamOwner() {
+  const userAccount = await factory.UserAccount.create();
+  await userAccount.$fetchGraph("user");
+  invariant(userAccount.user, "user not fetched");
+  invariant(userAccount.userId, "user account has no user");
+
+  const teamAccount = await factory.TeamAccount.create();
+  invariant(teamAccount.teamId, "team account has no team");
+
+  await factory.TeamUser.create({
+    teamId: teamAccount.teamId,
+    userId: userAccount.userId,
+    userLevel: "owner",
+  });
+
+  return { userAccount, teamAccount, user: userAccount.user };
+}
+
+describe("GraphQL createProject", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  it("creates a project without a Git provider", async () => {
+    const { userAccount, teamAccount, user } = await createTeamOwner();
+
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user, account: userAccount },
+    );
+
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: CreateProjectMutation,
+        variables: {
+          input: {
+            name: "my-standalone-project",
+            accountSlug: teamAccount.slug,
+          },
+        },
+      });
+
+    expectNoGraphQLError(res);
+    expect(res.body.data.createProject).toMatchObject({
+      name: "my-standalone-project",
+      slug: `${teamAccount.slug}/my-standalone-project`,
+    });
+
+    await expect(
+      Project.query().findById(res.body.data.createProject.id),
+    ).resolves.toMatchObject({
+      name: "my-standalone-project",
+      accountId: teamAccount.id,
+      githubRepositoryId: null,
+      gitlabProjectId: null,
+    });
+  });
+
+  it("returns a field error when the name is already used", async () => {
+    const { userAccount, teamAccount, user } = await createTeamOwner();
+    await factory.Project.create({
+      accountId: teamAccount.id,
+      name: "taken-name",
+    });
+
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user, account: userAccount },
+    );
+
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: CreateProjectMutation,
+        variables: {
+          input: { name: "taken-name", accountSlug: teamAccount.slug },
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.errors).toHaveLength(1);
+    expect(res.body.errors[0].extensions).toMatchObject({
+      code: "BAD_USER_INPUT",
+      field: "name",
+    });
+  });
+
+  it("forbids members without admin permission", async () => {
+    const { teamAccount } = await createTeamOwner();
+    const memberAccount = await factory.UserAccount.create();
+    await memberAccount.$fetchGraph("user");
+    invariant(memberAccount.user, "user not fetched");
+    invariant(memberAccount.userId, "user account has no user");
+    await factory.TeamUser.create({
+      teamId: teamAccount.teamId!,
+      userId: memberAccount.userId,
+      userLevel: "member",
+    });
+
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user: memberAccount.user, account: memberAccount },
+    );
+
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: CreateProjectMutation,
+        variables: {
+          input: { name: "no-permission", accountSlug: teamAccount.slug },
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.errors).toHaveLength(1);
+    expect(res.body.errors[0].extensions).toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("requires authentication", async () => {
+    const { teamAccount } = await createTeamOwner();
+
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      null,
+    );
+
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: CreateProjectMutation,
+        variables: {
+          input: { name: "unauthenticated", accountSlug: teamAccount.slug },
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.errors).toHaveLength(1);
+    expect(res.body.errors[0].extensions).toMatchObject({
+      code: "UNAUTHENTICATED",
+    });
+  });
+});

--- a/apps/frontend/src/containers/Project/ConnectRepository.tsx
+++ b/apps/frontend/src/containers/Project/ConnectRepository.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import { useQuery } from "@apollo/client/react";
+import { useSuspenseQuery } from "@apollo/client/react";
 import { assertNever } from "@argos/util/assertNever";
 import { invariant } from "@argos/util/invariant";
 import { MarkGithubIcon } from "@primer/octicons-react";
@@ -21,7 +21,6 @@ import {
   LinkButtonProps,
 } from "@/ui/Button";
 import { Link } from "@/ui/Link";
-import { PageLoader } from "@/ui/PageLoader";
 import { TextInput } from "@/ui/TextInput";
 import * as storage from "@/util/storage";
 
@@ -305,23 +304,11 @@ export function ConnectRepository(props: ConnectRepositoryProps) {
     }
   }, []);
 
-  const result = useQuery(ConnectRepositoryQuery, {
+  const result = useSuspenseQuery(ConnectRepositoryQuery, {
     variables: {
       accountSlug: props.accountSlug,
     },
   });
-
-  if (result.error) {
-    throw result.error;
-  }
-
-  if (!result.data) {
-    return (
-      <div className="h-full">
-        <PageLoader />
-      </div>
-    );
-  }
 
   const { me, account } = result.data;
 
@@ -465,32 +452,31 @@ export function ConnectRepository(props: ConnectRepositoryProps) {
     case "import": {
       return (
         <div className="flex h-full flex-col items-center justify-center gap-4 py-4">
-          <div className="text-low">
+          <div className="text-low text-center text-sm">
             Select a Git provider to import an existing project from a Git
             Repository.
           </div>
-          <GitHubButton
-            size="large"
-            onPress={() => setAndStoreProvider(GitProvider.GitHub)}
-            hasInstallations={hasGhInstallations}
-            isLoggedIntoGitHub={!!me.githubAccount}
-          >
-            Continue with GitHub
-          </GitHubButton>
-          {ghLightGhInstallation && (
-            <GitHubBaseButton
-              size="large"
-              onPress={() => setAndStoreProvider(GitProvider.GitHubLight)}
+          <div className="flex flex-col items-center gap-3">
+            <GitHubButton
+              onPress={() => setAndStoreProvider(GitProvider.GitHub)}
+              hasInstallations={hasGhInstallations}
+              isLoggedIntoGitHub={!!me.githubAccount}
             >
-              Continue with GitHub (no content-access)
-            </GitHubBaseButton>
-          )}
-          <GitLabButton
-            size="large"
-            onPress={() => setAndStoreProvider(GitProvider.GitLab)}
-          >
-            Continue with GitLab
-          </GitLabButton>
+              Continue with GitHub
+            </GitHubButton>
+            {ghLightGhInstallation && (
+              <GitHubBaseButton
+                onPress={() => setAndStoreProvider(GitProvider.GitHubLight)}
+              >
+                Continue with GitHub (no content-access)
+              </GitHubBaseButton>
+            )}
+            <GitLabButton
+              onPress={() => setAndStoreProvider(GitProvider.GitLab)}
+            >
+              Continue with GitLab
+            </GitLabButton>
+          </div>
         </div>
       );
     }

--- a/apps/frontend/src/pages/Account/NewProject.tsx
+++ b/apps/frontend/src/pages/Account/NewProject.tsx
@@ -1,19 +1,26 @@
-import { useMutation } from "@apollo/client/react";
+import type { ApolloCache } from "@apollo/client";
+import { useApolloClient, useMutation } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { Heading, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
+import { SubmitHandler, useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 
 import { ConnectRepository } from "@/containers/Project/ConnectRepository";
 import { graphql } from "@/gql";
 import { Card } from "@/ui/Card";
+import { Form } from "@/ui/Form";
+import { FormRootError } from "@/ui/FormRootError";
+import { FormSubmit } from "@/ui/FormSubmit";
+import { FormTextInput } from "@/ui/FormTextInput";
 import {
   Page,
   PageContainer,
   PageHeader,
   PageHeaderContent,
 } from "@/ui/Layout";
+import { Separator } from "@/ui/Separator";
 import { getErrorMessage } from "@/util/error";
 
 import { useAccountParams } from "./AccountParams";
@@ -53,6 +60,80 @@ const ImportGitlabProjectMutation = graphql(`
   }
 `);
 
+const CreateProjectMutation = graphql(`
+  mutation NewProject_createProject($name: String!, $accountSlug: String!) {
+    createProject(input: { name: $name, accountSlug: $accountSlug }) {
+      id
+      slug
+    }
+  }
+`);
+
+/** Invalidate the cached account so the new project appears in its lists. */
+const invalidateAccount = (cache: ApolloCache) => {
+  cache.modify({
+    fields: {
+      account(_existingAccountRef, { INVALIDATE }) {
+        return INVALIDATE;
+      },
+    },
+  });
+};
+
+type CreateProjectInputs = {
+  name: string;
+};
+
+function CreateProjectForm(props: { accountSlug: string }) {
+  const navigate = useNavigate();
+  const client = useApolloClient();
+  const form = useForm<CreateProjectInputs>({
+    defaultValues: { name: "" },
+  });
+  const onSubmit: SubmitHandler<CreateProjectInputs> = async (data) => {
+    const result = await client.mutate({
+      mutation: CreateProjectMutation,
+      variables: {
+        name: data.name,
+        accountSlug: props.accountSlug,
+      },
+      update: invalidateAccount,
+    });
+    if (result.data) {
+      await navigate(`/${result.data.createProject.slug}`);
+    }
+  };
+  return (
+    <Form form={form} onSubmit={onSubmit}>
+      <p className="text-low mb-4 text-sm">
+        Start with just a name. You can connect a GitHub or GitLab repository
+        later from your project settings.
+      </p>
+      <FormTextInput
+        control={form.control}
+        {...form.register("name", {
+          required: "Please enter a project name",
+          maxLength: {
+            value: 100,
+            message: "Project name must be 100 characters or less",
+          },
+          pattern: {
+            value: /^[a-zA-Z0-9\-_.]+$/,
+            message:
+              "Project names must be alphanumeric characters with dots, hyphens and underscores.",
+          },
+        })}
+        label="Project name"
+        placeholder="e.g. my-project"
+      />
+      <div className="mt-4 flex items-center justify-end gap-4">
+        <FormRootError control={form.control} className="flex-1" />
+        <FormSubmit control={form.control}>Create project</FormSubmit>
+      </div>
+    </Form>
+  );
+}
+
 export function Component() {
   const params = useAccountParams();
   invariant(params, "Cannot create a new project outside of an account");
@@ -66,15 +147,7 @@ export function Component() {
           navigate(`/${project.slug}`);
         }
       },
-      update: (cache) => {
-        cache.modify({
-          fields: {
-            account(_existingAccountRef, { INVALIDATE }) {
-              return INVALIDATE;
-            },
-          },
-        });
-      },
+      update: invalidateAccount,
     },
   );
 
@@ -87,15 +160,7 @@ export function Component() {
           navigate(`/${project.slug}`);
         }
       },
-      update: (cache) => {
-        cache.modify({
-          fields: {
-            account(_existingAccountRef, { INVALIDATE }) {
-              return INVALIDATE;
-            },
-          },
-        });
-      },
+      update: invalidateAccount,
     },
   );
 
@@ -111,41 +176,55 @@ export function Component() {
           <PageHeaderContent>
             <Heading>Create a new Project</Heading>
             <Text slot="headline">
-              To add visual testing a new project, import an existing Git
-              repository.
+              Import an existing Git repository, or create a project and connect
+              a repository later.
             </Text>
           </PageHeaderContent>
         </PageHeader>
-        <div className="relative max-w-2xl flex-1">
-          <Card className="p-4">
-            <ConnectRepository
-              variant="import"
-              disabled={loading}
-              accountSlug={params.accountSlug}
-              onSelectRepository={({ repo, installationId }) => {
-                importGithubProject({
-                  variables: {
-                    repo: repo.name,
-                    owner: repo.owner_login,
-                    accountSlug: params.accountSlug,
-                    installationId,
-                  },
-                }).catch((error) => {
-                  toast.error(getErrorMessage(error));
-                });
-              }}
-              onSelectProject={(glProject) => {
-                importGitLabProject({
-                  variables: {
-                    gitlabProjectId: glProject.id,
-                    accountSlug: params.accountSlug,
-                  },
-                }).catch((error) => {
-                  toast.error(getErrorMessage(error));
-                });
-              }}
-            />
-          </Card>
+        <div className="flex max-w-6xl flex-col items-start gap-12 lg:flex-row">
+          <section className="flex w-full flex-1 flex-col gap-4">
+            <h2 className="text-xl font-medium">Import a Git repository</h2>
+            <Card className="relative p-4">
+              <ConnectRepository
+                variant="import"
+                disabled={loading}
+                accountSlug={params.accountSlug}
+                onSelectRepository={({ repo, installationId }) => {
+                  importGithubProject({
+                    variables: {
+                      repo: repo.name,
+                      owner: repo.owner_login,
+                      accountSlug: params.accountSlug,
+                      installationId,
+                    },
+                  }).catch((error) => {
+                    toast.error(getErrorMessage(error));
+                  });
+                }}
+                onSelectProject={(glProject) => {
+                  importGitLabProject({
+                    variables: {
+                      gitlabProjectId: glProject.id,
+                      accountSlug: params.accountSlug,
+                    },
+                  }).catch((error) => {
+                    toast.error(getErrorMessage(error));
+                  });
+                }}
+              />
+            </Card>
+          </section>
+          <Separator
+            orientation="vertical"
+            className="self-stretch max-lg:hidden"
+          />
+          <Separator orientation="horizontal" className="w-full lg:hidden" />
+          <section className="flex flex-1 flex-col gap-4">
+            <h2 className="text-xl font-medium">
+              Create a project without Git
+            </h2>
+            <CreateProjectForm accountSlug={params.accountSlug} />
+          </section>
         </div>
       </PageContainer>
     </Page>


### PR DESCRIPTION
## What

Adds the ability to create an Argos project **without connecting GitHub or GitLab**. Previously the only way to create a project was to import a repository from a Git provider.

## Changes

### Backend

- New `createProject(input: CreateProjectInput!): Project!` mutation. It requires `admin` permission on the target account, validates the project name (reserved/duplicate), and creates a project with no `githubRepositoryId`/`gitlabProjectId`.
- `notifyProjectCreation` now supports a `null` source (the Discord notification reads "created without a Git provider").
- e2e tests covering: happy path (asserts the row has no repo ids), duplicate-name field error, non-admin forbidden, and unauthenticated.

A repo-less project is already a supported state — the project settings page lets you link a GitHub/GitLab repository afterwards.

### Frontend

- Reworked the **New Project** page into a responsive two-column layout:
  - **Import a Git repository** — the existing provider flow.
  - **Create a project without Git** — a simple name form; on success it navigates to the new project.
- Stacks vertically when there isn't enough horizontal space; provider buttons are smaller with tighter spacing.

## Notes

- Generated GraphQL types are gitignored and regenerated by codegen, so they are not part of this diff.

## Test plan

- [x] `check-types` (backend + frontend)
- [x] `eslint --max-warnings 0` on changed files
- [x] backend e2e `createProject.e2e.test.ts` — 4 tests passing
- [ ] Manual: create a project from a name on the New Project page, then link a repo from settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
