### PR TITLE
feat(backend): resolve baseline from parent commits without a Git provider

### DIFF
--- a/apps/backend/src/api/handlers/findBaseline.e2e.test.ts
+++ b/apps/backend/src/api/handlers/findBaseline.e2e.test.ts
@@ -1,0 +1,232 @@
+import request from "supertest";
+import { test as base, beforeAll, describe, expect } from "vitest";
+import z from "zod";
+
+import type { Account, Project } from "@/database/models";
+import { factory, setupDatabase } from "@/database/testing";
+
+import { createTestHandlerApp } from "../test-util";
+import { findBaseline } from "./findBaseline";
+
+const app = createTestHandlerApp(findBaseline);
+
+const TOKEN = "the-awesome-token";
+
+const sha = (n: number) => n.toString(16).padStart(40, "0");
+
+type Fixtures = {
+  account: Account;
+  project: Project;
+};
+
+const test = base.extend<Fixtures>({
+  account: async ({}, use) => {
+    await setupDatabase();
+    await use(await factory.TeamAccount.create({ slug: "awesome-team" }));
+  },
+  project: async ({ account }, use) => {
+    await use(
+      await factory.Project.create({ token: TOKEN, accountId: account.id }),
+    );
+  },
+});
+
+/**
+ * Create an eligible baseline build at a given commit: complete, valid, and
+ * approved (a reference build is auto-approved).
+ */
+async function createEligibleBaseline(
+  project: Project,
+  commit: string,
+  overrides?: {
+    name?: string;
+    mode?: "ci" | "monitoring";
+    type?: "reference" | "orphan" | "check";
+  },
+) {
+  const bucket = await factory.ScreenshotBucket.create({
+    projectId: project.id,
+    name: overrides?.name ?? "default",
+    mode: overrides?.mode ?? "ci",
+    commit,
+    valid: true,
+    complete: true,
+  });
+  const build = await factory.Build.create({
+    projectId: project.id,
+    compareScreenshotBucketId: bucket.id,
+    name: overrides?.name ?? "default",
+    mode: overrides?.mode ?? "ci",
+    type: overrides?.type ?? "reference",
+    jobStatus: "complete",
+  });
+  return build;
+}
+
+describe("findBaseline", () => {
+  beforeAll(() => {
+    z.globalRegistry.clear();
+  });
+
+  test("requires authentication", async () => {
+    const res = await request(app)
+      .post("/baseline")
+      .send({ commits: [sha(1)] })
+      .expect(401);
+    expect(res.body.error).toBeDefined();
+  });
+
+  test("rejects an empty list of commits", async ({ project }) => {
+    const res = await request(app)
+      .post("/baseline")
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({ commits: [] })
+      .expect(400);
+    expect(res.body.error).toBeDefined();
+    expect(project).toBeDefined();
+  });
+
+  test("rejects invalid commit SHAs", async ({ project }) => {
+    const res = await request(app)
+      .post("/baseline")
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({ commits: ["not-a-sha"] })
+      .expect(400);
+    expect(res.body.error).toBeDefined();
+    expect(project).toBeDefined();
+  });
+
+  test("returns null when no commit has an eligible baseline", async ({
+    project,
+  }) => {
+    expect(project).toBeDefined();
+    await request(app)
+      .post("/baseline")
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({ commits: [sha(1), sha(2)] })
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.baseline).toBeNull();
+      });
+  });
+
+  test("finds the eligible baseline matching one of the commits", async ({
+    project,
+  }) => {
+    const build = await createEligibleBaseline(project, sha(10));
+
+    await request(app)
+      .post("/baseline")
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({ commits: [sha(99), sha(10), sha(98)] })
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.baseline).toMatchObject({
+          id: build.id,
+          head: { sha: sha(10) },
+        });
+      });
+  });
+
+  test("respects the order of the commits and picks the first match", async ({
+    project,
+  }) => {
+    const closest = await createEligibleBaseline(project, sha(20));
+    const furthest = await createEligibleBaseline(project, sha(21));
+
+    // The closest ancestor comes first in the list, so it wins.
+    await request(app)
+      .post("/baseline")
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({ commits: [sha(20), sha(21)] })
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.baseline.id).toBe(closest.id);
+      });
+
+    // Reversing the order makes the other commit win.
+    await request(app)
+      .post("/baseline")
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({ commits: [sha(21), sha(20)] })
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.baseline.id).toBe(furthest.id);
+      });
+  });
+
+  test("ignores builds that are not approved", async ({ project }) => {
+    // A check build without any review is not an eligible baseline.
+    await createEligibleBaseline(project, sha(30), { type: "check" });
+
+    await request(app)
+      .post("/baseline")
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({ commits: [sha(30)] })
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.baseline).toBeNull();
+      });
+  });
+
+  test("ignores rejected builds", async ({ project }) => {
+    const build = await createEligibleBaseline(project, sha(40));
+    await factory.BuildReview.create({ buildId: build.id, state: "rejected" });
+
+    await request(app)
+      .post("/baseline")
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({ commits: [sha(40)] })
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.baseline).toBeNull();
+      });
+  });
+
+  test("only considers builds with the requested name", async ({ project }) => {
+    await createEligibleBaseline(project, sha(50), { name: "other" });
+
+    // The default name does not match the "other" build.
+    await request(app)
+      .post("/baseline")
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({ commits: [sha(50)] })
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.baseline).toBeNull();
+      });
+
+    // Querying the right name finds it.
+    await request(app)
+      .post("/baseline")
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({ commits: [sha(50)], name: "other" })
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.baseline.head.sha).toBe(sha(50));
+      });
+  });
+
+  test("only considers builds with the requested mode", async ({ project }) => {
+    await createEligibleBaseline(project, sha(60), { mode: "monitoring" });
+
+    // The default "ci" mode does not match the monitoring build.
+    await request(app)
+      .post("/baseline")
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({ commits: [sha(60)] })
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.baseline).toBeNull();
+      });
+
+    await request(app)
+      .post("/baseline")
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({ commits: [sha(60)], mode: "monitoring" })
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.baseline.head.sha).toBe(sha(60));
+      });
+  });
+});

