### PR TITLE
fix: never use rejected builds as baseline

### DIFF
--- a/apps/backend/src/build/baselineEligibility.test.ts
+++ b/apps/backend/src/build/baselineEligibility.test.ts
@@ -9,6 +9,7 @@ type EligibilityArgs = Parameters<typeof getBuildBaselineEligibility>[0];
 function getEligibility(overrides: {
   build?: Partial<Pick<Build, "jobStatus" | "subset" | "type">>;
   valid?: boolean;
+  rejected?: boolean;
   hasAcceptedReview?: boolean;
   hasMergedPullRequest?: boolean;
 }) {
@@ -20,6 +21,7 @@ function getEligibility(overrides: {
       ...overrides.build,
     },
     valid: overrides.valid ?? true,
+    rejected: overrides.rejected ?? false,
     hasAcceptedReview: overrides.hasAcceptedReview ?? false,
     hasMergedPullRequest: overrides.hasMergedPullRequest ?? false,
   };
@@ -58,6 +60,34 @@ describe("getBuildBaselineEligibility", () => {
       eligible: false,
       reasons: ["not-approved"],
     });
+  });
+
+  it("is not eligible for a rejected check build", () => {
+    expect(
+      getEligibility({ build: { type: "check" }, rejected: true }),
+    ).toEqual({ eligible: false, reasons: ["rejected"] });
+  });
+
+  it("is not eligible for a rejected reference build", () => {
+    expect(
+      getEligibility({ build: { type: "reference" }, rejected: true }),
+    ).toEqual({ eligible: false, reasons: ["rejected"] });
+  });
+
+  it("is not eligible for a rejected orphan build", () => {
+    expect(
+      getEligibility({ build: { type: "orphan" }, rejected: true }),
+    ).toEqual({ eligible: false, reasons: ["rejected"] });
+  });
+
+  it("reports rejection instead of approval when both could apply", () => {
+    expect(
+      getEligibility({
+        build: { type: "check" },
+        rejected: true,
+        hasAcceptedReview: true,
+      }),
+    ).toEqual({ eligible: false, reasons: ["rejected"] });
   });
 
   it("is not eligible for a skipped build", () => {

--- a/apps/backend/src/build/baselineEligibility.ts
+++ b/apps/backend/src/build/baselineEligibility.ts
@@ -12,6 +12,7 @@ export type BuildBaselineIneligibilityReason =
   | "build-incomplete"
   | "tests-failed"
   | "subset"
+  | "rejected"
   | "not-approved";
 
 export type BuildBaselineEligibility = {
@@ -27,8 +28,12 @@ export type BuildBaselineEligibility = {
  * - The build is complete.
  * - All framework tests passed (the compare bucket is valid).
  * - The build is not marked as a subset.
+ * - The build has no active (non-dismissed) rejection.
  * - The build is auto-approved (reference), manually approved (an accepted
  *   review or a merged pull request), or an orphan.
+ *
+ * A rejection vetoes eligibility regardless of the build type, mirroring the
+ * baseline-selection query which never picks a rejected build.
  *
  * @see {@link file://./strategy/strategies/ci/query.ts} for the matching query.
  */
@@ -36,6 +41,8 @@ export function getBuildBaselineEligibility(args: {
   build: Pick<Build, "jobStatus" | "subset" | "type">;
   /** Whether the compare screenshot bucket is valid (framework tests passed). */
   valid: boolean;
+  /** Whether the build has an active (non-dismissed) rejection. */
+  rejected: boolean;
   /** Whether the build has an accepted review. */
   hasAcceptedReview: boolean;
   /** Whether the build is attached to a merged pull request. */
@@ -58,14 +65,20 @@ export function getBuildBaselineEligibility(args: {
     reasons.push("subset");
   }
 
-  const approved =
-    build.type === "reference" ||
-    build.type === "orphan" ||
-    (build.type === "check" &&
-      (args.hasAcceptedReview || args.hasMergedPullRequest));
+  // A rejection blocks the build whatever its type, so it takes precedence over
+  // the approval check (which would otherwise pass for reference/orphan builds).
+  if (args.rejected) {
+    reasons.push("rejected");
+  } else {
+    const approved =
+      build.type === "reference" ||
+      build.type === "orphan" ||
+      (build.type === "check" &&
+        (args.hasAcceptedReview || args.hasMergedPullRequest));
 
-  if (!approved) {
-    reasons.push("not-approved");
+    if (!approved) {
+      reasons.push("not-approved");
+    }
   }
 
   return { eligible: reasons.length === 0, reasons };

--- a/apps/backend/src/build/strategy/strategies/ci/query.e2e.test.ts
+++ b/apps/backend/src/build/strategy/strategies/ci/query.e2e.test.ts
@@ -148,6 +148,25 @@ describe("#getBaseBucketForBuildAndCommit", () => {
         expect(result).toEqual(baseBucket);
       });
     });
+
+    describe("if the associated reference build has been rejected", () => {
+      beforeEach(async () => {
+        await factory.BuildReview.create({
+          buildId: baseBucketBuild.id,
+          state: "rejected",
+        });
+      });
+
+      it("does not return the bucket even when approval is not required", async () => {
+        const result = await getBaseBucketForBuildAndCommit(
+          build,
+          "766b744bc5fa27a330283dfd47ffafdaf905a941",
+          // No `approved` option: mimics an auto-approved base branch, where a
+          // rejection must still prevent the build from being a baseline.
+        );
+        expect(result).toBeNull();
+      });
+    });
   });
 
   describe("when the build is triggered normally on main", () => {
@@ -283,6 +302,32 @@ describe("#getBucketFromCommits", () => {
     await createEligibleBucket("fe709bb92b38564a7547d0136206fca1b2e2d73f");
     const result = await getBucketFromCommits({
       shas: ["15c4ef8807c45a8af00eed56ccd3e3227a0bfd6d"],
+      build,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("does not return a bucket from a rejected build", async () => {
+    const bucket = await factory.ScreenshotBucket.create({
+      projectId: build.projectId,
+      commit: "b779e503ff5163689cf480c5c58548cb98f735c7",
+      mode: build.mode,
+      name: build.name,
+    });
+    const rejectedBuild = await factory.Build.create({
+      projectId: build.projectId,
+      compareScreenshotBucketId: bucket.id,
+      jobStatus: "complete",
+      name: build.name,
+      mode: build.mode,
+      type: "reference",
+    });
+    await factory.BuildReview.create({
+      buildId: rejectedBuild.id,
+      state: "rejected",
+    });
+    const result = await getBucketFromCommits({
+      shas: ["b779e503ff5163689cf480c5c58548cb98f735c7"],
       build,
     });
     expect(result).toBeNull();

--- a/apps/backend/src/build/strategy/strategies/ci/query.ts
+++ b/apps/backend/src/build/strategy/strategies/ci/query.ts
@@ -56,7 +56,11 @@ function queryBaseBucket(build: Build, options?: QueryBaseBucketOptions) {
     .where("jobStatus", "complete")
     .whereNot("id", build.id)
     .where("subset", false)
-    .whereNot("type", "skipped");
+    .whereNot("type", "skipped")
+    // A build with an active (non-dismissed) rejection can never be used as a
+    // baseline, whatever its type and even when an explicit approval is not
+    // required (e.g. auto-approved branches or the ancestor-commit fallback).
+    .whereNotExists(Build.rejectedReviewQuery());
 
   if (options?.approved) {
     buildQuery.where((qb) => {

--- a/apps/backend/src/graphql/definitions/Build.ts
+++ b/apps/backend/src/graphql/definitions/Build.ts
@@ -165,6 +165,8 @@ export const typeDefs = gql`
     TESTS_FAILED
     "The build is marked as a subset"
     SUBSET
+    "The build has been rejected"
+    REJECTED
     "The build is not auto-approved, manually approved, or an orphan"
     NOT_APPROVED
   }
@@ -223,6 +225,7 @@ const baselineIneligibilityReasonMap: Record<
   "build-incomplete": IBuildBaselineIneligibilityReason.BuildIncomplete,
   "tests-failed": IBuildBaselineIneligibilityReason.TestsFailed,
   subset: IBuildBaselineIneligibilityReason.Subset,
+  rejected: IBuildBaselineIneligibilityReason.Rejected,
   "not-approved": IBuildBaselineIneligibilityReason.NotApproved,
 };
 
@@ -447,6 +450,7 @@ export const resolvers: IResolvers = {
           return getBuildBaselineEligibility({
             build,
             valid: false,
+            rejected: false,
             hasAcceptedReview: false,
             hasMergedPullRequest: false,
           });
@@ -462,6 +466,7 @@ export const resolvers: IResolvers = {
         return getBuildBaselineEligibility({
           build,
           valid: compareBucket?.valid ?? false,
+          rejected: aggregatedStatus === "rejected",
           hasAcceptedReview: aggregatedStatus === "accepted",
           hasMergedPullRequest: pullRequest?.merged ?? false,
         });

--- a/apps/frontend/src/util/build.tsx
+++ b/apps/frontend/src/util/build.tsx
@@ -175,6 +175,8 @@ export function getBaselineIneligibilityReasonLabel(
       return "Some end-to-end tests did not pass.";
     case BuildBaselineIneligibilityReason.Subset:
       return "The build is marked as a subset, so it only contains part of the snapshots.";
+    case BuildBaselineIneligibilityReason.Rejected:
+      return "The build has been rejected.";
     case BuildBaselineIneligibilityReason.NotApproved:
       return "The build is not auto-approved, manually approved, or an orphan.";
     default:


### PR DESCRIPTION
## Problem

Rejected builds were shown as **eligible baselines** (ARG-432) and could even be **picked** by the baseline-selection query. The new per-user review/approval flow (`BuildReview` rows, with dismissal) was not fully honored:

- **Build-picking** (`ci/query.ts`): the review filter only ran when `approved: true` was passed, and even then `reference`/`orphan` builds bypassed it. The ancestor-commit fallback (`getBucketFromCommits`) calls the query *without* `approved`, so it applied **no** review filter at all — letting a rejected build be selected as baseline.
- **Eligibility indicator** (`getBuildBaselineEligibility`): had **no rejection input**. Its `approved` check short-circuited on `type === "reference" | "orphan"`, so a rejected reference/orphan build was reported eligible.

## Fix

One rule, applied consistently in both places:

> A build with an active (non-dismissed) rejection can never be a baseline, regardless of type.

- `query.ts`: add `.whereNotExists(Build.rejectedReviewQuery())` to the **base** query — covers every path (incl. the fallback and auto-approved branches) and every type. `rejectedReviewQuery` already handles "not dismissed" + latest-review-per-user.
- `baselineEligibility.ts`: add a `rejected` input + dedicated `rejected` reason that vetoes eligibility before the type-based approval check.
- `graphql/Build.ts`: add the `REJECTED` enum value + map entry; wire `rejected: aggregatedStatus === "rejected"` into the resolver (same latest-per-user, non-dismissed source already used for `accepted`).
- `frontend/util/build.tsx`: label the new reason ("The build has been rejected.").

## Tests

- Eligibility unit tests: rejected `reference`/`orphan`/`check` builds are not eligible; rejection takes precedence over an approval.
- e2e regression tests: a rejected `reference` build is excluded both via `getBucketFromCommits` and via the no-approval (auto-approved branch) path — both returned the bucket before this fix.

✅ `baselineEligibility` unit (14/14) · ✅ `ci/query.e2e` (12/12) · ✅ backend + frontend typecheck · ✅ lint + format

Closes ARG-432

🤖 Generated with [Claude Code](https://claude.com/claude-code)