### PR TITLE
fix(frontend): prevent reviewer avatar from being clipped in build status chip

### DIFF
--- a/apps/frontend/src/containers/BuildStatusChip.tsx
+++ b/apps/frontend/src/containers/BuildStatusChip.tsx
@@ -42,9 +42,9 @@ export function BuildStatusChip(props: {
       <Chip icon={descriptor.icon} color={descriptor.color} scale={props.scale}>
         <span
           aria-label={getChipLabel(build) ?? undefined}
-          className="flex items-center gap-(--chip-gap)"
+          className="flex min-w-0 items-center gap-(--chip-gap)"
         >
-          {descriptor.label}
+          <span className="min-w-0 truncate">{descriptor.label}</span>
           <BuildReviewUsers reviews={reviewWithUsers} />
         </span>
       </Chip>
@@ -93,7 +93,7 @@ function BuildReviewUsers(props: {
     return null;
   }
   return (
-    <StackedItems>
+    <StackedItems className="shrink-0">
       {props.reviews.map((review) => {
         if (!review.user) {
           return null;


### PR DESCRIPTION
## ARG-418 — Fix buggy chip

Fixes the clipped reviewer avatar in the `BuildStatusChip` (visible on the project builds page, e.g. `/smooth/big`).

### Problem
`BuildStatusChip` renders reviewer avatars after the status label. The `Chip` component wraps its children in a `flex-1 truncate` span (`overflow: hidden`). Inside the fixed-width `w-38` builds column, the label consumed the available width and the **trailing avatar overflowed and got clipped** by the chip's rounded edge.

| Before |
|---|
| ![clipped avatar](https://uploads.linear.app/acf5a5ba-11b6-4409-8c98-76f8aff6d3fd/dba9a996-24a0-467d-97e3-e3eac8d61459/1ca0b6b9-6f43-42d6-9f43-de518d8ce19b) |

### Fix
- Wrapped the label in its own `min-w-0 truncate` span so the **label** absorbs overflow (ellipsis) instead of the avatar.
- Added `min-w-0` to the inner flex container so the label can shrink.
- Added `shrink-0` to the avatars so they keep full size and stay fully visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)