### PR TITLE
fix(frontend): point error screens to contact page instead of Discord

### DIFF
--- a/apps/frontend/src/pages/ErrorPage.tsx
+++ b/apps/frontend/src/pages/ErrorPage.tsx
@@ -14,9 +14,9 @@ export function ErrorPage() {
       <Alert>
         <AlertTitle>Sorry, an error occurred</AlertTitle>
         <AlertText>
-          Something went wrong. If the error persists, please reach us on{" "}
-          <Link href="https://argos-ci.com/discord" target="_blank">
-            Discord
+          Something went wrong. If the error persists, please{" "}
+          <Link href="https://argos-ci.com/contact" target="_blank">
+            contact us
           </Link>
           .
         </AlertText>

--- a/apps/frontend/src/pages/Login.tsx
+++ b/apps/frontend/src/pages/Login.tsx
@@ -54,9 +54,9 @@ export function Component() {
                 Error message: {error}
               </p>
               <p>
-                Try again, if the error persists, please reach us on{" "}
-                <Link href="https://argos-ci.com/discord" target="_blank">
-                  Discord
+                Try again, if the error persists, please{" "}
+                <Link href="https://argos-ci.com/contact" target="_blank">
+                  contact us
                 </Link>
                 .
               </p>


### PR DESCRIPTION
## What changed

The two "Sorry, an error occurred" screens previously told users to **reach us on Discord** when an error persisted. They now redirect users to our **contact page** (`https://argos-ci.com/contact`) instead.

- `apps/frontend/src/pages/ErrorPage.tsx` — generic error fallback page.
- `apps/frontend/src/pages/Login.tsx` — login error message (same title and pattern).

In both, the wording changed from "please reach us on **Discord**" → "please **contact us**", with the link now pointing to the contact page.

## Why

Support requests originating from error states should flow through our official contact channel rather than Discord.

## Notes for reviewers

- Other Discord links that are **not** error screens were intentionally left untouched: the "Help & Community" navbar link and the "Discord community" user-menu option. Happy to update those too if we want full consistency.