### PR TITLE
perf(backend): fix slow team Tests dashboard

### DIFF
--- a/apps/backend/db/migrations/20260627120000_add-screenshots-has-parent-index.js
+++ b/apps/backend/db/migrations/20260627120000_add-screenshots-has-parent-index.js
@@ -1,0 +1,32 @@
+/**
+ * Partial index supporting the anti-join in `queryActiveTests`
+ * (apps/backend/src/graphql/services/test.ts). The team "Tests" dashboard used
+ * to hash-join the whole `screenshots` table (300M+ rows) just to keep the
+ * screenshots with a null `parentName`. Since ~99.6% of screenshots have a null
+ * `parentName`, we instead exclude the rare child screenshots via an anti-join;
+ * this index makes that anti-join cheap (it only holds the ~0.4% of rows that
+ * have a `parentName`).
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async (knex) => {
+  await knex.raw(`
+    create index concurrently if not exists
+      screenshots_id_has_parent_idx
+    on screenshots ("id")
+    where "parentName" is not null;
+  `);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async (knex) => {
+  await knex.raw(`
+    drop index concurrently if exists screenshots_id_has_parent_idx;
+  `);
+};
+
+export const config = { transaction: false };

--- a/apps/backend/src/graphql/services/test.ts
+++ b/apps/backend/src/graphql/services/test.ts
@@ -1,4 +1,4 @@
-import { Build, ScreenshotDiff, Test } from "@/database/models";
+import { Build, Screenshot, ScreenshotDiff, Test } from "@/database/models";
 import { getStartDateFromPeriod } from "@/metrics/test";
 import { sqids } from "@/util/sqids";
 
@@ -198,13 +198,18 @@ export function queryActiveTests(input: {
     .distinct("sd.testId")
     .join(latestRef, "latest_reference_build.id", "sd.buildId")
     .whereNotNull("sd.testId")
-    .joinRelated("compareScreenshot")
-    .whereNull("compareScreenshot.parentName")
-    .modify((query) => {
-      if (search) {
-        query.whereILike("compareScreenshot.name", `%${search}%`);
-      }
-    })
+    .whereNotNull("sd.compareScreenshotId")
+    // Don't hash-join the whole `screenshots` table (300M+ rows, ~99.6% with a
+    // null `parentName`) just to keep the non-child ones. Instead exclude the
+    // rare child screenshots (those with a `parentName`) via an anti-join backed
+    // by `screenshots_id_has_parent_idx`. Equivalent to
+    // `compareScreenshot.parentName IS NULL` since the foreign key guarantees the
+    // screenshot exists when `compareScreenshotId` is set.
+    .whereNotExists(
+      Screenshot.query()
+        .whereRaw('"screenshots"."id" = "sd"."compareScreenshotId"')
+        .whereNotNull("parentName"),
+    )
     .as("active_tests");
 
   return (
@@ -213,6 +218,16 @@ export function queryActiveTests(input: {
       .where((qb) => {
         if (filters?.buildName) {
           qb.where("tests.buildName", filters.buildName);
+        }
+      })
+      .modify((qb) => {
+        if (search) {
+          // A test's name is its screenshot's name (see
+          // `insertFilesAndScreenshots`) and a diff's `testId` always points to
+          // its compare screenshot's test (see `createBuildDiffs`), so matching
+          // `tests.name` is equivalent to matching the compare screenshot name —
+          // and avoids joining the huge `screenshots` table for search too.
+          qb.whereILike("tests.name", `%${search}%`);
         }
       })
       // only ongoing

--- a/apps/backend/src/graphql/services/test.ts
+++ b/apps/backend/src/graphql/services/test.ts
@@ -162,17 +162,50 @@ const FLAKINESS_ORDER_BY = `
 `;
 
 /**
+ * Resolve the id of the latest reference build for each distinct build name in a
+ * project.
+ *
+ * Done one project at a time on purpose: with `projectId` and `type` fixed, the
+ * `(projectId, type, name, createdAt desc)` index already yields rows in the
+ * `DISTINCT ON (name)` order, so Postgres can satisfy this with an ordered index
+ * scan. Folding every project into a single `whereIn(projectId)` instead forces
+ * a sort over the project's *entire* reference-build history (hundreds of
+ * thousands of rows for active teams), which spills to disk.
+ */
+async function getLatestReferenceBuildIds(projectIds: string[]) {
+  const perProject = await Promise.all(
+    projectIds.map((projectId) =>
+      Build.query()
+        .select("id")
+        .distinctOn("name")
+        .where("projectId", projectId)
+        .where("type", "reference")
+        .orderBy("name")
+        .orderBy("createdAt", "desc"),
+    ),
+  );
+  return perProject.flat().map((build) => build.id);
+}
+
+/**
  * Query the "active" tests for a set of projects, sorted by flakiness.
  *
  * A test is active when it appears in the latest reference build of its build
- * name (per project) as a non-orphan compare screenshot. Pass a single project
- * id for the per-project Tests page, or every visible project id for the
- * account-wide aggregate.
+ * name (per project) as a non-child compare screenshot (`parentName IS NULL`).
+ * Pass a single project id for the per-project Tests page, or every visible
+ * project id for the account-wide aggregate.
+ *
+ * The active set is resolved in a few small, well-indexed steps rather than one
+ * statement. The candidate set is tiny (≈ the number of active tests), so doing
+ * the child-screenshot check and the final pagination on concrete id lists lets
+ * Postgres use primary-key lookups throughout — instead of sorting every
+ * reference build and hash-joining the whole `screenshots` table, which it picks
+ * when it has to plan the whole thing from (badly wrong) row estimates.
  *
  * Returns Objection's `{ total, results }` range page so the caller can hand it
  * straight to `paginateResult`.
  */
