### PR TITLE
Show user card on test activity

### DIFF
--- a/apps/backend/src/graphql/definitions/User.ts
+++ b/apps/backend/src/graphql/definitions/User.ts
@@ -29,6 +29,7 @@ import { sendNotification } from "@/notification";
 import {
   type IResolvers,
   type ITeamUserLevel,
+  type IUserType,
 } from "../__generated__/resolver-types";
 import type { Context } from "../context";
 import { deleteAccount, getAdminAccount } from "../services/account";
@@ -124,6 +125,13 @@ export const typeDefs = gql`
     timezone: String
     "Team role of the user on the given project, null if not a team member"
     role(accountSlug: String!, projectName: String!): TeamUserLevel
+    "Whether the account is a real person or an automated account (e.g. the Argos bot)."
+    type: UserType!
+  }
+
+  enum UserType {
+    user
+    bot
   }
 
   type UserPresenceChangeEvent {
@@ -541,6 +549,12 @@ export const resolvers: IResolvers = {
       }
       const presence = await loadVisiblePresence(ctx, account.userId);
       return presence?.timezone ?? null;
+    },
+    type: async (account, _args, ctx) => {
+      invariant(account.userId, "account.userId is undefined");
+      const user = await ctx.loaders.User.load(account.userId);
+      invariant(user, "user is undefined");
+      return user.type as IUserType;
     },
   },
   Subscription: {

--- a/apps/frontend/src/containers/Build/TestTrail.ts
+++ b/apps/frontend/src/containers/Build/TestTrail.ts
@@ -2,6 +2,7 @@ import type { ApolloCache } from "@apollo/client";
 import { invariant } from "@argos/util/invariant";
 
 import { graphql, type DocumentType } from "@/gql";
+import { UserType } from "@/gql/graphql";
 
 import type { JWTData } from "../Auth";
 
@@ -23,6 +24,7 @@ const AuditTrailFragment = graphql(`
     action
     user {
       ...Test_AuditTrailUser
+      ...UserCard_user
     }
   }
 `);
@@ -40,8 +42,10 @@ export function addAuditTrailEntry(args: {
   action: "files.ignored" | "files.unignored";
   testId: string;
   authPayload: JWTData;
+  accountSlug: string;
+  projectName: string;
 }) {
-  const { cache, action, testId, authPayload } = args;
+  const { cache, action, testId, authPayload, accountSlug, projectName } = args;
   const testCacheId = cache.identify({
     __typename: "Test",
     id: testId,
@@ -64,12 +68,24 @@ export function addAuditTrailEntry(args: {
   const trailRef = cache.writeFragment({
     fragment: AuditTrailFragment,
     fragmentName: "Test_AuditTrail",
+    // `role` is keyed on these args, so the optimistic entry must be written
+    // under the same variables the activity query reads with.
+    variables: { accountSlug, projectName },
     data: {
       __typename: "AuditTrail" as const,
       id: `local-audit-trail-${Date.now()}`,
       date: new Date().toISOString(),
       action,
-      user,
+      user: {
+        ...user,
+        // The actor ignoring a change is always the signed-in person, never a
+        // bot. Presence/role aren't known locally; the card tolerates nulls and
+        // the next fetch fills them in.
+        type: UserType.User,
+        role: null,
+        lastSeenAt: new Date().toISOString(),
+        timezone: null,
+      },
     },
   });
 

--- a/apps/frontend/src/containers/Build/toolbar/IgnoreButton.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/IgnoreButton.tsx
@@ -86,6 +86,8 @@ function EnabledIgnoreButton(props: {
           action: "files.ignored",
           authPayload,
           testId: diff.test.id,
+          accountSlug: params.accountSlug,
+          projectName: params.projectName,
         });
       }
     },
@@ -123,6 +125,8 @@ function EnabledIgnoreButton(props: {
           action: "files.unignored",
           authPayload,
           testId: diff.test.id,
+          accountSlug: params.accountSlug,
+          projectName: params.projectName,
         });
       }
     },

--- a/apps/frontend/src/pages/Build/sidebar/TestActivitySection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/TestActivitySection.tsx
@@ -5,6 +5,7 @@ import { graphql, type DocumentType } from "@/gql";
 import { Activity, ActivityItem } from "@/ui/Activity";
 import { SidebarHeader, SidebarHeading, SidebarSection } from "@/ui/Sidebar";
 import { Time } from "@/ui/Time";
+import { getUserCardData, UserHoverCard } from "@/ui/UserCard";
 
 const _TestFragment = graphql(`
   fragment TestActivitySection_Test on Test {
@@ -41,10 +42,14 @@ export function TestActivitySection(props: {
             <ActivityItem
               key={trail.id}
               icon={
-                <AccountAvatar
-                  avatar={trail.user.avatar}
-                  className="size-3.5 border"
-                />
+                <UserHoverCard user={getUserCardData(trail.user)}>
+                  <span tabIndex={0} className="shrink-0">
+                    <AccountAvatar
+                      avatar={trail.user.avatar}
+                      className="size-3.5 border"
+                    />
+                  </span>
+                </UserHoverCard>
               }
             >
               {getActionLabel(trail.action)} · <Time date={trail.date} />

--- a/apps/frontend/src/pages/Build/sidebar/TestChangeSection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/TestChangeSection.tsx
@@ -7,6 +7,7 @@ import { AccountAvatar } from "@/containers/AccountAvatar";
 import { graphql, type DocumentType } from "@/gql";
 import { HeadlessLink } from "@/ui/Link";
 import { SidebarHeader, SidebarHeading, SidebarSection } from "@/ui/Sidebar";
+import { getUserCardData, UserHoverCard } from "@/ui/UserCard";
 
 import { useProjectParams } from "../../Project/ProjectParams";
 import { getTestURL } from "../../Test/TestParams";
@@ -89,11 +90,18 @@ export function TestChangeSection(props: {
               {lastIgnoredTrail ? (
                 <>
                   by{" "}
-                  <AccountAvatar
-                    avatar={lastIgnoredTrail.user.avatar}
-                    className="size-3.5 border"
-                  />
-                  {lastIgnoredTrail.user.name || lastIgnoredTrail.user.slug}
+                  <UserHoverCard user={getUserCardData(lastIgnoredTrail.user)}>
+                    <span
+                      tabIndex={0}
+                      className="inline-flex items-center gap-1.5"
+                    >
+                      <AccountAvatar
+                        avatar={lastIgnoredTrail.user.avatar}
+                        className="size-3.5 border"
+                      />
+                      {lastIgnoredTrail.user.name || lastIgnoredTrail.user.slug}
+                    </span>
+                  </UserHoverCard>
                 </>
               ) : null}
               .

--- a/apps/frontend/src/ui/UserCard.tsx
+++ b/apps/frontend/src/ui/UserCard.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 import { useSubscription } from "@apollo/client/react";
 import { clsx } from "clsx";
-import { ClockIcon } from "lucide-react";
+import { BotIcon, ClockIcon } from "lucide-react";
 
 import { DocumentType, graphql } from "@/gql";
+import { UserType } from "@/gql/graphql";
 
 import { type MentionUser } from "./Editor/mention";
 import { Time } from "./Time";
@@ -27,6 +28,7 @@ export const UserCardFragment = graphql(`
     lastSeenAt
     timezone
     role(accountSlug: $accountSlug, projectName: $projectName)
+    type
   }
 `);
 
@@ -60,6 +62,8 @@ export interface UserCardData {
   lastSeenAt?: string | null;
   /** IANA timezone (e.g. "Europe/Paris"); null when unknown/not visible. */
   timezone?: string | null;
+  /** Automated account (e.g. the Argos bot) — shown instead of presence. */
+  isBot?: boolean;
 }
 
 /** Map the `UserCard_user` fragment to the data the card renders. */
@@ -75,6 +79,7 @@ export function getUserCardData(
     role: user.role,
     lastSeenAt: user.lastSeenAt,
     timezone: user.timezone,
+    isBot: user.type === UserType.Bot,
   };
 }
 
@@ -227,6 +232,21 @@ function UserCardPresence(props: {
 }
 
 /**
+ * Shown below the divider for automated accounts (e.g. the Argos bot) in place
+ * of the presence/local-time block — a bot has no presence to report.
+ */
+function UserCardBotInfo() {
+  return (
+    <div className="text-low border-t-thin mt-3 flex items-center gap-2 pt-3 text-xs">
+      <BotIcon className="size-3.5 shrink-0 opacity-70" />
+      <span>
+        Automated account — actions are performed by Argos, not a person.
+      </span>
+    </div>
+  );
+}
+
+/**
  * The body of the user hover card: avatar, name, slug, role, then a live
  * presence dot and local time. Rendered inside a {@link Tooltip} by
  * {@link UserHoverCard}, but exported so it can be embedded elsewhere if needed.
@@ -240,14 +260,15 @@ function UserCard(props: { user: UserCardData }) {
 
   // Keep presence live while the card is open. Apollo merges the normalized
   // `user` result into the cache, so the dot recolors without an explicit
-  // handler. Skipped for cards built without an id (e.g. mention resolution).
+  // handler. Skipped for cards built without an id (e.g. mention resolution)
+  // and for bots, which have no presence.
   useSubscription(UserPresenceChangedSubscription, {
     variables: { userId: user.id ?? "" },
-    skip: !user.id,
+    skip: !user.id || user.isBot,
   });
 
   return (
-    <div className="min-w-52">
+    <div className="max-w-80 min-w-52">
       <div className="flex items-center gap-3">
         <UserCardAvatar user={user} className="size-10 shrink-0" />
         <div className="min-w-0 leading-tight">
@@ -265,7 +286,9 @@ function UserCard(props: { user: UserCardData }) {
           </div>
         </div>
       </div>
-      {user.id ? (
+      {user.isBot ? (
+        <UserCardBotInfo />
+      ) : user.id ? (
         <UserCardPresence
           lastSeenAt={user.lastSeenAt}
           timezone={user.timezone}


### PR DESCRIPTION
Fixes ARG-413.

## What

Adds the shared user hover card to the test **Activity** flow in the build sidebar — the actor avatar on each "Change ignored/unignored" entry ([TestActivitySection](apps/frontend/src/pages/Build/sidebar/TestActivitySection.tsx)) and the "ignored by …" line in the [Change section](apps/frontend/src/pages/Build/sidebar/TestChangeSection.tsx). Previously these showed only a bare avatar/name with no card, unlike the Review activity flow which already had one.

## Bot handling

When a change is auto-ignored by the **Argos bot**, the card suppresses the online/away dot and local-time rows and instead explains it's an automated account. It also skips the live presence subscription for bots.

To detect this on the client, `User.type` (`user` / `bot`) is now exposed in GraphQL — resolved from the existing `User.type` model column (the same one the avatar resolver uses to serve the bot avatar).

<img width="978" height="450" alt="CleanShot 2026-06-25 at 22 20 53@2x" src="https://github.com/user-attachments/assets/4b1dda8b-b533-47dc-8655-d60f3e1d34cd" />


## Plumbing

The audit-trail user now selects `...UserCard_user`. Since the card's `role` field is keyed on `accountSlug`/`projectName`, those are threaded from `IgnoreButton` into the optimistic `writeFragment` variables, and the optimistic entry fills card fields for the signed-in actor (presence = now, role/timezone null; the next fetch fills them). The minimal `AuditTrail_currentAccount` read fragment is left untouched so the optimistic read still succeeds.

## Verification

- `pnpm codegen` clean
- `check-types` passes for both backend and frontend
- ESLint clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)