### PR TITLE
fix(backend): degrade glNamespaces to null on GitLab API failure

### DIFF
--- a/apps/backend/src/graphql/definitions/Account.ts
+++ b/apps/backend/src/graphql/definitions/Account.ts
@@ -369,14 +369,25 @@ export const commonAccountResolvers: IResolvers["Team"] = {
     if (!client) {
       return null;
     }
-    const namespaces = await client.Namespaces.all();
-    return {
-      edges: namespaces,
-      pageInfo: {
-        hasNextPage: false,
-        totalCount: namespaces.length,
-      },
-    };
+    // Listing namespaces hits the GitLab API and can fail for reasons we can't
+    // control (transient 5xx, rate limiting, network). Degrade to `null` rather
+    // than throwing a field error: with the default `errorPolicy: "none"`, a
+    // GraphQL error makes Apollo discard the whole response, which then surfaces
+    // client-side as a `MissingFieldError` and crashes the New Project page. The
+    // frontend already treats `null` as "no namespaces" and shows the GitLab
+    // setup prompt.
+    try {
+      const namespaces = await client.Namespaces.all();
+      return {
+        edges: namespaces,
+        pageInfo: {
+          hasNextPage: false,
+          totalCount: namespaces.length,
+        },
+      };
+    } catch {
+      return null;
+    }
   },
   slackInstallation: async (account, _args, ctx) => {
     if (!account.slackInstallationId) {


### PR DESCRIPTION
## Problem

Sentry [#7580209879](https://app.argos-ci.com): the New Project page crashes with `MissingFieldError: Can't find field 'gitlabAccessToken' on Account object` (surfaced confusingly as a `TypeError: Cannot assign to read only property 'name'` — that's `@sentry/react` itself failing while trying to *report* the frozen Apollo error).

Fix ARGOS-BROWSER-HT
Fix ARGOS-BROWSER-HS

## Root cause

The cascade:

1. `Account.glNamespaces` calls the GitLab API (`client.Namespaces.all()`). On any failure outside the three known auth-error messages handled by `getGitlabClientFromAccount` (transient 5xx, rate limiting, network), it **throws**.
2. That becomes a GraphQL field error in the response.
3. With Apollo's default `errorPolicy: "none"`, a GraphQL error makes the client **discard the entire response and write nothing to the cache**.
4. The New Project page's `useSuspenseQuery` then falls back to reading the partial `Account` entity written by the account layout query — which only has `id`/`slug`/`permissions`, **not `gitlabAccessToken`**.
5. The first missing field in the selection is `gitlabAccessToken` → `MissingFieldError` → ErrorBoundary → unhandled Sentry crash.

## Fix

Wrap `client.Namespaces.all()` in a `try/catch` and return `null` on failure instead of throwing a field error. No GraphQL error means the full account (including `gitlabAccessToken`) is written to cache normally.

The frontend already treats `null` namespaces as "no namespaces" and renders the GitLab setup prompt, so the UX is correct: a user with a broken GitLab token sees the re-setup prompt instead of a white screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)