### PR TITLE
fix(merge-base): resolve baseline for GitHub Light app

### DIFF
--- a/apps/backend/src/build/strategy/strategies/ci/base.ts
+++ b/apps/backend/src/build/strategy/strategies/ci/base.ts
@@ -9,7 +9,11 @@ import {
 
 import type { CIStrategyContext } from ".";
 import type { GetBaseResult } from "../../types";
-import { getBaseBucketForBuildAndCommit, getBucketFromCommits } from "./query";
+import {
+  getBaseBucketForBuildAndCommit,
+  getBucketFromCommits,
+  getLatestBaseBucketForBranch,
+} from "./query";
 import { GithubStrategy } from "./strategies/github";
 import { GitlabStrategy } from "./strategies/gitlab";
 import type { MergeBaseStrategy } from "./types";
@@ -114,17 +118,41 @@ export async function getCIBase(args: GetCIBaseArgs): GetBaseResult {
     });
   })();
 
+  const isBaseBranchAutoApproved = baseBranch
+    ? context.checkIsAutoApproved(baseBranch)
+    : false;
+
+  // The "light" GitHub app has no read access to the repository, so we can't
+  // resolve the commit ancestry (merge base / parent commits) from the API and
+  // rely entirely on what the CLI sent. When that isn't enough to find a base
+  // bucket, fall back to the most recent valid bucket on the base branch.
+  // It is a best effort: the bucket is not guaranteed to be an ancestor of the
+  // build commit, but it is far better than reporting the build as orphan.
+  const resolveBaseBucket = async (baseBucket: ScreenshotBucket | null) => {
+    if (baseBucket) {
+      return baseBucket;
+    }
+    if (baseBranch && !gitProvider.hasCommitHistoryAccess(ctx)) {
+      return getLatestBaseBucketForBranch({
+        build,
+        branch: baseBranch,
+        options: {
+          // If the base branch is auto-approved, then we don't need to check if
+          // the build is approved.
+          approved: isBaseBranchAutoApproved ? undefined : true,
+        },
+      });
+    }
+    return null;
+  };
+
   if (!mergeBaseCommitSha) {
     return {
-      baseBucket: null,
+      baseBucket: await resolveBaseBucket(null),
       baseBranch,
       baseBranchResolvedFrom,
     };
   }
-
-  const isBaseBranchAutoApproved = baseBranch
-    ? context.checkIsAutoApproved(baseBranch)
-    : false;
 
   // If the merge base is the same as the head, then we have to found an ancestor
   // It happens when we are on a auto-approved branch.
@@ -142,7 +170,7 @@ export async function getCIBase(args: GetCIBaseArgs): GetBaseResult {
       build,
     });
     return {
-      baseBucket,
+      baseBucket: await resolveBaseBucket(baseBucket),
       baseBranch,
       baseBranchResolvedFrom,
     };
@@ -183,7 +211,7 @@ export async function getCIBase(args: GetCIBaseArgs): GetBaseResult {
   });
 
   return {
-    baseBucket,
+    baseBucket: await resolveBaseBucket(baseBucket),
     baseBranch,
     baseBranchResolvedFrom,
   };

