### PR TITLE
feat: surface baseline eligibility on builds

### DIFF
--- a/apps/backend/src/build/baselineEligibility.test.ts
+++ b/apps/backend/src/build/baselineEligibility.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import type { Build } from "@/database/models";
+
+import { getBuildBaselineEligibility } from "./baselineEligibility";
+
+type EligibilityArgs = Parameters<typeof getBuildBaselineEligibility>[0];
+
+function getEligibility(overrides: {
+  build?: Partial<Pick<Build, "jobStatus" | "subset" | "type">>;
+  valid?: boolean;
+  hasAcceptedReview?: boolean;
+  hasMergedPullRequest?: boolean;
+}) {
+  const args: EligibilityArgs = {
+    build: {
+      jobStatus: "complete",
+      subset: false,
+      type: "reference",
+      ...overrides.build,
+    },
+    valid: overrides.valid ?? true,
+    hasAcceptedReview: overrides.hasAcceptedReview ?? false,
+    hasMergedPullRequest: overrides.hasMergedPullRequest ?? false,
+  };
+  return getBuildBaselineEligibility(args);
+}
+
+describe("getBuildBaselineEligibility", () => {
+  it("is eligible for an auto-approved (reference) build", () => {
+    expect(getEligibility({ build: { type: "reference" } })).toEqual({
+      eligible: true,
+      reasons: [],
+    });
+  });
+
+  it("is eligible for an orphan build", () => {
+    expect(getEligibility({ build: { type: "orphan" } })).toEqual({
+      eligible: true,
+      reasons: [],
+    });
+  });
+
+  it("is eligible for a check build with an accepted review", () => {
+    expect(
+      getEligibility({ build: { type: "check" }, hasAcceptedReview: true }),
+    ).toEqual({ eligible: true, reasons: [] });
+  });
+
+  it("is eligible for a check build with a merged pull request", () => {
+    expect(
+      getEligibility({ build: { type: "check" }, hasMergedPullRequest: true }),
+    ).toEqual({ eligible: true, reasons: [] });
+  });
+
+  it("is not eligible for an unapproved check build", () => {
+    expect(getEligibility({ build: { type: "check" } })).toEqual({
+      eligible: false,
+      reasons: ["not-approved"],
+    });
+  });
+
+  it("is not eligible for a skipped build", () => {
+    expect(getEligibility({ build: { type: "skipped" } })).toEqual({
+      eligible: false,
+      reasons: ["not-approved"],
+    });
+  });
+
+  it("is not eligible when framework tests did not pass", () => {
+    expect(getEligibility({ valid: false })).toEqual({
+      eligible: false,
+      reasons: ["tests-failed"],
+    });
+  });
+
+  it("is not eligible when the build is a subset", () => {
+    expect(getEligibility({ build: { subset: true } })).toEqual({
+      eligible: false,
+      reasons: ["subset"],
+    });
+  });
+
+  it("reports every unmet reason", () => {
+    expect(
+      getEligibility({
+        build: { type: "check", subset: true },
+        valid: false,
+      }),
+    ).toEqual({
+      eligible: false,
+      reasons: ["tests-failed", "subset", "not-approved"],
+    });
+  });
+
+  it("only reports incompleteness while the build is not complete", () => {
+    expect(
+      getEligibility({
+        build: { jobStatus: "progress", type: "check", subset: true },
+        valid: false,
+      }),
+    ).toEqual({ eligible: false, reasons: ["build-incomplete"] });
+  });
+});

