### PR TITLE
feat: allow uploading a single build across multiple requests

### DIFF
--- a/apps/backend/src/api/handlers/createBuild.e2e.test.ts
+++ b/apps/backend/src/api/handlers/createBuild.e2e.test.ts
@@ -1,0 +1,47 @@
+import request from "supertest";
+import { test as base, beforeAll, describe, expect } from "vitest";
+import z from "zod";
+
+import type { Project } from "@/database/models";
+import { factory, setupDatabase } from "@/database/testing";
+
+import { createTestHandlerApp } from "../test-util";
+import { createBuild } from "./createBuild";
+
+const app = createTestHandlerApp(createBuild);
+
+const test = base.extend<{ project: Project }>({
+  project: async ({}, use) => {
+    await setupDatabase();
+    const account = await factory.TeamAccount.create({ slug: "awesome-team" });
+    const project = await factory.Project.create({
+      token: "the-awesome-token",
+      accountId: account.id,
+    });
+    await use(project);
+  },
+});
+
+describe("createBuild", () => {
+  beforeAll(() => {
+    z.globalRegistry.clear();
+  });
+
+  describe("with more than 5000 screenshots", () => {
+    test("rejects the build and points to parallel mode", async () => {
+      const screenshots = Array.from({ length: 5001 }, (_, index) => ({
+        key: index.toString(16).padStart(64, "0"),
+        contentType: "image/png",
+      }));
+
+      await request(app)
+        .post("/builds")
+        .set("Authorization", "Bearer the-awesome-token")
+        .send({ commit: "a".repeat(40), branch: "main", screenshots })
+        .expect(400)
+        .expect((res) => {
+          expect(JSON.stringify(res.body)).toContain("parallel mode");
+        });
+    });
+  });
+});

--- a/apps/backend/src/api/handlers/createBuild.ts
+++ b/apps/backend/src/api/handlers/createBuild.ts
@@ -47,6 +47,24 @@ const MAX_UPLOAD_FILE_BYTES = 25 * 1024 * 1024;
  */
 const PLAYWRIGHT_TRACE_CONTENT_TYPE = "application/zip";
 
