### PR TITLE
feat(api): enrich OpenAPI spec for GitBook reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,7 @@ tsconfig.tsbuildinfo
 # Storybook
 *storybook.log
 storybook-static
+# Generated OpenAPI specification
+/apps/backend/openapi.yaml
 # Claude
 .claude/settings.local.json

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,6 +20,7 @@
     "db:migrate:rollback": "knex migrate:rollback",
     "db:migrate:make": "knex migrate:make",
     "db:reset": "pnpm run db:drop && pnpm run db:create && pnpm run db:load",
+    "generate-openapi": "pnpm run build && node dist/api/bin/generate-openapi.js",
     "watch-server-worker": "node --watch ./dist/processes/proc/worker.js",
     "watch-server-web": "node --watch ./dist/processes/proc/web.js",
     "watch-server": "concurrently \"npm:watch-server-*\"",

--- a/apps/backend/src/api/bin/generate-openapi.ts
+++ b/apps/backend/src/api/bin/generate-openapi.ts
@@ -1,0 +1,22 @@
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { stringify } from "yaml";
+
+import { schema } from "../schema";
+
+/**
+ * Generate the OpenAPI specification from the Zod schema and write it to disk as
+ * YAML. Handy for debugging the spec or previewing it in an external tool (e.g.
+ * the Swagger editor or GitBook) without running the server.
+ *
+ * Usage: `node dist/api/bin/generate-openapi.js [output-path]`
+ * Defaults to `openapi.yaml` in the current working directory.
+ */
+const outputPath = resolve(process.cwd(), process.argv[2] ?? "openapi.yaml");
+
+const yamlSchema = stringify(schema, { aliasDuplicateObjects: false });
+
+writeFileSync(outputPath, yamlSchema);
+
+console.log(`OpenAPI specification written to ${outputPath}`);
+process.exit(0);