--- a/apps/backend/src/build/baselineEligibility.ts
+++ b/apps/backend/src/build/baselineEligibility.ts
@@ -1,0 +1,72 @@
+import type { Build } from "@/database/models";
+
+/**
+ * Reasons why a build is not eligible to be used as a baseline.
+ *
+ * These mirror the intrinsic (per-build) criteria applied by the baseline
+ * selection query in `strategy/strategies/ci/query.ts`. The remaining criteria
+ * (same build name and commit ancestry) depend on the build being compared
+ * against, so they cannot be evaluated for a build in isolation.
+ */
+export type BuildBaselineIneligibilityReason =
+  | "build-incomplete"
+  | "tests-failed"
+  | "subset"
+  | "not-approved";
+
+export type BuildBaselineEligibility = {
+  eligible: boolean;
+  reasons: BuildBaselineIneligibilityReason[];
+};
+
+/**
+ * Compute whether a build is eligible to be used as a baseline by a future
+ * build.
+ *
+ * A build is eligible when ALL of the following are true:
+ * - The build is complete.
+ * - All framework tests passed (the compare bucket is valid).
+ * - The build is not marked as a subset.
+ * - The build is auto-approved (reference), manually approved (an accepted
+ *   review or a merged pull request), or an orphan.
+ *
+ * @see {@link file://./strategy/strategies/ci/query.ts} for the matching query.
+ */
+export function getBuildBaselineEligibility(args: {
+  build: Pick<Build, "jobStatus" | "subset" | "type">;
+  /** Whether the compare screenshot bucket is valid (framework tests passed). */
+  valid: boolean;
+  /** Whether the build has an accepted review. */
+  hasAcceptedReview: boolean;
+  /** Whether the build is attached to a merged pull request. */
+  hasMergedPullRequest: boolean;
+}): BuildBaselineEligibility {
+  const { build } = args;
+
+  // Until the build is complete, its eligibility cannot be determined.
+  if (build.jobStatus !== "complete") {
+    return { eligible: false, reasons: ["build-incomplete"] };
+  }
+
+  const reasons: BuildBaselineIneligibilityReason[] = [];
+
+  if (!args.valid) {
+    reasons.push("tests-failed");
+  }
+
+  if (build.subset) {
+    reasons.push("subset");
+  }
+
+  const approved =
+    build.type === "reference" ||
+    build.type === "orphan" ||
+    (build.type === "check" &&
+      (args.hasAcceptedReview || args.hasMergedPullRequest));
+
+  if (!approved) {
+    reasons.push("not-approved");
+  }
+
+  return { eligible: reasons.length === 0, reasons };
+}

--- a/apps/backend/src/graphql/definitions/Build.ts
+++ b/apps/backend/src/graphql/definitions/Build.ts
@@ -3,12 +3,17 @@ import { invariant } from "@argos/util/invariant";
 import gqlTag from "graphql-tag";
 
 import { getPreviousDiffApprovalIds } from "@/build/approval";
+import {
+  getBuildBaselineEligibility,
+  type BuildBaselineIneligibilityReason,
+} from "@/build/baselineEligibility";
 import { Build, BuildNotificationSubscription } from "@/database/models";
 import { sortScreenshotDiffsForBuild } from "@/database/services/screenshot-diffs";
 import { getProjectMemberIds } from "@/project/members";
 
 import {
   IBaseBranchResolution,
+  IBuildBaselineIneligibilityReason,
   IBuildStatus,
   type IResolvers,
 } from "../__generated__/resolver-types";