--- a/apps/backend/src/api/handlers/findBaseline.ts
+++ b/apps/backend/src/api/handlers/findBaseline.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+import { ZodOpenApiOperationObject } from "zod-openapi";
+
+import { getEligibleBaselineBuildFromCommits } from "@/build/strategy/strategies/ci/query";
+
+import { getAuthProjectPayloadFromExpressReq } from "../auth/project";
+import { BuildSchema, serializeBuild } from "../schema/primitives/build";
+import { Sha1HashSchema } from "../schema/primitives/sha";
+import {
+  invalidParameters,
+  serverError,
+  unauthorized,
+} from "../schema/util/error";
+import { projectTokenAuth } from "../schema/util/security";
+import { CreateAPIHandler } from "../util";
+
+const RequestBodySchema = z.object({
+  commits: z.array(Sha1HashSchema).min(1).meta({
+    description:
+      "The commits to look for an eligible baseline, ordered from the closest to the furthest ancestor. The first commit with an eligible baseline wins.",
+  }),
+  name: z
+    .string()
+    .min(1)
+    .default("default")
+    .meta({ description: "The name of the build to find a baseline for." }),
+  mode: z
+    .enum(["ci", "monitoring"])
+    .default("ci")
+    .meta({ description: "The mode of the build to find a baseline for." }),
+});
+
+const ResponseSchema = z.object({
+  baseline: BuildSchema.nullable().meta({
+    description:
+      "The eligible baseline build found among the commits, or null when none is found.",
+  }),
+});
+
+export const findBaselineOperation = {
+  operationId: "findBaseline",
+  summary: "Find an eligible baseline from a list of commits",
+  description:
+    "Find the build eligible to be used as a baseline among a list of commits. Useful when no Git provider is connected: the CLI can send the candidate ancestor commits and let Argos pick the closest one that has an eligible (complete, valid, approved and not rejected) baseline build.",
+  tags: ["Builds"],
+  security: projectTokenAuth,
+  requestBody: {
+    content: {
+      "application/json": {
+        schema: RequestBodySchema,
+      },
+    },
+  },
+  responses: {
+    "200": {
+      description: "The eligible baseline build, or null when none is found",
+      content: {
+        "application/json": {
+          schema: ResponseSchema,
+        },
+      },
+    },
+    "400": invalidParameters,
+    "401": unauthorized,
+    "500": serverError,
+  },
+} satisfies ZodOpenApiOperationObject;
+
+export const findBaseline: CreateAPIHandler = ({ post }) => {
+  post("/baseline", async (req, res) => {
+    const auth = await getAuthProjectPayloadFromExpressReq(req);
+    const { commits, name, mode } = req.ctx.body;
+
+    const build = await getEligibleBaselineBuildFromCommits({
+      projectId: auth.project.id,
+      name,
+      mode,
+      shas: commits,
+    });
+
+    res.send({
+      baseline: build ? await serializeBuild(build) : null,
+    });
+  });
+};

