### PR TITLE
fix(github): prompt login when the GitHub token is missing or expired

### DIFF
--- a/apps/backend/src/graphql/definitions/User.ts
+++ b/apps/backend/src/graphql/definitions/User.ts
@@ -103,7 +103,8 @@ export const typeDefs = gql`
     lastSubscription: AccountSubscription
     teams: [Team!]!
     invites: [TeamInvite!]!
-    ghInstallations: GhApiInstallationConnection!
+    "The GitHub app installations accessible to the user. Null when the user has no usable GitHub connection (never linked, or the token has expired or been revoked)."
+    ghInstallations: GhApiInstallationConnection
     projectsContributedOn(
       after: Int = 0
       first: Int = 30
@@ -444,12 +445,15 @@ export const resolvers: IResolvers = {
         account.id === ctx.auth.account.id,
         "ghInstallations can only be accessed by the authenticated user",
       );
+      // Return `null` when there is no usable GitHub connection so the client
+      // can tell "the token is invalid, ask the user to (re)connect" apart from
+      // "the token is valid but no app is installed".
       if (!account.githubAccountId) {
-        return { edges: [], pageInfo: { hasNextPage: false, totalCount: 0 } };
+        return null;
       }
       const githubAccount = await account.$relatedQuery("githubAccount");
       if (!githubAccount?.accessToken) {
-        return { edges: [], pageInfo: { hasNextPage: false, totalCount: 0 } };
+        return null;
       }
       const octokit = getTokenOctokit({
         token: githubAccount.accessToken,
@@ -467,9 +471,9 @@ export const resolvers: IResolvers = {
           },
         };
       } catch (error) {
-        // If the token has been revoked, we should return an empty list.
+        // If the token has been revoked, the connection is no longer usable.
         if (checkOctokitErrorStatus(401, error)) {
-          return { edges: [], pageInfo: { hasNextPage: false, totalCount: 0 } };
+          return null;
         }
 
         throw error;

--- a/apps/backend/src/graphql/tests/userGhInstallations.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/userGhInstallations.e2e.test.ts
@@ -1,0 +1,64 @@
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { Account, User } from "@/database/models";
+import { factory, setupDatabase } from "@/database/testing";
+
+import { apolloServer, createApolloMiddleware } from "../apollo";
+import { expectNoGraphQLError } from "../testing";
+import { createApolloServerApp } from "./util";
+
+const QUERY = `
+  query UserGhInstallations {
+    me {
+      id
+      ghInstallations {
+        pageInfo {
+          totalCount
+        }
+      }
+    }
+  }
+`;
+
+async function queryGhInstallations(input: { user: User; account: Account }) {
+  const app = await createApolloServerApp(
+    apolloServer,
+    createApolloMiddleware,
+    {
+      user: input.user,
+      account: input.account,
+    },
+  );
+  const result = await request(app).post("/graphql").send({ query: QUERY });
+  expectNoGraphQLError(result);
+  expect(result.status).toBe(200);
+  return result.body.data.me.ghInstallations;
+}
+
+describe("GraphQL User.ghInstallations", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  it("is null when the account has no linked GitHub account", async () => {
+    const user = await factory.User.create();
+    const account = await factory.UserAccount.create({
+      userId: user.id,
+      githubAccountId: null,
+    });
+    await expect(queryGhInstallations({ user, account })).resolves.toBeNull();
+  });
+
+  it("is null when the linked GitHub account has no access token", async () => {
+    const user = await factory.User.create();
+    const githubAccount = await factory.GithubAccount.create({
+      accessToken: null,
+    });
+    const account = await factory.UserAccount.create({
+      userId: user.id,
+      githubAccountId: githubAccount.id,
+    });
+    await expect(queryGhInstallations({ user, account })).resolves.toBeNull();
+  });
+});

--- a/apps/frontend/src/containers/Project/ConnectRepository.tsx
+++ b/apps/frontend/src/containers/Project/ConnectRepository.tsx
@@ -58,9 +58,6 @@ const ConnectRepositoryQuery = graphql(`
     }
     me {
       id
-      githubAccount {
-        id
-      }
       ghInstallations {
         edges {
           id
@@ -75,8 +72,10 @@ const ConnectRepositoryQuery = graphql(`
 `);
 
 type GithubInstallation = NonNullable<
-  DocumentType<typeof ConnectRepositoryQuery>["me"]
->["ghInstallations"]["edges"][0];
+  NonNullable<
+    DocumentType<typeof ConnectRepositoryQuery>["me"]
+  >["ghInstallations"]
+>["edges"][0];
 
 type GitlabNamespace = NonNullable<
   NonNullable<
@@ -223,14 +222,18 @@ enum GitProvider {
 function GitHubButton(props: {
   onPress: LinkButtonProps["onPress"];
   hasInstallations: boolean;
-  isLoggedIntoGitHub: boolean;
+  hasValidGitHubToken: boolean;
   children?: React.ReactNode;
   size?: ButtonProps["size"];
 }) {
-  if (!props.isLoggedIntoGitHub) {
-    return (
-      <GitHubLoginButton {...props} redirect={getMainGitHubAppInstallURL()} />
-    );
+  if (!props.hasValidGitHubToken) {
+    // The user has no usable GitHub connection: they never linked GitHub, or
+    // their token has expired/been revoked. Ask them to log in first — without
+    // forcing the app-install flow. After login they return here with a fresh
+    // token and we either show their installations or, if the app really isn't
+    // installed, prompt them to install it. This is what prevents a user with a
+    // stale token from getting stuck on an "install" link they don't need.
+    return <GitHubLoginButton {...props} />;
   }
   if (!props.hasInstallations) {
     return (
@@ -325,7 +328,11 @@ export function ConnectRepository(props: ConnectRepositoryProps) {
     );
   }
 
-  const hasGhInstallations = me.ghInstallations.edges.length > 0;
+  // `ghInstallations` is `null` when the user has no usable GitHub connection
+  // (never linked, or an expired/revoked token). An empty list means the token
+  // is valid but no app is installed.
+  const hasValidGitHubToken = me.ghInstallations != null;
+  const hasGhInstallations = (me.ghInstallations?.edges.length ?? 0) > 0;
   const ghLightGhInstallation =
     account.__typename === "Team"
       ? account.githubLightInstallation?.ghInstallation
@@ -337,7 +344,7 @@ export function ConnectRepository(props: ConnectRepositoryProps) {
         return (
           <GithubInstallations
             onSelectRepository={props.onSelectRepository}
-            installations={me.ghInstallations.edges}
+            installations={me.ghInstallations?.edges ?? []}
             disabled={props.disabled}
             connectButtonLabel={buttonLabels[props.variant]}
             onSwitch={() => setAndStoreProvider(null)}
@@ -423,7 +430,7 @@ export function ConnectRepository(props: ConnectRepositoryProps) {
             <GitHubButton
               onPress={() => setAndStoreProvider(GitProvider.GitHub)}
               hasInstallations={hasGhInstallations}
-              isLoggedIntoGitHub={!!me.githubAccount}
+              hasValidGitHubToken={hasValidGitHubToken}
             >
               GitHub
             </GitHubButton>
@@ -460,7 +467,7 @@ export function ConnectRepository(props: ConnectRepositoryProps) {
             <GitHubButton
               onPress={() => setAndStoreProvider(GitProvider.GitHub)}
               hasInstallations={hasGhInstallations}
-              isLoggedIntoGitHub={!!me.githubAccount}
+              hasValidGitHubToken={hasValidGitHubToken}
             >
               Continue with GitHub
             </GitHubButton>

--- a/apps/frontend/src/containers/Team/GitHubSSO/Configure.tsx
+++ b/apps/frontend/src/containers/Team/GitHubSSO/Configure.tsx
@@ -84,7 +84,7 @@ function GitHubInstallationsSelectControl<
       return [];
     }
     invariant(data.me, "Expected me");
-    return data.me.ghInstallations.edges;
+    return data.me.ghInstallations?.edges ?? [];
   })();
 
   const installationType = (() => {


### PR DESCRIPTION
## Problem

In the "connect repository" flow, a user with a linked GitHub account whose OAuth token had **expired or been revoked** was shown an **"Install the app"** link with no way back to login — effectively locked out.

Root cause: `GitHubButton` decides between *login* / *install* / *select* using `!!me.githubAccount` (true if the user *ever* linked GitHub) and `ghInstallations`. But `ghInstallations` **swallowed the 401** from an invalid token and returned an empty list, so "expired token" and "genuinely no installations" were indistinguishable — both landed on the install branch.

The install link that surfaced this: `https://github.com/apps/argos-ci/installations/new?state=…` — a direct `href`, which only renders in the *logged-in-but-no-installations* branch, confirming the user was never in the "not logged in" branch at all.

## Fix

- **Backend** — `User.ghInstallations` is now nullable and returns `null` when there is no usable GitHub connection (never linked, or the token is missing/expired/revoked). A valid token returns a connection (possibly with empty edges).
- **Frontend** — `GitHubButton` branches on token validity (`ghInstallations != null`) instead of `!!me.githubAccount`, and `Configure.tsx` handles the nullable field.

Resulting flow:

| State | `ghInstallations` | Button |
|---|---|---|
| Never linked GitHub | `null` | Login with GitHub |
| Linked, **token expired/revoked** | `null` | Login with GitHub (reconnect) ← the fix |
| Valid token, app not installed | `[]` | Install the app |
| Valid token, has installations | non-empty | Installation selector |

No loop: after a stale-token user logs in, the fresh token makes `ghInstallations` non-null, so they reach the selector (or the install button if genuinely not installed).

## Tests

- Added `userGhInstallations.e2e.test.ts` covering the two `null` cases (no linked account, no access token).
- The valid-token path isn't unit-tested (needs GitHub API mocking — no existing pattern); worth a manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)