@@ -141,6 +146,27 @@ export const typeDefs = gql`
     members: [User!]!
     "Users requested to review this build"
     reviewers: [User!]!
+    "Whether this build is eligible to be used as a baseline by future builds"
+    baselineEligibility: BuildBaselineEligibility!
+  }
+
+  "Whether a build is eligible to be used as a baseline, with the reasons when it is not."
+  type BuildBaselineEligibility {
+    "Whether the build is eligible to be used as a baseline"
+    eligible: Boolean!
+    "Reasons why the build is not eligible (empty when eligible)"
+    reasons: [BuildBaselineIneligibilityReason!]!
+  }
+
+  enum BuildBaselineIneligibilityReason {
+    "The build is not complete yet"
+    BUILD_INCOMPLETE
+    "Some framework tests did not pass"
+    TESTS_FAILED
+    "The build is marked as a subset"
+    SUBSET
+    "The build is not auto-approved, manually approved, or an orphan"
+    NOT_APPROVED
   }
 
   type BuildMetadata {
@@ -189,6 +215,16 @@ async function getProject(ctx: Context, build: Build) {
   invariant(project, "project not found");
   return project;
 }
+
+const baselineIneligibilityReasonMap: Record<
+  BuildBaselineIneligibilityReason,
+  IBuildBaselineIneligibilityReason
+> = {
+  "build-incomplete": IBuildBaselineIneligibilityReason.BuildIncomplete,
+  "tests-failed": IBuildBaselineIneligibilityReason.TestsFailed,
+  subset: IBuildBaselineIneligibilityReason.Subset,
+  "not-approved": IBuildBaselineIneligibilityReason.NotApproved,
+};
 
 export const resolvers: IResolvers = {
   Build: {
@@ -402,6 +438,40 @@ export const resolvers: IResolvers = {
         ),
       );
       return accounts.filter((account) => account !== null);
+    },
+    baselineEligibility: async (build, _args, ctx) => {
+      const eligibility = await (async () => {
+        // Until the build is complete, eligibility cannot be determined and we
+        // can skip the extra loads.
+        if (build.jobStatus !== "complete") {
+          return getBuildBaselineEligibility({
+            build,
+            valid: false,
+            hasAcceptedReview: false,
+            hasMergedPullRequest: false,
+          });
+        }
+        const [compareBucket, aggregatedStatus, pullRequest] =
+          await Promise.all([
+            ctx.loaders.ScreenshotBucket.load(build.compareScreenshotBucketId),
+            ctx.loaders.BuildAggregatedStatus.load(build),
+            build.githubPullRequestId
+              ? ctx.loaders.GithubPullRequest.load(build.githubPullRequestId)
+              : null,
+          ]);
+        return getBuildBaselineEligibility({
+          build,
+          valid: compareBucket?.valid ?? false,
+          hasAcceptedReview: aggregatedStatus === "accepted",
+          hasMergedPullRequest: pullRequest?.merged ?? false,
+        });
+      })();
+      return {
+        eligible: eligibility.eligible,
+        reasons: eligibility.reasons.map(
+          (reason) => baselineIneligibilityReasonMap[reason],
+        ),
+      };
     },
   },
 };

--- a/apps/frontend/src/containers/BuildBaselineEligibilityChip.tsx
+++ b/apps/frontend/src/containers/BuildBaselineEligibilityChip.tsx
@@ -1,0 +1,68 @@
+import { DocumentType, graphql } from "@/gql";
+import { BuildBaselineIneligibilityReason } from "@/gql/graphql";
+import { Chip, ChipProps } from "@/ui/Chip";
+import { Tooltip } from "@/ui/Tooltip";
+import {
+  getBaselineEligibilityDescriptor,
+  getBaselineIneligibilityReasonLabel,
+} from "@/util/build";
+
+const _BuildFragment = graphql(`
+  fragment BuildBaselineEligibilityChip_Build on Build {
+    baselineEligibility {
+      eligible
+      reasons
+    }
+  }
+`);
+
+export function BuildBaselineEligibilityChip(props: {
+  build: DocumentType<typeof _BuildFragment>;
+  scale?: ChipProps["scale"];
+}) {
+  const { eligible, reasons } = props.build.baselineEligibility;
+
+  // Eligibility cannot be determined until the build is complete: stay quiet
+  // rather than showing a misleading "not eligible" chip.
+  if (reasons.includes(BuildBaselineIneligibilityReason.BuildIncomplete)) {
+    return null;
+  }
+
+  const descriptor = getBaselineEligibilityDescriptor(eligible);
+
+  return (
+    <Tooltip
+      variant="info"
+      content={
+        <BaselineEligibilityDescription eligible={eligible} reasons={reasons} />
+      }
+    >
+      <Chip
+        icon={descriptor.icon}
+        color={descriptor.color}
+        scale={props.scale}
+        aria-label={descriptor.label}
+      />
+    </Tooltip>
+  );
+}
+
+function BaselineEligibilityDescription(props: {
+  eligible: boolean;
+  reasons: BuildBaselineIneligibilityReason[];
+}) {
+  const descriptor = getBaselineEligibilityDescriptor(props.eligible);
+  if (props.eligible) {
+    return <>{descriptor.description}</>;
+  }
+  return (
+    <div className="flex flex-col gap-1">
+      <div>{descriptor.description}</div>
+      <ul className="list-disc pl-4">
+        {props.reasons.map((reason) => (
+          <li key={reason}>{getBaselineIneligibilityReasonLabel(reason)}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/Build/BuildInfos.tsx
+++ b/apps/frontend/src/pages/Build/BuildInfos.tsx
@@ -9,12 +9,17 @@ import {
 import { DocumentType, graphql } from "@/gql";
 import {
   BaseBranchResolution,
+  BuildBaselineIneligibilityReason,
   BuildStatus,
   TestReportStatus,
 } from "@/gql/graphql";
 import { Link } from "@/ui/Link";
 import { Time } from "@/ui/Time";
-import { getTestReportStatusDescriptor } from "@/util/build";
+import {
+  getBaselineEligibilityDescriptor,
+  getBaselineIneligibilityReasonLabel,
+  getTestReportStatusDescriptor,
+} from "@/util/build";
 import { lowTextColorClassNames } from "@/util/colors";
 
 import { getProjectURL } from "../Project/ProjectParams";
@@ -53,6 +58,10 @@ const _BuildFragment = graphql(`
       testReport {
         status
       }
+    }
+    baselineEligibility {
+      eligible
+      reasons
     }
     baseBranch
     baseBranchResolvedFrom