+/**
+ * Maximum number of screenshots that can be registered in a single
+ * (non-parallel) build. Larger test suites must use parallel mode to split the
+ * screenshots across several builds.
+ */
+const MAX_SCREENSHOTS_PER_BUILD = 5000;
+
+const tooManyScreenshotsMessage =
+  `A build cannot contain more than ${MAX_SCREENSHOTS_PER_BUILD} screenshots. ` +
+  `Use parallel mode to split a larger test suite across several builds.`;
+
+const tooManyTracesMessage =
+  `A build cannot contain more than ${MAX_SCREENSHOTS_PER_BUILD} Playwright traces. ` +
+  `Use parallel mode to split a larger test suite across several builds.`;
+
+const withinScreenshotLimit = (items: unknown[]) =>
+  items.length <= MAX_SCREENSHOTS_PER_BUILD;
+
 const CommonRequestBodySchema = z.object({
   commit: Sha1HashSchema.meta({
     description: "The commit the build is running on",
@@ -54,9 +72,13 @@ const CommonRequestBodySchema = z.object({
   branch: GitBranchSchema.meta({
     description: "The branch the build is running on",
   }),
-  pwTraceKeys: UniqueSha256HashArraySchema.optional().meta({
-    description: "Keys of Playwright trace files",
-  }),
+  pwTraceKeys: UniqueSha256HashArraySchema.refine(withinScreenshotLimit, {
+    message: tooManyTracesMessage,
+  })
+    .optional()
+    .meta({
+      description: "Keys of Playwright trace files",
+    }),
   name: z.string().nullish().meta({
     description: "The name of the build (for multi-build setups)",
   }),
@@ -133,13 +155,16 @@ type ScreenshotUploadRequest = z.infer<typeof ScreenshotUploadRequestSchema>;
 
 const UniqueScreenshotUploadsSchema = z
   .array(ScreenshotUploadRequestSchema)
+  .max(MAX_SCREENSHOTS_PER_BUILD, { message: tooManyScreenshotsMessage })
   .refine(
     (items) => new Set(items.map((item) => item.key)).size === items.length,
     { message: "Must be an array of uploads with unique keys" },
   );
 
 const LegacyUploadRequestSchema = z.object({
-  screenshotKeys: UniqueSha256HashArraySchema.meta({
+  screenshotKeys: UniqueSha256HashArraySchema.refine(withinScreenshotLimit, {
+    message: tooManyScreenshotsMessage,
+  }).meta({
     deprecated: true,
     description: "Keys of screenshot files",
   }),
@@ -359,7 +384,8 @@ async function createSkippedBuild(ctx: BuildContext): Promise<Build> {
   const build = await createBuildFromRequest(ctx);
   await finalizeBuild({
     build,
-    single: { metadata: null, screenshots: { all: 0, storybook: 0 } },
+    metadata: null,
+    screenshotCount: { all: 0, storybook: 0 },
   });
   await buildJob.push(build.id);
   return build;

--- a/apps/backend/src/api/handlers/updateBuild.e2e.test.ts
+++ b/apps/backend/src/api/handlers/updateBuild.e2e.test.ts
@@ -4,7 +4,7 @@ import { test as base, beforeAll, describe, expect, vi } from "vitest";
 import z from "zod";
 
 import type { Build, Project, ScreenshotBucket } from "@/database/models";
-import { Screenshot } from "@/database/models";
+import { BuildShard, Screenshot } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
 
 import { createTestHandlerApp } from "../test-util";
@@ -173,5 +173,178 @@ describe("updateBuild", () => {
 
       expect(await countScreenshots(compareScreenshotBucket.id)).toBe(1);
     });
+  });
+
+  describe("parallel build", () => {
+    const parallelTest = test.extend<{ build: Build }>({
+      build: async ({ project, compareScreenshotBucket }, use) => {
+        const build = await factory.Build.create({
+          name: "default",
+          projectId: project.id,
+          compareScreenshotBucketId: compareScreenshotBucket.id,
+          batchCount: 0,
+        });
+        await use(build);
+      },
+    });
+
+    const countShards = (buildId: string) =>
+      BuildShard.query().where("buildId", buildId).resultSize();
+
+    parallelTest(
+      "finalizes once every shard has been received",
+      async ({ build }) => {
+        await put(build.id, {
+          parallel: true,
+          parallelTotal: 2,
+          parallelIndex: 1,
+          screenshots: [screenshot("a", "a")],
+        }).expect(200);
+
+        const partial = await build
+          .$query()
+          .withGraphFetched("compareScreenshotBucket");
+        invariant(partial.compareScreenshotBucket);
+        expect(partial.compareScreenshotBucket.complete).toBe(false);
+
+        await put(build.id, {
+          parallel: true,
+          parallelTotal: 2,
+          parallelIndex: 2,
+          screenshots: [screenshot("b", "b")],
+        }).expect(200);
+
+        const finalized = await build
+          .$query()
+          .withGraphFetched("compareScreenshotBucket");
+        invariant(finalized.compareScreenshotBucket);
+        expect(finalized.compareScreenshotBucket.complete).toBe(true);
+        expect(finalized.batchCount).toBe(2);
+        expect(await countShards(build.id)).toBe(2);
+      },
+    );
+
+    parallelTest(
+      "counts a shard split across requests as a single batch",
+      async ({ build, compareScreenshotBucket }) => {
+        const shard1 = {
+          parallel: true as const,
+          parallelTotal: 2,
+          parallelIndex: 1,
+        };
+
+        // First chunk of shard 1.
+        await put(build.id, {
+          ...shard1,
+          screenshots: [screenshot("a", "a")],
+          final: false,
+        }).expect(200);
+
+        let current = await build
+          .$query()
+          .withGraphFetched("compareScreenshotBucket");
+        invariant(current.compareScreenshotBucket);
+        expect(current.compareScreenshotBucket.complete).toBe(false);
+        // The shard exists but isn't counted yet.
+        expect(current.batchCount).toBe(0);
+        expect(await countShards(build.id)).toBe(1);
+
+        // Final chunk of shard 1: the shard is now counted, but the build still
+        // waits for shard 2.
+        await put(build.id, {
+          ...shard1,
+          screenshots: [screenshot("b", "b")],
+          final: true,
+        }).expect(200);
+
+        current = await build
+          .$query()
+          .withGraphFetched("compareScreenshotBucket");
+        invariant(current.compareScreenshotBucket);
+        expect(current.compareScreenshotBucket.complete).toBe(false);
+        expect(current.batchCount).toBe(1);
+        expect(await countShards(build.id)).toBe(1);
+
+        // Shard 2 in a single request finalizes the build.
+        await put(build.id, {
+          parallel: true,
+          parallelTotal: 2,
+          parallelIndex: 2,
+          screenshots: [screenshot("c", "c")],
+        }).expect(200);
+
+        const finalized = await build
+          .$query()
+          .withGraphFetched("compareScreenshotBucket");
+        invariant(finalized.compareScreenshotBucket);
+        expect(finalized.compareScreenshotBucket.complete).toBe(true);
+        // Two shards (3 requests), three screenshots.
+        expect(finalized.batchCount).toBe(2);
+        expect(await countShards(build.id)).toBe(2);
+        expect(finalized.compareScreenshotBucket.screenshotCount).toBe(3);
+        expect(await countScreenshots(compareScreenshotBucket.id)).toBe(3);
+      },
+    );
+
+    parallelTest(
+      "does not double-count a retried finalizing shard request",
+      async ({ build }) => {
+        const finalChunk = {
+          parallel: true as const,
+          parallelTotal: 2,
+          parallelIndex: 1,
+          screenshots: [screenshot("a", "a")],
+          final: true,
+        };
+        await put(build.id, finalChunk).expect(200);
+        // Retry of the same finalizing request.
+        await put(build.id, finalChunk).expect(200);
+
+        const current = await build.$query();
+        expect(current.batchCount).toBe(1);
+        expect(await countShards(build.id)).toBe(1);
+      },
+    );
+
+    parallelTest(
+      "returns the build when the finalizing request is retried (no request id)",
+      async ({ build }) => {
+        const onlyShard = {
+          parallel: true as const,
+          parallelTotal: 1,
+          parallelIndex: 1,
+          screenshots: [screenshot("a", "a")],
+        };
+        // Finalizes the build (1 of 1 shard).
+        await put(build.id, onlyShard).expect(200);
+        const finalized = await build
+          .$query()
+          .withGraphFetched("compareScreenshotBucket");
+        invariant(finalized.compareScreenshotBucket);
+        expect(finalized.compareScreenshotBucket.complete).toBe(true);
+
+        // Retry of that request after the build is finalized must not 409.
+        await put(build.id, onlyShard).expect(200);
+        expect(await countShards(build.id)).toBe(1);
+      },
+    );
+
+    parallelTest(
+      "requires a parallelIndex when the request is not final",
+      async ({ build }) => {
+        await put(build.id, {
+          parallel: true,
+          parallelTotal: 2,
+          screenshots: [screenshot("a", "a")],
+          final: false,
+        })
+          .expect(400)
+          .expect((res) => {
+            expect(res.body.error).toBe(
+              "`parallelIndex` is required when `final` is `false`",
+            );
+          });
+      },
+    );
   });
 });

--- a/apps/backend/src/api/handlers/updateBuild.e2e.test.ts
+++ b/apps/backend/src/api/handlers/updateBuild.e2e.test.ts
@@ -1,0 +1,177 @@
+import { invariant } from "@argos/util/invariant";
+import request from "supertest";
+import { test as base, beforeAll, describe, expect, vi } from "vitest";
+import z from "zod";
+
+import type { Build, Project, ScreenshotBucket } from "@/database/models";
+import { Screenshot } from "@/database/models";
+import { factory, setupDatabase } from "@/database/testing";
+
+import { createTestHandlerApp } from "../test-util";
+import { updateBuild } from "./updateBuild";
+
+vi.mock("@/build", () => ({
+  job: { push: vi.fn(() => Promise.resolve()) },
+}));
+
+const app = createTestHandlerApp(updateBuild);
+
+const test = base.extend<{
+  project: Project;
+  compareScreenshotBucket: ScreenshotBucket;
+  build: Build;
+}>({
+  project: async ({}, use) => {
+    await setupDatabase();
+    const account = await factory.TeamAccount.create({ slug: "awesome-team" });
+    const project = await factory.Project.create({
+      token: "the-awesome-token",
+      accountId: account.id,
+    });
+    await use(project);
+  },
+  compareScreenshotBucket: async ({ project }, use) => {
+    const compareScreenshotBucket = await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      complete: false,
+    });
+    await use(compareScreenshotBucket);
+  },
+  build: async ({ project, compareScreenshotBucket }, use) => {
+    const build = await factory.Build.create({
+      name: "default",
+      projectId: project.id,
+      compareScreenshotBucketId: compareScreenshotBucket.id,
+    });
+    await use(build);
+  },
+});
+
+/** Build a valid 64-char SHA256-like key from a single character. */
+const key = (char: string) => char.repeat(64);
+
+const screenshot = (name: string, keyChar: string) => ({
+  key: key(keyChar),
+  name,
+  contentType: "image/png",
+});
+
+const put = (buildId: string, body: unknown) =>
+  request(app)
+    .put(`/builds/${buildId}`)
+    .set("Authorization", "Bearer the-awesome-token")
+    .send(body as object);
+
+const countScreenshots = (bucketId: string) =>
+  Screenshot.query().where("screenshotBucketId", bucketId).resultSize();
+
+describe("updateBuild", () => {
+  beforeAll(() => {
+    z.globalRegistry.clear();
+  });
+
+  describe("single build uploaded across multiple requests", () => {
+    test("only finalizes on the final request", async ({
+      build,
+      compareScreenshotBucket,
+    }) => {
+      await put(build.id, {
+        screenshots: [screenshot("a", "a")],
+        final: false,
+      }).expect(200);
+
+      const partial = await build
+        .$query()
+        .withGraphFetched("compareScreenshotBucket");
+      invariant(partial.compareScreenshotBucket);
+      expect(partial.compareScreenshotBucket.complete).toBe(false);
+      expect(await countScreenshots(compareScreenshotBucket.id)).toBe(1);
+
+      await put(build.id, {
+        screenshots: [screenshot("b", "b")],
+        final: true,
+      }).expect(200);
+
+      const finalized = await build
+        .$query()
+        .withGraphFetched("compareScreenshotBucket");
+      invariant(finalized.compareScreenshotBucket);
+      expect(finalized.compareScreenshotBucket.complete).toBe(true);
+      expect(finalized.compareScreenshotBucket.screenshotCount).toBe(2);
+      expect(await countScreenshots(compareScreenshotBucket.id)).toBe(2);
+    });
+
+    test("finalizes immediately when `final` is omitted", async ({
+      build,
+      compareScreenshotBucket,
+    }) => {
+      await put(build.id, { screenshots: [screenshot("a", "a")] }).expect(200);
+
+      const finalized = await build
+        .$query()
+        .withGraphFetched("compareScreenshotBucket");
+      invariant(finalized.compareScreenshotBucket);
+      expect(finalized.compareScreenshotBucket.complete).toBe(true);
+      expect(await countScreenshots(compareScreenshotBucket.id)).toBe(1);
+    });
+  });
+
+  describe("when a request is retried", () => {
+    test("a non-final request is idempotent", async ({
+      build,
+      compareScreenshotBucket,
+    }) => {
+      const body = { screenshots: [screenshot("a", "a")], final: false };
+      await put(build.id, body).expect(200);
+      await put(build.id, body).expect(200);
+      expect(await countScreenshots(compareScreenshotBucket.id)).toBe(1);
+    });
+
+    test("the finalizing request returns the build instead of 409", async ({
+      build,
+      compareScreenshotBucket,
+    }) => {
+      const body = { screenshots: [screenshot("a", "a")], final: true };
+      await put(build.id, body).expect(200);
+      await put(build.id, body).expect(200);
+      expect(await countScreenshots(compareScreenshotBucket.id)).toBe(1);
+    });
+  });
+
+  describe("when the build is already finalized", () => {
+    test("adding new screenshots returns 409", async ({ build }) => {
+      await put(build.id, {
+        screenshots: [screenshot("a", "a")],
+        final: true,
+      }).expect(200);
+
+      await put(build.id, {
+        screenshots: [screenshot("b", "b")],
+        final: true,
+      })
+        .expect(409)
+        .expect((res) => {
+          expect(res.body.error).toBe("Build is already finalized");
+        });
+    });
+  });
+
+  describe("when a name is uploaded with two different files", () => {
+    test("rejects the conflicting screenshot", async ({
+      build,
+      compareScreenshotBucket,
+    }) => {
+      await put(build.id, {
+        screenshots: [screenshot("a", "a")],
+        final: false,
+      }).expect(200);
+
+      await put(build.id, {
+        screenshots: [screenshot("a", "b")],
+        final: true,
+      }).expect(500);
+
+      expect(await countScreenshots(compareScreenshotBucket.id)).toBe(1);
+    });
+  });
+});

--- a/apps/backend/src/api/handlers/updateBuild.ts
+++ b/apps/backend/src/api/handlers/updateBuild.ts
@@ -5,7 +5,13 @@ import { ZodOpenApiOperationObject } from "zod-openapi";
 import { job as buildJob } from "@/build";
 import { finalizeBuild } from "@/build/finalizeBuild";
 import { raw, transaction } from "@/database";
-import { Build, BuildShard, Project } from "@/database/models";
+import {
+  Build,
+  BuildShard,
+  Project,
+  Screenshot,
+  ScreenshotBucket,
+} from "@/database/models";
 import { insertFilesAndScreenshots } from "@/database/services/screenshots";
 import { boom } from "@/util/error";
 import { redisLock } from "@/util/redis";
@@ -36,6 +42,17 @@ const RequestBodySchema = z.object({
   parallel: z.boolean().nullish(),
   parallelTotal: z.number().int().min(-1).nullish(),
   parallelIndex: z.number().int().min(1).nullish(),
+  final: z
+    .boolean()
+    .nullish()
+    .meta({
+      description:
+        "Only used for non-parallel builds. Indicates that this is the last " +
+        "request of the build, so Argos can finalize it. A build whose " +
+        "screenshots are too large to fit in a single request can split them " +
+        "across several sequential requests, leaving `final` falsy on every " +
+        "request but the last. Defaults to `true`.",
+    }),
   metadata: BuildMetadataSchema.optional().meta({
     description: "Build metadata",
     id: "BuildMetadata",
@@ -109,11 +126,18 @@ export const updateBuild: CreateAPIHandler = ({ put }) => {
     });
 
     if (build.compareScreenshotBucket.complete) {
-      const duplicateParallelRequest =
-        body.parallel && requestId
+      // The request that finalized the build may be retried (e.g. its response
+      // was lost). If it has already been processed, we return the build
+      // instead of failing so retries are idempotent.
+      const duplicateRequest = body.parallel
+        ? requestId
           ? await hasShardBeenProcessed({ buildId: build.id, requestId })
-          : false;
-      if (duplicateParallelRequest) {
+          : false
+        : await areAllScreenshotsInserted({
+            build,
+            screenshots: body.screenshots,
+          });
+      if (duplicateRequest) {
         res.send({
           build: await serializeBuild(build),
         });
@@ -160,6 +184,32 @@ async function hasShardBeenProcessed(params: {
     nonce: params.requestId,
   });
   return Boolean(shard);
+}
+
+/**
+ * Whether every screenshot of the request is already stored in the build with
+ * the same file, meaning the request has already been processed. Used to make
+ * non-parallel build updates idempotent against retries.
+ */
+async function areAllScreenshotsInserted(params: {
+  build: Build;
+  screenshots: RequestBody["screenshots"];
+}) {
+  const { build, screenshots } = params;
+  if (screenshots.length === 0) {
+    return true;
+  }
+  const existing = await Screenshot.query()
+    .select("name", "s3Id")
+    .where("screenshotBucketId", build.compareScreenshotBucketId)
+    .whereIn(
+      "name",
+      screenshots.map((screenshot) => screenshot.name),
+    );
+  const keyByName = new Map(existing.map((row) => [row.name, row.s3Id]));
+  return screenshots.every(
+    (screenshot) => keyByName.get(screenshot.name) === screenshot.key,
+  );
 }
 
 /**
@@ -233,17 +283,49 @@ async function handleUpdateParallel(ctx: Context) {
 
 /**
  * Single build update.
+ *
+ * A single build can be uploaded in one request or, when its screenshots are
+ * too large to fit in a single request, split across several sequential
+ * requests sharing the same build. Every request inserts its own screenshots;
+ * only the last one (`final`) finalizes the build. Unlike parallel builds, the
+ * screenshots all belong to the same bucket (no shard).
  */
 async function handleUpdateSingle(ctx: Context) {
   const { body, build } = ctx;
-  const metadata = ctx.body.metadata ?? null;
-  await transaction(async (trx) => {
-    const screenshots = await insertFilesAndScreenshots({
-      screenshots: body.screenshots,
-      build,
-      trx,
-    });
-    await finalizeBuild({ trx, build, single: { metadata, screenshots } });
-  });
-  await buildJob.push(build.id);
+  const final = body.final ?? true;
+  const metadata = body.metadata ?? null;
+  // Serialize the requests of a single build. The api-client aborts and retries
+  // a request after a timeout while the server may still be processing the
+  // original one, so two requests can run concurrently. Without a unique
+  // constraint to rely on, concurrent runs would otherwise double-insert
+  // screenshots or finalize the build twice.
+  const finalized = await redisLock.acquire(
+    ["update-build-single", build.id],
+    () =>
+      transaction(async (trx) => {
+        await insertFilesAndScreenshots({
+          screenshots: body.screenshots,
+          build,
+          trx,
+        });
+        if (!final) {
+          return false;
+        }
+        // A retry that overlapped the original finalizing request must not
+        // finalize the build twice.
+        const bucket = await ScreenshotBucket.query(trx)
+          .findById(build.compareScreenshotBucketId)
+          .select("complete");
+        if (bucket?.complete) {
+          return false;
+        }
+        // The screenshot counts are computed from the database so they account
+        // for the screenshots inserted by every request of the build.
+        await finalizeBuild({ trx, build, metadata });
+        return true;
+      }),
+  );
+  if (finalized) {
+    await buildJob.push(build.id);
+  }
 }

--- a/apps/backend/src/api/handlers/updateBuild.ts
+++ b/apps/backend/src/api/handlers/updateBuild.ts
@@ -1,4 +1,8 @@
-import { BuildMetadataSchema } from "@argos/schemas/build-metadata";
+import {
+  BuildMetadata,
+  BuildMetadataSchema,
+} from "@argos/schemas/build-metadata";
+import { TransactionOrKnex } from "objection";
 import { z } from "zod";
 import { ZodOpenApiOperationObject } from "zod-openapi";
 
@@ -127,16 +131,14 @@ export const updateBuild: CreateAPIHandler = ({ put }) => {
 
     if (build.compareScreenshotBucket.complete) {
       // The request that finalized the build may be retried (e.g. its response
-      // was lost). If it has already been processed, we return the build
-      // instead of failing so retries are idempotent.
-      const duplicateRequest = body.parallel
-        ? requestId
-          ? await hasShardBeenProcessed({ buildId: build.id, requestId })
-          : false
-        : await areAllScreenshotsInserted({
-            build,
-            screenshots: body.screenshots,
-          });
+      // was lost). If it has already been processed — every screenshot it
+      // carries is already stored — we return the build instead of failing so
+      // retries are idempotent. This holds for both single and parallel builds
+      // and does not rely on a request id (not every SDK sends one).
+      const duplicateRequest = await areAllScreenshotsInserted({
+        build,
+        screenshots: body.screenshots,
+      });
       if (duplicateRequest) {
         res.send({
           build: await serializeBuild(build),
@@ -175,21 +177,10 @@ type Context = {
   requestId: string | null;
 };
 
-async function hasShardBeenProcessed(params: {
-  buildId: string;
-  requestId: string;
-}) {
-  const shard = await BuildShard.query().select("id").findOne({
-    buildId: params.buildId,
-    nonce: params.requestId,
-  });
-  return Boolean(shard);
-}
-
 /**
  * Whether every screenshot of the request is already stored in the build with
  * the same file, meaning the request has already been processed. Used to make
- * non-parallel build updates idempotent against retries.
+ * build updates idempotent against retries.
  */
 async function areAllScreenshotsInserted(params: {
   build: Build;
@@ -217,6 +208,8 @@ async function areAllScreenshotsInserted(params: {
  */
 async function handleUpdateParallel(ctx: Context) {
   const { body, build, requestId } = ctx;
+  const final = body.final ?? true;
+  const parallelIndex = body.parallelIndex ?? null;
   const parallelTotal =
     typeof body.parallelTotal === "number" ? body.parallelTotal : null;
   const expectedTotal =
@@ -226,32 +219,28 @@ async function handleUpdateParallel(ctx: Context) {
     throw boom(400, "`parallelTotal` must be the same on every batch");
   }
 
+  // A shard uploaded across several requests is identified by its
+  // `parallelIndex`, so it is required as soon as the upload is split.
+  if (!final && parallelIndex === null) {
+    throw boom(400, "`parallelIndex` is required when `final` is `false`");
+  }
+
   const complete = await redisLock.acquire(
     ["update-build-parallel", build.id],
-    async () => {
-      return transaction(async (trx) => {
-        const shard = await BuildShard.query(trx)
-          .insert({
-            buildId: build.id,
-            index: body.parallelIndex ?? null,
-            nonce: requestId,
-            metadata: body.metadata ?? null,
-          })
-          .onConflict(["buildId", "nonce"])
-          .ignore();
+    () =>
+      transaction(async (trx) => {
+        const shard = await resolveParallelShard({
+          trx,
+          build,
+          requestId,
+          parallelIndex,
+        });
 
-        // If a shard already exists for this (buildId, nonce), the insert is a no-op:
-        // this is a retried request that has already been processed.
-        if (!shard.id) {
+        // The request has already been fully processed: a retry of a completed
+        // shard or of an index-less request.
+        if (!shard) {
           return false;
         }
-
-        const patchedBuild = await Build.query(trx)
-          .patchAndFetchById(build.id, {
-            batchCount: raw('"batchCount" + 1'),
-            totalBatch: parallelTotal,
-          })
-          .select("batchCount");
 
         await insertFilesAndScreenshots({
           screenshots: body.screenshots,
@@ -260,25 +249,124 @@ async function handleUpdateParallel(ctx: Context) {
           trx,
         });
 
-        if (expectedTotal && expectedTotal === patchedBuild.batchCount) {
-          await Promise.all([
-            finalizeBuild({ build, trx }),
-            // If the build was marked as partial, then it was obviously an error, we unmark it.
-            build.partial
-              ? Build.query(trx).where("id", build.id).patch({ partial: false })
-              : null,
-          ]);
-          return true;
+        // The shard isn't complete yet: more requests of the same shard will
+        // follow before it counts towards the build's batches.
+        if (!final) {
+          return false;
         }
 
-        return false;
-      });
-    },
+        return completeParallelShard({
+          trx,
+          build,
+          shard,
+          requestId,
+          metadata: body.metadata ?? null,
+          parallelTotal,
+          expectedTotal,
+        });
+      }),
   );
 
   if (complete) {
     await buildJob.push(build.id);
   }
+}
+
+/**
+ * Resolve the shard a parallel request belongs to, creating it if needed.
+ *
+ * Like a single build, a parallel shard can be uploaded across several
+ * requests. Requests of the same shard share their `parallelIndex` and the
+ * shard's `nonce` stays null until its last request (`final`). Index-less
+ * shards (manual finalization) can't be split and are identified by the request
+ * nonce, as before.
+ *
+ * Returns `null` when the request has already been fully processed (a retry).
+ */
+async function resolveParallelShard(params: {
+  trx: TransactionOrKnex;
+  build: Build;
+  requestId: string | null;
+  parallelIndex: number | null;
+}): Promise<BuildShard | null> {
+  const { trx, build, requestId, parallelIndex } = params;
+
+  if (parallelIndex === null) {
+    const shard = await BuildShard.query(trx)
+      .insert({ buildId: build.id, index: null, nonce: requestId })
+      .onConflict(["buildId", "nonce"])
+      .ignore();
+    // If a shard already exists for this (buildId, nonce), the insert is a
+    // no-op: this is a retried request that has already been processed.
+    return shard.id ? shard : null;
+  }
+
+  const existingShard = await BuildShard.query(trx).findOne({
+    buildId: build.id,
+    index: parallelIndex,
+  });
+
+  if (existingShard) {
+    // A completed shard (nonce set) hit again is a retried finalizing request:
+    // screenshots are idempotent, so there is nothing left to do.
+    return existingShard.nonce ? null : existingShard;
+  }
+
+  return BuildShard.query(trx).insert({
+    buildId: build.id,
+    index: parallelIndex,
+    nonce: null,
+  });
+}
+
+/**
+ * Complete a parallel shard: mark it done and count it towards the build's
+ * batches, finalizing the build once every batch has been received.
+ */
+async function completeParallelShard(params: {
+  trx: TransactionOrKnex;
+  build: Build;
+  shard: BuildShard;
+  requestId: string | null;
+  metadata: BuildMetadata | null;
+  parallelTotal: number | null;
+  expectedTotal: number | null;
+}): Promise<boolean> {
+  const {
+    trx,
+    build,
+    shard,
+    requestId,
+    metadata,
+    parallelTotal,
+    expectedTotal,
+  } = params;
+
+  // `nonce` marks the shard as complete, so it must be non-null even when the
+  // request carries no id; the shard's own id is a safe fallback marker.
+  await BuildShard.query(trx)
+    .findById(shard.id)
+    .patch({ nonce: requestId ?? shard.id, metadata });
+
+  const patchedBuild = await Build.query(trx)
+    .patchAndFetchById(build.id, {
+      batchCount: raw('"batchCount" + 1'),
+      totalBatch: parallelTotal,
+    })
+    .select("batchCount");
+
+  if (expectedTotal && expectedTotal === patchedBuild.batchCount) {
+    await Promise.all([
+      finalizeBuild({ build, trx }),
+      // If the build was marked as partial, then it was obviously an error, we unmark it.
+      build.partial
+        ? Build.query(trx).where("id", build.id).patch({ partial: false })
+        : null,
+    ]);
+    return true;
+  }
+
+  return false;
 }
 
 /**

--- a/apps/backend/src/build/finalizeBuild.ts
+++ b/apps/backend/src/build/finalizeBuild.ts
@@ -80,42 +80,48 @@ export async function finalizeBuild(input: {
    */
   build: Build;
   /**
-   * Options passed when the build is a single one, it means no shards are involved.
+   * Explicit build metadata, used for builds that are not split into shards
+   * (single builds and chunked single builds). When provided (even as `null`),
+   * shard metadata aggregation is skipped. When omitted, metadata is aggregated
+   * from the build shards.
    */
-  single?: {
-    metadata: BuildMetadata | null;
-    screenshots: { all: number; storybook: number };
-  };
+  metadata?: BuildMetadata | null;
+  /**
+   * Pre-computed screenshot counts. When omitted, the counts are computed from
+   * the database. Chunked single builds omit this so the counts reflect the
+   * screenshots inserted across every chunk.
+   */
+  screenshotCount?: { all: number; storybook: number };
   /**
    * Transaction object for database operations.
    */
   trx?: TransactionOrKnex;
 }) {
-  const { trx, build, single } = input;
+  const { trx, build, screenshotCount } = input;
+  const hasExplicitMetadata = input.metadata !== undefined;
   const countQuery = Screenshot.query(trx).where(
     "screenshotBucketId",
     build.compareScreenshotBucketId,
   );
-  const [screenshotCount, storybookScreenshotCount, shards] = await Promise.all(
-    [
-      single?.screenshots.all ?? countQuery.resultSize(),
-      single?.screenshots.storybook ??
+  const [screenshotCountResult, storybookScreenshotCount, shards] =
+    await Promise.all([
+      screenshotCount?.all ?? countQuery.resultSize(),
+      screenshotCount?.storybook ??
         countQuery
           .clone()
           .where(ref("metadata:sdk.name").castText(), ARGOS_STORYBOOK_SDK_NAME)
           .resultSize(),
-      single
+      hasExplicitMetadata
         ? []
         : BuildShard.query(trx).select("metadata").where("buildId", build.id),
-    ],
-  );
+    ]);
 
   const buildData: Partial<Pick<Build, "metadata" | "finalizedAt">> = {
     finalizedAt: new Date().toISOString(),
   };
 
-  if (single) {
-    buildData.metadata = single.metadata;
+  if (hasExplicitMetadata) {
+    buildData.metadata = input.metadata ?? null;
   } else if (shards.length > 0) {
     buildData.metadata = aggregateMetadata(
       shards.map((shard) => shard.metadata),
@@ -131,7 +137,7 @@ export async function finalizeBuild(input: {
       build.$clone().$query(trx).patch(buildData),
       build.$relatedQuery("compareScreenshotBucket", trx).patch({
         complete: true,
-        screenshotCount,
+        screenshotCount: screenshotCountResult,
         storybookScreenshotCount,
         valid,
       }),

--- a/apps/backend/src/database/services/screenshots.ts
+++ b/apps/backend/src/database/services/screenshots.ts
@@ -118,7 +118,7 @@ export async function insertFilesAndScreenshots(
         .ignore();
     }
 
-    const [files, tests, duplicates] = await Promise.all([
+    const [files, tests, existing] = await Promise.all([
       File.query(trx)
         .select("id", "key", "type")
         .whereIn("key", [...screenshotKeys, ...pwTraceKeys]),
@@ -131,69 +131,92 @@ export async function insertFilesAndScreenshots(
         trx,
       }),
       Screenshot.query(trx)
-        .select("name")
-        .where({
-          name: params.screenshots.map((screenshot) => screenshot.name),
-          screenshotBucketId: params.build.compareScreenshotBucketId,
-        }),
+        .select("name", "s3Id")
+        .where("screenshotBucketId", params.build.compareScreenshotBucketId)
+        .whereIn(
+          "name",
+          params.screenshots.map((screenshot) => screenshot.name),
+        ),
     ]);
 
-    if (duplicates.length > 0) {
+    // A build can be uploaded across several requests, and a request can be
+    // retried. A screenshot already stored with the same file is considered
+    // already inserted by a previous (retried) request and is skipped, making
+    // the insert idempotent. A screenshot stored with a different file is a real
+    // conflict: the same name was uploaded for two different screenshots.
+    const existingKeyByName = new Map(
+      existing.map((screenshot) => [screenshot.name, screenshot.s3Id]),
+    );
+    const conflicts: string[] = [];
+    const screenshotsToInsert = params.screenshots.filter((screenshot) => {
+      const existingKey = existingKeyByName.get(screenshot.name);
+      if (existingKey === undefined) {
+        return true;
+      }
+      if (existingKey !== screenshot.key) {
+        conflicts.push(screenshot.name);
+      }
+      return false;
+    });
+
+    if (conflicts.length > 0) {
       throw new Error(
-        `Screenshots already uploaded for ${duplicates
-          .map((screenshot) => screenshot.name)
-          .join(
-            ", ",
-          )}. Please ensure to not upload a screenshot with the same name multiple times.`,
+        `Screenshots already uploaded for ${conflicts.join(
+          ", ",
+        )}. Please ensure to not upload a screenshot with the same name multiple times.`,
       );
     }
 
     // Insert screenshots
-    await Screenshot.query(trx).insert(
-      params.screenshots.map((screenshot): PartialModelObject<Screenshot> => {
-        const file = files.find((f) => f.key === screenshot.key);
-        invariant(file, `File not found for key ${screenshot.key}`);
+    if (screenshotsToInsert.length > 0) {
+      await Screenshot.query(trx).insert(
+        screenshotsToInsert.map(
+          (screenshot): PartialModelObject<Screenshot> => {
+            const file = files.find((f) => f.key === screenshot.key);
+            invariant(file, `File not found for key ${screenshot.key}`);
 
-        const test = tests.find((t) => t.name === screenshot.name);
-        invariant(test, `Test not found for screenshot ${screenshot.name}`);
+            const test = tests.find((t) => t.name === screenshot.name);
+            invariant(test, `Test not found for screenshot ${screenshot.name}`);
 
-        const pwTraceFile = (() => {
-          if (screenshot.pwTraceKey) {
-            const pwTraceFile = files.find(
-              (f) => f.key === screenshot.pwTraceKey,
-            );
-            invariant(
-              pwTraceFile,
-              `File not found for key ${screenshot.pwTraceKey}`,
-            );
-            invariant(
-              pwTraceFile.type === "playwrightTrace",
-              `File ${screenshot.pwTraceKey} is not a playwright trace`,
-            );
-            return pwTraceFile;
-          }
-          return null;
-        })();
+            const pwTraceFile = (() => {
+              if (screenshot.pwTraceKey) {
+                const pwTraceFile = files.find(
+                  (f) => f.key === screenshot.pwTraceKey,
+                );
+                invariant(
+                  pwTraceFile,
+                  `File not found for key ${screenshot.pwTraceKey}`,
+                );
+                invariant(
+                  pwTraceFile.type === "playwrightTrace",
+                  `File ${screenshot.pwTraceKey} is not a playwright trace`,
+                );
+                return pwTraceFile;
+              }
+              return null;
+            })();
 
-        return {
-          screenshotBucketId: params.build.compareScreenshotBucketId,
-          name: screenshot.name,
-          s3Id: screenshot.key,
-          fileId: file.id,
-          testId: test.id,
-          metadata: screenshot.metadata ?? null,
-          playwrightTraceFileId: pwTraceFile?.id ?? null,
-          buildShardId: params.shard?.id ?? null,
-          threshold: screenshot.threshold ?? null,
-          baseName: screenshot.baseName ?? null,
-          parentName: screenshot.parentName ?? null,
-        };
-      }),
-    );
+            return {
+              screenshotBucketId: params.build.compareScreenshotBucketId,
+              name: screenshot.name,
+              s3Id: screenshot.key,
+              fileId: file.id,
+              testId: test.id,
+              metadata: screenshot.metadata ?? null,
+              playwrightTraceFileId: pwTraceFile?.id ?? null,
+              buildShardId: params.shard?.id ?? null,
+              threshold: screenshot.threshold ?? null,
+              baseName: screenshot.baseName ?? null,
+              parentName: screenshot.parentName ?? null,
+            };
+          },
+        ),
+      );
+    }
 
     return {
-      all: params.screenshots.length,
-      storybook: params.screenshots.filter(
+      all: screenshotsToInsert.length,
+      storybook: screenshotsToInsert.filter(
         (screenshot) =>
           screenshot.metadata?.sdk.name === ARGOS_STORYBOOK_SDK_NAME,
       ).length,


### PR DESCRIPTION
## Why

A build sends its per-screenshot metadata via `PUT /builds/{buildId}`. As a suite grows, that body exceeds the API's 3MB limit and the upload fails with `PayloadTooLargeError`. (See ARG-430.)

## What

Allow a build's screenshots to be uploaded across **several sequential `updateBuild` requests**, for both single and parallel builds.

### Single (non-parallel) builds
- New optional `final` body flag (default `true`). Each request inserts its screenshots into the same bucket (no shard); only the `final` one finalizes the build (counting screenshots from the DB so the total spans every request; build metadata travels on the last request).
- Updates are serialized with a `redisLock` so a retry that overlaps the original (the api-client aborts after a 30s timeout while the server keeps processing, then retries) cannot double-insert or finalize twice.

### Parallel builds
- A single shard can now span several requests too. Requests of the same shard share their `parallelIndex`; the shard's `nonce` stays null until its last request (`final`), which is when the shard counts towards `batchCount`. No schema change: `parallelIndex` identifies the shard across requests (the redis lock already serializes them) and `nonce` doubles as the completion marker.
- Index-less shards (manual finalization) keep one-shard-per-request — splitting there just creates several shards, which is fine since finalization is explicit.

### Idempotency & misc
- `insertFilesAndScreenshots` treats an existing `(bucket, name)` row with the same key as already-inserted (skip); a same-name/different-key collision still errors. The already-finalized retry check returns the build instead of `409` when every screenshot is already stored — for both single and parallel builds, **without relying on a request id** (not every SDK sends one).
- `finalizeBuild`: split the old `single` param into `metadata` + `screenshotCount`.
- `createBuild`: cap at 5000 screenshots, pointing larger suites to parallel mode.
- Fixes a latent bug: the existing-screenshot lookup used `.where({ name: [...] })`, which never generated an `IN` clause.

The matching SDK change lives in argos-javascript (`greg/arg-430-...`).

## Tests

`updateBuild.e2e.test.ts` (single chunked upload, idempotent retries, finalize-retry, conflict; parallel multi-shard, shard split across requests, retry dedup, manual-finalize retry, validation) and `createBuild.e2e.test.ts` (5000 cap). `build` + `api` suites pass (202); types + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)