--- a/apps/backend/src/api/index.ts
+++ b/apps/backend/src/api/index.ts
@@ -15,6 +15,7 @@ import { exchangeGitHubActionsOidcToken } from "./handlers/exchangeGitHubActions
 import { exchangeGitHubActionsTokenlessToken } from "./handlers/exchangeGitHubActionsTokenlessToken";
 import { finalizeBuilds } from "./handlers/finalizeBuilds";
 import { finalizeDeployment } from "./handlers/finalizeDeployment";
+import { findBaseline } from "./handlers/findBaseline";
 import { getAuthProject } from "./handlers/getAuthProject";
 import { getBuild } from "./handlers/getBuild";
 import { getBuildDiffs } from "./handlers/getBuildDiffs";
@@ -84,6 +85,7 @@ registerHandler(router, exchangeGitHubActionsOidcToken);
 registerHandler(router, exchangeGitHubActionsTokenlessToken);
 registerHandler(router, createDeployment);
 registerHandler(router, finalizeBuilds);
+registerHandler(router, findBaseline);
 registerHandler(router, finalizeDeployment);
 registerHandler(router, getDeployment);
 registerHandler(router, getAuthProject);

--- a/apps/backend/src/api/schema.ts
+++ b/apps/backend/src/api/schema.ts
@@ -14,6 +14,7 @@ import { exchangeGitHubActionsOidcTokenOperation } from "./handlers/exchangeGitH
 import { exchangeGitHubActionsTokenlessTokenOperation } from "./handlers/exchangeGitHubActionsTokenlessToken";
 import { finalizeBuildsOperation } from "./handlers/finalizeBuilds";
 import { finalizeDeploymentOperation } from "./handlers/finalizeDeployment";
+import { findBaselineOperation } from "./handlers/findBaseline";
 import { getAuthProjectOperation } from "./handlers/getAuthProject";
 import { getBuildOperation } from "./handlers/getBuild";
 import { getBuildDiffsOperation } from "./handlers/getBuildDiffs";
