### PR TITLE
fix(frontend): test view snapshot layout & hide comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,30 @@ All checks must pass.
 - Split by concern for parallelism
 - Avoid shared global setup
 - Avoid mocking unless necessary
+
+## E2E / visual tests (Playwright + Argos)
+
+- Specs live in `tests/*.spec.ts` and run against the built app.
+- **Run with `NODE_ENV=test pnpm test:e2e`.** This is required: the test
+  process (which seeds the DB) and the web server must both resolve to the
+  `test` Postgres DB. Without `NODE_ENV=test` the seeds write to `development`
+  while the server reads `test`, and pages render "Page not found".
+  - Single test: `NODE_ENV=test pnpm test:e2e --project=chromium -g "<title>"`.
+  - The `setup` project truncates the DB; each test seeds its own data via the
+    `loggedTest` fixtures, so keep seeded data isolated (e.g. don't request the
+    `builds` fixture if you don't need it).
+- **Rebuild the frontend before running** if you changed it — the server serves
+  `apps/frontend/dist`: `pnpm turbo run build --filter=@argos/frontend`. The
+  backend serves from `dist` too, but specs import seeds from
+  `apps/backend/src` directly, so seed changes need no backend rebuild.
+- Auth is set via `loggedTest` (real session cookie); take screenshots with the
+  `screenshot()` helper in `tests/util.ts` (wraps `argosScreenshot`). Dynamic
+  content marked `data-visual-test="transparent"` (e.g. `<Time>`) is neutralized
+  automatically; use the helper's `replacements` for other unstable text.
+- Seeds live in `apps/backend/src/database/seeds.ts`. Add a focused scenario
+  function rather than bending `createBuildScenario` (which many baselines
+  depend on). Use a unique `keyPrefix` (e.g. the project id) for `File` keys.
+  Image fixtures are served from `files.argos-ci.com/test/<s3Id>`; reuse
+  existing keys (`dummy-*`, `diff-*`) so images load.
+- A guard test should fail without the fix — verify by temporarily reverting the
+  fix, rebuilding, and re-running before trusting it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,13 @@ All checks must pass.
 
 - Do not use `!` (non-null assertion)
 - Use `invariant` for required values
+- Program by assertion, not by defense: when a value is _expected_ to be
+  present (a context provided by an ancestor, a required param, an invariant of
+  the call site), assert it with `invariant` (or a hook built on it, e.g.
+  `useNonNullable` / `useProjectPermission`) and then use it directly. Do not
+  paper over the expectation with optional chaining or `?? <fallback>` — that
+  silently degrades instead of surfacing a broken assumption. Reserve `?.` /
+  `??` for values that are genuinely, legitimately optional.
 - Avoid `as` type assertions; prefer proper typing, type guards, or
   `satisfies`. `as const` is fine.
 

--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -508,15 +508,11 @@ export async function createBuildScenario(input: {
  * a non-null fingerprint. Kept separate from {@link createBuildScenario} so it
  * can be used in isolation (e.g. the test-view visual test) without perturbing
  * the other scenarios' baselines.
- *
- * @param keyPrefix - A unique prefix for file keys to avoid conflicts across
- *   parallel test workers.
  */
 export async function createTestChangeScenario(input: {
   projectId: string;
-  keyPrefix?: string;
 }): Promise<{ test: Test; build: Build }> {
-  const { projectId, keyPrefix = "" } = input;
+  const { projectId } = input;
   const now = new Date().toISOString();
 
   const bucketProps = {
@@ -542,30 +538,47 @@ export async function createTestChangeScenario(input: {
   ]);
   invariant(test);
 
-  const [baseFile, compareFile, diffFile] = await File.query().insertAndFetch([
-    {
-      type: "screenshot" as const,
+  // Point at the shared image fixtures already hosted on the CDN
+  // (`files.argos-ci.com/<env>/<key>`) so the screenshots actually render. Each
+  // `key` is globally unique, so reuse an existing row when present — the DB
+  // isn't truncated between a test's retries.
+  const ensureFile = async (props: {
+    type: "screenshot" | "screenshotDiff";
+    width: number;
+    height: number;
+    key: string;
+    contentType: string;
+  }): Promise<File> => {
+    const existing = await File.query().findOne({ key: props.key });
+    if (existing) {
+      return existing;
+    }
+    return File.query().insertAndFetch(props);
+  };
+
+  const [baseFile, compareFile, diffFile] = await Promise.all([
+    ensureFile({
+      type: "screenshot",
       width: 375,
       height: 1024,
-      key: `${keyPrefix}dummy-375x1024.png`,
+      key: "dummy-375x1024.png",
       contentType: "image/png",
-    },
-    {
-      type: "screenshot" as const,
+    }),
+    ensureFile({
+      type: "screenshot",
       width: 375,
       height: 720,
-      key: `${keyPrefix}dummy-375x720.png`,
+      key: "dummy-375x720.png",
       contentType: "image/png",
-    },
-    {
-      type: "screenshotDiff" as const,
+    }),
+    ensureFile({
+      type: "screenshotDiff",
       width: 375,
       height: 1024,
-      key: `${keyPrefix}diff-1024-to-720.png`,
+      key: "diff-1024-to-720.png",
       contentType: "image/png",
-    },
+    }),
   ]);
-  invariant(baseFile && compareFile && diffFile);
 
   const [baseScreenshot, compareScreenshot] =
     await Screenshot.query().insertAndFetch([
@@ -573,14 +586,14 @@ export async function createTestChangeScenario(input: {
         screenshotBucketId: baseBucket.id,
         testId: test.id,
         name: "penelope-argos.jpg",
-        s3Id: "dummy-375x1024.png",
+        s3Id: baseFile.key,
         fileId: baseFile.id,
       },
       {
         screenshotBucketId: compareBucket.id,
         testId: test.id,
         name: "penelope-argos.jpg",
-        s3Id: "dummy-375x720.png",
+        s3Id: compareFile.key,
         fileId: compareFile.id,
       },
     ]);
@@ -609,7 +622,7 @@ export async function createTestChangeScenario(input: {
       testId: test.id,
       score: 0.3,
       jobStatus: "complete" as const,
-      s3Id: "diff-1024-to-720.png",
+      s3Id: diffFile.key,
       fileId: diffFile.id,
       fingerprint: "penelope-argos-change",
       createdAt: now,

--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -499,6 +499,128 @@ export async function createBuildScenario(input: {
 }
 
 /**
+ * Seeds a single test that has a detected change within the default metrics
+ * period (last 7 days), so the test trends page renders its snapshot diff
+ * viewer.
+ *
+ * A change is surfaced by `Test.changes`, which requires a `reference` build —
+ * created within the period — carrying a screenshot diff with a score > 0 and
+ * a non-null fingerprint. Kept separate from {@link createBuildScenario} so it
+ * can be used in isolation (e.g. the test-view visual test) without perturbing
+ * the other scenarios' baselines.
+ *
+ * @param keyPrefix - A unique prefix for file keys to avoid conflicts across
+ *   parallel test workers.
+ */
+export async function createTestChangeScenario(input: {
+  projectId: string;
+  keyPrefix?: string;
+}): Promise<{ test: Test; build: Build }> {
+  const { projectId, keyPrefix = "" } = input;
+  const now = new Date().toISOString();
+
+  const bucketProps = {
+    name: "default",
+    branch: "main",
+    projectId,
+    complete: true,
+    valid: true,
+    screenshotCount: 0,
+    storybookScreenshotCount: 0,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const [baseBucket, compareBucket] =
+    await ScreenshotBucket.query().insertAndFetch([
+      { ...bucketProps, commit: "029b662f3ae57bae7a215301067262c1e95bbc95" },
+      { ...bucketProps, commit: "5a23b6f173d9596a09a73864ab051ea5972e8804" },
+    ]);
+  invariant(baseBucket && compareBucket);
+
+  const [test] = await Test.query().insertAndFetch([
+    { name: "penelope-argos.jpg", buildName: "default", projectId },
+  ]);
+  invariant(test);
+
+  const [baseFile, compareFile, diffFile] = await File.query().insertAndFetch([
+    {
+      type: "screenshot" as const,
+      width: 375,
+      height: 1024,
+      key: `${keyPrefix}dummy-375x1024.png`,
+      contentType: "image/png",
+    },
+    {
+      type: "screenshot" as const,
+      width: 375,
+      height: 720,
+      key: `${keyPrefix}dummy-375x720.png`,
+      contentType: "image/png",
+    },
+    {
+      type: "screenshotDiff" as const,
+      width: 375,
+      height: 1024,
+      key: `${keyPrefix}diff-1024-to-720.png`,
+      contentType: "image/png",
+    },
+  ]);
+  invariant(baseFile && compareFile && diffFile);
+
+  const [baseScreenshot, compareScreenshot] =
+    await Screenshot.query().insertAndFetch([
+      {
+        screenshotBucketId: baseBucket.id,
+        testId: test.id,
+        name: "penelope-argos.jpg",
+        s3Id: "dummy-375x1024.png",
+        fileId: baseFile.id,
+      },
+      {
+        screenshotBucketId: compareBucket.id,
+        testId: test.id,
+        name: "penelope-argos.jpg",
+        s3Id: "dummy-375x720.png",
+        fileId: compareFile.id,
+      },
+    ]);
+  invariant(baseScreenshot && compareScreenshot);
+
+  const [build] = await Build.query().insertAndFetch([
+    {
+      name: "main",
+      number: 1,
+      type: "reference" as const,
+      jobStatus: "complete" as const,
+      baseScreenshotBucketId: baseBucket.id,
+      compareScreenshotBucketId: compareBucket.id,
+      projectId,
+      createdAt: now,
+      updatedAt: now,
+    },
+  ]);
+  invariant(build);
+
+  await ScreenshotDiff.query().insert([
+    {
+      buildId: build.id,
+      baseScreenshotId: baseScreenshot.id,
+      compareScreenshotId: compareScreenshot.id,
+      testId: test.id,
+      score: 0.3,
+      jobStatus: "complete" as const,
+      s3Id: "diff-1024-to-720.png",
+      fileId: diffFile.id,
+      fingerprint: "penelope-argos-change",
+      createdAt: now,
+      updatedAt: now,
+    },
+  ]);
+
+  return { test, build };
+}
+
+/**
  * Manifest for the "real world" build scenario below.
  *
  * The referenced assets (screenshots, diffs, Playwright traces and markdown

--- a/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
@@ -284,9 +284,13 @@ function ScreenshotActionsMenu(props: {
 /**
  * "Copy" submenu sharing the link and Markdown embed actions across screenshot
  * panes.
+ *
+ * `publicUrl` should be the screenshot's public (files.argos-ci.com CDN) URL — a
+ * stable, shareable link — not the expiring signed original: a copied link or
+ * Markdown embed needs to keep working for whoever it's shared with.
  */
-function CopyScreenshotSubmenu(props: { url: string; alt: string }) {
-  const { url, alt } = props;
+function CopyScreenshotSubmenu(props: { publicUrl: string; alt: string }) {
+  const { publicUrl, alt } = props;
   const clipboard = useClipboard();
   return (
     <SubmenuTrigger>
@@ -300,7 +304,7 @@ function CopyScreenshotSubmenu(props: { url: string; alt: string }) {
         <Menu aria-label="Copy screenshot">
           <MenuItem
             onAction={() => {
-              clipboard.copy(url);
+              clipboard.copy(publicUrl);
               toast.success("Link copied", {
                 id: SCREENSHOT_COPY_TOAST_ID,
                 description:
@@ -315,7 +319,7 @@ function CopyScreenshotSubmenu(props: { url: string; alt: string }) {
           </MenuItem>
           <MenuItem
             onAction={() => {
-              clipboard.copy(`![${alt}](${url})`);
+              clipboard.copy(`![${alt}](${publicUrl})`);
               toast.success("Markdown copied", {
                 id: SCREENSHOT_COPY_TOAST_ID,
                 description:
@@ -666,7 +670,7 @@ function BaseScreenshotActionsMenu({
       tooltip="Baseline screenshot actions"
       ariaLabel="Baseline screenshot actions"
     >
-      <CopyScreenshotSubmenu url={baseScreenshot.originalUrl} alt={diff.name} />
+      <CopyScreenshotSubmenu publicUrl={baseScreenshot.url} alt={diff.name} />
       <MenuSeparator />
       <MenuItem
         onAction={() => {
@@ -849,7 +853,7 @@ function CompareScreenshotActionsMenu({
       ariaLabel="Changes screenshot actions"
     >
       <CopyScreenshotSubmenu
-        url={compareScreenshot.originalUrl}
+        publicUrl={compareScreenshot.url}
         alt={diff.name}
       />
       <MenuSeparator />

--- a/apps/frontend/src/containers/Build/BuildDiffDetailToolbar.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetailToolbar.tsx
@@ -1,7 +1,7 @@
 import { use } from "react";
 import { invariant } from "@argos/util/invariant";
 
-import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
+import { useProjectPermission } from "@/containers/Project/PermissionsContext";
 import { ProjectPermission, ScreenshotDiffStatus } from "@/gql/graphql";
 import { useProjectParams } from "@/pages/Project/ProjectParams";
 import { ButtonGroup } from "@/ui/ButtonGroup";
@@ -9,6 +9,7 @@ import { Separator } from "@/ui/Separator";
 import { checkIsImageContentType } from "@/util/content-type";
 
 import type { BuildDiffDetailDocument } from "./BuildDiffDetail";
+import { CommentsEnabledContext } from "./CommentsContext";
 import { CommentsVisibilityToggle } from "./toolbar/CommentsVisibilityToggle";
 import { CommentToolToggle } from "./toolbar/CommentToolToggle";
 import { FitToggle } from "./toolbar/FitToggle";
@@ -65,8 +66,9 @@ export function BuildDiffDetailToolbar(props: BuildDiffDetailToolbarProps) {
   const params = useProjectParams();
   invariant(params, "can't be used outside of a project route");
 
-  const permissions = use(ProjectPermissionsContext);
-  const canComment = permissions?.includes(ProjectPermission.Review) ?? false;
+  const commentsEnabled = use(CommentsEnabledContext);
+  const canReview = useProjectPermission(ProjectPermission.Review);
+  const canComment = commentsEnabled && canReview;
   // The hand/comment tool switch only makes sense on image diffs (point
   // comments). Text diffs use the gutter "+" instead.
   const showCommentTool = canComment && checkCanCommentOnDiff(diff);

--- a/apps/frontend/src/containers/Build/CommentsContext.tsx
+++ b/apps/frontend/src/containers/Build/CommentsContext.tsx
@@ -1,0 +1,12 @@
+import { createContext } from "react";
+
+/**
+ * Whether comments are available in the current diff viewer — the toolbar's
+ * comment tool and visibility toggle, the point comments on images, and the
+ * line comments on text diffs.
+ *
+ * Comments belong to a build review, so views that reuse the diff viewer
+ * outside of a build review (e.g. the test trends page) provide `false` to hide
+ * them entirely. Defaults to `true` for the build review itself.
+ */
+export const CommentsEnabledContext = createContext<boolean>(true);

--- a/apps/frontend/src/containers/Project/PermissionsContext.tsx
+++ b/apps/frontend/src/containers/Project/PermissionsContext.tsx
@@ -1,7 +1,24 @@
 import { createContext } from "react";
 
 import { ProjectPermission } from "@/gql/graphql";
+import { useNonNullable } from "@/util/useNonNullable";
 
 export const ProjectPermissionsContext = createContext<
   ProjectPermission[] | null
 >(null);
+
+/**
+ * Returns the current project's permissions, asserting they are provided. Use
+ * within a project route, where `ProjectPermissionsContext` is always set.
+ */
+export function useProjectPermissions(): ProjectPermission[] {
+  return useNonNullable(
+    ProjectPermissionsContext,
+    "Project permissions must be provided",
+  );
+}
+
+/** Whether the current user has the given permission on the project. */
+export function useProjectPermission(permission: ProjectPermission): boolean {
+  return useProjectPermissions().includes(permission);
+}

--- a/apps/frontend/src/pages/Build/ReviewCommentSubmitButton.tsx
+++ b/apps/frontend/src/pages/Build/ReviewCommentSubmitButton.tsx
@@ -1,7 +1,6 @@
-import { use } from "react";
 import { ArrowUpIcon, MessageSquarePlusIcon } from "lucide-react";
 
-import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
+import { useProjectPermission } from "@/containers/Project/PermissionsContext";
 import { DocumentType, graphql } from "@/gql";
 import { BuildStatus, ProjectPermission } from "@/gql/graphql";
 import { MOD } from "@/ui/Editor/EditorToolbar.shortcuts";
@@ -33,11 +32,11 @@ const REVIEWABLE_STATUSES: BuildStatus[] = [
 export function useCanAddToReview(
   build: DocumentType<typeof ReviewCommentSubmitButton_Build>,
 ): boolean {
-  const permissions = use(ProjectPermissionsContext);
+  const canReview = useProjectPermission(ProjectPermission.Review);
   return (
     !build.viewerHasSubmittedReview &&
     REVIEWABLE_STATUSES.includes(build.status) &&
-    Boolean(permissions?.includes(ProjectPermission.Review))
+    canReview
   );
 }
 

--- a/apps/frontend/src/pages/Build/TrackButtons.tsx
+++ b/apps/frontend/src/pages/Build/TrackButtons.tsx
@@ -2,12 +2,11 @@ import { memo } from "react";
 import { ThumbsDownIcon, ThumbsUpIcon } from "lucide-react";
 
 import { useBuildHotkey } from "@/containers/Build/BuildHotkeys";
-import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
+import { useProjectPermission } from "@/containers/Project/PermissionsContext";
 import { ProjectPermission } from "@/gql/graphql";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 import { IconButton } from "@/ui/IconButton";
 import { useEventCallback } from "@/ui/useEventCallback";
-import { useNonNullable } from "@/util/useNonNullable";
 
 import { Diff, useBuildDiffState } from "./BuildDiffState";
 import {
@@ -125,8 +124,8 @@ export const TrackButtons = memo(function TrackButtons(props: {
   diff: Diff;
   disabled: boolean;
 }) {
-  const permissions = useNonNullable(ProjectPermissionsContext);
-  if (!permissions.includes(ProjectPermission.Review)) {
+  const canReview = useProjectPermission(ProjectPermission.Review);
+  if (!canReview) {
     return null;
   }
   return (

--- a/apps/frontend/src/pages/Build/diffComments/DiffCommentLayer.tsx
+++ b/apps/frontend/src/pages/Build/diffComments/DiffCommentLayer.tsx
@@ -10,9 +10,10 @@ import { useAtomValue } from "jotai/react";
 import { toast } from "sonner";
 
 import { useAuthTokenPayload } from "@/containers/Auth";
+import { CommentsEnabledContext } from "@/containers/Build/CommentsContext";
 import { commentsVisibleAtom } from "@/containers/Build/CommentTool";
 import { DiffEditor } from "@/containers/Build/DiffEditor";
-import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
+import { useProjectPermission } from "@/containers/Project/PermissionsContext";
 import { DocumentType, graphql } from "@/gql";
 import { ProjectPermission } from "@/gql/graphql";
 import { useProjectParams } from "@/pages/Project/ProjectParams";
@@ -104,9 +105,10 @@ export function DiffCommentLayer(props: {
     modifiedLanguage,
     renderSideBySide,
   } = props;
-  const visible = useAtomValue(commentsVisibleAtom);
-  const permissions = use(ProjectPermissionsContext);
-  const canComment = permissions?.includes(ProjectPermission.Review) ?? false;
+  const commentsEnabled = use(CommentsEnabledContext);
+  const visible = useAtomValue(commentsVisibleAtom) && commentsEnabled;
+  const canReview = useProjectPermission(ProjectPermission.Review);
+  const canComment = commentsEnabled && canReview;
   const canAddToReview = useCanAddToReview(build);
   const { accountSlug, projectName } = useProjectParams() ?? {};
   invariant(accountSlug && projectName, "Missing project route params");

--- a/apps/frontend/src/pages/Build/screenshotComments/ScreenshotCommentLayer.tsx
+++ b/apps/frontend/src/pages/Build/screenshotComments/ScreenshotCommentLayer.tsx
@@ -13,6 +13,7 @@ import { useAtom, useAtomValue } from "jotai/react";
 import { toast } from "sonner";
 
 import { useAuthTokenPayload } from "@/containers/Auth";
+import { CommentsEnabledContext } from "@/containers/Build/CommentsContext";
 import {
   commentsVisibleAtom,
   commentToolModeAtom,
@@ -22,7 +23,7 @@ import {
   ZOOMER_OVERLAY_INTERACTIVE_CLASS,
   type PaneSize,
 } from "@/containers/Build/Zoomer";
-import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
+import { useProjectPermission } from "@/containers/Project/PermissionsContext";
 import { DocumentType, graphql } from "@/gql";
 import { ProjectPermission } from "@/gql/graphql";
 import { useProjectParams } from "@/pages/Project/ProjectParams";
@@ -119,10 +120,11 @@ export function ScreenshotCommentLayer(props: {
   paneSize: PaneSize | null;
 }) {
   const { build, screenshotDiffId, imgSize, paneSize } = props;
+  const commentsEnabled = use(CommentsEnabledContext);
   const mode = useAtomValue(commentToolModeAtom);
   const visible = useAtomValue(commentsVisibleAtom);
-  const permissions = use(ProjectPermissionsContext);
-  const canComment = permissions?.includes(ProjectPermission.Review) ?? false;
+  const canReview = useProjectPermission(ProjectPermission.Review);
+  const canComment = commentsEnabled && canReview;
   const canAddToReview = useCanAddToReview(build);
   const { accountSlug, projectName } = useProjectParams() ?? {};
   invariant(accountSlug && projectName, "Missing project route params");
@@ -358,7 +360,7 @@ export function ScreenshotCommentLayer(props: {
     ],
   );
 
-  if (!ready) {
+  if (!ready || !commentsEnabled) {
     return null;
   }
 

--- a/apps/frontend/src/pages/Build/sidebar/CommentReactions.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentReactions.tsx
@@ -4,14 +4,13 @@ import { SmilePlusIcon } from "lucide-react";
 import { Button } from "react-aria-components";
 import { toast } from "sonner";
 
-import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
+import { useProjectPermission } from "@/containers/Project/PermissionsContext";
 import { DocumentType, graphql } from "@/gql";
 import { ProjectPermission } from "@/gql/graphql";
 import { EmojiPickerPopover, EmojiPickerTrigger } from "@/ui/EmojiPicker";
 import { IconButton } from "@/ui/IconButton";
 import { Tooltip } from "@/ui/Tooltip";
 import { getErrorMessage } from "@/util/error";
-import { useNonNullable } from "@/util/useNonNullable";
 
 const _CommentFragment = graphql(`
   fragment CommentReactions_Comment on Comment {
@@ -57,8 +56,7 @@ type ReactionGroup = Comment["reactions"][number];
  * "review" permission on the project as commenting does.
  */
 function useCanReact(): boolean {
-  const permissions = useNonNullable(ProjectPermissionsContext);
-  return permissions.includes(ProjectPermission.Review);
+  return useProjectPermission(ProjectPermission.Review);
 }
 
 /**

--- a/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
@@ -14,7 +14,7 @@ import { AnimatePresence, motion } from "motion/react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 
-import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
+import { useProjectPermission } from "@/containers/Project/PermissionsContext";
 import { DocumentType, graphql } from "@/gql";
 import {
   CommentChangeType,
@@ -31,7 +31,6 @@ import { useLiveRef } from "@/ui/useLiveRef";
 import { getMentionUser, getUserCardData, UserHoverCard } from "@/ui/UserCard";
 import { buildReviewDescriptors } from "@/util/build-review";
 import { getErrorMessage } from "@/util/error";
-import { useNonNullable } from "@/util/useNonNullable";
 
 import { AddCommentForm } from "./AddCommentForm";
 import { CommentCard } from "./CommentCard";
@@ -337,8 +336,7 @@ export function ReviewActivitySection(props: { build: Build }) {
       });
     },
   });
-  const permissions = useNonNullable(ProjectPermissionsContext);
-  const canComment = permissions.includes(ProjectPermission.Review);
+  const canComment = useProjectPermission(ProjectPermission.Review);
   const entries = getActivityEntries(build);
   const highlightedCommentId = useHighlightedCommentId(
     build.comments.map((comment) => comment.id),

--- a/apps/frontend/src/pages/Build/sidebar/ReviewersSection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewersSection.tsx
@@ -20,7 +20,7 @@ import { AccountAvatar } from "@/containers/AccountAvatar";
 import { useAuthTokenPayload } from "@/containers/Auth";
 import { useBuildHotkey } from "@/containers/Build/BuildHotkeys";
 import { BuildReviewersStatusList } from "@/containers/BuildReviewersStatusList";
-import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
+import { useProjectPermissions } from "@/containers/Project/PermissionsContext";
 import { DocumentType, graphql } from "@/gql";
 import { BuildStatus, BuildType, ProjectPermission } from "@/gql/graphql";
 import { useProjectParams } from "@/pages/Project/ProjectParams";
@@ -46,7 +46,6 @@ import {
   getLatestReviewByUser,
 } from "@/util/build-review";
 import { getErrorMessage } from "@/util/error";
-import { useNonNullable } from "@/util/useNonNullable";
 
 const _BuildFragment = graphql(`
   fragment ReviewersSection_Build on Build {
@@ -149,7 +148,7 @@ function getEmptyStateMessage(build: Build): string {
 
 export function ReviewersSection(props: { build: Build }) {
   const { build } = props;
-  const permissions = useNonNullable(ProjectPermissionsContext);
+  const permissions = useProjectPermissions();
   const projectParams = useProjectParams();
   invariant(projectParams);
   const [reviewToDismiss, setReviewToDismiss] = useState<Review | null>(null);

--- a/apps/frontend/src/pages/Test/index.tsx
+++ b/apps/frontend/src/pages/Test/index.tsx
@@ -22,6 +22,7 @@ import {
   DiffImage,
   ListItemButton,
 } from "@/containers/Build/BuildDiffListPrimitives";
+import { CommentsEnabledContext } from "@/containers/Build/CommentsContext";
 import { IgnoreButton } from "@/containers/Build/toolbar/IgnoreButton";
 import {
   NextButton,
@@ -331,20 +332,23 @@ function ChangesExplorer(props: {
       {activeChange && (
         <ZoomerSyncProvider id={activeChange.stats.lastSeenDiff.build.id}>
           <BuildDiffHighlighterProvider>
-            <div className="flex flex-col">
-              <div className="border-b-thin sticky top-0 z-20 shrink-0 p-2">
-                <BuildHeader
-                  change={activeChange}
-                  test={test}
-                  onActiveTestChange={setActiveChangeId}
+            {/* Comments belong to a build review, not to the test trends view. */}
+            <CommentsEnabledContext value={false}>
+              <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+                <div className="border-b-thin sticky top-0 z-20 shrink-0 p-2">
+                  <BuildHeader
+                    change={activeChange}
+                    test={test}
+                    onActiveTestChange={setActiveChangeId}
+                  />
+                </div>
+                <BuildDiffDetail
+                  build={activeChange.stats.lastSeenDiff.build}
+                  diff={activeChange.stats.lastSeenDiff}
+                  repoUrl={null}
                 />
               </div>
-              <BuildDiffDetail
-                build={activeChange.stats.lastSeenDiff.build}
-                diff={activeChange.stats.lastSeenDiff}
-                repoUrl={null}
-              />
-            </div>
+            </CommentsEnabledContext>
           </BuildDiffHighlighterProvider>
         </ZoomerSyncProvider>
       )}

--- a/tests/project-tests.spec.ts
+++ b/tests/project-tests.spec.ts
@@ -39,15 +39,6 @@ loggedTest("test detail", async ({ page, team, project, builds }) => {
   });
 });
 
-/**
- * The test trends page reuses the build diff viewer to show a detected change.
- * This guards the two fixes made to that view:
- *
- * 1. The snapshot diff viewer must stay within its container (it used to
- *    overflow the layout horizontally).
- * 2. Comments belong to a build review, so the comment tool and visibility
- *    toggle must not appear here — even for a user who can review.
- */
 loggedTest("test view with a change", async ({ page, team, project }) => {
   const { test } = await createTestChangeScenario({
     projectId: project.id,
@@ -57,7 +48,7 @@ loggedTest("test view with a change", async ({ page, team, project }) => {
 
   await page.goto(`/${team.account.slug}/${project.name}/tests/${testId}`);
 
-  // The change's snapshot diff viewer (the part that overflowed) is rendered.
+  // The change's snapshot diff viewer is rendered.
   await expect(
     page.getByRole("heading", { name: "penelope-argos.jpg" }),
   ).toBeVisible();

--- a/tests/project-tests.spec.ts
+++ b/tests/project-tests.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from "@playwright/test";
 
+import { createTestChangeScenario } from "../apps/backend/src/database/seeds";
+import { formatTestId } from "../apps/backend/src/graphql/services/test";
 import { loggedTest } from "./logged-test";
 import { ensureTeamOwner, screenshot } from "./util";
 
@@ -35,4 +37,39 @@ loggedTest("test detail", async ({ page, team, project, builds }) => {
       [testId]: "SPARKLE-XXX",
     },
   });
+});
+
+/**
+ * The test trends page reuses the build diff viewer to show a detected change.
+ * This guards the two fixes made to that view:
+ *
+ * 1. The snapshot diff viewer must stay within its container (it used to
+ *    overflow the layout horizontally).
+ * 2. Comments belong to a build review, so the comment tool and visibility
+ *    toggle must not appear here — even for a user who can review.
+ */
+loggedTest("test view with a change", async ({ page, team, project }) => {
+  const { test } = await createTestChangeScenario({
+    projectId: project.id,
+    keyPrefix: `${project.id}-`,
+  });
+  const testId = formatTestId({ projectName: project.name, testId: test.id });
+
+  await page.goto(`/${team.account.slug}/${project.name}/tests/${testId}`);
+
+  // The change's snapshot diff viewer (the part that overflowed) is rendered.
+  await expect(
+    page.getByRole("heading", { name: "penelope-argos.jpg" }),
+  ).toBeVisible();
+  await expect(page.getByText("Occurrences")).toBeVisible();
+  await expect(page.getByText("Baseline", { exact: false })).toBeVisible();
+
+  // No comment affordances in this view, despite the user being able to review.
+  await expect(page.getByRole("button", { name: "Comment tool" })).toHaveCount(
+    0,
+  );
+  await expect(page.getByRole("button", { name: "Move tool" })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: /comments$/ })).toHaveCount(0);
+
+  await screenshot(page, "test-view-change");
 });

--- a/tests/project-tests.spec.ts
+++ b/tests/project-tests.spec.ts
@@ -40,10 +40,7 @@ loggedTest("test detail", async ({ page, team, project, builds }) => {
 });
 
 loggedTest("test view with a change", async ({ page, team, project }) => {
-  const { test } = await createTestChangeScenario({
-    projectId: project.id,
-    keyPrefix: `${project.id}-`,
-  });
+  const { test } = await createTestChangeScenario({ projectId: project.id });
   const testId = formatTestId({ projectName: project.name, testId: test.id });
 
   await page.goto(`/${team.account.slug}/${project.name}/tests/${testId}`);
@@ -61,6 +58,17 @@ loggedTest("test view with a change", async ({ page, team, project }) => {
   );
   await expect(page.getByRole("button", { name: "Move tool" })).toHaveCount(0);
   await expect(page.getByRole("button", { name: /comments$/ })).toHaveCount(0);
+
+  // The change image is served from the CDN and actually renders (it isn't a
+  // broken image).
+  await expect
+    .poll(() =>
+      page
+        .getByRole("img", { name: "Changes screenshot" })
+        .first()
+        .evaluate((el: HTMLImageElement) => el.complete && el.naturalWidth > 0),
+    )
+    .toBe(true);
 
   await screenshot(page, "test-view-change");
 });


### PR DESCRIPTION
## Problem

On the **Test** (test trends) page, the snapshot diff viewer — reused from the build review screen — was broken in two ways:

1. **Layout overflow.** The snapshot view spilled out of its container horizontally.
2. **Comments leaked in.** The comment tool and visibility toggle showed up, even though comments belong to a build *review*, not the test trends view.

## Fix

- **Layout:** the wrapper around the toolbar + `BuildDiffDetail` was missing `min-w-0 flex-1` (the working build workspace has it). Without a min-width floor the diff content pushed past the layout. Now matches the build workspace wrapper.
- **Comments:** new `CommentsEnabledContext` (defaults to `true`), consumed by the toolbar and the screenshot/diff comment layers. The test view provides `false`, so no comment affordances render there. The build review is unaffected.

## Refactor (preceding the fix)

While wiring the toolbar, the duplicated `permissions?.includes(ProjectPermission.Review) ?? false` checks were centralized into `useProjectPermission` / `useProjectPermissions` hooks that **assert** the permissions context is present (via `invariant`) instead of optional-chaining. Applied across the build review call sites. This safe-programming convention is now documented in `AGENTS.md`.

## Test

Adds a Playwright/Argos visual test (`tests/project-tests.spec.ts`) that opens the test trends page for a test with a detected change, so the diff viewer actually renders. It asserts the viewer is present and the comment tool/visibility toggle are absent, then screenshots (the screenshot guards the layout in CI).

This needed a seed: `Test.changes` only surfaces a change for a recent `reference` build carrying a `score > 0`, fingerprinted diff — which the existing seed never produced (the old "test detail" test only ever rendered the empty state). New `createTestChangeScenario` provides exactly that, isolated from `createBuildScenario` so other baselines are untouched.

Verified locally (`NODE_ENV=test pnpm test:e2e --project=chromium`): passes with the fix, **fails** with comments re-enabled — so the test genuinely guards the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)