### PR TITLE
fix(tsconfig): correct graphqlsp schema path

### DIFF
--- a/packages/tsconfig/base/tsconfig.json
+++ b/packages/tsconfig/base/tsconfig.json
@@ -5,7 +5,7 @@
     "plugins": [
       {
         "name": "@0no-co/graphqlsp",
-        "schema": "../backend/src/graphql/__generated__/schema.gql"
+        "schema": "../../../apps/backend/src/graphql/__generated__/schema.gql"
       }
     ]
   }


### PR DESCRIPTION
## Problem

Opening any file with GraphQL fragments in the editor triggered:

```
Failed to load the GraphQL schema: ENOENT: no such file or directory, open
'.../packages/tsconfig/backend/src/graphql/__generated__/schema.gql' ts(52006)
```

The `@0no-co/graphqlsp` plugin resolves its `schema` path relative to the tsconfig that declares it (`packages/tsconfig/base/tsconfig.json`). The old value `../backend/src/graphql/__generated__/schema.gql` therefore resolved to `packages/tsconfig/backend/...`, which doesn't exist.

## Fix

Point the schema at its real location under `apps/backend`, three levels up from the base config:

```
../../../apps/backend/src/graphql/__generated__/schema.gql
```

## Impact

Editor-only. The `plugins` array is consumed exclusively by the TypeScript language service — `tsc` and the build pipeline ignore it, so there's no runtime or compilation impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)