@@ -155,6 +156,9 @@ export const zodSchema = {
     },
     "/builds/finalize": {
       post: finalizeBuildsOperation,
+    },
+    "/baseline": {
+      post: findBaselineOperation,
     },
     "/auth/cli/token": {
       post: exchangeCliTokenOperation,

--- a/apps/backend/src/build/strategy/strategies/ci/base.e2e.test.ts
+++ b/apps/backend/src/build/strategy/strategies/ci/base.e2e.test.ts
@@ -1,0 +1,171 @@
+import { test as baseTest, beforeEach, describe, expect } from "vitest";
+
+import type { Build, Project, ScreenshotBucket } from "@/database/models";
+import { factory, setupDatabase } from "@/database/testing";
+
+import { getCIBase, type GetCIBaseArgs } from "./base";
+
+const HEAD_COMMIT = "0000000000000000000000000000000000000000";
+
+type Fixtures = {
+  project: Project;
+  compareBucket: ScreenshotBucket;
+  build: Build;
+  args: GetCIBaseArgs;
+};
+
+/**
+ * These tests focus on the path where no git provider (GitHub/GitLab) is
+ * detected on the project. In that case we can only rely on the information
+ * sent by the build itself: `baseCommit` and `parentCommits`.
+ */
+const test = baseTest.extend<Fixtures>({
+  // A project without any git provider attached.
+  project: async ({}, use) => {
+    await use(await factory.Project.create({ githubRepositoryId: null }));
+  },
+  compareBucket: async ({ project }, use) => {
+    await use(
+      await factory.ScreenshotBucket.create({
+        projectId: project.id,
+        commit: HEAD_COMMIT,
+        branch: "feature",
+      }),
+    );
+  },
+  build: async ({ project, compareBucket }, use) => {
+    await use(
+      await factory.Build.create({
+        projectId: project.id,
+        compareScreenshotBucketId: compareBucket.id,
+        name: "default",
+        mode: "ci",
+        type: "check",
+        baseBranch: null,
+        baseCommit: null,
+        parentCommits: null,
+      }),
+    );
+  },
+  args: async ({ build, compareBucket, project }, use) => {
+    await use({
+      build,
+      compareScreenshotBucket: compareBucket,
+      project,
+      pullRequest: null,
+      context: { checkIsAutoApproved: () => false },
+    });
+  },
+});
+
+/**
+ * Create an eligible baseline bucket for the project at a given commit, backed
+ * by a completed & approved build so it can be picked as a base.
+ */
+async function createBaseline(project: Project, commit: string) {
+  const bucket = await factory.ScreenshotBucket.create({
+    projectId: project.id,
+    name: "default",
+    mode: "ci",
+    commit,
+  });
+  const build = await factory.Build.create({
+    projectId: project.id,
+    compareScreenshotBucketId: bucket.id,
+    name: "default",
+    mode: "ci",
+    type: "check",
+    jobStatus: "complete",
+  });
+  await factory.BuildReview.create({ buildId: build.id, state: "approved" });
+  return bucket;
+}
+
+describe("#getCIBase (no git provider)", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  test("returns no base bucket when there is no base commit nor parent commits", async ({
+    args,
+  }) => {
+    const result = await getCIBase(args);
+    expect(result.baseBucket).toBeNull();
+    expect(result.baseBranch).toBe("main");
+    expect(result.baseBranchResolvedFrom).toBe("project");
+  });
+
+  test("returns the bucket matching the base commit", async ({
+    args,
+    build,
+    project,
+  }) => {
+    const baseCommit = "1111111111111111111111111111111111111111";
+    const baseBucket = await createBaseline(project, baseCommit);
+    await build.$query().patch({ baseCommit });
+
+    const result = await getCIBase(args);
+    expect(
+      result.baseBucket && "id" in result.baseBucket && result.baseBucket.id,
+    ).toBe(baseBucket.id);
+    // A base commit without a base branch leaves the branch unresolved.
+    expect(result.baseBranch).toBeNull();
+    expect(result.baseBranchResolvedFrom).toBeNull();
+  });
+
+  test("uses parent commits to find a base bucket when there is no base commit", async ({
+    args,
+    build,
+    project,
+  }) => {
+    const ancestorCommit = "2222222222222222222222222222222222222222";
+    const baseBucket = await createBaseline(project, ancestorCommit);
+    // The first element is the head itself, it is sliced off before searching.
+    await build
+      .$query()
+      .patch({ parentCommits: [HEAD_COMMIT, ancestorCommit] });
+
+    const result = await getCIBase(args);
+    expect(
+      result.baseBucket && "id" in result.baseBucket && result.baseBucket.id,
+    ).toBe(baseBucket.id);
+    expect(result.baseBranch).toBe("main");
+    expect(result.baseBranchResolvedFrom).toBe("project");
+  });
+
+  test("falls back to parent commits when the base commit has no bucket", async ({
+    args,
+    build,
+    project,
+  }) => {
+    const baseCommit = "5555555555555555555555555555555555555555";
+    const ancestorCommit = "6666666666666666666666666666666666666666";
+    const baseBucket = await createBaseline(project, ancestorCommit);
+    await build
+      .$query()
+      .patch({ baseCommit, parentCommits: [baseCommit, ancestorCommit] });
+
+    const result = await getCIBase(args);
+    expect(
+      result.baseBucket && "id" in result.baseBucket && result.baseBucket.id,
+    ).toBe(baseBucket.id);
+  });
+
+  test("uses parent commits when the base commit equals the head", async ({
+    args,
+    build,
+    project,
+  }) => {
+    const ancestorCommit = "7777777777777777777777777777777777777777";
+    const baseBucket = await createBaseline(project, ancestorCommit);
+    await build.$query().patch({
+      baseCommit: HEAD_COMMIT,
+      parentCommits: [HEAD_COMMIT, ancestorCommit],
+    });
+
+    const result = await getCIBase(args);
+    expect(
+      result.baseBucket && "id" in result.baseBucket && result.baseBucket.id,
+    ).toBe(baseBucket.id);
+  });
+});