--- a/apps/backend/src/api/handlers/addCommentReaction.ts
+++ b/apps/backend/src/api/handlers/addCommentReaction.ts
@@ -18,6 +18,7 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { personalAccessTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 const AddReactionBodySchema = z.object({
@@ -27,6 +28,10 @@ const AddReactionBodySchema = z.object({
 export const addCommentReactionOperation = {
   operationId: "addCommentReaction",
   summary: "Add an emoji reaction to a comment",
+  description:
+    "Add an emoji reaction to a comment on behalf of the authenticated user.",
+  tags: ["Comments"],
+  security: personalAccessTokenAuth,
   requestParams: {
     path: z.object({
       owner: AccountSlug,

--- a/apps/backend/src/api/handlers/createBuild.ts
+++ b/apps/backend/src/api/handlers/createBuild.ts
@@ -30,6 +30,7 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { projectTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 /**
@@ -186,6 +187,11 @@ const ResponseSchema = z.object({
 
 export const createBuildOperation = {
   operationId: "createBuild",
+  summary: "Create a build",
+  description:
+    "Create a build and receive signed upload targets for its screenshots and Playwright traces. The response lists, for every file Argos doesn't already have, a secure `postUrl` with `fields` (or a legacy `putUrl`) to upload it to. Supports single and parallel builds.",
+  tags: ["Builds"],
+  security: projectTokenAuth,
   requestBody: {
     content: {
       "application/json": {

--- a/apps/backend/src/api/handlers/createComment.ts
+++ b/apps/backend/src/api/handlers/createComment.ts
@@ -32,6 +32,7 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { personalAccessTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 const CreateCommentBodySchema = z.object({
@@ -54,6 +55,10 @@ const CreateCommentBodySchema = z.object({
 export const createCommentOperation = {
   operationId: "createComment",
   summary: "Post a comment (or reply) on a build",
+  description:
+    "Post a comment on a build. Start a new thread, reply to an existing one with `threadId`, optionally anchor the comment to a screenshot diff, or attach it to your pending review with `addToReview`.",
+  tags: ["Comments"],
+  security: personalAccessTokenAuth,
   requestParams: {
     path: z.object({
       owner: AccountSlug,

--- a/apps/backend/src/api/handlers/createDeployment.ts
+++ b/apps/backend/src/api/handlers/createDeployment.ts
@@ -29,6 +29,7 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { projectTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 const FileEntrySchema = z.object({
@@ -67,6 +68,11 @@ const ResponseSchema = z.object({
 
 export const createDeploymentOperation = {
   operationId: "createDeployment",
+  summary: "Create a deployment",
+  description:
+    "Create a deployment and receive signed upload URLs for the files Argos doesn't already store. Files already present (matched by content hash) are reused and omitted from `uploadFiles`. The environment is inferred from the branch when omitted.",
+  tags: ["Deployments"],
+  security: projectTokenAuth,
   requestBody: {
     content: {
       "application/json": {

--- a/apps/backend/src/api/handlers/createReview.ts
+++ b/apps/backend/src/api/handlers/createReview.ts
@@ -33,6 +33,7 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { personalAccessTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 const SnapshotConclusionSchema = z.enum(["APPROVE", "REQUEST_CHANGES"]);
@@ -99,7 +100,11 @@ const CreateReviewBodySchema = z.object({
 
 export const createReviewOperation = {
   operationId: "createReview",
-  summary: "Create a review on a specified build",
+  summary: "Create a review on a build",
+  description:
+    "Submit a review on a build to approve or reject the changes it captured.",
+  tags: ["Reviews"],
+  security: personalAccessTokenAuth,
   requestParams: {
     path: z.object({
       owner: AccountSlug,

--- a/apps/backend/src/api/handlers/deleteComment.ts
+++ b/apps/backend/src/api/handlers/deleteComment.ts
@@ -16,11 +16,16 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { personalAccessTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 export const deleteCommentOperation = {
   operationId: "deleteComment",
   summary: "Delete a comment on a build",
+  description:
+    "Delete a comment on a build. Only the comment's author can delete it.",
+  tags: ["Comments"],
+  security: personalAccessTokenAuth,
   requestParams: {
     path: z.object({
       owner: AccountSlug,

--- a/apps/backend/src/api/handlers/dismissReview.ts
+++ b/apps/backend/src/api/handlers/dismissReview.ts
@@ -19,11 +19,16 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { personalAccessTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 export const dismissReviewOperation = {
   operationId: "dismissReview",
   summary: "Dismiss a submitted review on a build",
+  description:
+    "Dismiss a previously submitted review on a build, clearing its effect on the build's review status.",
+  tags: ["Reviews"],
+  security: personalAccessTokenAuth,
   requestParams: {
     path: z.object({
       owner: AccountSlug,

--- a/apps/backend/src/api/handlers/exchangeCliToken.ts
+++ b/apps/backend/src/api/handlers/exchangeCliToken.ts
@@ -9,6 +9,7 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { noAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 const CliTokenExchangeRequestSchema = z.object({
@@ -28,7 +29,9 @@ const CliTokenResponseSchema = z.object({
 
 export const exchangeCliTokenOperation = {
   operationId: "exchangeCliToken",
-  summary: "Exchange CLI authorization code for a token",
+  summary: "Exchange a CLI authorization code for a token",
+  tags: ["Authentication"],
+  security: noAuth,
   description:
     "Called by the CLI to exchange a PKCE authorization code for an API token.",
   requestBody: {

--- a/apps/backend/src/api/handlers/exchangeGitHubActionsOidcToken.ts
+++ b/apps/backend/src/api/handlers/exchangeGitHubActionsOidcToken.ts
@@ -10,6 +10,7 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { noAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 const GitHubActionsOidcExchangeRequestSchema = z.object({
@@ -40,9 +41,10 @@ const GitHubActionsOidcExchangeResponseSchema = z.object({
 export const exchangeGitHubActionsOidcTokenOperation = {
   operationId: "exchangeGitHubActionsOidcToken",
   summary: "Exchange a GitHub Actions OIDC token for an Argos token",
+  tags: ["Authentication"],
   description:
     "Called by GitHub Actions to exchange an OIDC token for a short-lived Argos project token.",
-  security: [],
+  security: noAuth,
   requestBody: {
     content: {
       "application/json": {

--- a/apps/backend/src/api/handlers/exchangeGitHubActionsTokenlessToken.ts
+++ b/apps/backend/src/api/handlers/exchangeGitHubActionsTokenlessToken.ts
@@ -12,6 +12,7 @@ import {
   serviceUnavailable,
   unauthorized,
 } from "../schema/util/error";
+import { noAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 const GitHubActionsTokenlessExchangeRequestSchema = z.object({
@@ -38,9 +39,10 @@ const GitHubActionsTokenlessExchangeResponseSchema = z.object({
 export const exchangeGitHubActionsTokenlessTokenOperation = {
   operationId: "exchangeGitHubActionsTokenlessToken",
   summary: "Exchange a tokenless GitHub Actions token for an Argos token",
+  tags: ["Authentication"],
   description:
     "Called by GitHub Actions to exchange a tokenless bearer token for a short-lived Argos project token. The provided commit and branch must match the GitHub workflow run.",
-  security: [],
+  security: noAuth,
   requestBody: {
     content: {
       "application/json": {

--- a/apps/backend/src/api/handlers/finalizeBuilds.ts
+++ b/apps/backend/src/api/handlers/finalizeBuilds.ts
@@ -20,6 +20,7 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { projectTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 const RequestBodySchema = z.object({ parallelNonce: z.string().min(1) });
@@ -28,6 +29,11 @@ const ResponseSchema = z.object({ builds: z.array(BuildSchema) });
 
 export const finalizeBuildsOperation = {
   operationId: "finalizeBuilds",
+  summary: "Finalize parallel builds",
+  description:
+    "Mark every parallel shard sharing the given `parallelNonce` as complete. Once finalized, Argos compares the aggregated screenshots and starts processing the build.",
+  tags: ["Builds"],
+  security: projectTokenAuth,
   requestBody: {
     content: {
       "application/json": {

--- a/apps/backend/src/api/handlers/finalizeDeployment.ts
+++ b/apps/backend/src/api/handlers/finalizeDeployment.ts
@@ -29,6 +29,7 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { projectTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 /**
@@ -180,6 +181,11 @@ async function updateDeploymentAliases(input: {
 
 export const finalizeDeploymentOperation = {
   operationId: "finalizeDeployment",
+  summary: "Finalize a deployment",
+  description:
+    "Mark a deployment as ready once all of its files have been uploaded. Argos assigns the deployment's aliases and starts serving it.",
+  tags: ["Deployments"],
+  security: projectTokenAuth,
   requestParams: {
     path: z.object({
       deploymentId: z.string().meta({ description: "The deployment ID" }),

--- a/apps/backend/src/api/handlers/getAuthProject.ts
+++ b/apps/backend/src/api/handlers/getAuthProject.ts
@@ -3,6 +3,7 @@ import { ZodOpenApiOperationObject } from "zod-openapi";
 import { getAuthProjectPayloadFromExpressReq } from "../auth/project";
 import { ProjectSchema, serializeProject } from "../schema/primitives/project";
 import { serverError, unauthorized } from "../schema/util/error";
+import { projectTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 const responses = {
@@ -20,6 +21,11 @@ const responses = {
 
 export const getAuthProjectOperation = {
   operationId: "getAuthProject",
+  summary: "Get the current project",
+  description:
+    "Retrieve the project associated with the project token used to authenticate the request.",
+  tags: ["Projects"],
+  security: projectTokenAuth,
   responses,
 } satisfies ZodOpenApiOperationObject;
 

--- a/apps/backend/src/api/handlers/getBuild.ts
+++ b/apps/backend/src/api/handlers/getBuild.ts
@@ -21,10 +21,16 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { anyTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 export const getBuildOperation = {
   operationId: "getBuild",
+  summary: "Get a build",
+  description:
+    "Retrieve a single build by its number within a project, including its status and metadata.",
+  tags: ["Builds"],
+  security: anyTokenAuth,
   requestParams: {
     path: z.object({
       owner: AccountSlug,

--- a/apps/backend/src/api/handlers/getBuildDiffs.ts
+++ b/apps/backend/src/api/handlers/getBuildDiffs.ts
@@ -22,6 +22,7 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { anyTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 const GetBuildDiffsParams = PageParamsSchema.extend({
@@ -46,6 +47,11 @@ const GetBuildDiffsParams = PageParamsSchema.extend({
 
 export const getBuildDiffsOperation = {
   operationId: "getBuildDiffs",
+  summary: "List a build's screenshot diffs",
+  description:
+    "List the screenshot diffs of a build, with pagination. Each diff compares a baseline screenshot to the one captured by the build. Use `onlyChanged` to return only the diffs that require review.",
+  tags: ["Builds"],
+  security: anyTokenAuth,
   requestParams: {
     path: z.object({
       owner: AccountSlug,

--- a/apps/backend/src/api/handlers/getComment.ts
+++ b/apps/backend/src/api/handlers/getComment.ts
@@ -19,11 +19,15 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { personalAccessTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 export const getCommentOperation = {
   operationId: "getComment",
   summary: "Get a single comment on a build",
+  description: "Retrieve a single comment on a build by its ID.",
+  tags: ["Comments"],
+  security: personalAccessTokenAuth,
   requestParams: {
     path: z.object({
       owner: AccountSlug,

--- a/apps/backend/src/api/handlers/getDeployment.ts
+++ b/apps/backend/src/api/handlers/getDeployment.ts
@@ -15,10 +15,15 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { projectTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 export const getDeploymentOperation = {
   operationId: "getDeployment",
+  summary: "Get a deployment",
+  description: "Retrieve a single deployment by its ID.",
+  tags: ["Deployments"],
+  security: projectTokenAuth,
   requestParams: {
     path: z.object({
       deploymentId: z.string().meta({ description: "The deployment ID" }),

--- a/apps/backend/src/api/handlers/getProject.ts
+++ b/apps/backend/src/api/handlers/getProject.ts
@@ -14,10 +14,16 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { anyTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 export const getProjectOperation = {
   operationId: "getProject",
+  summary: "Get a project",
+  description:
+    "Retrieve a project by its owner (account slug) and project name.",
+  tags: ["Projects"],
+  security: anyTokenAuth,
   requestParams: {
     path: z.object({
       owner: AccountSlug,

--- a/apps/backend/src/api/handlers/getProjectBuilds.ts
+++ b/apps/backend/src/api/handlers/getProjectBuilds.ts
@@ -17,6 +17,7 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { anyTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 const GetProjectBuildsParams = PageParamsSchema.extend({
@@ -42,6 +43,11 @@ const GetProjectBuildsParams = PageParamsSchema.extend({
 
 export const getProjectBuildsOperation = {
   operationId: "getProjectBuilds",
+  summary: "List a project's builds",
+  description:
+    "List the builds of a project, most recent first. Results are paginated. Use `distinctName` to return only the latest build per name and commit.",
+  tags: ["Builds"],
+  security: anyTokenAuth,
   requestParams: {
     path: z.object({
       owner: AccountSlug,

--- a/apps/backend/src/api/handlers/listComments.ts
+++ b/apps/backend/src/api/handlers/listComments.ts
@@ -14,11 +14,15 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { personalAccessTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 export const listCommentsOperation = {
   operationId: "listComments",
   summary: "List the comments on a build",
+  description: "List the comments on a build, with pagination.",
+  tags: ["Comments"],
+  security: personalAccessTokenAuth,
   requestParams: {
     path: z.object({
       owner: AccountSlug,

--- a/apps/backend/src/api/handlers/listReviews.ts
+++ b/apps/backend/src/api/handlers/listReviews.ts
@@ -17,11 +17,15 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { personalAccessTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 export const listReviewsOperation = {
   operationId: "listReviews",
   summary: "List the reviews submitted on a build",
+  description: "List the reviews submitted on a build, with pagination.",
+  tags: ["Reviews"],
+  security: personalAccessTokenAuth,
   requestParams: {
     path: z.object({
       owner: AccountSlug,

--- a/apps/backend/src/api/handlers/removeCommentReaction.ts
+++ b/apps/backend/src/api/handlers/removeCommentReaction.ts
@@ -18,11 +18,16 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { personalAccessTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 export const removeCommentReactionOperation = {
   operationId: "removeCommentReaction",
   summary: "Remove an emoji reaction from a comment",
+  description:
+    "Remove an emoji reaction previously added by the authenticated user from a comment.",
+  tags: ["Comments"],
+  security: personalAccessTokenAuth,
   requestParams: {
     path: z.object({
       owner: AccountSlug,

--- a/apps/backend/src/api/handlers/resolveCommentThread.ts
+++ b/apps/backend/src/api/handlers/resolveCommentThread.ts
@@ -21,6 +21,7 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { personalAccessTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 const PathParams = z.object({
@@ -35,6 +36,9 @@ const PathParams = z.object({
 export const resolveCommentThreadOperation = {
   operationId: "resolveCommentThread",
   summary: "Mark a comment thread as resolved",
+  description: "Mark a comment thread as resolved.",
+  tags: ["Comments"],
+  security: personalAccessTokenAuth,
   requestParams: { path: PathParams },
   responses: {
     "200": {
@@ -56,6 +60,9 @@ export const resolveCommentThreadOperation = {
 export const unresolveCommentThreadOperation = {
   operationId: "unresolveCommentThread",
   summary: "Reopen a resolved comment thread",
+  description: "Reopen a previously resolved comment thread.",
+  tags: ["Comments"],
+  security: personalAccessTokenAuth,
   requestParams: { path: PathParams },
   responses: {
     "200": {

--- a/apps/backend/src/api/handlers/resolveDeploymentDomain.ts
+++ b/apps/backend/src/api/handlers/resolveDeploymentDomain.ts
@@ -9,6 +9,7 @@ import {
 import { boom } from "@/util/error";
 
 import { invalidParameters, notFound, serverError } from "../schema/util/error";
+import { noAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 const ResponseSchema = z.object({
@@ -23,7 +24,11 @@ const CACHE_CONTROL =
 
 export const resolveDeploymentDomainOperation = {
   operationId: "resolveDeploymentDomain",
-  security: [],
+  summary: "Resolve a deployment domain",
+  description:
+    "Resolve a deployment domain or URL to the deployment it currently serves. This endpoint is public and does not require authentication.",
+  tags: ["Deployments"],
+  security: noAuth,
   requestParams: {
     path: z.object({
       domain: z.string().meta({ description: "A deployment domain or URL" }),

--- a/apps/backend/src/api/handlers/subscribeCommentThread.ts
+++ b/apps/backend/src/api/handlers/subscribeCommentThread.ts
@@ -21,6 +21,7 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { personalAccessTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 const PathParams = z.object({
@@ -35,6 +36,10 @@ const PathParams = z.object({
 export const subscribeCommentThreadOperation = {
   operationId: "subscribeCommentThread",
   summary: "Subscribe to a comment thread's notifications",
+  description:
+    "Subscribe the authenticated user to a comment thread to receive notifications about new replies.",
+  tags: ["Comments"],
+  security: personalAccessTokenAuth,
   requestParams: { path: PathParams },
   responses: {
     "200": {
@@ -56,6 +61,10 @@ export const subscribeCommentThreadOperation = {
 export const unsubscribeCommentThreadOperation = {
   operationId: "unsubscribeCommentThread",
   summary: "Unsubscribe from a comment thread's notifications",
+  description:
+    "Unsubscribe the authenticated user from a comment thread's notifications.",
+  tags: ["Comments"],
+  security: personalAccessTokenAuth,
   requestParams: { path: PathParams },
   responses: {
     "200": {

--- a/apps/backend/src/api/handlers/updateBuild.ts
+++ b/apps/backend/src/api/handlers/updateBuild.ts
@@ -28,6 +28,7 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { projectTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 const RequestBodySchema = z.object({
@@ -45,6 +46,11 @@ type RequestBody = z.infer<typeof RequestBodySchema>;
 
 export const updateBuildOperation = {
   operationId: "updateBuild",
+  summary: "Update a build",
+  description:
+    "Add screenshots to an existing build and update its metadata. Used to push the screenshots of a parallel shard, identified by `parallelIndex` and `parallelTotal`.",
+  tags: ["Builds"],
+  security: projectTokenAuth,
   requestParams: {
     path: z.object({
       buildId: BuildIdSchema,

--- a/apps/backend/src/api/handlers/updateComment.ts
+++ b/apps/backend/src/api/handlers/updateComment.ts
@@ -21,6 +21,7 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
+import { personalAccessTokenAuth } from "../schema/util/security";
 import { CreateAPIHandler } from "../util";
 
 const UpdateCommentBodySchema = z.object({
@@ -30,6 +31,10 @@ const UpdateCommentBodySchema = z.object({
 export const updateCommentOperation = {
   operationId: "updateComment",
   summary: "Update a comment on a build",
+  description:
+    "Update the body of a comment on a build. Only the comment's author can edit it.",
+  tags: ["Comments"],
+  security: personalAccessTokenAuth,
   requestParams: {
     path: z.object({
       owner: AccountSlug,

--- a/apps/backend/src/api/schema.ts
+++ b/apps/backend/src/api/schema.ts
@@ -37,10 +37,45 @@ import { updateBuildOperation } from "./handlers/updateBuild";
 import { updateCommentOperation } from "./handlers/updateComment";
 
 export const zodSchema = {
-  openapi: "3.1.1",
+  openapi: "3.2.0",
   info: {
     title: "Argos API",
     version: "2.0.0",
+    description: [
+      "The Argos API lets you create and inspect visual testing builds, review",
+      "screenshot diffs, collaborate through comments, and ship deployments.",
+      "",
+      "## Authentication",
+      "",
+      "Requests are authenticated with a bearer token in the `Authorization`",
+      "header:",
+      "",
+      "```http",
+      "Authorization: Bearer <token>",
+      "```",
+      "",
+      "Two kinds of token exist, and each endpoint documents which one it",
+      "accepts:",
+      "",
+      "- **Project token** — identifies a project. Used by CI and the SDK to",
+      "  create builds and deployments. Find it in your Argos project settings.",
+      "- **Personal access token** — identifies a user. Required by endpoints",
+      "  that perform user actions, such as reviewing builds and posting",
+      "  comments.",
+      "",
+      "A few endpoints are public, including those under **Authentication** used",
+      "to obtain a token in the first place.",
+    ].join("\n"),
+    contact: {
+      name: "Argos Support",
+      url: "https://argos-ci.com",
+      email: "contact@argos-ci.com",
+    },
+    termsOfService: "https://argos-ci.com/terms",
+  },
+  externalDocs: {
+    description: "Argos API reference",
+    url: "https://argos-ci.com/docs/api-reference",
   },
   servers: [
     {
@@ -48,17 +83,85 @@ export const zodSchema = {
       description: "API Endpoint",
     },
   ],
+  tags: [
+    {
+      name: "Authentication",
+      description:
+        "Exchange CI and CLI credentials for an Argos project token. Use these endpoints to obtain the bearer token that authenticates every other request.",
+      "x-page-icon": "key",
+    },
+    {
+      name: "Projects",
+      description:
+        "Retrieve project metadata, either by slug or for the project tied to the current token.",
+      "x-page-icon": "folder-open",
+    },
+    {
+      name: "Builds",
+      description:
+        "Create, finalize, update, and inspect visual testing builds, including their screenshot diffs. This is the core of the visual testing workflow.",
+      "x-page-icon": "images",
+    },
+    {
+      name: "Reviews",
+      description:
+        "Submit, list, and dismiss reviews to approve or reject the changes captured in a build.",
+      "x-page-icon": "clipboard-check",
+    },
+    {
+      name: "Comments",
+      description:
+        "Collaborate on builds with threaded comments: post and edit comments, react with emojis, resolve threads, and manage notification subscriptions.",
+      "x-page-icon": "comments",
+    },
+    {
+      name: "Deployments",
+      description:
+        "Create, finalize, and resolve deployments to publish and serve project artifacts.",
+      "x-page-icon": "rocket",
+    },
+  ],
   components: {
     securitySchemes: {
-      tokenAuth: {
+      projectToken: {
         type: "http",
         scheme: "bearer",
         bearerFormat: "Project Token",
-        description: "A project token is required to access the API.",
+        description: [
+          "Authenticate as a **project** with a project token.",
+          "",
+          "Send it as a bearer token in the `Authorization` header:",
+          "",
+          "```http",
+          "Authorization: Bearer <project-token>",
+          "```",
+          "",
+          "You can find your project token in your Argos project settings.",
+          "Project tokens are used by CI and the SDK to create builds and",
+          "deployments.",
+        ].join("\n"),
+      },
+      personalAccessToken: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "Personal Access Token",
+        description: [
+          "Authenticate as a **user** with a personal access token.",
+          "",
+          "Send it as a bearer token in the `Authorization` header:",
+          "",
+          "```http",
+          "Authorization: Bearer <personal-access-token>",
+          "```",
+          "",
+          "Personal access tokens act on behalf of the user that created them",
+          "and are required by endpoints that perform user actions, such as",
+          "reviewing builds and posting comments.",
+        ].join("\n"),
       },
     },
   },
-  security: [{ tokenAuth: [] }],
+  security: [{ projectToken: [] }],
   paths: {
     "/builds": {
       post: createBuildOperation,

--- a/apps/backend/src/api/schema/util/security.ts
+++ b/apps/backend/src/api/schema/util/security.ts
@@ -1,0 +1,38 @@
+/**
+ * Security requirements referencing the security schemes declared in
+ * `schema.ts` (`projectToken` and `personalAccessToken`). Operations use these
+ * to document, per endpoint, which kind of token authenticates the request.
+ *
+ * This mirrors OpenAPI's `SecurityRequirementObject[]`, typed structurally so
+ * the operations that consume it stay portable (the underlying type is not
+ * exported from `zod-openapi`).
+ */
+type Security = Record<string, string[]>[];
+
+/**
+ * Authenticate with a **project token**. Used by the build and deployment
+ * endpoints that act on behalf of a project (typically from CI or the SDK).
+ */
+export const projectTokenAuth: Security = [{ projectToken: [] }];
+
+/**
+ * Authenticate with a **personal access token**. Used by endpoints that perform
+ * user actions (reviews and comments), where the acting user's identity
+ * matters.
+ */
+export const personalAccessTokenAuth: Security = [{ personalAccessToken: [] }];
+
+/**
+ * Accept **either** a project token or a personal access token. Used by
+ * read-only endpoints that are reachable from both CI and a user.
+ */
+export const anyTokenAuth: Security = [
+  { projectToken: [] },
+  { personalAccessToken: [] },
+];
+
+/**
+ * **No authentication.** Used by public endpoints and by the token-exchange
+ * endpoints that mint a token in the first place.
+ */
+export const noAuth: Security = [];


### PR DESCRIPTION
## What

Makes the Argos API a first-class, browsable reference in GitBook by enriching the OpenAPI spec generated from `apps/backend/src/api/schema.ts` and the operation handlers.

### Changes

- **Tags & grouping** — every operation is grouped under a tag: `Authentication`, `Projects`, `Builds`, `Reviews`, `Comments`, `Deployments`. Each tag has a description and a Font Awesome `x-page-icon` (GitBook navigation icon).
- **Summaries & descriptions** — every operation now has a `summary` and a `description`.
- **Document-level info** — added an `info.description` with an authentication guide (Markdown), `contact`, `termsOfService`, and `externalDocs` pointing at https://argos-ci.com/docs/api-reference.
- **Per-endpoint authentication** — split the single bearer scheme into two documented security schemes:
  - `projectToken` — project-scoped, used by CI/SDK to create builds & deployments.
  - `personalAccessToken` — user-scoped, required by review & comment endpoints.

  Each operation now advertises which token it accepts via a shared helper (`schema/util/security.ts`): `projectTokenAuth`, `personalAccessTokenAuth`, `anyTokenAuth`, or `noAuth` (public endpoints). This mirrors the actual auth enforced in the handlers.
- **OpenAPI 3.2.0** — upgraded from 3.1.1 (supported by `zod-openapi` v6).
- **Generation script** — `pnpm --filter @argos/backend generate-openapi` builds and dumps the spec to `openapi.yaml` for debugging / previewing. The output file is gitignored.

## Verification

- `tsc --noEmit` clean for `src/api` (pre-existing unrelated errors in `graphql/definitions/Project.ts` remain).
- `eslint src/api --max-warnings 0` passes.
- Generated the spec and confirmed: `openapi: 3.2.0`, both security schemes present, all 6 tags with icons, all 29 operations carry a summary + description, and per-endpoint security matches handler auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)