### PR TITLE
feat(account): add account-wide flaky Tests page

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ pnpm-lock.yaml
 pnpm-workspace.yaml
 /skills
 .agents
+.claude/worktrees

--- a/apps/backend/src/graphql/definitions/Account.ts
+++ b/apps/backend/src/graphql/definitions/Account.ts
@@ -37,6 +37,8 @@ import {
 import type { Context } from "../context";
 import { getAdminAccount } from "../services/account";
 import { getAccountAvatar } from "../services/avatar";
+import { getVisibleProjectIds } from "../services/project";
+import { queryActiveTests } from "../services/test";
 import { badUserInput, unauthenticated } from "../util";
 import { paginateResult } from "./PageInfo";
 
@@ -137,6 +139,13 @@ export const typeDefs = gql`
     hasForcedPlan: Boolean!
     permissions: [AccountPermission!]!
     projects(after: Int = 0, first: Int = 30): ProjectConnection!
+    "List all tests across the account's visible projects, sorted by flakiness."
+    tests(
+      after: Int = 0
+      first: Int = 30
+      period: MetricsPeriod!
+      filters: TestsFilterInput
+    ): TestConnection!
     avatar: AccountAvatar!
     gitlabAccessToken: String
     gitlabBaseUrl: String
@@ -324,6 +333,27 @@ export const commonAccountResolvers: IResolvers["Team"] = {
       default:
         assertNever(account.type);
     }
+  },
+  tests: async (account, { first, after, period, filters }, ctx) => {
+    const { auth } = ctx;
+    if (!auth) {
+      throw unauthenticated();
+    }
+    const projectIds = await getVisibleProjectIds({
+      account,
+      user: auth.user,
+    });
+    if (projectIds.length === 0) {
+      return { pageInfo: { totalCount: 0, hasNextPage: false }, edges: [] };
+    }
+    const result = await queryActiveTests({
+      projectIds,
+      period,
+      filters: filters ?? null,
+      after,
+      first,
+    });
+    return paginateResult({ result, first, after });
   },
   consumptionRatio: async (account) => {
     const manager = account.$getSubscriptionManager();

--- a/apps/backend/src/graphql/definitions/Account.ts
+++ b/apps/backend/src/graphql/definitions/Account.ts
@@ -8,7 +8,7 @@ import { disconnectGitHubAuth } from "@/auth/github";
 import { disconnectGitLabAuth } from "@/auth/gitlab";
 import { disconnectGoogleAuth } from "@/auth/google";
 import { startSession } from "@/auth/login";
-import { Account, Project, ProjectUser, TeamUser } from "@/database/models";
+import { Account, Project } from "@/database/models";
 import {
   authenticateWithEmail,
   checkAccountSlug,
@@ -37,7 +37,10 @@ import {
 import type { Context } from "../context";
 import { getAdminAccount } from "../services/account";
 import { getAccountAvatar } from "../services/avatar";
-import { getVisibleProjectIds } from "../services/project";
+import {
+  applyProjectVisibility,
+  getVisibleProjectIds,
+} from "../services/project";
 import { queryActiveTests } from "../services/test";
 import { badUserInput, unauthenticated } from "../util";
 import { paginateResult } from "./PageInfo";
@@ -262,77 +265,25 @@ export const commonAccountResolvers: IResolvers["Team"] = {
     if (!auth) {
       throw unauthenticated();
     }
-    const projectsQuery = Project.query()
-      .where("accountId", account.id)
-      // Sort by most recently created project or build
-      .orderByRaw(
-        `greatest(projects."createdAt", (select max("createdAt") from builds where builds."projectId" = projects.id)) desc`,
-      )
-      .range(args.after, args.after + args.first - 1);
-
-    // Staff can view all projects
-    if (auth.user.staff) {
-      const result = await projectsQuery;
-      return paginateResult({
-        after: args.after,
-        first: args.first,
-        result,
-      });
+    const query = applyProjectVisibility(
+      Project.query()
+        .where("accountId", account.id)
+        // Sort by most recently created project or build
+        .orderByRaw(
+          `greatest(projects."createdAt", (select max("createdAt") from builds where builds."projectId" = projects.id)) desc`,
+        )
+        .range(args.after, args.after + args.first - 1),
+      { account, user: auth.user },
+    );
+    if (!query) {
+      throw unauthenticated();
     }
-
-    switch (account.type) {
-      case "user": {
-        if (account.userId !== auth.user.id) {
-          throw unauthenticated();
-        }
-
-        const result = await projectsQuery;
-        return paginateResult({
-          after: args.after,
-          first: args.first,
-          result,
-        });
-      }
-      case "team": {
-        const teamUserQuery = TeamUser.query().where({
-          teamId: account.teamId,
-          userId: auth.user.id,
-        });
-
-        const result = await projectsQuery.where((qb) => {
-          // User is a team member or owner
-          qb.whereExists(
-            teamUserQuery
-              .select(1)
-              .clone()
-              .whereIn("userLevel", ["owner", "member"]),
-          ).orWhere((qb) => {
-            // User is a contributor
-            qb.whereExists(
-              teamUserQuery.select(1).clone().where("userLevel", "contributor"),
-            ).where((qb) => {
-              // And is a contributor to the project
-              qb.whereExists(
-                ProjectUser.query()
-                  .select(1)
-                  .whereRaw(`projects.id = project_users."projectId"`)
-                  .where("userId", auth.user.id),
-              )
-                // Or where there is a default user level set on the project
-                .orWhereNotNull("projects.defaultUserLevel");
-            });
-          });
-        });
-
-        return paginateResult({
-          after: args.after,
-          first: args.first,
-          result,
-        });
-      }
-      default:
-        assertNever(account.type);
-    }
+    const result = await query;
+    return paginateResult({
+      after: args.after,
+      first: args.first,
+      result,
+    });
   },
   tests: async (account, { first, after, period, filters }, ctx) => {
     const { auth } = ctx;

--- a/apps/backend/src/graphql/definitions/Project.ts
+++ b/apps/backend/src/graphql/definitions/Project.ts
@@ -17,8 +17,6 @@ import {
   Project,
   ProjectUser,
   Screenshot,
-  ScreenshotDiff,
-  Test,
   User,
 } from "@/database/models";
 import {
@@ -35,7 +33,6 @@ import { notifyDiscord } from "@/discord";
 import { getInstallationOctokit } from "@/github/client";
 import { formatGlProject, getGitlabClientFromAccount } from "@/gitlab";
 import { getOrCreateGithubRepository } from "@/graphql/services/github";
-import { getStartDateFromPeriod } from "@/metrics/test";
 import { HTTPError } from "@/util/error";
 
 import {
@@ -46,7 +43,7 @@ import {
   IResolvers,
 } from "../__generated__/resolver-types";
 import { deleteProject, getAdminProject } from "../services/project";
-import { safeParseTestId } from "../services/test";
+import { queryActiveTests, safeParseTestId } from "../services/test";
 import { badUserInput, forbidden, unauthenticated } from "../util";
 import { paginateResult } from "./PageInfo";
 
@@ -703,102 +700,13 @@ export const resolvers: IResolvers = {
       return test;
     },
     tests: async (project, { first, after, period, filters }) => {
-      const search = filters?.search?.trim();
-      const latestRef = Build.query()
-        .alias("b")
-        .select("b.id", "b.projectId", "b.name")
-        .distinctOn(["b.projectId", "b.name"])
-        .where("b.type", "reference")
-        .where("b.projectId", project.id)
-        .orderBy("b.projectId")
-        .orderBy("b.name")
-        .orderBy("b.createdAt", "desc")
-        .as("latest_reference_build");
-
-      const activeTests = ScreenshotDiff.query()
-        .alias("sd")
-        .distinct("sd.testId")
-        .join(latestRef, "latest_reference_build.id", "sd.buildId")
-        .whereNotNull("sd.testId")
-        .joinRelated("compareScreenshot")
-        .whereNull("compareScreenshot.parentName")
-        .modify((query) => {
-          if (search) {
-            query.whereILike("compareScreenshot.name", `%${search}%`);
-          }
-        })
-        .as("active_tests");
-
-      const result = await Test.query()
-        .where("tests.projectId", project.id)
-        .where((qb) => {
-          if (filters?.buildName) {
-            qb.where("tests.buildName", filters.buildName);
-          }
-        })
-        // only ongoing
-        .join(activeTests, "active_tests.testId", "tests.id")
-        .orderByRaw(
-          `
-    (
-      with
-        totals as (
-          select sum(tsb.value)::numeric as total
-          from test_stats_builds tsb
-          where tsb."testId" = "tests"."id"
-            and tsb."date" >= :from::timestamp
-            and tsb."date" <  :to::timestamp
-        ),
-        fp_agg as (
-          select
-            tsf."fingerprint",
-            sum(tsf.value)::numeric as changes_value,
-            count(*) as fp_count
-          from test_stats_fingerprints tsf
-          where tsf."testId" = "tests"."id"
-            and tsf."date" >= :from::timestamp
-            and tsf."date" <  :to::timestamp
-          group by tsf."fingerprint"
-        ),
-        changes as (
-          select
-            sum(changes_value)::numeric as changes,
-            count(*) filter (where fp_count = 1)::numeric as "uniqueChanges"
-          from fp_agg
-        )
-      select
-        round(
-          (
-            1 - (
-              (
-                case
-                  when coalesce(changes.changes, 0) > 0
-                    then 1 - changes.changes / nullif(totals.total, 0)
-                  else 1
-                end
-              +
-                case
-                  when coalesce(changes.changes, 0) > 0
-                    then coalesce(changes."uniqueChanges", 0) / nullif(changes.changes, 0)
-                  else 1
-                end
-              ) / 2
-            )
-          ),
-          2
-        )
-      from totals, changes
-    ) desc,
-    "tests"."createdAt" desc,
-    "tests"."id" desc
-    `,
-          {
-            from: getStartDateFromPeriod(period).toISOString(),
-            to: new Date().toISOString(),
-          },
-        )
-        .range(after, after + first - 1);
-
+      const result = await queryActiveTests({
+        projectIds: [project.id],
+        period,
+        filters: filters ?? null,
+        after,
+        first,
+      });
       return paginateResult({ result, first, after });
     },
     deployments: async (project, { first, after }) => {

--- a/apps/backend/src/graphql/definitions/Team.ts
+++ b/apps/backend/src/graphql/definitions/Team.ts
@@ -92,6 +92,12 @@ export const typeDefs = gql`
     canExtendTrial: Boolean!
     permissions: [AccountPermission!]!
     projects(after: Int = 0, first: Int = 30): ProjectConnection!
+    tests(
+      after: Int = 0
+      first: Int = 30
+      period: MetricsPeriod!
+      filters: TestsFilterInput
+    ): TestConnection!
     avatar: AccountAvatar!
     hasForcedPlan: Boolean!
     gitlabAccessToken: String

--- a/apps/backend/src/graphql/definitions/Test.ts
+++ b/apps/backend/src/graphql/definitions/Test.ts
@@ -82,6 +82,7 @@ export const typeDefs = gql`
     name: String!
     buildName: String!
     status: TestStatus!
+    project: Project!
     screenshot: Screenshot
     firstSeenDiff: ScreenshotDiff
     lastSeenDiff: ScreenshotDiff
@@ -123,6 +124,11 @@ export const resolvers: IResolvers = {
       const project = await ctx.loaders.Project.load(test.projectId);
       invariant(project);
       return formatTestId({ projectName: project.name, testId: test.id });
+    },
+    project: async (test, _args, ctx) => {
+      const project = await ctx.loaders.Project.load(test.projectId);
+      invariant(project);
+      return project;
     },
     status: async (test, _args, ctx) => {
       return ctx.loaders.TestStatusLoader.load({

--- a/apps/backend/src/graphql/definitions/User.ts
+++ b/apps/backend/src/graphql/definitions/User.ts
@@ -81,6 +81,12 @@ export const typeDefs = gql`
     canExtendTrial: Boolean!
     permissions: [AccountPermission!]!
     projects(after: Int = 0, first: Int = 30): ProjectConnection!
+    tests(
+      after: Int = 0
+      first: Int = 30
+      period: MetricsPeriod!
+      filters: TestsFilterInput
+    ): TestConnection!
     avatar: AccountAvatar!
     hasForcedPlan: Boolean!
     gitlabAccessToken: String

--- a/apps/backend/src/graphql/services/project.ts
+++ b/apps/backend/src/graphql/services/project.ts
@@ -1,5 +1,6 @@
+import { assertNever } from "@argos/util/assertNever";
 import { invariant } from "@argos/util/invariant";
-import { TransactionOrKnex } from "objection";
+import { QueryBuilder, TransactionOrKnex } from "objection";
 
 import {
   Account,
@@ -91,45 +92,37 @@ export async function getAdminProject(args: {
 }
 
 /**
- * Resolve the ids of the projects an authenticated user can see within an
- * account, applying the same visibility rules as the `Account.projects`
- * resolver:
+ * Apply the project-visibility rules for a user to a `Project` query, returning
+ * the filtered query — or `null` when the user can see no project at all, so the
+ * caller can decide whether to throw or return an empty result.
+ *
+ * This is the single source of truth shared by the `Account.projects` resolver
+ * and {@link getVisibleProjectIds}:
  * - staff see every project
  * - on a user account, only the owner
  * - on a team, owners/members see all; contributors see projects they are a
  *   contributor on (or that expose a default user level)
- *
- * Returns an empty array when the user can see nothing, so callers can short
- * circuit without a query.
  */
-export async function getVisibleProjectIds(args: {
-  account: Account;
-  user: { id: string; staff: boolean };
-}): Promise<string[]> {
+export function applyProjectVisibility<R>(
+  query: QueryBuilder<Project, R>,
+  args: { account: Account; user: { id: string; staff: boolean } },
+): QueryBuilder<Project, R> | null {
   const { account, user } = args;
-  const query = Project.query()
-    .where("accountId", account.id)
-    .select("projects.id");
 
+  // Staff can view all projects
   if (user.staff) {
-    const rows = await query;
-    return rows.map((row) => row.id);
+    return query;
   }
 
   switch (account.type) {
-    case "user": {
-      if (account.userId !== user.id) {
-        return [];
-      }
-      const rows = await query;
-      return rows.map((row) => row.id);
-    }
+    case "user":
+      return account.userId === user.id ? query : null;
     case "team": {
       const teamUserQuery = TeamUser.query().where({
         teamId: account.teamId,
         userId: user.id,
       });
-      const rows = await query.where((qb) => {
+      return query.where((qb) => {
         // User is a team member or owner
         qb.whereExists(
           teamUserQuery
@@ -153,11 +146,32 @@ export async function getVisibleProjectIds(args: {
           });
         });
       });
-      return rows.map((row) => row.id);
     }
     default:
-      return [];
+      return assertNever(account.type);
   }
+}
+
+/**
+ * Resolve the ids of the projects an authenticated user can see within an
+ * account.
+ *
+ * Returns an empty array when the user can see nothing, so callers can short
+ * circuit without a query.
+ */
+export async function getVisibleProjectIds(args: {
+  account: Account;
+  user: { id: string; staff: boolean };
+}): Promise<string[]> {
+  const query = applyProjectVisibility(
+    Project.query().where("accountId", args.account.id).select("projects.id"),
+    args,
+  );
+  if (!query) {
+    return [];
+  }
+  const rows = await query;
+  return rows.map((row) => row.id);
 }
 
 /**

--- a/apps/backend/src/graphql/services/project.ts
+++ b/apps/backend/src/graphql/services/project.ts
@@ -2,6 +2,7 @@ import { invariant } from "@argos/util/invariant";
 import { TransactionOrKnex } from "objection";
 
 import {
+  Account,
   AuditTrail,
   AutomationActionRun,
   AutomationRule,
@@ -87,6 +88,76 @@ export async function getAdminProject(args: {
   const permissions = await project.$getPermissions(args.user);
   invariant(permissions.includes("admin"), "not admin");
   return project;
+}
+
+/**
+ * Resolve the ids of the projects an authenticated user can see within an
+ * account, applying the same visibility rules as the `Account.projects`
+ * resolver:
+ * - staff see every project
+ * - on a user account, only the owner
+ * - on a team, owners/members see all; contributors see projects they are a
+ *   contributor on (or that expose a default user level)
+ *
+ * Returns an empty array when the user can see nothing, so callers can short
+ * circuit without a query.
+ */
+export async function getVisibleProjectIds(args: {
+  account: Account;
+  user: { id: string; staff: boolean };
+}): Promise<string[]> {
+  const { account, user } = args;
+  const query = Project.query()
+    .where("accountId", account.id)
+    .select("projects.id");
+
+  if (user.staff) {
+    const rows = await query;
+    return rows.map((row) => row.id);
+  }
+
+  switch (account.type) {
+    case "user": {
+      if (account.userId !== user.id) {
+        return [];
+      }
+      const rows = await query;
+      return rows.map((row) => row.id);
+    }
+    case "team": {
+      const teamUserQuery = TeamUser.query().where({
+        teamId: account.teamId,
+        userId: user.id,
+      });
+      const rows = await query.where((qb) => {
+        // User is a team member or owner
+        qb.whereExists(
+          teamUserQuery
+            .select(1)
+            .clone()
+            .whereIn("userLevel", ["owner", "member"]),
+        ).orWhere((qb) => {
+          // User is a contributor
+          qb.whereExists(
+            teamUserQuery.select(1).clone().where("userLevel", "contributor"),
+          ).where((qb) => {
+            // And is a contributor to the project
+            qb.whereExists(
+              ProjectUser.query()
+                .select(1)
+                .whereRaw(`projects.id = project_users."projectId"`)
+                .where("userId", user.id),
+            )
+              // Or where there is a default user level set on the project
+              .orWhereNotNull("projects.defaultUserLevel");
+          });
+        });
+      });
+      return rows.map((row) => row.id);
+    }
+    default:
+      return [];
+  }
 }
 
 /**

--- a/apps/backend/src/graphql/services/test.ts
+++ b/apps/backend/src/graphql/services/test.ts
@@ -207,18 +207,20 @@ export function queryActiveTests(input: {
     })
     .as("active_tests");
 
-  return Test.query()
-    .whereIn("tests.projectId", projectIds)
-    .where((qb) => {
-      if (filters?.buildName) {
-        qb.where("tests.buildName", filters.buildName);
-      }
-    })
-    // only ongoing
-    .join(activeTests, "active_tests.testId", "tests.id")
-    .orderByRaw(FLAKINESS_ORDER_BY, {
-      from: getStartDateFromPeriod(period).toISOString(),
-      to: new Date().toISOString(),
-    })
-    .range(after, after + first - 1);
+  return (
+    Test.query()
+      .whereIn("tests.projectId", projectIds)
+      .where((qb) => {
+        if (filters?.buildName) {
+          qb.where("tests.buildName", filters.buildName);
+        }
+      })
+      // only ongoing
+      .join(activeTests, "active_tests.testId", "tests.id")
+      .orderByRaw(FLAKINESS_ORDER_BY, {
+        from: getStartDateFromPeriod(period).toISOString(),
+        to: new Date().toISOString(),
+      })
+      .range(after, after + first - 1)
+  );
 }

--- a/apps/backend/src/graphql/services/test.ts
+++ b/apps/backend/src/graphql/services/test.ts
@@ -1,5 +1,8 @@
+import { Build, ScreenshotDiff, Test } from "@/database/models";
+import { getStartDateFromPeriod } from "@/metrics/test";
 import { sqids } from "@/util/sqids";
 
+import type { IMetricsPeriod } from "../__generated__/resolver-types";
 import { decodeFingerprint, encodeFingerprint } from "./fingerprint";
 
 interface TestIdPayload {
@@ -87,4 +90,135 @@ export function safeParseTestChangeId(
     console.error("Failed to parse test change ID:", input, error);
     return null;
   }
+}
+
+/**
+ * Order tests by their flakiness score over a period, descending.
+ *
+ * Flakiness is not stored — it is derived at read-time from the daily-bucketed
+ * `test_stats_builds` (how many builds saw the test) and
+ * `test_stats_fingerprints` (how many changes, and how many were unique). The
+ * formula mirrors `getTestAllMetrics` in `@/metrics/test`:
+ *   stability   = changes > 0 ? 1 - changes / total : 1
+ *   consistency = changes > 0 ? uniqueChanges / changes : 1
+ *   flakiness   = 1 - (stability + consistency) / 2
+ *
+ * The subquery is correlated only on `tests.id` + the period bounds, so it does
+ * not depend on how many projects the candidate set spans — that is what lets
+ * one definition power both the per-project and the account-wide list.
+ */
+const FLAKINESS_ORDER_BY = `
+    (
+      with
+        totals as (
+          select sum(tsb.value)::numeric as total
+          from test_stats_builds tsb
+          where tsb."testId" = "tests"."id"
+            and tsb."date" >= :from::timestamp
+            and tsb."date" <  :to::timestamp
+        ),
+        fp_agg as (
+          select
+            tsf."fingerprint",
+            sum(tsf.value)::numeric as changes_value,
+            count(*) as fp_count
+          from test_stats_fingerprints tsf
+          where tsf."testId" = "tests"."id"
+            and tsf."date" >= :from::timestamp
+            and tsf."date" <  :to::timestamp
+          group by tsf."fingerprint"
+        ),
+        changes as (
+          select
+            sum(changes_value)::numeric as changes,
+            count(*) filter (where fp_count = 1)::numeric as "uniqueChanges"
+          from fp_agg
+        )
+      select
+        round(
+          (
+            1 - (
+              (
+                case
+                  when coalesce(changes.changes, 0) > 0
+                    then 1 - changes.changes / nullif(totals.total, 0)
+                  else 1
+                end
+              +
+                case
+                  when coalesce(changes.changes, 0) > 0
+                    then coalesce(changes."uniqueChanges", 0) / nullif(changes.changes, 0)
+                  else 1
+                end
+              ) / 2
+            )
+          ),
+          2
+        )
+      from totals, changes
+    ) desc,
+    "tests"."createdAt" desc,
+    "tests"."id" desc
+`;
+
+/**
+ * Query the "active" tests for a set of projects, sorted by flakiness.
+ *
+ * A test is active when it appears in the latest reference build of its build
+ * name (per project) as a non-orphan compare screenshot. Pass a single project
+ * id for the per-project Tests page, or every visible project id for the
+ * account-wide aggregate.
+ *
+ * Returns Objection's `{ total, results }` range page so the caller can hand it
+ * straight to `paginateResult`.
+ */
+export function queryActiveTests(input: {
+  projectIds: string[];
+  period: IMetricsPeriod;
+  filters?: { buildName?: string | null; search?: string | null } | null;
+  after: number;
+  first: number;
+}) {
+  const { projectIds, period, filters, after, first } = input;
+  const search = filters?.search?.trim();
+
+  const latestRef = Build.query()
+    .alias("b")
+    .select("b.id", "b.projectId", "b.name")
+    .distinctOn(["b.projectId", "b.name"])
+    .where("b.type", "reference")
+    .whereIn("b.projectId", projectIds)
+    .orderBy("b.projectId")
+    .orderBy("b.name")
+    .orderBy("b.createdAt", "desc")
+    .as("latest_reference_build");
+
+  const activeTests = ScreenshotDiff.query()
+    .alias("sd")
+    .distinct("sd.testId")
+    .join(latestRef, "latest_reference_build.id", "sd.buildId")
+    .whereNotNull("sd.testId")
+    .joinRelated("compareScreenshot")
+    .whereNull("compareScreenshot.parentName")
+    .modify((query) => {
+      if (search) {
+        query.whereILike("compareScreenshot.name", `%${search}%`);
+      }
+    })
+    .as("active_tests");
+
+  return Test.query()
+    .whereIn("tests.projectId", projectIds)
+    .where((qb) => {
+      if (filters?.buildName) {
+        qb.where("tests.buildName", filters.buildName);
+      }
+    })
+    // only ongoing
+    .join(activeTests, "active_tests.testId", "tests.id")
+    .orderByRaw(FLAKINESS_ORDER_BY, {
+      from: getStartDateFromPeriod(period).toISOString(),
+      to: new Date().toISOString(),
+    })
+    .range(after, after + first - 1);
 }

--- a/apps/backend/src/graphql/tests/accountTests.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/accountTests.e2e.test.ts
@@ -1,0 +1,162 @@
+import { invariant } from "@argos/util/invariant";
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { Project } from "@/database/models";
+import { factory, setupDatabase } from "@/database/testing";
+import { upsertTestStats } from "@/metrics/test";
+
+import { apolloServer, createApolloMiddleware } from "../apollo";
+import { expectNoGraphQLError } from "../testing";
+import { createApolloServerApp } from "./util";
+
+const ACCOUNT_TESTS_QUERY = `
+  query AccountTests($accountSlug: String!, $period: MetricsPeriod!) {
+    account(slug: $accountSlug) {
+      id
+      tests(first: 30, after: 0, period: $period) {
+        pageInfo {
+          totalCount
+        }
+        edges {
+          name
+          project {
+            name
+          }
+          metrics(period: $period) {
+            all {
+              flakiness
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Create a test that shows up as "active": present in the latest reference
+ * build of its project via a non-orphan compare screenshot diff.
+ */
+async function createActiveTest(project: Project, name: string) {
+  const test = await factory.Test.create({ projectId: project.id, name });
+  const build = await factory.Build.create({
+    projectId: project.id,
+    type: "reference",
+  });
+  await factory.ScreenshotDiff.create({ buildId: build.id, testId: test.id });
+  return test;
+}
+
+describe("GraphQL Account.tests", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  it("aggregates active tests across projects sorted by flakiness", async () => {
+    // A team account whose owner is making the request (exercises the team
+    // visibility gate, not the staff shortcut).
+    const user = await factory.User.create();
+    const account = await factory.TeamAccount.create();
+    invariant(account.teamId, "team account should have a team");
+    await factory.TeamUser.create({
+      teamId: account.teamId,
+      userId: user.id,
+      userLevel: "owner",
+    });
+
+    const [projectA, projectB] = await Promise.all([
+      factory.Project.create({ accountId: account.id, name: "project-a" }),
+      factory.Project.create({ accountId: account.id, name: "project-b" }),
+    ]);
+
+    const flakyTest = await createActiveTest(projectA, "flaky-test");
+    const stableTest = await createActiveTest(projectB, "stable-test");
+
+    const file = await factory.File.create({
+      type: "screenshotDiff",
+      fingerprint: "flaky-fp",
+    });
+
+    // Drive the stats over the period. The flaky test changes on the same
+    // fingerprint every day (stability 0, consistency 0 -> flakiness ~1); the
+    // stable test is only ever seen with no change (flakiness 0).
+    const today = new Date();
+    for (let i = 0; i < 6; i++) {
+      const date = new Date(today);
+      date.setDate(today.getDate() - i);
+      await upsertTestStats({
+        testId: flakyTest.id,
+        date,
+        change: { fileId: file.id, fingerprint: "flaky-fp" },
+      });
+      await upsertTestStats({
+        testId: stableTest.id,
+        date,
+        change: null,
+      });
+    }
+
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user, account },
+    );
+
+    const result = await request(app)
+      .post("/graphql")
+      .send({
+        query: ACCOUNT_TESTS_QUERY,
+        variables: { accountSlug: account.slug, period: "LAST_7_DAYS" },
+      });
+
+    expectNoGraphQLError(result);
+    expect(result.status).toBe(200);
+
+    const tests = result.body.data.account.tests;
+
+    // Both projects' active tests are aggregated into one list.
+    expect(tests.pageInfo.totalCount).toBe(2);
+    expect(tests.edges.map((edge: { name: string }) => edge.name)).toEqual(
+      expect.arrayContaining(["flaky-test", "stable-test"]),
+    );
+
+    // Sorted by flakiness descending, across project boundaries, with the
+    // owning project resolved on each row.
+    expect(tests.edges[0].name).toBe("flaky-test");
+    expect(tests.edges[0].project.name).toBe("project-a");
+    expect(tests.edges[1].name).toBe("stable-test");
+    expect(tests.edges[1].project.name).toBe("project-b");
+    expect(tests.edges[0].metrics.all.flakiness).toBeGreaterThan(
+      tests.edges[1].metrics.all.flakiness,
+    );
+  });
+
+  it("returns an empty connection when the account has no visible projects", async () => {
+    const user = await factory.User.create();
+    const account = await factory.TeamAccount.create();
+    invariant(account.teamId, "team account should have a team");
+    await factory.TeamUser.create({
+      teamId: account.teamId,
+      userId: user.id,
+      userLevel: "owner",
+    });
+
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user, account },
+    );
+
+    const result = await request(app)
+      .post("/graphql")
+      .send({
+        query: ACCOUNT_TESTS_QUERY,
+        variables: { accountSlug: account.slug, period: "LAST_7_DAYS" },
+      });
+
+    expectNoGraphQLError(result);
+    expect(result.body.data.account.tests.pageInfo.totalCount).toBe(0);
+    expect(result.body.data.account.tests.edges).toEqual([]);
+  });
+});

--- a/apps/frontend/src/pages/Account/Tests.tsx
+++ b/apps/frontend/src/pages/Account/Tests.tsx
@@ -1,0 +1,428 @@
+import { Suspense, useDeferredValue, useEffect, useMemo, useRef } from "react";
+import { useSuspenseQuery } from "@apollo/client/react";
+import { invariant } from "@argos/util/invariant";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import clsx from "clsx";
+import { FileImageIcon, SearchIcon } from "lucide-react";
+import { parseAsString, useQueryStates } from "nuqs";
+import { useNumberFormatter } from "react-aria";
+import { Heading, Text } from "react-aria-components";
+import { Helmet } from "react-helmet";
+
+import {
+  constraintSize,
+  DiffCard,
+  SingleImage,
+} from "@/containers/Build/BuildDiffListPrimitives";
+import { PeriodSelect } from "@/containers/PeriodSelect";
+import { FlakinessCircleIndicator } from "@/containers/Test/FlakinessCircleIndicator";
+import { useTestPeriodState } from "@/containers/Test/Period";
+import { SeenChange } from "@/containers/Test/SeenChange";
+import { graphql, type DocumentType } from "@/gql";
+import { Button } from "@/ui/Button";
+import {
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateIcon,
+  Page,
+  PageContainer,
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderContent,
+} from "@/ui/Layout";
+import { HeadlessLink } from "@/ui/Link";
+import { List, ListHeaderRow, ListRowLink, ListRowLoader } from "@/ui/List";
+import { PageLoader } from "@/ui/PageLoader";
+import { TextInput, TextInputGroup, TextInputIcon } from "@/ui/TextInput";
+import { Tooltip } from "@/ui/Tooltip";
+import { Truncable } from "@/ui/Truncable";
+import { useEventCallback } from "@/ui/useEventCallback";
+import { checkAreDefaultValues } from "@/util/search-params";
+
+import {
+  ChangesTooltip,
+  ConsistencyTooltip,
+  FlakinessTooltip,
+  StabilityTooltip,
+} from "../Test/Widgets";
+import { useAccountParams } from "./AccountParams";
+
+const AccountTestsQuery = graphql(`
+  query AccountTests_account_tests(
+    $accountSlug: String!
+    $after: Int!
+    $first: Int!
+    $filters: TestsFilterInput
+    $period: MetricsPeriod!
+  ) {
+    account(slug: $accountSlug) {
+      id
+      tests(first: $first, after: $after, period: $period, filters: $filters) {
+        pageInfo {
+          totalCount
+          hasNextPage
+        }
+        edges {
+          id
+          name
+          buildName
+          status
+          project {
+            id
+            name
+          }
+          screenshot {
+            id
+            width
+            height
+            contentType
+            url
+          }
+          lastSeenDiff {
+            id
+            ...ScreenChange_ScreenshotDiff
+          }
+          metrics(period: $period) {
+            all {
+              total
+              flakiness
+              stability
+              changes
+              consistency
+            }
+          }
+        }
+      }
+    }
+  }
+`);
+
+type AccountTestsDocument = DocumentType<typeof AccountTestsQuery>;
+type Tests = NonNullable<AccountTestsDocument["account"]>["tests"];
+type Test = Tests["edges"][0];
+
+const filtersSchema = {
+  search: parseAsString,
+};
+
+function PageContent(props: { accountSlug: string }) {
+  const { accountSlug } = props;
+  const periodState = useTestPeriodState();
+  const [filters, setFilters] = useQueryStates(filtersSchema);
+  const hasFilters = !checkAreDefaultValues(filtersSchema, filters);
+  const deferredFilters = useDeferredValue(filters);
+  const deferredPeriod = useDeferredValue(periodState.value);
+  const isUpdating =
+    filters !== deferredFilters || periodState.value !== deferredPeriod;
+  const filtersVariable = useMemo(() => {
+    return { search: deferredFilters.search || undefined };
+  }, [deferredFilters]);
+  const { fetchMore, data } = useSuspenseQuery(AccountTestsQuery, {
+    variables: {
+      accountSlug,
+      filters: filtersVariable,
+      period: deferredPeriod,
+      after: 0,
+      first: 20,
+    },
+  });
+  const tests = data.account?.tests;
+  const fetchNextPage = useEventCallback(() => {
+    invariant(tests);
+    fetchMore({
+      variables: { after: tests.edges.length },
+      updateQuery: (prev, { fetchMoreResult }) => {
+        if (!prev.account?.tests?.edges || !fetchMoreResult?.account?.tests) {
+          return fetchMoreResult;
+        }
+        return {
+          ...prev,
+          account: {
+            ...prev.account,
+            tests: {
+              ...prev.account.tests,
+              ...fetchMoreResult.account.tests,
+              edges: [
+                ...prev.account.tests.edges,
+                ...fetchMoreResult.account.tests.edges,
+              ],
+            },
+          },
+        };
+      },
+    });
+  });
+
+  if (!tests) {
+    return null;
+  }
+
+  if (tests.pageInfo.totalCount === 0 && !hasFilters) {
+    return (
+      <EmptyState>
+        <EmptyStateIcon>
+          <FileImageIcon strokeWidth={1} />
+        </EmptyStateIcon>
+        <Heading>No tests</Heading>
+        <Text slot="description">
+          There are no tests yet across this account's projects.
+        </Text>
+      </EmptyState>
+    );
+  }
+
+  if (hasFilters && tests.pageInfo.totalCount === 0) {
+    return (
+      <EmptyState>
+        <EmptyStateIcon>
+          <FileImageIcon strokeWidth={1} />
+        </EmptyStateIcon>
+        <Heading>No tests</Heading>
+        <Text slot="description">There is no tests matching the filters.</Text>
+        <EmptyStateActions>
+          <Button onPress={() => setFilters(null)}>Reset filters</Button>
+        </EmptyStateActions>
+      </EmptyState>
+    );
+  }
+
+  return (
+    <TestsList
+      accountSlug={accountSlug}
+      tests={tests}
+      fetchNextPage={fetchNextPage}
+      isUpdating={isUpdating}
+    />
+  );
+}
+
+function TestsList(props: {
+  accountSlug: string;
+  tests: Tests;
+  isUpdating: boolean;
+  fetchNextPage: () => void;
+}) {
+  const { accountSlug, tests, isUpdating, fetchNextPage } = props;
+  const parentRef = useRef<HTMLDivElement>(null);
+  const { hasNextPage } = tests.pageInfo;
+  const displayCount = tests.edges.length;
+  const rowVirtualizer = useVirtualizer({
+    count: hasNextPage ? displayCount + 1 : displayCount,
+    estimateSize: () => 75,
+    getScrollElement: () => parentRef.current,
+    overscan: 20,
+    getItemKey: (index) => tests.edges[index]?.id ?? "loader",
+  });
+
+  const virtualItems = rowVirtualizer.getVirtualItems();
+  const lastItem = virtualItems[virtualItems.length - 1];
+  useEffect(() => {
+    if (lastItem && lastItem.index === displayCount && hasNextPage) {
+      fetchNextPage();
+    }
+  }, [lastItem, displayCount, hasNextPage, fetchNextPage]);
+
+  return (
+    <List
+      className={clsx(
+        "absolute max-h-full w-full overflow-hidden",
+        isUpdating && "animate-pulse",
+      )}
+    >
+      <ListHeaderRow>
+        <div className="flex-1 truncate">Test</div>
+        <div className="w-40 truncate">Project</div>
+        <div className="w-30 text-right">Last change</div>
+        <div className="w-20 text-center">
+          <Tooltip content={<FlakinessTooltip />}>
+            <span className="underline-emphasis">Flakiness</span>
+          </Tooltip>
+        </div>
+        <div className="w-20 text-right">
+          <Tooltip content={<TestsChangesTooltip />}>
+            <span className="underline-emphasis">Changes</span>
+          </Tooltip>
+        </div>
+        <div className="w-20 text-right">
+          <Tooltip content={<StabilityTooltip />}>
+            <span className="underline-emphasis">Stability</span>
+          </Tooltip>
+        </div>
+        <div className="w-20 text-right">
+          <Tooltip content={<ConsistencyTooltip />}>
+            <span className="underline-emphasis">Consistency</span>
+          </Tooltip>
+        </div>
+      </ListHeaderRow>
+      <div ref={parentRef} className="overflow-auto">
+        <div className="relative" style={{ height: rowVirtualizer.getTotalSize() }}>
+          {virtualItems.map((virtualRow) => {
+            const test = tests.edges[virtualRow.index];
+            const style: React.CSSProperties = {
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: "100%",
+              height: virtualRow.size,
+              transform: `translateY(${virtualRow.start}px)`,
+            };
+            if (!test) {
+              return (
+                <ListRowLoader key={virtualRow.key} style={style}>
+                  Fetching tests...
+                </ListRowLoader>
+              );
+            }
+            return (
+              <TestRow
+                key={virtualRow.key}
+                accountSlug={accountSlug}
+                test={test}
+                style={style}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </List>
+  );
+}
+
+function TestsChangesTooltip() {
+  const periodState = useTestPeriodState();
+  return (
+    <ChangesTooltip
+      periodLabel={periodState.definition[periodState.value].label}
+    />
+  );
+}
+
+const DIFF_IMAGE_CONFIG = {
+  maxWidth: 112,
+  maxHeight: 56,
+  defaultHeight: 56,
+};
+
+function TestRow(props: {
+  accountSlug: string;
+  test: Test;
+  style: React.CSSProperties;
+}) {
+  const { accountSlug, test, style } = props;
+  const compactFormatter = useNumberFormatter({ notation: "compact" });
+  const projectName = test.project.name;
+  const rowParams = { accountSlug, projectName };
+  return (
+    <ListRowLink
+      href={`/${accountSlug}/${projectName}/tests/${test.id}`}
+      className="flex items-center gap-6 p-4 text-sm"
+      style={style}
+    >
+      <div className="flex flex-1 gap-4 truncate">
+        {test.screenshot ? (
+          <DiffCard isActive={false} variant="neutral" className="w-28 shrink-0">
+            <SingleImage
+              contentType={test.screenshot.contentType}
+              dimensions={
+                test.screenshot.width != null && test.screenshot.height != null
+                  ? constraintSize(
+                      {
+                        width: test.screenshot.width,
+                        height: test.screenshot.height,
+                      },
+                      DIFF_IMAGE_CONFIG,
+                    )
+                  : {
+                      height: DIFF_IMAGE_CONFIG.defaultHeight,
+                      width: DIFF_IMAGE_CONFIG.maxWidth,
+                    }
+              }
+              url={test.screenshot.url}
+            />
+          </DiffCard>
+        ) : null}
+        <div className="flex flex-col justify-center truncate">
+          <Truncable className="font-medium">{test.name}</Truncable>
+          {test.buildName !== "default" ? (
+            <Truncable className="text-low">{test.buildName}</Truncable>
+          ) : null}
+        </div>
+      </div>
+      <div className="w-40 truncate">
+        <HeadlessLink
+          href={`/${accountSlug}/${projectName}/tests`}
+          className="rac-focus hover:text-default truncate underline"
+        >
+          {projectName}
+        </HeadlessLink>
+      </div>
+      <div className="w-30 text-right">
+        <SeenChange params={rowParams} diff={test.lastSeenDiff ?? null} />
+      </div>
+      <div className="flex w-20 justify-center">
+        <FlakinessCircleIndicator
+          value={test.metrics.all.flakiness}
+          className="size-12"
+        />
+      </div>
+      <div className="w-20 text-right tabular-nums">
+        {test.metrics.all.changes}
+      </div>
+      <div className="w-20 text-right tabular-nums">
+        {compactFormatter.format(test.metrics.all.stability * 100)}
+        <small className="text-low ml-0.5">%</small>
+      </div>
+      <div className="w-20 text-right tabular-nums">
+        {compactFormatter.format(test.metrics.all.consistency * 100)}
+        <small className="text-low ml-0.5">%</small>
+      </div>
+    </ListRowLink>
+  );
+}
+
+export function Component() {
+  const params = useAccountParams();
+  invariant(params, "it is an account route");
+  const periodState = useTestPeriodState();
+  const [filters, setFilters] = useQueryStates(filtersSchema);
+
+  return (
+    <Page>
+      <Helmet>
+        <title>Tests • {params.accountSlug}</title>
+      </Helmet>
+      <PageContainer>
+        <PageHeader>
+          <PageHeaderContent>
+            <Heading>Tests</Heading>
+            <Text slot="headline">
+              View all the tests across your projects sorted by flakiness score.
+            </Text>
+          </PageHeaderContent>
+          <PageHeaderActions>
+            <PeriodSelect state={periodState} />
+            <TextInputGroup className="w-64">
+              <TextInputIcon>
+                <SearchIcon />
+              </TextInputIcon>
+              <TextInput
+                type="search"
+                placeholder="Search tests…"
+                scale="sm"
+                value={filters.search ?? ""}
+                onChange={(event) =>
+                  setFilters({ search: event.target.value || null })
+                }
+              />
+            </TextInputGroup>
+          </PageHeaderActions>
+        </PageHeader>
+        <div className="relative flex-1">
+          <Suspense fallback={<PageLoader />}>
+            <PageContent accountSlug={params.accountSlug} />
+          </Suspense>
+        </div>
+      </PageContainer>
+    </Page>
+  );
+}

--- a/apps/frontend/src/pages/Account/Tests.tsx
+++ b/apps/frontend/src/pages/Account/Tests.tsx
@@ -1,4 +1,11 @@
-import { Suspense, useDeferredValue, useEffect, useMemo, useRef } from "react";
+import {
+  Suspense,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useTransition,
+} from "react";
 import { useSuspenseQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -127,29 +134,32 @@ function PageContent(props: { accountSlug: string }) {
     },
   });
   const tests = data.account?.tests;
+  const [isFetchingMore, startFetchMoreTransition] = useTransition();
   const fetchNextPage = useEventCallback(() => {
     invariant(tests);
-    fetchMore({
-      variables: { after: tests.edges.length },
-      updateQuery: (prev, { fetchMoreResult }) => {
-        if (!prev.account?.tests?.edges || !fetchMoreResult?.account?.tests) {
-          return fetchMoreResult;
-        }
-        return {
-          ...prev,
-          account: {
-            ...prev.account,
-            tests: {
-              ...prev.account.tests,
-              ...fetchMoreResult.account.tests,
-              edges: [
-                ...prev.account.tests.edges,
-                ...fetchMoreResult.account.tests.edges,
-              ],
+    startFetchMoreTransition(() => {
+      fetchMore({
+        variables: { after: tests.edges.length },
+        updateQuery: (prev, { fetchMoreResult }) => {
+          if (!prev.account?.tests?.edges || !fetchMoreResult?.account?.tests) {
+            return fetchMoreResult;
+          }
+          return {
+            ...prev,
+            account: {
+              ...prev.account,
+              tests: {
+                ...prev.account.tests,
+                ...fetchMoreResult.account.tests,
+                edges: [
+                  ...prev.account.tests.edges,
+                  ...fetchMoreResult.account.tests.edges,
+                ],
+              },
             },
-          },
-        };
-      },
+          };
+        },
+      });
     });
   });
 
@@ -191,6 +201,7 @@ function PageContent(props: { accountSlug: string }) {
       accountSlug={accountSlug}
       tests={tests}
       fetchNextPage={fetchNextPage}
+      isFetchingMore={isFetchingMore}
       isUpdating={isUpdating}
     />
   );
@@ -200,9 +211,11 @@ function TestsList(props: {
   accountSlug: string;
   tests: Tests;
   isUpdating: boolean;
+  isFetchingMore: boolean;
   fetchNextPage: () => void;
 }) {
-  const { accountSlug, tests, isUpdating, fetchNextPage } = props;
+  const { accountSlug, tests, isUpdating, isFetchingMore, fetchNextPage } =
+    props;
   const parentRef = useRef<HTMLDivElement>(null);
   const { hasNextPage } = tests.pageInfo;
   const displayCount = tests.edges.length;
@@ -217,10 +230,15 @@ function TestsList(props: {
   const virtualItems = rowVirtualizer.getVirtualItems();
   const lastItem = virtualItems[virtualItems.length - 1];
   useEffect(() => {
-    if (lastItem && lastItem.index === displayCount && hasNextPage) {
+    if (
+      lastItem &&
+      lastItem.index === displayCount &&
+      !isFetchingMore &&
+      hasNextPage
+    ) {
       fetchNextPage();
     }
-  }, [lastItem, displayCount, hasNextPage, fetchNextPage]);
+  }, [lastItem, displayCount, isFetchingMore, hasNextPage, fetchNextPage]);
 
   return (
     <List
@@ -255,7 +273,10 @@ function TestsList(props: {
         </div>
       </ListHeaderRow>
       <div ref={parentRef} className="overflow-auto">
-        <div className="relative" style={{ height: rowVirtualizer.getTotalSize() }}>
+        <div
+          className="relative"
+          style={{ height: rowVirtualizer.getTotalSize() }}
+        >
           {virtualItems.map((virtualRow) => {
             const test = tests.edges[virtualRow.index];
             const style: React.CSSProperties = {
@@ -320,7 +341,11 @@ function TestRow(props: {
     >
       <div className="flex flex-1 gap-4 truncate">
         {test.screenshot ? (
-          <DiffCard isActive={false} variant="neutral" className="w-28 shrink-0">
+          <DiffCard
+            isActive={false}
+            variant="neutral"
+            className="w-28 shrink-0"
+          >
             <SingleImage
               contentType={test.screenshot.contentType}
               dimensions={

--- a/apps/frontend/src/pages/Account/index.tsx
+++ b/apps/frontend/src/pages/Account/index.tsx
@@ -40,6 +40,7 @@ function AccountTabs({ account }: { account: Account }) {
       <TabList className="px-4" aria-label="Account navigation">
         <TabLink href="">Projects</TabLink>
         <TabLink href="~/analytics">Analytics</TabLink>
+        <TabLink href="~/tests">Tests</TabLink>
         <TabLink href="settings">Settings</TabLink>
       </TabList>
       <hr className="border-t" />

--- a/apps/frontend/src/router.tsx
+++ b/apps/frontend/src/router.tsx
@@ -369,6 +369,11 @@ export const router: ReturnType<typeof createBrowserRouter> =
                   lazy: () => import("./pages/Account/Analytics"),
                 },
                 {
+                  path: "~/tests",
+                  HydrateFallback,
+                  lazy: () => import("./pages/Account/Tests"),
+                },
+                {
                   path: "settings/*",
                   HydrateFallback,
                   lazy: () => import("./pages/Account/Settings"),


### PR DESCRIPTION
Re-lands the account-wide Tests page from #2288. The original PR was opened from a **fork** (`ton03:antonn/account-tests-page`), so it's re-created here as a branch on the main repo to allow pushing review fixes directly.

## What's included

- The original feature commit from #2288: aggregate active tests across all of an account's visible projects into a single flakiness-sorted list, surfaced as a new **Tests** tab on the account (next to Analytics). Extracts the per-project flakiness query into a shared `queryActiveTests()`.
- Code-review fixes on top:
  - **Pagination guard** — the account Tests infinite-scroll fired `fetchNextPage()` repeatedly while a page was already in flight, causing duplicate page requests and duplicate rows. Now wraps `fetchMore` in a transition and gates the effect on `!isFetchingMore`, matching the per-project Tests page.
  - **Shared visibility logic** — extracted `applyProjectVisibility()` so the `Account.projects` resolver and `getVisibleProjectIds()` share one source of truth for authorization rules instead of two hand-maintained copies.

## Test plan

- `accountTests.e2e.test.ts` passes (2 tests).
- `latestProductionDeployment.e2e.test.ts` passes — confirms the refactored `Account.projects` resolver preserves behavior.
- Backend + frontend typecheck and lint clean.

Supersedes #2288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)