### PR TITLE
feat(comment): show ignored snapshots in PR comment details

### DIFF
--- a/apps/backend/src/build/stats.ts
+++ b/apps/backend/src/build/stats.ts
@@ -22,5 +22,8 @@ export function getStatsMessage(
   if (stats.failure > 0) {
     parts.push(`${stats.failure} failure${stats.failure > 1 ? "s" : ""}`);
   }
+  if (stats.ignored > 0) {
+    parts.push(`${stats.ignored} ignored`);
+  }
   return parts.join(", ");
 }

--- a/apps/backend/src/git-platform/comment.e2e.test.ts
+++ b/apps/backend/src/git-platform/comment.e2e.test.ts
@@ -129,6 +129,40 @@ describe("getCommentBody", () => {
     expect(body).not.toContain(olderDeployment.url);
   });
 
+  test("shows ignored screenshots in the build details column", async ({
+    project,
+  }) => {
+    const compareBucket = await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      commit,
+    });
+    const build = await factory.Build.create({
+      projectId: project.id,
+      compareScreenshotBucketId: compareBucket.id,
+      name: "default",
+      jobStatus: "complete",
+      conclusion: "no-changes",
+      updatedAt: "2026-05-07T12:00:00.000Z",
+      stats: {
+        failure: 0,
+        added: 0,
+        unchanged: 0,
+        changed: 4,
+        removed: 0,
+        total: 7,
+        retryFailure: 0,
+        ignored: 3,
+      },
+    });
+
+    const buildUrl = await build.getUrl();
+    const body = await getCommentBody({ commit });
+
+    expect(body).toContain(
+      `| **default** ([Inspect](${buildUrl})) | ✅ No changes detected | 4 changed, 3 ignored | May 7, 2026, 12:00 PM |`,
+    );
+  });
+
   test("prefixes rows when multiple projects share the commit", async ({
     project,
   }) => {


### PR DESCRIPTION
## Summary

The PR comment build table didn't surface ignored screenshots. This adds the ignored count to the build stats message, so it now appears in the **Details** column of the table.

A build now reads e.g.:
> 16 changed, 12 added, 2 removed, 2 failures, **3 ignored**

## Changes

- `getStatsMessage` now appends `N ignored` when `stats.ignored > 0`.
- Since `getStatsMessage` is shared, the ignored count also shows wherever build stats are rendered (Slack unfurls, Slack automation blocks, build notifications) — consistent behavior.
- Added an e2e test asserting the ignored count renders in the build row's Details column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)