--- a/apps/backend/src/build/strategy/strategies/ci/base.ts
+++ b/apps/backend/src/build/strategy/strategies/ci/base.ts
@@ -63,43 +63,33 @@ export async function getCIBase(args: GetCIBaseArgs): GetBaseResult {
     };
   })();
 
-  // If we don't have a strategy then we could only count on baseCommit
-  // specified by the user in the build.
-  if (!gitProvider) {
-    if (build.baseCommit) {
-      const baseBucket = await getBaseBucketForBuildAndCommit(
-        build,
-        build.baseCommit,
-      );
-      return {
-        baseBucket,
-        baseBranch,
-        baseBranchResolvedFrom,
-      };
-    }
-
-    return {
-      baseBucket: null,
-      baseBranch,
-      baseBranchResolvedFrom,
-    };
-  }
+  const result = (baseBucket: ScreenshotBucket | null) => ({
+    baseBucket,
+    baseBranch,
+    baseBranchResolvedFrom,
+  });
 
   const head = compareScreenshotBucket.commit;
 
-  const ctx = await gitProvider.getContext(project);
+  // Resolve the git provider context when a provider is detected. The context
+  // lets us query the provider (GitHub/GitLab) to compute the merge base and
+  // list parent commits. Without a provider — or for "light" apps — we rely
+  // solely on the information sent by the build (baseCommit & parentCommits).
+  const ctx = gitProvider ? await gitProvider.getContext(project) : null;
 
