### PR TITLE
chore(frontend): remove "deployments" feature flag

### DIFF
--- a/apps/frontend/src/containers/ProjectList.tsx
+++ b/apps/frontend/src/containers/ProjectList.tsx
@@ -1,5 +1,4 @@
 import { GitBranchIcon } from "@primer/octicons-react";
-import { useFlag } from "@reflag/react-sdk";
 import { FolderIcon, PlusCircleIcon } from "lucide-react";
 import { Heading, Text } from "react-aria-components";
 
@@ -72,7 +71,6 @@ function RepositoryChip(props: { repository: Project["repository"] }) {
 }
 
 function ProjectCard({ project }: { project: Project }) {
-  const deploymentsFlag = useFlag("deployments");
   return (
     <div
       key={project.id}
@@ -85,27 +83,25 @@ function ProjectCard({ project }: { project: Project }) {
       />
       <div className="w-full min-w-0">
         <div className="truncate font-medium">{project.name}</div>
-        {deploymentsFlag.isEnabled && (
-          <div className="text-low mt-1 truncate text-sm">
-            {project.latestProductionDeployment?.status ===
-              DeploymentStatus.Ready && project.domain ? (
-              <Link
-                className="relative"
-                variant="neutral"
-                href={`https://${project.domain}`}
-                target="_blank"
-                external={false}
-              >
-                {project.domain}
-              </Link>
-            ) : (
-              "Not deployed"
-            )}
-          </div>
-        )}
+        <div className="text-low mt-1 truncate text-sm">
+          {project.latestProductionDeployment?.status ===
+            DeploymentStatus.Ready && project.domain ? (
+            <Link
+              className="relative"
+              variant="neutral"
+              href={`https://${project.domain}`}
+              target="_blank"
+              external={false}
+            >
+              {project.domain}
+            </Link>
+          ) : (
+            "Not deployed"
+          )}
+        </div>
       </div>
       <RepositoryChip repository={project.repository} />
-      {deploymentsFlag.isEnabled && project.latestProductionDeployment ? (
+      {project.latestProductionDeployment ? (
         <div className="text-low relative text-xs">
           Deployed <Time date={project.latestProductionDeployment.createdAt} />{" "}
           on <GitBranchIcon className="inline size-3 align-middle" />{" "}

--- a/apps/frontend/src/pages/Project/Deployments.tsx
+++ b/apps/frontend/src/pages/Project/Deployments.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useTransition } from "react";
 import { useSuspenseQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { GitBranchIcon, GitCommitIcon } from "@primer/octicons-react";
-import { useFlag } from "@reflag/react-sdk";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import clsx from "clsx";
 import { BoxesIcon, CircleArrowUpIcon, GlobeIcon } from "lucide-react";
@@ -438,15 +437,6 @@ function PageContent() {
 export function Component() {
   const params = useProjectParams();
   invariant(params, "it is a project route");
-  const deploymentsFlag = useFlag("deployments");
-
-  if (deploymentsFlag.isLoading) {
-    return null;
-  }
-
-  if (!deploymentsFlag.isEnabled) {
-    return <NotFound />;
-  }
 
   return (
     <Page>

--- a/apps/frontend/src/pages/Project/Settings.tsx
+++ b/apps/frontend/src/pages/Project/Settings.tsx
@@ -7,7 +7,6 @@ import {
 } from "react";
 import { useSuspenseQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
-import { useFlag } from "@reflag/react-sdk";
 import { Heading, Text } from "react-aria-components";
 import { Navigate, Route, Routes } from "react-router-dom";
 
@@ -119,7 +118,6 @@ function PageContent() {
   invariant(params, "it is a project route");
   const { accountSlug, projectName } = params;
   const { permissions } = useProjectOutletContext();
-  const deploymentsFlag = useFlag("deployments");
   const {
     data: { account, project },
   } = useSuspenseQuery(ProjectQuery, {
@@ -200,7 +198,7 @@ function PageContent() {
     {
       name: "Deployments",
       slug: "deployments",
-      element: hasAdminPermission && deploymentsFlag.isEnabled && (
+      element: hasAdminPermission && (
         <ProjectDeployments project={project} isTeam={isTeam} />
       ),
     },

--- a/apps/frontend/src/pages/Project/index.tsx
+++ b/apps/frontend/src/pages/Project/index.tsx
@@ -1,7 +1,6 @@
 import { Suspense } from "react";
 import { useSuspenseQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
-import { useFlag } from "@reflag/react-sdk";
 import { Outlet } from "react-router-dom";
 
 import { useVisitAccount } from "@/containers/AccountHistory";
@@ -50,7 +49,7 @@ function ProjectTabs(props: {
       <TabList className="px-4" aria-label="Project navigation">
         <TabLink href="">Builds</TabLink>
         <TabLink href="tests">Tests</TabLink>
-        {deploymentEnabled && <DeploymentsTab />}
+        {deploymentEnabled && <TabLink href="deployments">Deployments</TabLink>}
         {showAutomationsTab && (
           <TabLink href="automations">Automations</TabLink>
         )}
@@ -65,14 +64,6 @@ function ProjectTabs(props: {
       </TabLinkPanel>
     </TabsLink>
   );
-}
-
-function DeploymentsTab() {
-  const deploymentsFlag = useFlag("deployments");
-  if (!deploymentsFlag.isEnabled) {
-    return null;
-  }
-  return <TabLink href="deployments">Deployments</TabLink>;
 }
 
 function Project(props: { params: ProjectParams }) {


### PR DESCRIPTION
## Summary

The deployments feature is now generally available, so this removes the `useFlag("deployments")` guards from the frontend and inlines the always-on behavior.

## Changes

- **ProjectList.tsx** — deployment domain/info blocks now always render; removed the hook and unused import.
- **Settings.tsx** — the "Deployments" settings route gates only on `hasAdminPermission`.
- **Project/index.tsx** — inlined the trivial `DeploymentsTab` wrapper to a `TabLink` (still gated on `deploymentEnabled`).
- **Project/Deployments.tsx** — removed the loading/not-found flag guards in `Component`.

Removed the now-unused `useFlag` imports from all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)