--- a/apps/backend/src/build/strategy/strategies/ci/light.e2e.test.ts
+++ b/apps/backend/src/build/strategy/strategies/ci/light.e2e.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ScreenshotBucket } from "@/database/models";
+import { factory, setupDatabase } from "@/database/testing";
+
+import { getCIBase } from "./base";
+
+// The GitHub "light" app has no read access to the repository, so it can't
+// call the GitHub API to resolve the merge base or list parent commits.
+// We still need a (stub) octokit so that `getContext` succeeds.
+vi.mock("@/github", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/github")>();
+  return {
+    ...actual,
+    getInstallationOctokit: vi.fn(async () => ({}) as never),
+  };
+});
+
+describe("getCIBase - GitHub Light app", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  it("falls back to the latest valid bucket on the base branch when the baseline is far from the merge base", async () => {
+    const githubAccount = await factory.GithubAccount.create({
+      login: "argos",
+    });
+    const githubRepository = await factory.GithubRepository.create({
+      name: "repo",
+      githubAccountId: githubAccount.id,
+    });
+    const installation = await factory.GithubInstallation.create({
+      app: "light",
+    });
+    await factory.GithubRepositoryInstallation.create({
+      githubRepositoryId: githubRepository.id,
+      githubInstallationId: installation.id,
+    });
+    const project = await factory.Project.create({
+      githubRepositoryId: githubRepository.id,
+      defaultBaseBranch: "main",
+    });
+
+    // The baseline: an approved (reference) build on "main".
+    // Its commit is far behind (~244 commits) and is NOT part of the parent
+    // commits the CLI was able to send.
+    const baseBucket = await factory.ScreenshotBucket.create({
+      name: "default",
+      branch: "main",
+      mode: "ci",
+      projectId: project.id,
+      commit: "1111111111111111111111111111111111111111",
+    });
+    await factory.Build.create({
+      projectId: project.id,
+      name: "default",
+      mode: "ci",
+      type: "reference",
+      jobStatus: "complete",
+      compareScreenshotBucketId: baseBucket.id,
+    });
+
+    // The compare build on a feature branch. The CLI provided the merge-base
+    // commit (no bucket exists there) and a short list of parent commits that
+    // does not reach the baseline commit.
+    const compareBucket = await factory.ScreenshotBucket.create({
+      name: "default",
+      branch: "feature",
+      mode: "ci",
+      projectId: project.id,
+      commit: "2222222222222222222222222222222222222222",
+    });
+    const build = await factory.Build.create({
+      projectId: project.id,
+      name: "default",
+      mode: "ci",
+      type: "check",
+      jobStatus: "pending",
+      compareScreenshotBucketId: compareBucket.id,
+      baseCommit: "3333333333333333333333333333333333333333",
+      baseBranch: "main",
+      parentCommits: [
+        "2222222222222222222222222222222222222222",
+        "4444444444444444444444444444444444444444",
+      ],
+    });
+
+    const result = await getCIBase({
+      build,
+      compareScreenshotBucket: compareBucket,
+      project,
+      pullRequest: null,
+      context: { checkIsAutoApproved: () => false },
+    });
+
+    expect(result.baseBucket).toBeInstanceOf(ScreenshotBucket);
+    expect((result.baseBucket as ScreenshotBucket | null)?.id).toBe(
+      baseBucket.id,
+    );
+  });
+});

