### PR TITLE
fix(build): prevent BuildBaselineEligibilityChip from shrinking

### DIFF
--- a/apps/frontend/src/containers/BuildBaselineEligibilityChip.tsx
+++ b/apps/frontend/src/containers/BuildBaselineEligibilityChip.tsx
@@ -38,6 +38,7 @@ export function BuildBaselineEligibilityChip(props: {
       }
     >
       <Chip
+        className="shrink-0"
         icon={descriptor.icon}
         color={descriptor.color}
         scale={props.scale}


### PR DESCRIPTION
## Problem

<img width="278" height="100" alt="CleanShot 2026-07-03 at 07 21 27@2x" src="https://github.com/user-attachments/assets/82ff6696-47d0-42f0-be18-1c2af1128914" />


`BuildBaselineEligibilityChip` is icon-only, so it renders as a fixed-size circle. In both call sites it sits in a flex row next to a wider text chip:

- [`Builds.tsx`](apps/frontend/src/pages/Project/Builds.tsx#L152) — inside a fixed-width `w-28` container
- [`BuildHeader.tsx`](apps/frontend/src/pages/Build/header/BuildHeader.tsx#L255)

Since `Chip` carries `min-w-0` and the default `flex-shrink: 1`, the circle was getting squished into an oval when horizontal space ran tight.

## Fix

Add `shrink-0` to the chip so it keeps its circular shape. This matches the guard `BuildStatusChip` already uses (`shrink-0` on its wrapper). The neighboring `BuildTestStatusChip` has a text label, so it correctly keeps truncating instead.

Note: `Tooltip` clones its child rather than wrapping it, so the `Chip` is the actual flex item — which is why the class belongs on the `Chip` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)