### PR TITLE
fix(backend): don't block signup/signin on a stale session cookie

### DIFF
--- a/apps/backend/src/graphql/context.ts
+++ b/apps/backend/src/graphql/context.ts
@@ -2,11 +2,10 @@ import type { IncomingMessage } from "node:http";
 import type { BaseContext } from "@apollo/server";
 import { captureException } from "@sentry/node";
 import type { Request, Response } from "express";
-import { GraphQLError } from "graphql";
 
 import type { AuthSessionPayload } from "@/auth/payload";
 import { touchPresence } from "@/auth/presence";
-import { readSessionCookie } from "@/auth/session-cookie";
+import { clearSessionCookies, readSessionCookie } from "@/auth/session-cookie";
 import {
   safeSessionAuthFromExpressReq,
   sessionAuthFromExpressReq,
@@ -52,8 +51,8 @@ async function getContextAuth(
   }
 
   // No cookie → anonymous request (allowed). A present-but-invalid cookie
-  // throws a 401, which surfaces as UNAUTHENTICATED below so the client logs
-  // out.
+  // throws a 401, which the caller turns into an anonymous request (clearing
+  // the stale cookie) rather than failing the whole request.
   const rawToken = readSessionCookie(request);
   if (!rawToken) {
     return null;
@@ -65,38 +64,42 @@ export async function getContext(
   request: Request,
   response: Response,
 ): Promise<Context> {
+  const requestLocation = extractLocationFromRequest(request);
+
+  let auth: AuthSessionPayload | null;
   try {
-    const auth = await getContextAuth(request);
-    const requestLocation = extractLocationFromRequest(request);
-    if (auth) {
-      // Record live presence. Best-effort and fire-and-forget — a presence
-      // write must never turn a query into a 500. Timezone rides on the
-      // Cloudflare `cf-timezone` header (absent locally).
-      void touchPresence({
-        userId: auth.user.id,
-        timezone: getHeaderString(request, "cf-timezone"),
-      }).catch(captureException);
-    }
-    return {
-      auth,
-      requestLocation,
-      loaders: createLoaders(),
-      req: request,
-      res: response,
-    };
+    auth = await getContextAuth(request);
   } catch (error) {
     if (error instanceof HTTPError && error.statusCode === 401) {
-      throw new GraphQLError("User is not authenticated", {
-        originalError: error,
-        extensions: {
-          code: "UNAUTHENTICATED",
-          http: { status: 401 },
-        },
-      });
+      // The request carries a session cookie that is invalid, expired, or
+      // revoked. Treat the request as anonymous and clear the stale cookies so
+      // the client stops sending them — failing here would block public
+      // operations like signup and signin. Resolvers that require auth still
+      // throw UNAUTHENTICATED on their own, which drives the client logout.
+      clearSessionCookies(response);
+      auth = null;
+    } else {
+      throw error;
     }
-
-    throw error;
   }
+
+  if (auth) {
+    // Record live presence. Best-effort and fire-and-forget — a presence
+    // write must never turn a query into a 500. Timezone rides on the
+    // Cloudflare `cf-timezone` header (absent locally).
+    void touchPresence({
+      userId: auth.user.id,
+      timezone: getHeaderString(request, "cf-timezone"),
+    }).catch(captureException);
+  }
+
+  return {
+    auth,
+    requestLocation,
+    loaders: createLoaders(),
+    req: request,
+    res: response,
+  };
 }
 
 /**


### PR DESCRIPTION
## Problem

A user trying to **sign up with their email** got a `User not authenticated` toast — even though they were logged out and signup requires no authentication.

## Root cause

Every GraphQL HTTP request builds its context via `getContext`, which validates the session cookie. The logic was:

- **No cookie** → anonymous (allowed) ✅
- **Present-but-invalid cookie** (expired / revoked / deleted user) → `sessionAuthFromExpressReq` throws `boom(401, ...)`, which `getContext` rethrew as a `UNAUTHENTICATED` GraphQL error for the **whole request** ❌

So any user holding a stale `argos_session` cookie could not run public operations (`requestEmailSignup`, `requestEmailSignin`, `authenticateWithEmail`) — the resolver never ran, and the frontend toasted the error.

The WebSocket context already handled this correctly via `safeSessionAuthFromExpressReq` (returns `null` instead of throwing); only the HTTP context was strict.

## Fix

When the session cookie is invalid, treat the request as **anonymous** and **clear the stale cookies** on the response, instead of failing the request. Resolvers that genuinely require auth still throw `unauthenticated()` → `UNAUTHENTICATED`, which the frontend route error boundary catches to drive logout — so that UX is preserved.

`extractLocationFromRequest` now runs before the auth step so anonymous signup requests still get `ctx.requestLocation` (used by the email mutations).

## Testing

- `tsc --noEmit` passes.
- Manual: set a junk `argos_session` cookie, go to `/signup`, submit an email — previously toasted "User not authenticated"; now proceeds to the code-verification screen and the response clears the stale cookie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)