--- a/apps/backend/src/build/strategy/strategies/ci/query.ts
+++ b/apps/backend/src/build/strategy/strategies/ci/query.ts
@@ -88,6 +88,24 @@ function queryBaseBucket(build: Build, options?: QueryBaseBucketOptions) {
 }
 
 /**
+ * Get the most recent valid bucket on a given branch.
+ *
+ * Used as a best-effort baseline when we can't resolve the commit ancestry
+ * (e.g. the GitHub "light" app, which has no read access to the repository).
+ * The returned bucket is not guaranteed to be an ancestor of the build commit.
+ */
+export async function getLatestBaseBucketForBranch(args: {
+  build: Build;
+  branch: string;
+  options?: QueryBaseBucketOptions;
+}) {
+  const bucket = await queryBaseBucket(args.build, args.options)
+    .where("branch", args.branch)
+    .first();
+  return bucket ?? null;
+}
+
+/**
  * Get the bucket from a list of commits, ordered by the order of the commits.
  */
 export async function getBucketFromCommits(args: {

--- a/apps/backend/src/build/strategy/strategies/ci/strategies/github.ts
+++ b/apps/backend/src/build/strategy/strategies/ci/strategies/github.ts
@@ -53,10 +53,15 @@ export const GithubStrategy: MergeBaseStrategy<{
     return { octokit, owner, repo, installation };
   },
 
+  // The "light" app has no read access to the repository, so it can't resolve
+  // the commit ancestry from the GitHub API.
+  hasCommitHistoryAccess: (ctx) => ctx.installation.app !== "light",
+
   getMergeBaseCommitSha: async (args) => {
-    // If the app is light, then we rely on the base commit provided by the user in CLI.
-    // It is already handled in the common logic, so at this point we return null.
-    // Note it may indicates a bad setup.
+    // The light app has no read access to the repository, so it can't resolve
+    // the merge base. We rely on the base commit provided by the user in the CLI
+    // and, as a fallback, on the latest bucket of the base branch (see
+    // `hasCommitHistoryAccess` handling in the common logic).
     if (args.ctx.installation.app === "light") {
       return null;
     }
@@ -85,11 +90,9 @@ export const GithubStrategy: MergeBaseStrategy<{
     );
   },
   listParentCommitShas: async (args) => {
-    // If the app is light, we just find the last bucket ancest on the base branch.
-    // We can't know for sure that it's a parent, but it's the best we can do.
-    // It can result into diffs that includes changes more recent than the current branch.
-    // It is already handled in the common logic, so at this point we return [].
-    // Note it may indicates a bad setup.
+    // The light app has no read access to the repository, so it can't list the
+    // parent commits. The common logic falls back to the latest bucket of the
+    // base branch (see `hasCommitHistoryAccess`), so we return [] here.
     if (args.ctx.installation.app === "light") {
       return [];
     }

--- a/apps/backend/src/build/strategy/strategies/ci/strategies/gitlab.ts
+++ b/apps/backend/src/build/strategy/strategies/ci/strategies/gitlab.ts
@@ -31,6 +31,8 @@ export const GitlabStrategy: MergeBaseStrategy<{
 
     return { client, gitlabProjectId: project.gitlabProject.gitlabId };
   },
+  // GitLab always grants repository read access.
+  hasCommitHistoryAccess: () => true,
   getMergeBaseCommitSha: async (args) => {
     const result = await args.ctx.client.Repositories.mergeBase(
       args.ctx.gitlabProjectId,

--- a/apps/backend/src/build/strategy/strategies/ci/types.ts
+++ b/apps/backend/src/build/strategy/strategies/ci/types.ts
@@ -3,6 +3,12 @@ import type { Build, Project } from "@/database/models";
 export type MergeBaseStrategy<TCtx> = {
   detect: (project: Project) => Promise<boolean> | boolean;
   getContext: (project: Project) => Promise<TCtx | null> | TCtx | null;
+  /**
+   * Whether we can read the repository commit history (merge base & parent
+   * commits) from the provider. The GitHub "light" app has no read access, so
+   * it returns `false` and we fall back to a branch-based baseline resolution.
+   */
+  hasCommitHistoryAccess: (ctx: TCtx) => boolean;
   getMergeBaseCommitSha: (args: {
     project: Project;
     ctx: TCtx;


### PR DESCRIPTION
## Problem

A customer using the **GitHub Light app** reported builds stuck as **orphan** even though a baseline existed ~244 commits away.

The light app has **no read access to the repository**, so it can't resolve the merge base (`getMergeBaseCommitSha` → `null`) or list parent commits (`listParentCommitShas` → `[]`). Baseline resolution therefore depends entirely on the `baseCommit` / `parentCommits` the CLI sends.

When the baseline is far behind (beyond the `parentCommits` depth) **and** no bucket exists at the exact merge-base commit, no base bucket was found → **orphan build**. A code comment claimed this case was *"already handled in the common logic"*, but that fallback **was never implemented**.

## Fix

- Add `getLatestBaseBucketForBranch` ([query.ts](apps/backend/src/build/strategy/strategies/ci/query.ts)) — most recent valid bucket on the base branch (respects the `approved` filter).
- Add `hasCommitHistoryAccess(ctx)` to the `MergeBaseStrategy` interface; GitHub returns `false` for the light app, `true` otherwise; GitLab always `true`.
- In [base.ts](apps/backend/src/build/strategy/strategies/ci/base.ts), when the strategy has no commit-history access, fall back to the latest valid bucket on the base branch instead of returning `null`.

Best effort: the bucket is not guaranteed to be an ancestor of the build commit, but it's far better than reporting the build as orphan. Behavior for the regular GitHub app and GitLab is unchanged (they keep `hasCommitHistoryAccess: true`).

## Test

New [light.e2e.test.ts](apps/backend/src/build/strategy/strategies/ci/light.e2e.test.ts) reproduces the scenario (light installation, baseline neither at the merge-base nor in `parentCommits`):
- **Before:** `baseBucket` `undefined` → orphan ❌
- **After:** resolves to the baseline bucket ✅

`check-types` ✅ · `eslint` ✅ · full CI strategy e2e suite 18/18 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)