### PR TITLE
fix(gitlab): only notify owners of an invalid token in headless mode

### DIFF
--- a/apps/backend/src/build-notification/services/gitlab.ts
+++ b/apps/backend/src/build-notification/services/gitlab.ts
@@ -30,7 +30,9 @@ export async function getGitLabNotificationContext(
     return null;
   }
 
-  const gitlabClient = await getGitlabClientFromAccount(account);
+  const gitlabClient = await getGitlabClientFromAccount(account, {
+    mode: "headless",
+  });
 
   if (!gitlabClient) {
     return null;

--- a/apps/backend/src/build/job.ts
+++ b/apps/backend/src/build/job.ts
@@ -93,7 +93,9 @@ async function syncGitlabProject(project: Project) {
 
   invariant(project.account, "no account found", UnretryableError);
 
-  const gitlabClient = await getGitlabClientFromAccount(project.account);
+  const gitlabClient = await getGitlabClientFromAccount(project.account, {
+    mode: "headless",
+  });
 
   if (!gitlabClient) {
     return;

--- a/apps/backend/src/build/strategy/strategies/ci/strategies/gitlab.ts
+++ b/apps/backend/src/build/strategy/strategies/ci/strategies/gitlab.ts
@@ -23,7 +23,9 @@ export const GitlabStrategy: MergeBaseStrategy<{
       UnretryableError,
     );
 
-    const client = await getGitlabClientFromAccount(project.account);
+    const client = await getGitlabClientFromAccount(project.account, {
+      mode: "headless",
+    });
 
     if (!client) {
       return null;

--- a/apps/backend/src/gitlab/client.e2e.test.ts
+++ b/apps/backend/src/gitlab/client.e2e.test.ts
@@ -1,0 +1,76 @@
+import { Gitlab } from "@gitbeaker/rest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { factory, setupDatabase } from "@/database/testing";
+import { sendNotification } from "@/notification";
+
+import { getGitlabClientFromAccount } from "./client";
+
+vi.mock("@/notification", () => ({
+  sendNotification: vi.fn(),
+}));
+
+vi.mock("@gitbeaker/rest", () => ({
+  Gitlab: vi.fn(),
+}));
+
+const mockSendNotification = vi.mocked(sendNotification);
+const mockGitlab = vi.mocked(Gitlab);
+
+/**
+ * Make `new Gitlab(...)` return a client whose `PersonalAccessTokens.show()`
+ * rejects, simulating an invalid/expired token.
+ */
+function mockInvalidToken() {
+  // Use a regular function (not an arrow) so it can be invoked with `new`.
+  mockGitlab.mockImplementation(function () {
+    return {
+      PersonalAccessTokens: {
+        show: vi.fn().mockRejectedValue(new Error("Unauthorized")),
+      },
+    } as unknown as InstanceType<typeof Gitlab>;
+  });
+}
+
+describe("getGitlabClientFromAccount", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+    vi.clearAllMocks();
+  });
+
+  it("notifies the owners when the token is invalid in headless mode", async () => {
+    mockInvalidToken();
+    const account = await factory.UserAccount.create({
+      gitlabAccessToken: "invalid-token",
+      gitlabBaseUrl: null,
+    });
+
+    const client = await getGitlabClientFromAccount(account, {
+      mode: "headless",
+    });
+
+    expect(client).toBeNull();
+    expect(mockSendNotification).toHaveBeenCalledTimes(1);
+    expect(mockSendNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "invalid_gitlab_token",
+        recipients: [account.userId],
+      }),
+    );
+  });
+
+  it("does not notify the owners when the token is invalid in manual mode", async () => {
+    mockInvalidToken();
+    const account = await factory.UserAccount.create({
+      gitlabAccessToken: "invalid-token",
+      gitlabBaseUrl: null,
+    });
+
+    const client = await getGitlabClientFromAccount(account, {
+      mode: "manual",
+    });
+
+    expect(client).toBeNull();
+    expect(mockSendNotification).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/gitlab/client.ts
+++ b/apps/backend/src/gitlab/client.ts
@@ -34,6 +34,19 @@ export function getGitlabClient(params: {
 
 export async function getGitlabClientFromAccount(
   account: Account,
+  options: {
+    /**
+     * Controls whether the account owners are notified by email when the token
+     * turns out to be invalid:
+     * - `"headless"`: the client is used server-side with no user watching (e.g.
+     *   build processing). The failure is invisible to the user, so we email the
+     *   owners to ask them to reconnect GitLab.
+     * - `"manual"`: the client serves an interactive request (e.g. selecting
+     *   repositories in the UI). The failure is surfaced in the UI directly, so
+     *   we don't send an email.
+     */
+    mode: "manual" | "headless";
+  },
 ): Promise<GitlabClient | null> {
   if (!account.gitlabAccessToken) {
     return null;
@@ -58,20 +71,25 @@ export async function getGitlabClientFromAccount(
         error.message === "Not Found" ||
         error.message === "invalid_token")
     ) {
-      const ownerIds = await account.$getOwnerIds();
-      await sendNotification({
-        type: "invalid_gitlab_token",
-        data: {
-          account: {
-            name: account.name || account.slug,
-            settingsURL: new URL(
-              `/${account.slug}/settings/integrations#gitlab`,
-              config.get("server.url"),
-            ).toString(),
+      // Only notify the owners when the failure happens headlessly. In manual
+      // mode the caller surfaces the error to the user directly, so an email
+      // would be redundant noise.
+      if (options.mode === "headless") {
+        const ownerIds = await account.$getOwnerIds();
+        await sendNotification({
+          type: "invalid_gitlab_token",
+          data: {
+            account: {
+              name: account.name || account.slug,
+              settingsURL: new URL(
+                `/${account.slug}/settings/integrations#gitlab`,
+                config.get("server.url"),
+              ).toString(),
+            },
           },
-        },
-        recipients: ownerIds,
-      });
+          recipients: ownerIds,
+        });
+      }
       return null;
     }
     throw error;

--- a/apps/backend/src/graphql/definitions/Account.ts
+++ b/apps/backend/src/graphql/definitions/Account.ts
@@ -365,7 +365,9 @@ export const commonAccountResolvers: IResolvers["Team"] = {
     return getAccountAvatar(account, ctx.loaders);
   },
   glNamespaces: async (account) => {
-    const client = await getGitlabClientFromAccount(account);
+    const client = await getGitlabClientFromAccount(account, {
+      mode: "manual",
+    });
     if (!client) {
       return null;
     }

--- a/apps/backend/src/graphql/definitions/GlApiProject.ts
+++ b/apps/backend/src/graphql/definitions/GlApiProject.ts
@@ -47,7 +47,9 @@ export const resolvers: IResolvers = {
       if (!account.gitlabAccessToken) {
         throw notFound("Account has no GitLab access token.");
       }
-      const client = await getGitlabClientFromAccount(account);
+      const client = await getGitlabClientFromAccount(account, {
+        mode: "manual",
+      });
       if (!client) {
         throw notFound("Invalid GitLab access token.");
       }

--- a/apps/backend/src/graphql/definitions/Project.ts
+++ b/apps/backend/src/graphql/definitions/Project.ts
@@ -439,7 +439,9 @@ const getOrCreateGitlabProject = async (props: {
   account: Account;
   gitlabProjectId: string;
 }): Promise<GitlabProject> => {
-  const client = await getGitlabClientFromAccount(props.account);
+  const client = await getGitlabClientFromAccount(props.account, {
+    mode: "manual",
+  });
   invariant(client, "Gitlab client not found");
 
   const gitlabProjectId = Number(props.gitlabProjectId);


### PR DESCRIPTION
## Problem

`getGitlabClientFromAccount` sent the `invalid_gitlab_token` email to the account owners whenever it encountered an invalid or expired GitLab token — regardless of context. Since `invalid_gitlab_token` is in the non-configurable **"security"** notification category, owners can't opt out. As a result, ordinary interactive UI actions that touch GitLab with a stale token (selecting repositories, listing namespaces, linking a project) fired an email at the owners.

## Fix

Added a required `mode: "manual" | "headless"` parameter to `getGitlabClientFromAccount` and gated the email on `mode === "headless"`. Making it required forces every call site to make the choice explicitly, so no path can accidentally send (or suppress) the email.

**Headless → still emails owners** (server-side, no user watching):

- `build-notification/services/gitlab.ts` — commit-status notifications
- `build/job.ts` — `syncGitlabProject`
- `build/strategy/.../ci/strategies/gitlab.ts` — merge-base strategy

**Manual → no email** (interactive GraphQL/UI; the error surfaces in the UI):

- `graphql/definitions/GlApiProject.ts` — repository selection
- `graphql/definitions/Account.ts` — `glNamespaces`
- `graphql/definitions/Project.ts` — `importGitlabProject` / `linkGitlabProject`

Behavior is otherwise unchanged: manual callers still receive `null` on an invalid token and degrade gracefully — they just no longer send an email.

## Tests

- New `apps/backend/src/gitlab/client.e2e.test.ts`: headless mode notifies owners, manual mode does not.
- `tsc --noEmit` passes; backend integration suite passes (556).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
