### PR TITLE
fix(impact-analysis): exclude ignored and failed screenshots

### DIFF
--- a/apps/backend/src/build/approval.e2e.test.ts
+++ b/apps/backend/src/build/approval.e2e.test.ts
@@ -270,6 +270,44 @@ describe("getPreviousDiffApprovalIds", () => {
     expect(diffIds).toEqual([]);
   });
 
+  test("excludes ignored diffs of the current build", async ({
+    previousBuild,
+    build,
+    compareBucket,
+  }) => {
+    const fingerprint = "fp-ignored-diff";
+    const previousScreenshot = await factory.Screenshot.create();
+    const previousDiff = await factory.ScreenshotDiff.create({
+      buildId: previousBuild.id,
+      compareScreenshotId: previousScreenshot.id,
+      fingerprint,
+    });
+    const buildReview = await factory.BuildReview.create({
+      buildId: previousBuild.id,
+      state: "approved",
+    });
+    await factory.ScreenshotDiffReview.create({
+      buildReviewId: buildReview.id,
+      screenshotDiffId: previousDiff.id,
+      state: "approved",
+    });
+    // The current diff matches the previous approval by fingerprint, but it is
+    // ignored — so it must not count as a previously-approved change.
+    const currentScreenshot = await factory.Screenshot.create();
+    const currentDiff = await factory.ScreenshotDiff.create({
+      buildId: build.id,
+      compareScreenshotId: currentScreenshot.id,
+      fingerprint,
+    });
+    await currentDiff.$query().patch({ ignored: true });
+
+    const diffIds = await getPreviousDiffApprovalIds({
+      build,
+      compareBucket,
+    });
+    expect(diffIds).toEqual([]);
+  });
+
   test("filters approvals by user id", async ({
     previousBuild,
     build,

--- a/apps/backend/src/build/approval.ts
+++ b/apps/backend/src/build/approval.ts
@@ -32,6 +32,10 @@ export async function getPreviousDiffApprovalIds(
     .select("screenshot_diffs.id")
     .leftJoinRelated("[compareScreenshot,baseScreenshot]")
     .where("screenshot_diffs.buildId", args.build.id)
+    // Ignored diffs are not part of the review, so they never count as a
+    // previously-approved change — even when their fingerprint or file matches
+    // a prior approval.
+    .where("screenshot_diffs.ignored", false)
     .where((qb) => {
       if (previousApprovals.fingerprints.size > 0) {
         qb.orWhereIn(

--- a/apps/backend/src/build/impact-analysis.e2e.test.ts
+++ b/apps/backend/src/build/impact-analysis.e2e.test.ts
@@ -177,6 +177,130 @@ describe("getBuildImpactAnalysis", () => {
     });
   });
 
+  test("excludes failed and retried screenshots from affected tests", async ({
+    compareBucket,
+    build,
+  }) => {
+    const [addedScreenshot, failedScreenshot, retriedFailedScreenshot] =
+      await factory.Screenshot.createMany(3, [
+        {
+          screenshotBucketId: compareBucket.id,
+          metadata: {
+            browser: { name: "chromium", version: "120.0" },
+            story: { id: "forms-input--default" },
+            sdk: { name: "@argos-ci/storybook", version: "1.0.0" },
+            automationLibrary: { name: "storybook", version: "8.0.0" },
+          },
+        },
+        {
+          screenshotBucketId: compareBucket.id,
+          name: "Login flow (failed).png",
+          metadata: {
+            test: { title: "Login flow", titlePath: ["Login flow"] },
+            sdk: { name: "@argos-ci/playwright", version: "1.0.0" },
+            automationLibrary: { name: "playwright", version: "1.0.0" },
+          },
+        },
+        {
+          screenshotBucketId: compareBucket.id,
+          name: "Signup flow (failed).png",
+          metadata: {
+            // A retried failure: `retry` differs from `retries`.
+            test: {
+              title: "Signup flow",
+              titlePath: ["Signup flow"],
+              retry: 0,
+              retries: 2,
+            },
+            sdk: { name: "@argos-ci/playwright", version: "1.0.0" },
+            automationLibrary: { name: "playwright", version: "1.0.0" },
+          },
+        },
+      ]);
+    // Only the added screenshot is a real change; the (retried) failures have
+    // no base either, but they must not be counted as affected.
+    await factory.ScreenshotDiff.createMany(
+      3,
+      [addedScreenshot!, failedScreenshot!, retriedFailedScreenshot!].map(
+        (screenshot) => ({
+          buildId: build.id,
+          baseScreenshotId: null,
+          compareScreenshotId: screenshot.id,
+          score: null,
+        }),
+      ),
+    );
+
+    const analysis = await getBuildImpactAnalysis(build);
+
+    expect(analysis.affectedComponents).toEqual([
+      { name: "forms-input", count: 1 },
+    ]);
+    expect(analysis.affectedStories).toEqual([
+      { name: "forms-input--default", count: 1 },
+    ]);
+    expect(analysis.affectedTests).toEqual([]);
+  });
+
+  test("excludes ignored screenshots from the analysis", async ({
+    project,
+    compareBucket,
+    build,
+  }) => {
+    const [changedScreenshot, ignoredScreenshot] =
+      await factory.Screenshot.createMany(2, [
+        {
+          screenshotBucketId: compareBucket.id,
+          metadata: {
+            browser: { name: "chromium", version: "120.0" },
+            story: { id: "actions-button--primary" },
+            sdk: { name: "@argos-ci/storybook", version: "1.0.0" },
+            automationLibrary: { name: "storybook", version: "8.0.0" },
+          },
+        },
+        {
+          screenshotBucketId: compareBucket.id,
+          metadata: {
+            browser: { name: "chromium", version: "120.0" },
+            story: { id: "actions-menu--open" },
+            sdk: { name: "@argos-ci/storybook", version: "1.0.0" },
+            automationLibrary: { name: "storybook", version: "8.0.0" },
+          },
+        },
+      ]);
+    const baseScreenshots = await factory.Screenshot.createMany(2, {
+      screenshotBucketId: (
+        await factory.ScreenshotBucket.create({ projectId: project.id })
+      ).id,
+    });
+    await factory.ScreenshotDiff.createMany(2, [
+      {
+        buildId: build.id,
+        baseScreenshotId: baseScreenshots[0]!.id,
+        compareScreenshotId: changedScreenshot!.id,
+        score: 0.4,
+      },
+      // An ignored change must be excluded from every aggregate.
+      {
+        buildId: build.id,
+        baseScreenshotId: baseScreenshots[1]!.id,
+        compareScreenshotId: ignoredScreenshot!.id,
+        score: 0.4,
+        ignored: true,
+      },
+    ]);
+
+    const analysis = await getBuildImpactAnalysis(build);
+
+    expect(analysis.changedCount).toBe(1);
+    expect(analysis.affectedComponents).toEqual([
+      { name: "actions-button", count: 1 },
+    ]);
+    expect(analysis.affectedStories).toEqual([
+      { name: "actions-button--primary", count: 1 },
+    ]);
+  });
+
   test("returns empty aggregates without metadata", async ({ build }) => {
     const analysis = await getBuildImpactAnalysis(build);
     expect(analysis).toEqual({

--- a/apps/backend/src/build/impact-analysis.ts
+++ b/apps/backend/src/build/impact-analysis.ts
@@ -235,19 +235,16 @@ export async function getBuildImpactAnalysis(
           ),
         )
         .castTo<ChangedRow[]>(),
-      // Components/tests impacted by the build: changed screenshots AND brand-new
-      // (added) ones. Added screenshots have no base, so they're excluded from
-      // `changedRows`, but they still affect their component/test.
+      // Components/tests impacted by the build's changes: modified ("changed")
+      // and brand-new ("added") screenshots. Added screenshots have no base, so
+      // they're excluded from `changedRows`, but they still affect their
+      // component/test. Failures and retried failures also lack a base, but they
+      // are test failures rather than visual changes to review — so, like
+      // removed, unchanged and ignored diffs, they must not be counted here.
       ScreenshotDiff.query()
         .where("screenshot_diffs.buildId", build.id)
-        .whereNotNull("screenshot_diffs.compareScreenshotId")
-        .where("screenshot_diffs.ignored", false)
-        .where((qb) =>
-          qb
-            .whereNull("screenshot_diffs.baseScreenshotId")
-            .orWhere("screenshot_diffs.score", ">", 0),
-        )
         .joinRelated("compareScreenshot")
+        .whereIn(raw(ScreenshotDiff.selectDiffStatus), ["added", "changed"])
         .select(
           raw(`"compareScreenshot"."metadata"->'story'->>'id'`).as("storyId"),
           raw(`"compareScreenshot"."metadata"->'test'->>'title'`).as(


### PR DESCRIPTION
## Problem

The build overview's impact analysis surfaced entities that aren't actual changes to review:

1. **Ignored diffs counted as "already approved."** `previouslyApprovedCount` is derived from `getPreviousDiffApprovalIds`, which matched current-build diffs against prior approvals by fingerprint/file **without** filtering the `ignored` flag. An ignored change matching a previous approval was reported as "already approved" in the review-insights card.

2. **Failed & retried-failure screenshots counted as affected components/tests.** The `affectedRows` query used a `no base OR score > 0` predicate. Failures and retried failures also have no base screenshot, so they were swept into `affectedComponents`/`affectedTests` alongside genuine additions.

## Fix

- `approval.ts`: filter `ignored = false` in the current-build lookup of `getPreviousDiffApprovalIds`. This is safe for its other callers (`branchApprovedDiffs`, `autoApproveBuild`) — the reviewable-diff set never includes ignored diffs, so the coverage check is unaffected, and ignored diffs shouldn't offer to reapply anyway.
- `impact-analysis.ts`: scope `affectedRows` to the canonical `added`/`changed` diff statuses via `ScreenshotDiff.selectDiffStatus` (the same definition used by `getBuildReviewableDiffIds`). This excludes failures, retried failures, removed, unchanged and ignored diffs.

## Tests

- `approval.e2e.test.ts`: an ignored current-build diff matching a prior approval is no longer counted.
- `impact-analysis.e2e.test.ts`: failed/retried screenshots are excluded from affected tests; ignored screenshots are excluded from all aggregates.

All affected e2e suites pass; type-check and lint are clean.

> Note: two pre-existing `autoApproveBuild.e2e.test.ts` tests time out locally (5s) on `main` as well — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)