### PR TITLE
fix(backend): drop "cache" from logout Clear-Site-Data to fix slow logout

### DIFF
--- a/apps/backend/src/web/app-router.ts
+++ b/apps/backend/src/web/app-router.ts
@@ -160,7 +160,7 @@ export const installAppRouter = async (app: express.Application) => {
         await revokeSessionByToken(rawToken);
       }
       clearSessionCookies(res);
-      res.setHeader("Clear-Site-Data", '"cookies", "storage", "cache"');
+      res.setHeader("Clear-Site-Data", '"cookies", "storage"');
       res.sendStatus(204);
     }),
   );


### PR DESCRIPTION
## Problem

`/auth/logout` was slow to respond. The handler itself does almost nothing expensive — an indexed Postgres `UPDATE`, a Redis `DEL`, and cookie clearing. The actual cause was the response header:

```
Clear-Site-Data: "cookies", "storage", "cache"
```

The `"cache"` directive instructs the browser to clear its **entire HTTP cache for the origin**, which stalls for multiple seconds in Chromium and blocks the fetch from resolving — so logout feels slow even though the server work is sub-millisecond. The frontend waits on that fetch before redirecting to `/login`.

## Fix

Drop the `"cache"` directive, keeping `"cookies", "storage"`. The session cookies are already cleared explicitly via `clearSessionCookies`, so clearing the HTTP cache adds no security benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)