### PR TITLE
feat: ignore nothing on new builds when the ignore feature is disabled

### DIFF
--- a/apps/backend/src/screenshot-diff/computeScreenshotDiff.e2e.test.ts
+++ b/apps/backend/src/screenshot-diff/computeScreenshotDiff.e2e.test.ts
@@ -250,6 +250,48 @@ describe("#computeScreenshotDiff", () => {
       });
       expect(ignoredChange).toBeFalsy();
     });
+
+    test("does not apply existing ignored changes when the ignore feature is disabled", async ({
+      fixture,
+    }) => {
+      // Compute a first diff to learn its fingerprint.
+      await computeScreenshotDiff(screenshotDiff, {
+        s3: fixture.s3,
+        bucket: config.get("s3.screenshotsBucket"),
+      });
+      await screenshotDiff.reload();
+      expect(screenshotDiff.fingerprint).toBeTruthy();
+
+      // Register that fingerprint as an ignored change. With the feature
+      // enabled this would mark matching diffs as ignored.
+      await IgnoredChange.query().insert({
+        projectId: fixture.project.id,
+        testId: screenshotTest.id,
+        fingerprint: screenshotDiff.fingerprint!,
+      });
+
+      // Disable the ignore feature for the project.
+      await fixture.project.$query().patch({
+        ignoreConfig: { enabled: false },
+      });
+
+      // A new build computing the same change must not be ignored.
+      const secondScreenshotDiff = await factory.ScreenshotDiff.create({
+        buildId: fixture.build.id,
+        baseScreenshotId: screenshotDiff.baseScreenshotId,
+        compareScreenshotId: screenshotDiff.compareScreenshotId,
+        jobStatus: "pending",
+        testId: screenshotTest.id,
+      });
+
+      await computeScreenshotDiff(secondScreenshotDiff, {
+        s3: fixture.s3,
+        bucket: config.get("s3.screenshotsBucket"),
+      });
+      await secondScreenshotDiff.reload();
+
+      expect(secondScreenshotDiff.ignored).toBe(false);
+    });
   });
 
   describe("with two same screenshots", () => {

--- a/apps/backend/src/screenshot-diff/computeScreenshotDiff.ts
+++ b/apps/backend/src/screenshot-diff/computeScreenshotDiff.ts
@@ -106,12 +106,13 @@ export async function computeScreenshotDiff(
     : null;
 
   // Resolve the project's ignore configuration. When the ignore feature is
-  // disabled, auto-ignore is also disabled (existing ignored changes are still
-  // applied so previously ignored diffs stay ignored).
+  // disabled, new builds ignore nothing: existing ignored changes are not
+  // applied and auto-ignore is disabled. Previously computed builds keep their
+  // persisted `ignored` flag, so they are not affected.
   const ignoreConfig = resolveIgnoreConfig(build.project?.ignoreConfig);
 
   const ignoredChange =
-    diffFile && !diffFile.isCreated
+    ignoreConfig.enabled && diffFile && !diffFile.isCreated
       ? await IgnoredChange.query().select("fingerprint").findOne({
           projectId: build.projectId,
           testId: screenshotDiff.testId,

--- a/apps/frontend/src/containers/Project/Ignore.tsx
+++ b/apps/frontend/src/containers/Project/Ignore.tsx
@@ -89,9 +89,9 @@ function IgnoreFeatureCard(props: { project: Project }) {
           <CardTitle>Ignore changes</CardTitle>
           <CardParagraph>
             Let reviewers mark recurring or flaky changes as ignored so they no
-            longer require review. When disabled, changes can no longer be
-            ignored and automatic flaky-change detection is turned off. Changes
-            that were already ignored stay ignored.
+            longer require review. When disabled, new builds ignore nothing —
+            every change is treated as not ignored and auto-ignore is turned
+            off. Previous builds are not affected.
           </CardParagraph>
           <FormSwitch
             control={form.control}

--- a/apps/frontend/src/containers/Project/Ignore.tsx
+++ b/apps/frontend/src/containers/Project/Ignore.tsx
@@ -90,8 +90,8 @@ function IgnoreFeatureCard(props: { project: Project }) {
           <CardParagraph>
             Let reviewers mark recurring or flaky changes as ignored so they no
             longer require review. When disabled, changes can no longer be
-            ignored and previously ignored changes are treated as regular
-            changes again.
+            ignored and automatic flaky-change detection is turned off. Changes
+            that were already ignored stay ignored.
           </CardParagraph>
           <FormSwitch
             control={form.control}


### PR DESCRIPTION
## Behavior

When a project disables the ignore feature, **new builds ignore nothing**:

- Existing `IgnoredChange` records are no longer applied at compute time ([computeScreenshotDiff.ts](apps/backend/src/screenshot-diff/computeScreenshotDiff.ts) — the `IgnoredChange` lookup is now gated on `ignoreConfig.enabled`).
- Auto-ignore stays off (already the case).

**Previous builds are untouched.** The `ignored` flag is a persisted column on `screenshot_diffs`, written once when a diff is computed. We only change the compute-time path, and leave the on-the-fly status derivation (`$getDiffStatus`, `selectDiffStatus`/`sortDiffByStatus`) alone — so already-computed diffs keep their stored `ignored` value and historical builds still show "X ignored".

## Copy

The settings card previously claimed (incorrectly) that disabling treats *previously* ignored changes as regular changes. Updated to:

> When disabled, new builds ignore nothing — every change is treated as not ignored and auto-ignore is turned off. Previous builds are not affected.

## Tests

Added an e2e test: with the feature disabled, a new diff matching an existing `IgnoredChange` is **not** marked ignored. Existing compute tests still pass (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)