@@ -142,6 +151,35 @@ function TestReportStatusLabel(props: { status: TestReportStatus }) {
         {descriptor.label}
       </div>
       <Description>{descriptor.description}</Description>
+    </>
+  );
+}
+
+function BaselineEligibilityLabel(props: {
+  eligibility: DocumentType<typeof _BuildFragment>["baselineEligibility"];
+}) {
+  const { eligibility } = props;
+  const descriptor = getBaselineEligibilityDescriptor(eligibility.eligible);
+  return (
+    <>
+      <div>
+        <descriptor.icon
+          className={clsx(
+            "mr-1 inline-block",
+            lowTextColorClassNames[descriptor.color],
+          )}
+          size="1em"
+        />
+        {descriptor.label}
+      </div>
+      <Description>{descriptor.description}</Description>
+      {eligibility.reasons.length > 0 ? (
+        <ul className="text-low mt-1 list-disc pl-4 text-xs font-normal">
+          {eligibility.reasons.map((reason) => (
+            <li key={reason}>{getBaselineIneligibilityReasonLabel(reason)}</li>
+          ))}
+        </ul>
+      ) : null}
     </>
   );
 }
@@ -289,6 +327,17 @@ export function BuildInfos(props: {
           <Dt>Tests status</Dt>
           <Dd>
             <TestReportStatusLabel status={build.metadata.testReport.status} />
+          </Dd>
+        </>
+      )}
+
+      {build.baselineEligibility.reasons.includes(
+        BuildBaselineIneligibilityReason.BuildIncomplete,
+      ) ? null : (
+        <>
+          <Dt>Baseline eligibility</Dt>
+          <Dd>
+            <BaselineEligibilityLabel eligibility={build.baselineEligibility} />
           </Dd>
         </>
       )}

--- a/apps/frontend/src/pages/Build/header/BuildHeader.tsx
+++ b/apps/frontend/src/pages/Build/header/BuildHeader.tsx
@@ -4,6 +4,7 @@ import { CheckIcon, RefreshCcwIcon, SparklesIcon } from "lucide-react";
 import { useClipboard } from "use-clipboard-copy";
 
 import { useIsLoggedIn } from "@/containers/Auth";
+import { BuildBaselineEligibilityChip } from "@/containers/BuildBaselineEligibilityChip";
 import { BuildMergeQueueIndicator } from "@/containers/BuildMergeQueueIndicator";
 import { BuildModeIndicator } from "@/containers/BuildModeIndicator";
 import { BuildStatusChip } from "@/containers/BuildStatusChip";
@@ -44,6 +45,7 @@ const _BuildFragment = graphql(`
     }
     ...BuildStatusChip_Build
     ...BuildTestStatusChip_Build
+    ...BuildBaselineEligibilityChip_Build
   }
 `);
 