-  if (!ctx) {
-    return {
-      baseBucket: null,
-      baseBranch,
-      baseBranchResolvedFrom,
-    };
+  // A git provider was detected but its context could not be resolved.
+  if (gitProvider && !ctx) {
+    return result(null);
   }
 
   const mergeBaseCommitSha = await (() => {
     if (build.baseCommit) {
       return build.baseCommit;
+    }
+    // Without a git provider context, we can't compute a merge base from the
+    // base branch, so we only rely on the build's baseCommit (handled above).
+    if (!gitProvider || !ctx) {
+      return null;
     }
     invariant(
       baseBranch,
@@ -114,77 +104,59 @@ export async function getCIBase(args: GetCIBaseArgs): GetBaseResult {
     });
   })();
 
-  if (!mergeBaseCommitSha) {
-    return {
-      baseBucket: null,
-      baseBranch,
-      baseBranchResolvedFrom,
-    };
+  // When a git provider is detected, a merge base commit is required to find a
+  // base bucket, otherwise the build is considered an orphan.
+  // When there is no git provider, we can still fall back to the build's parent
+  // commits below to find a base bucket.
+  if (gitProvider && !mergeBaseCommitSha) {
+    return result(null);
   }
 
-  const isBaseBranchAutoApproved = baseBranch
-    ? context.checkIsAutoApproved(baseBranch)
-    : false;
+  // Lists the parent commits used to find an ancestor bucket. We prefer the
+  // parent commits sent by the build (CLI), and fall back to the git provider
+  // when one is available.
+  const listParentCommitShas = async (sha: string): Promise<string[]> => {
+    if (build.parentCommits) {
+      return build.parentCommits;
+    }
+    if (gitProvider && ctx) {
+      return gitProvider.listParentCommitShas({ project, build, ctx, sha });
+    }
+    return [];
+  };
 
-  // If the merge base is the same as the head, then we have to found an ancestor
-  // It happens when we are on a auto-approved branch.
-  if (mergeBaseCommitSha === head) {
-    const shas =
-      build.parentCommits ??
-      (await gitProvider.listParentCommitShas({
-        project,
-        build,
-        ctx,
-        sha: mergeBaseCommitSha,
-      }));
-    const baseBucket = await getBucketFromCommits({
-      shas: shas.slice(1),
+  // When we have a merge base commit that differs from the head, we first try
+  // to find a bucket for that exact commit.
+  if (mergeBaseCommitSha && mergeBaseCommitSha !== head) {
+    const isBaseBranchAutoApproved = baseBranch
+      ? context.checkIsAutoApproved(baseBranch)
+      : false;
+
+    const mergeBaseBucket = await getBaseBucketForBuildAndCommit(
       build,
-    });
-    return {
-      baseBucket,
-      baseBranch,
-      baseBranchResolvedFrom,
-    };
+      mergeBaseCommitSha,
+      {
+        // If the base branch is auto-approved, then we don't need to check if the build is approved.
+        // We assume that by merging the base branch, the user has approved the build.
+        approved: isBaseBranchAutoApproved ? undefined : true,
+      },
+    );
+
+    // A bucket exists for the merge base commit.
+    if (mergeBaseBucket) {
+      return result(mergeBaseBucket);
+    }
   }
 
-  const mergeBaseBucket = await getBaseBucketForBuildAndCommit(
-    build,
-    mergeBaseCommitSha,
-    {
-      // If the base branch is auto-approved, then we don't need to check if the build is approved.
-      // We assume that by merging the base branch, the user has approved the build.
-      approved: isBaseBranchAutoApproved ? undefined : true,
-    },
-  );
-
-  // A bucket exists for the merge base commit
-  if (mergeBaseBucket) {
-    return {
-      baseBucket: mergeBaseBucket,
-      baseBranch,
-      baseBranchResolvedFrom,
-    };
-  }
-
-  // If we don't have a bucket for the merge base commit, then we have to found an ancestor
-  const shas =
-    build.parentCommits ??
-    (await gitProvider.listParentCommitShas({
-      project,
-      build,
-      ctx,
-      sha: mergeBaseCommitSha,
-    }));
-
+  // Otherwise we have to find an ancestor. This happens when:
+  // - the merge base is the same as the head (e.g. on an auto-approved branch),
+  // - no bucket exists for the merge base commit,
+  // - there is no merge base at all (no git provider and no baseCommit).
+  const shas = await listParentCommitShas(mergeBaseCommitSha ?? head);
   const baseBucket = await getBucketFromCommits({
     shas: shas.slice(1),
     build,
   });
 
-  return {
-    baseBucket,
-    baseBranch,
-    baseBranchResolvedFrom,
-  };
+  return result(baseBucket);
 }

--- a/apps/backend/src/build/strategy/strategies/ci/query.ts
+++ b/apps/backend/src/build/strategy/strategies/ci/query.ts
@@ -1,4 +1,9 @@
-import { Build, GithubPullRequest, ScreenshotBucket } from "@/database/models";
+import {
+  Build,
+  GithubPullRequest,
+  ScreenshotBucket,
+  type BuildMode,
+} from "@/database/models";
 
 /**
  * Get the base bucket for a build and a commit.
@@ -35,41 +40,45 @@ type QueryBaseBucketOptions = {
 };
 
 /**
- * Query the base bucket from a build.
+ * Query the builds eligible to be used as a baseline.
+ *
+ * These are the intrinsic (per-build) criteria mirrored by
+ * `baselineEligibility.ts`. Commit ancestry is not handled here as it depends
+ * on the build being compared against.
+ *
+ * Columns are qualified with the `builds` table so the query can safely be
+ * used both as a sub-query and joined to other relations.
  */
-function queryBaseBucket(build: Build, options?: QueryBaseBucketOptions) {
-  const query = ScreenshotBucket.query()
-    .where({
-      projectId: build.projectId,
-      name: build.name,
-      complete: true,
-      valid: true,
-      mode: build.mode,
-    })
-    .orderBy("id", "desc");
-
-  const buildQuery = Build.query()
-    .select("compareScreenshotBucketId")
-    .where("projectId", build.projectId)
-    .where("name", build.name)
-    .where("mode", build.mode)
-    .where("jobStatus", "complete")
-    .whereNot("id", build.id)
-    .where("subset", false)
-    .whereNot("type", "skipped")
+function queryEligibleBaselineBuilds(args: {
+  projectId: string;
+  name: string;
+  mode: BuildMode;
+  /**
+   * Only return approved builds (reference, orphan, or a check with an
+   * approved review or a merged pull request).
+   */
+  approved?: boolean | undefined;
+}) {
+  const query = Build.query()
+    .where("builds.projectId", args.projectId)
+    .where("builds.name", args.name)
+    .where("builds.mode", args.mode)
+    .where("builds.jobStatus", "complete")
+    .where("builds.subset", false)
+    .whereNot("builds.type", "skipped")
     // A build with an active (non-dismissed) rejection can never be used as a
     // baseline, whatever its type and even when an explicit approval is not
     // required (e.g. auto-approved branches or the ancestor-commit fallback).
     .whereNotExists(Build.rejectedReviewQuery());
 
-  if (options?.approved) {
-    buildQuery.where((qb) => {
+  if (args.approved) {
+    query.where((qb) => {
       // We consider as approved:
       // - reference (auto-approved)
       // - orphans
       // - checks that have an approved review or a merged pull request
-      qb.whereIn("type", ["reference", "orphan"]).orWhere((qb) => {
-        qb.where("type", "check").where((qb) =>
+      qb.whereIn("builds.type", ["reference", "orphan"]).orWhere((qb) => {
+        qb.where("builds.type", "check").where((qb) =>
           qb
             // An approved review exists
             .whereExists(Build.acceptedReviewQuery())
@@ -85,6 +94,32 @@ function queryBaseBucket(build: Build, options?: QueryBaseBucketOptions) {
       });
     });
   }
+
+  return query;
+}
+
+/**
+ * Query the base bucket from a build.
+ */
+function queryBaseBucket(build: Build, options?: QueryBaseBucketOptions) {
+  const query = ScreenshotBucket.query()
+    .where({
+      projectId: build.projectId,
+      name: build.name,
+      complete: true,
+      valid: true,
+      mode: build.mode,
+    })
+    .orderBy("id", "desc");
+
+  const buildQuery = queryEligibleBaselineBuilds({
+    projectId: build.projectId,
+    name: build.name,
+    mode: build.mode,
+    approved: options?.approved,
+  })
+    .select("compareScreenshotBucketId")
+    .whereNot("builds.id", build.id);
 
   query.whereIn("id", buildQuery);
 
@@ -116,4 +151,61 @@ export async function getBucketFromCommits(args: {
     .orderBy("id", "desc")
     .first();
   return bucket ?? null;
+}
+
+/**
+ * Find the build eligible to be used as a baseline among a list of commits.
+ *
+ * Commits are searched in the order they are given: the first commit that has
+ * an eligible baseline build wins. When several builds exist for the winning
+ * commit, the most recent one is returned. Returns null when none of the
+ * commits has an eligible baseline build.
+ */
+export async function getEligibleBaselineBuildFromCommits(args: {
+  projectId: string;
+  name: string;
+  mode: BuildMode;
+  shas: string[];
+}): Promise<Build | null> {
+  if (args.shas.length === 0) {
+    return null;
+  }
+
+  const valuesClause = args.shas.map(() => "(?, ?)").join(",");
+  const bindings: (string | number)[] = [];
+  args.shas.forEach((sha, index) => {
+    bindings.push(sha, index);
+  });
+
+  const match = await queryEligibleBaselineBuilds({
+    projectId: args.projectId,
+    name: args.name,
+    mode: args.mode,
+    approved: true,
+  })
+    .joinRelated("compareScreenshotBucket")
+    // The baseline bucket must be a complete and valid one (tests passed).
+    .where("compareScreenshotBucket.complete", true)
+    .where("compareScreenshotBucket.valid", true)
+    .whereIn("compareScreenshotBucket.commit", args.shas)
+    .joinRaw(
+      `join (values ${valuesClause}) as ordering(sha, rank) on "compareScreenshotBucket"."commit" = ordering.sha`,
+      bindings,
+    )
+    .select("builds.id")
+    .orderBy("ordering.rank")
+    .orderBy("builds.id", "desc")
+    .first();
+
+  if (!match) {
+    return null;
+  }
+
+  const build = await Build.query()
+    .withGraphFetched(
+      "[project.account, compareScreenshotBucket, baseScreenshotBucket]",
+    )
+    .findById(match.id);
+
+  return build ?? null;
 }


### PR DESCRIPTION
## Summary

Improves baseline resolution when **no Git provider (GitHub/GitLab) is connected**, and exposes a new API to find an eligible baseline from a list of commits.

### 1. `getCIBase` refactor — use `parentCommits` without a Git provider
Previously `getCIBase` skipped early as soon as no Git provider was detected and could only match an exact `baseCommit`. It now follows the same flow as the Git provider path (like the "light" app): it falls back to the build's `parentCommits` to find an ancestor baseline bucket, and applies the same approved-bucket filtering.

### 2. New API: `POST /baseline`
Finds the build eligible to be used as a baseline among a list of commits. Useful when no Git provider is connected: a client can send candidate ancestor commits (closest first) and let Argos pick the first one that has an eligible baseline.

- Project-token auth.
- Body: `{ commits: Sha1Hash[] (min 1), name? = "default", mode? = "ci" }`.
- Response: `{ baseline: Build | null }`.
- Commits are searched **in order**, so the closest ancestor with a baseline wins.

### Internal
- Extracted a shared `queryEligibleBaselineBuilds` builder out of `queryBaseBucket` (single source of truth for baseline eligibility, mirroring `baselineEligibility.ts`).
- Added `getEligibleBaselineBuildFromCommits` to back the endpoint.

## Tests
- `base.e2e.test.ts` (new): no-provider baseline resolution via `baseCommit` / `parentCommits`.
- `findBaseline.e2e.test.ts` (new): auth, validation, matching, commit ordering, and filtering by eligibility / name / mode.
- Existing `query` / `merge-queue` / `bucket-merge` suites still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)