### PR TITLE
fix(backend): return 400 on duplicate screenshot name

### DIFF
--- a/apps/backend/src/api/handlers/updateBuild.e2e.test.ts
+++ b/apps/backend/src/api/handlers/updateBuild.e2e.test.ts
@@ -166,11 +166,12 @@ describe("updateBuild", () => {
         final: false,
       }).expect(200);
 
-      await put(build.id, {
+      const res = await put(build.id, {
         screenshots: [screenshot("a", "b")],
         final: true,
-      }).expect(500);
+      }).expect(400);
 
+      expect(res.body.error).toMatch(/already uploaded/);
       expect(await countScreenshots(compareScreenshotBucket.id)).toBe(1);
     });
   });

--- a/apps/backend/src/database/services/screenshots.ts
+++ b/apps/backend/src/database/services/screenshots.ts
@@ -6,6 +6,7 @@ import type { PartialModelObject, TransactionOrKnex } from "objection";
 import { transaction } from "@/database";
 import { Build, BuildShard, File, Screenshot, Test } from "@/database/models";
 import { ARGOS_STORYBOOK_SDK_NAME } from "@/util/argos-sdk";
+import { boom } from "@/util/error";
 
 import { getUnknownFileKeys } from "./file";
 
@@ -160,7 +161,8 @@ export async function insertFilesAndScreenshots(
     });
 
     if (conflicts.length > 0) {
-      throw new Error(
+      throw boom(
+        400,
         `Screenshots already uploaded for ${conflicts.join(
           ", ",
         )}. Please ensure to not upload a screenshot with the same name multiple times.`,


### PR DESCRIPTION
## Problem

A production error surfaced in Sentry as an unhandled 500:

> Screenshots already uploaded for chromium/Benchmarks Auth Table Screenshot.png. Please ensure to not upload a screenshot with the same name multiple times.

The screenshot `key` is the file's content hash (`s3Id`). The conflict in `insertFilesAndScreenshots` only fires when the **same screenshot name** is uploaded with a **different file content** within a build. Retries reuse identical keys, so they're skipped idempotently — meaning this only triggers on a genuine **client mistake** (a duplicate screenshot name), not a server bug.

It was thrown as a plain `Error`, so:
- The error handler defaulted it to **500**.
- The api-client treats 5xx as retryable → it retried the request (observed `clientRetryAttempt: 3`), each retry guaranteed to fail the same way.
- It was reported to Sentry as an unhandled server error.

## Fix

Throw `boom(400, ...)` instead. The client now gets a proper client error and stops retrying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)