### PR TITLE
feat(backend): increase maximum upload file size to 50MB

### DIFF
--- a/apps/backend/src/api/handlers/createBuild.ts
+++ b/apps/backend/src/api/handlers/createBuild.ts
@@ -39,7 +39,7 @@ import { CreateAPIHandler } from "../util";
  * PUT upload path is kept for backward compatibility and does not enforce this
  * policy.
  */
-const MAX_UPLOAD_FILE_BYTES = 25 * 1024 * 1024;
+const MAX_UPLOAD_FILE_BYTES = 50 * 1024 * 1024;
 
 /**
  * Content type of Playwright trace files. Hard-coded because the SDK always


### PR DESCRIPTION
## What

Increase `MAX_UPLOAD_FILE_BYTES` from 25MB to 50MB in the build creation handler.

## Why

High-resolution viewports (2560px+) with tall pages can produce PNG screenshots in the 10–30MB range, and Playwright traces (especially with video recording or browser extensions) can exceed the previous 25MB limit. These uploads failed with an `EntityTooLarge` S3 error. Raising the limit to 50MB lets these legitimate files through.

Resolves argos-ci/argos-javascript#328

🤖 Generated with [Claude Code](https://claude.com/claude-code)