-export function queryActiveTests(input: {
+export async function queryActiveTests(input: {
   projectIds: string[];
   period: IMetricsPeriod;
   filters?: { buildName?: string | null; search?: string | null } | null;
@@ -182,60 +215,77 @@ export function queryActiveTests(input: {
   const { projectIds, period, filters, after, first } = input;
   const search = filters?.search?.trim();
 
-  const latestRef = Build.query()
-    .alias("b")
-    .select("b.id", "b.projectId", "b.name")
-    .distinctOn(["b.projectId", "b.name"])
-    .where("b.type", "reference")
-    .whereIn("b.projectId", projectIds)
-    .orderBy("b.projectId")
-    .orderBy("b.name")
-    .orderBy("b.createdAt", "desc")
-    .as("latest_reference_build");
+  // Step 1 — the latest reference build per (project, name).
+  const latestBuildIds = await getLatestReferenceBuildIds(projectIds);
+  if (latestBuildIds.length === 0) {
+    return { total: 0, results: [] };
+  }
 
-  const activeTests = ScreenshotDiff.query()
-    .alias("sd")
-    .distinct("sd.testId")
-    .join(latestRef, "latest_reference_build.id", "sd.buildId")
-    .whereNotNull("sd.testId")
-    .whereNotNull("sd.compareScreenshotId")
-    // Don't hash-join the whole `screenshots` table (300M+ rows, ~99.6% with a
-    // null `parentName`) just to keep the non-child ones. Instead exclude the
-    // rare child screenshots (those with a `parentName`) via an anti-join backed
-    // by `screenshots_id_has_parent_idx`. Equivalent to
-    // `compareScreenshot.parentName IS NULL` since the foreign key guarantees the
-    // screenshot exists when `compareScreenshotId` is set.
-    .whereNotExists(
-      Screenshot.query()
-        .whereRaw('"screenshots"."id" = "sd"."compareScreenshotId"')
-        .whereNotNull("parentName"),
-    )
-    .as("active_tests");
+  // Step 2 — the candidate `(testId, compareScreenshotId)` pairs in those builds.
+  const diffs = await ScreenshotDiff.query()
+    .distinct("testId", "compareScreenshotId")
+    .whereIn("buildId", latestBuildIds)
+    .whereNotNull("testId")
+    .whereNotNull("compareScreenshotId");
+  if (diffs.length === 0) {
+    return { total: 0, results: [] };
+  }
 
-  return (
-    Test.query()
-      .whereIn("tests.projectId", projectIds)
-      .where((qb) => {
-        if (filters?.buildName) {
-          qb.where("tests.buildName", filters.buildName);
-        }
-      })
-      .modify((qb) => {
-        if (search) {
-          // A test's name is its screenshot's name (see
-          // `insertFilesAndScreenshots`) and a diff's `testId` always points to
-          // its compare screenshot's test (see `createBuildDiffs`), so matching
-          // `tests.name` is equivalent to matching the compare screenshot name —
-          // and avoids joining the huge `screenshots` table for search too.
-          qb.whereILike("tests.name", `%${search}%`);
-        }
-      })
-      // only ongoing
-      .join(activeTests, "active_tests.testId", "tests.id")
-      .orderByRaw(FLAKINESS_ORDER_BY, {
-        from: getStartDateFromPeriod(period).toISOString(),
-        to: new Date().toISOString(),
-      })
-      .range(after, after + first - 1)
+  // Step 3 — drop the rare child screenshots (those with a `parentName`, ~0.4%).
+  // Looking them up by id is a handful of primary-key probes against the small
+  // candidate set, instead of hash-joining every child screenshot (~1.4M rows).
+  const compareScreenshotIds = [
+    ...new Set(
+      diffs
+        .map((diff) => diff.compareScreenshotId)
+        .filter((id): id is string => id !== null),
+    ),
+  ];
+  const childScreenshots = await Screenshot.query()
+    .select("id")
+    .whereIn("id", compareScreenshotIds)
+    .whereNotNull("parentName");
+  const childScreenshotIds = new Set(
+    childScreenshots.map((screenshot) => screenshot.id),
   );
+
+  const activeTestIds = [
+    ...new Set(
+      diffs
+        .filter(
+          (diff) =>
+            diff.compareScreenshotId !== null &&
+            !childScreenshotIds.has(diff.compareScreenshotId),
+        )
+        .map((diff) => diff.testId)
+        .filter((id): id is string => id !== null),
+    ),
+  ];
+  if (activeTestIds.length === 0) {
+    return { total: 0, results: [] };
+  }
+
+  // Step 4 — rank the active tests by flakiness and paginate. `activeTestIds`
+  // already scopes the result to the requested projects, so the id filter is all
+  // we need.
+  return Test.query()
+    .whereIn("tests.id", activeTestIds)
+    .where((qb) => {
+      if (filters?.buildName) {
+        qb.where("tests.buildName", filters.buildName);
+      }
+    })
+    .modify((qb) => {
+      if (search) {
+        // A test's name is its screenshot's name (see
+        // `insertFilesAndScreenshots`), so matching `tests.name` is equivalent to
+        // matching the compare screenshot name.
+        qb.whereILike("tests.name", `%${search}%`);
+      }
+    })
+    .orderByRaw(FLAKINESS_ORDER_BY, {
+      from: getStartDateFromPeriod(period).toISOString(),
+      to: new Date().toISOString(),
+    })
+    .range(after, after + first - 1);
 }

--- a/apps/backend/src/graphql/services/test.ts
+++ b/apps/backend/src/graphql/services/test.ts
@@ -165,26 +165,54 @@ const FLAKINESS_ORDER_BY = `
  * Resolve the id of the latest reference build for each distinct build name in a
  * project.
  *
- * Done one project at a time on purpose: with `projectId` and `type` fixed, the
- * `(projectId, type, name, createdAt desc)` index already yields rows in the
- * `DISTINCT ON (name)` order, so Postgres can satisfy this with an ordered index
- * scan. Folding every project into a single `whereIn(projectId)` instead forces
- * a sort over the project's *entire* reference-build history (hundreds of
- * thousands of rows for active teams), which spills to disk.
+ * Teams can accumulate a massive reference-build history under only a handful of
+ * build names (millions of builds, a few names). A plain `DISTINCT ON (name)`
+ * has to read every reference build to dedupe — which is what made this step
+ * take seconds. Instead we emulate a loose index scan ("skip scan") with a
+ * recursive CTE: jump to the first build name, then to each next name via the
+ * `(projectId, type, name, createdAt desc)` index, and grab that name's latest
+ * build. That's ~2 index probes per build name instead of scanning the whole
+ * history, so it no longer scales with the number of builds.
  */
 async function getLatestReferenceBuildIds(projectIds: string[]) {
   const perProject = await Promise.all(
-    projectIds.map((projectId) =>
-      Build.query()
-        .select("id")
-        .distinctOn("name")
-        .where("projectId", projectId)
-        .where("type", "reference")
-        .orderBy("name")
-        .orderBy("createdAt", "desc"),
-    ),
+    projectIds.map(async (projectId) => {
+      const result = (await Build.knex().raw(
+        `WITH RECURSIVE build_names AS (
+           SELECT min(name) AS name
+           FROM builds
+           WHERE "projectId" = :projectId AND "type" = 'reference'
+           UNION ALL
+           SELECT (
+             SELECT min(b.name)
+             FROM builds b
+             WHERE b."projectId" = :projectId
+               AND b."type" = 'reference'
+               AND b.name > build_names.name
+           )
+           FROM build_names
+           WHERE build_names.name IS NOT NULL
+         )
+         SELECT (
+           SELECT b.id
+           FROM builds b
+           WHERE b."projectId" = :projectId
+             AND b."type" = 'reference'
+             AND b.name = build_names.name
+           ORDER BY b."createdAt" DESC
+           LIMIT 1
+         ) AS id
+         FROM build_names
+         WHERE build_names.name IS NOT NULL`,
+        { projectId },
+      )) as { rows: { id: string | null }[] };
+      return result.rows;
+    }),
   );
-  return perProject.flat().map((build) => build.id);
+  return perProject
+    .flat()
+    .map((row) => row.id)
+    .filter((id): id is string => id !== null);
 }
 
 /**


### PR DESCRIPTION
## Problem

The team-level **Tests** dashboard (`Account.tests` → `queryActiveTests`) was slow to the point of timing out for large teams. Diagnosed with `EXPLAIN (ANALYZE, BUFFERS)` against real accounts.

Three independent bottlenecks, each only visible at a certain scale:

1. **Hash-joining the whole `screenshots` table** (~324M rows) just to keep non-child screenshots (`compareScreenshot.parentName IS NULL`). Since ~99.6% of screenshots have a null `parentName`, the planner scanned the entire table. → the original hang.
2. **`DISTINCT ON` over a project's entire reference-build history** to find the latest build per name — a sort that spills to disk (qonto-web: ~455k builds → 26MB external merge, ~1.1s).
3. **Reading every reference build** to dedupe to a few names. Teams with few build names but deep history (wiz: 2 projects, **3** names, millions of builds) spent ~5s here alone.

Flakiness scoring (the `ORDER BY` correlated subquery) was investigated and ruled out — the active-test counts are small (argos-ci 782, qonto-web 1.8k, wiz 740), so it's tens of ms.

## Changes

- **Partial index** `screenshots_id_has_parent_idx on screenshots (id) where "parentName" is not null` (only ~0.4% of rows) — migration `20260627120000`.
- **Resolve active tests in small, well-indexed steps** instead of one statement, so the child-screenshot check and pagination run on concrete id lists (primary-key lookups) rather than letting the planner pick hash joins / full scans from badly-wrong row estimates:
  1. latest reference build per name (skip scan, see below)
  2. candidate `(testId, compareScreenshotId)` pairs for those builds
  3. exclude the rare child screenshots by id
  4. rank by flakiness + paginate on the resulting test ids
- **Loose index scan (skip scan)** for "latest reference build per name": a recursive CTE that jumps name-to-name via the `(projectId, type, name, createdAt desc)` index — ~2 index probes per build name instead of reading the whole history.
- **Search matches `tests.name`** instead of `compareScreenshot.name` (they're always equal — a test's name is its screenshot's name, and a diff's `testId` is its compare screenshot's test), so search avoids the `screenshots` join too.

## Results (production data, warm cache)

| Team      | Before                                              | After              |
| --------- | --------------------------------------------------- | ------------------ |
| argos-ci  | ~5s (mostly the 324M screenshots scan)              | sub-second         |
| qonto-web | 2.1s warm / hung cold (455k-build sort + 1.4M hash) | low hundreds of ms |
| wiz       | 5.2s (reading millions of builds in step 1)         | step 1 → ms        |

## Notes

- The migration uses `CREATE INDEX CONCURRENTLY` (`config.transaction = false`); it scans the full `screenshots` table once to build (~few minutes), non-blocking.
- The skip scan does ~2 index probes per _distinct build name_, so it's a big win for deep-history teams and neutral elsewhere; a team with thousands of distinct build names would do thousands of probes (still fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
