### PR TITLE
refactor(backend): factorize comment link logic into getCommentUrl

### DIFF
--- a/apps/backend/src/comment/addCommentReaction.ts
+++ b/apps/backend/src/comment/addCommentReaction.ts
@@ -7,7 +7,7 @@ import { sendNotification } from "@/notification";
 import { boom } from "@/util/error";
 
 import { publishCommentChange } from "./commentEvents";
-import { formatCommentId } from "./id";
+import { getCommentUrl } from "./id";
 import { renderCommentHtmlWithMentions } from "./mentions";
 import { isValidEmoji } from "./reactions";
 
@@ -82,13 +82,12 @@ async function notifyCommentThreadSubscribers(input: {
   invariant(build.project, "project not found");
   invariant(build.project.account, "project account not found");
 
-  const [reactor, buildUrl] = await Promise.all([
+  const [reactor, commentUrl] = await Promise.all([
     User.query().findById(userId).withGraphFetched("account"),
-    build.getUrl(),
+    getCommentUrl({ build, comment }),
   ]);
 
   const reactorName = reactor?.account?.displayName ?? null;
-  const commentUrl = `${buildUrl}#${formatCommentId(comment.id)}`;
 
   await sendNotification({
     type: "comment_reaction",

--- a/apps/backend/src/comment/commentNotifications.ts
+++ b/apps/backend/src/comment/commentNotifications.ts
@@ -5,7 +5,7 @@ import { subscribeUserToCommentThread } from "@/database/services/comment-notifi
 import { sendNotification } from "@/notification";
 
 import { publishCommentChange } from "./commentEvents";
-import { formatCommentId } from "./id";
+import { getCommentUrl } from "./id";
 import {
   getCommentMentionedUserIds,
   renderCommentHtmlWithMentions,
@@ -23,12 +23,11 @@ export async function getCommentNotificationData(input: {
 }) {
   const { build, project, comment, userId } = input;
   invariant(project.account, "Build project account not found");
-  const [author, buildUrl, bodyHtml] = await Promise.all([
+  const [author, commentUrl, bodyHtml] = await Promise.all([
     User.query().findById(userId).withGraphFetched("account"),
-    build.getUrl(),
+    getCommentUrl({ build, comment }),
     renderCommentHtmlWithMentions(comment),
   ]);
-  const commentUrl = `${buildUrl}#${formatCommentId(comment.id)}`;
   return {
     accountSlug: project.account.slug,
     projectName: project.name,

--- a/apps/backend/src/comment/id.ts
+++ b/apps/backend/src/comment/id.ts
@@ -1,3 +1,4 @@
+import type { Build, Comment } from "@/database/models";
 import { sqids } from "@/util/sqids";
 
 const COMMENT_ID_PREFIX = "comment-";
@@ -25,4 +26,16 @@ export function parseCommentId(input: string): string {
   }
 
   return String(decoded);
+}
+
+/**
+ * Build the shareable URL pointing at a specific comment, i.e. the comment's
+ * build page with the comment ID as the fragment so the page scrolls to it.
+ */
+export async function getCommentUrl(input: {
+  build: Build;
+  comment: Comment;
+}): Promise<string> {
+  const buildUrl = await input.build.getUrl();
+  return `${buildUrl}#${formatCommentId(input.comment.id)}`;
 }


### PR DESCRIPTION
## What

The comment URL — `${buildUrl}#${formatCommentId(comment.id)}` — was built inline in two places:

- `getCommentNotificationData` ([commentNotifications.ts](apps/backend/src/comment/commentNotifications.ts)) — powers `comment_added`, `comment_mention`, `comment_replied`
- `addCommentReaction` ([addCommentReaction.ts](apps/backend/src/comment/addCommentReaction.ts)) — powers `comment_reaction`

This extracts a shared `getCommentUrl({ build, comment })` helper into [comment/id.ts](apps/backend/src/comment/id.ts), next to `formatCommentId` — whose doc comment already described it as being used "to build shareable links to a comment".

## Notes

- The `Build`/`Comment` import in `id.ts` is **type-only**, so the module stays runtime-pure and its fast isolated unit test (`id.test.ts`) keeps working.
- Both call sites await the helper directly inside their existing `Promise.all`, dropping the intermediate `buildUrl` variable. `getCommentNotificationData`'s return shape is unchanged, so its consumers in `createBuildComment.ts` are unaffected.
- A repo-wide grep confirmed these were the only two spots producing a comment URL. The remaining `formatCommentId` uses (GraphQL ID encoding) and the `comment_*.tsx` email handlers (which only consume `commentUrl`) are intentionally untouched.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on the three files
- [x] `vitest run apps/backend/src/comment/id.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)