@@ -240,6 +242,7 @@ export const BuildHeader = memo(
           </div>
           {build ? <BuildStatusChip build={build} /> : null}
           {build ? <BuildTestStatusChip build={build} /> : null}
+          {build ? <BuildBaselineEligibilityChip build={build} /> : null}
         </div>
         <div className="flex min-w-0 items-center gap-4">
           <div className="flex items-center gap-2 empty:hidden">

--- a/apps/frontend/src/pages/Project/Builds.tsx
+++ b/apps/frontend/src/pages/Project/Builds.tsx
@@ -19,6 +19,7 @@ import { useQueryStates } from "nuqs";
 import { Heading, Text } from "react-aria-components";
 import { useResolvedPath } from "react-router-dom";
 
+import { BuildBaselineEligibilityChip } from "@/containers/BuildBaselineEligibilityChip";
 import { BuildMergeQueueIndicator } from "@/containers/BuildMergeQueueIndicator";
 import { BuildModeIndicator } from "@/containers/BuildModeIndicator";
 import { BuildStatusChip } from "@/containers/BuildStatusChip";
@@ -109,6 +110,7 @@ const ProjectBuildsQuery = graphql(`
           }
           ...BuildStatusChip_Build
           ...BuildTestStatusChip_Build
+          ...BuildBaselineEligibilityChip_Build
         }
       }
     }
@@ -147,8 +149,9 @@ function BuildRow({
       <div className="flex w-38 shrink-0 flex-col items-start gap-1">
         <BuildStatusChip build={build} scale="sm" />
       </div>
-      <div className="hidden w-28 shrink-0 items-start lg:flex">
+      <div className="hidden w-28 shrink-0 items-start gap-1 lg:flex">
         <BuildTestStatusChip build={build} scale="sm" />
+        <BuildBaselineEligibilityChip build={build} scale="sm" />
       </div>
       <div className="flex grow">
         <div className="hidden lg:flex">

--- a/apps/frontend/src/util/build.tsx
+++ b/apps/frontend/src/util/build.tsx
@@ -2,6 +2,8 @@ import { assertNever } from "@argos/util/assertNever";
 import {
   AlertTriangleIcon,
   BadgeCheckIcon,
+  BookmarkCheckIcon,
+  BookmarkXIcon,
   CheckCircle2Icon,
   CheckIcon,
   CircleCheckIcon,
@@ -18,7 +20,12 @@ import {
   XIcon,
 } from "lucide-react";
 
-import { BuildStatus, BuildType, TestReportStatus } from "@/gql/graphql";
+import {
+  BuildBaselineIneligibilityReason,
+  BuildStatus,
+  BuildType,
+  TestReportStatus,
+} from "@/gql/graphql";
 
 export const buildStatusDescriptors: Record<
   BuildStatus,
@@ -131,6 +138,47 @@ export function getBuildDescriptor(
     }
     default:
       assertNever(type);
+  }
+}
+
+/**
+ * Get the descriptor for the baseline eligibility of a build.
+ */
+export function getBaselineEligibilityDescriptor(eligible: boolean) {
+  return eligible
+    ? {
+        label: "Eligible as baseline",
+        color: "success" as const,
+        icon: BookmarkCheckIcon,
+        description:
+          "This build is eligible to be used as a baseline by future builds.",
+      }
+    : {
+        label: "Not eligible as baseline",
+        color: "neutral" as const,
+        icon: BookmarkXIcon,
+        description:
+          "This build is not eligible to be used as a baseline by future builds.",
+      };
+}
+
+/**
+ * Get a human readable explanation of why a build is not eligible as a baseline.
+ */
+export function getBaselineIneligibilityReasonLabel(
+  reason: BuildBaselineIneligibilityReason,
+): string {
+  switch (reason) {
+    case BuildBaselineIneligibilityReason.BuildIncomplete:
+      return "The build is not complete yet.";
+    case BuildBaselineIneligibilityReason.TestsFailed:
+      return "Some end-to-end tests did not pass.";
+    case BuildBaselineIneligibilityReason.Subset:
+      return "The build is marked as a subset, so it only contains part of the snapshots.";
+    case BuildBaselineIneligibilityReason.NotApproved:
+      return "The build is not auto-approved, manually approved, or an orphan.";
+    default:
+      assertNever(reason);
   }
 }
 


### PR DESCRIPTION
## What

Make it explicit whether a build is **eligible to be used as a baseline** by future builds, and explain **why** when it is not.

### Eligibility rules

A build is eligible when it is:
- **complete**,
- **all framework tests passed** (compare bucket is valid),
- **not a subset**, and
- **auto-approved** (reference), **manually approved** (an accepted review or a merged pull request), or an **orphan**.

These mirror the intrinsic criteria of the CI baseline-selection query in `strategy/strategies/ci/query.ts`. The two *relational* criteria (same build name, and commit ancestry vs. the merge base) depend on the build being compared against, so they can't be evaluated for a build in isolation and are intentionally not shown.

## Changes

**Backend**
- New pure `getBuildBaselineEligibility` predicate (`apps/backend/src/build/baselineEligibility.ts`) + unit tests.
- New `Build.baselineEligibility` GraphQL field returning `{ eligible, reasons }` with a `BuildBaselineIneligibilityReason` enum (`BUILD_INCOMPLETE`, `TESTS_FAILED`, `SUBSET`, `NOT_APPROVED`). Resolved via existing dataloaders (no N+1).

**Frontend**
- New `BuildBaselineEligibilityChip` (icon-only chip with a tooltip listing the reasons): green `BookmarkCheck` when eligible, neutral `BookmarkX` when not. Hidden while the build is incomplete.
- Added the chip to the **build header** and the **builds list** (next to the test-status chip).
- New **"Baseline eligibility"** section in the build **Info panel** with status, description, and a bulleted list of reasons when ineligible.

## Notes
- The predicate models the standard CI baseline rules; merge-queue / monitoring nuances are not specially handled.

## Test plan
- [x] Backend `check-types`, frontend `check-types`, ESLint all clean
- [x] Unit tests for `getBuildBaselineEligibility` (10 cases) pass
- [ ] Visual check of the chip in the list/header and the Info panel section

🤖 Generated with [Claude Code](https://claude.com/claude-code)