### PR TITLE
feat(frontend): rework rejection note dialog (ARG-444)

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -1,0 +1,33 @@
+# Argos frontend
+
+## GraphQL / Apollo Client
+
+### Mutations: prefer `client.mutate` over `useMutation`
+
+Only reach for `useMutation` when you actually render from its result tuple —
+i.e. you read `loading` / `data` / `error` to drive the UI (a button spinner, an
+inline error, a success screen). `useMutation` subscribes the component to the
+mutation's own state and **re-renders it while the request is in flight even if
+you never read that state**, which is wasted work.
+
+When you only need to fire the mutation (you track pending/errors yourself, or
+not at all), call the client directly:
+
+```tsx
+const client = useApolloClient();
+// …
+await client.mutate({ mutation: MyMutation, variables });
+```
+
+Fold any `variables` / `update` / `optimisticResponse` / `context` you were
+passing to `useMutation` (or at the call site) into that single
+`client.mutate({ mutation, ... })` object.
+
+### Pending state in a dialog
+
+Don't track a dialog's submit-pending state with a local `useState` (nor with
+`useMutation`). Drive `ModalActionContext`'s `isPending` around the call: a
+dialog `Form` does this automatically, or set it yourself
+(`use(ModalActionContext)` → `setIsPending`). This disables the footer buttons
+(including `DialogDismiss`) and blocks dismissal for the whole modal while the
+request is in flight.

--- a/apps/frontend/src/pages/Build/RejectCommentDialog.tsx
+++ b/apps/frontend/src/pages/Build/RejectCommentDialog.tsx
@@ -4,9 +4,10 @@ import {
   useCallback,
   useId,
   useMemo,
+  useRef,
   useState,
 } from "react";
-import { useMutation } from "@apollo/client/react";
+import { useApolloClient } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { toast } from "sonner";
 
@@ -23,7 +24,7 @@ import {
 } from "@/ui/Dialog";
 import { Editor, type EditorValue } from "@/ui/Editor/Editor";
 import { hasEditorContent } from "@/ui/Editor/util";
-import { Modal } from "@/ui/Modal";
+import { Modal, ModalActionContext } from "@/ui/Modal";
 import { getMentionUser } from "@/ui/UserCard";
 import { getErrorMessage } from "@/util/error";
 
@@ -154,13 +155,21 @@ function RejectCommentDialog(props: {
     [build.members],
   );
   const [value, setValue] = useState<EditorValue>(null);
-  const [isPending, setIsPending] = useState(false);
   const emptyToastId = useId();
   const isEmpty = !hasEditorContent(value);
-  const [addBuildComment] = useMutation(AddBuildCommentMutation);
+  const client = useApolloClient();
+  // Drive the modal's pending state (rather than a local one) so the footer
+  // buttons disable and the modal can't be dismissed while submitting — the
+  // same mechanism a dialog `Form` uses. We call the Apollo client directly
+  // instead of `useMutation` to avoid re-rendering on the mutation's own state.
+  const actionContext = use(ModalActionContext);
+  const isPending = actionContext?.isPending ?? false;
+  // Synchronous guard against a double submit, since the pending state above
+  // only updates on the next render.
+  const submittingRef = useRef(false);
 
   const submit = () => {
-    if (isPending) {
+    if (submittingRef.current) {
       return;
     }
     if (isEmpty) {
@@ -170,19 +179,22 @@ function RejectCommentDialog(props: {
       });
       return;
     }
-    setIsPending(true);
-    addBuildComment({
-      variables: {
-        input: {
-          buildId: build.id,
-          screenshotDiffId,
-          body: value,
-          addToReview: true,
+    submittingRef.current = true;
+    actionContext?.setIsPending(true);
+    client
+      .mutate({
+        mutation: AddBuildCommentMutation,
+        variables: {
+          input: {
+            buildId: build.id,
+            screenshotDiffId,
+            body: value,
+            addToReview: true,
+          },
+          accountSlug: projectParams.accountSlug,
+          projectName: projectParams.projectName,
         },
-        accountSlug: projectParams.accountSlug,
-        projectName: projectParams.projectName,
-      },
-    })
+      })
       .then(() => {
         // Close, reveal the new comment in the review panel, and move on to the
         // next snapshot so the reviewer can keep going.
@@ -193,7 +205,12 @@ function RejectCommentDialog(props: {
       .catch((error) => {
         toast.error(getErrorMessage(error));
         // Keep the content so the user can retry.
-        setIsPending(false);
+        submittingRef.current = false;
+      })
+      .finally(() => {
+        // Reset even on success: the parent Modal (and its pending state) is
+        // reused across opens, so leaving it pending would lock the next one.
+        actionContext?.setIsPending(false);
       });
   };
 
@@ -229,7 +246,8 @@ function RejectCommentDialog(props: {
         />
       </DialogBody>
       <DialogFooter>
-        <DialogDismiss isDisabled={isPending}>Skip</DialogDismiss>
+        {/* DialogDismiss disables itself while the modal action is pending. */}
+        <DialogDismiss>Skip</DialogDismiss>
         <Button
           variant="primary"
           isPending={isPending}

--- a/apps/frontend/src/pages/Build/RejectCommentDialog.tsx
+++ b/apps/frontend/src/pages/Build/RejectCommentDialog.tsx
@@ -1,10 +1,18 @@
-import { createContext, use, useCallback, useMemo, useState } from "react";
+import {
+  createContext,
+  use,
+  useCallback,
+  useId,
+  useMemo,
+  useState,
+} from "react";
 import { useMutation } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { toast } from "sonner";
 
 import { DocumentType, graphql } from "@/gql";
 import { useProjectParams } from "@/pages/Project/ProjectParams";
+import { Button } from "@/ui/Button";
 import {
   Dialog,
   DialogBody,
@@ -13,11 +21,15 @@ import {
   DialogText,
   DialogTitle,
 } from "@/ui/Dialog";
-import { type EditorValue } from "@/ui/Editor/Editor";
-import { StandaloneEditor } from "@/ui/Editor/StandaloneEditor";
+import { Editor, type EditorValue } from "@/ui/Editor/Editor";
+import { hasEditorContent } from "@/ui/Editor/util";
 import { Modal } from "@/ui/Modal";
 import { getMentionUser } from "@/ui/UserCard";
 import { getErrorMessage } from "@/util/error";
+
+import { useBuildDiffState, useGoToNextDiff } from "./BuildDiffState";
+import { useOpenReviewSidebar } from "./RightSidebarState";
+import { ScreenshotDiffThumbnail } from "./sidebar/ScreenshotDiffThumbnail";
 
 const _BuildFragment = graphql(`
   fragment RejectCommentDialog_Build on Build {
@@ -127,32 +139,64 @@ function RejectCommentDialog(props: {
   const { build, screenshotDiffId, onClose } = props;
   const projectParams = useProjectParams();
   invariant(projectParams);
+  const { diffs, allDiffs } = useBuildDiffState();
+  const goToNextDiff = useGoToNextDiff();
+  const openReviewSidebar = useOpenReviewSidebar();
+  // The snapshot the note will be attached to, shown above the field so the
+  // reviewer sees what they're commenting on (the reject flow always acts on a
+  // loaded diff, so this is normally found).
+  const diff =
+    diffs.find((candidate) => candidate.id === screenshotDiffId) ??
+    allDiffs.find((candidate) => candidate.id === screenshotDiffId) ??
+    null;
   const mentions = useMemo(
     () => build.members.map(getMentionUser),
     [build.members],
   );
+  const [value, setValue] = useState<EditorValue>(null);
+  const [isPending, setIsPending] = useState(false);
+  const emptyToastId = useId();
+  const isEmpty = !hasEditorContent(value);
   const [addBuildComment] = useMutation(AddBuildCommentMutation);
-  const handleSubmit = async (body: EditorValue) => {
-    try {
-      await addBuildComment({
-        variables: {
-          input: {
-            buildId: build.id,
-            screenshotDiffId,
-            body,
-            addToReview: true,
-          },
-          accountSlug: projectParams.accountSlug,
-          projectName: projectParams.projectName,
-        },
-      });
-      onClose();
-    } catch (error) {
-      toast.error(getErrorMessage(error));
-      // Rethrow so the editor keeps the content and the user can retry.
-      throw error;
+
+  const submit = () => {
+    if (isPending) {
+      return;
     }
+    if (isEmpty) {
+      toast.warning("Comment required", {
+        id: emptyToastId,
+        description: "Please add a comment before submitting.",
+      });
+      return;
+    }
+    setIsPending(true);
+    addBuildComment({
+      variables: {
+        input: {
+          buildId: build.id,
+          screenshotDiffId,
+          body: value,
+          addToReview: true,
+        },
+        accountSlug: projectParams.accountSlug,
+        projectName: projectParams.projectName,
+      },
+    })
+      .then(() => {
+        // Close, reveal the new comment in the review panel, and move on to the
+        // next snapshot so the reviewer can keep going.
+        onClose();
+        openReviewSidebar();
+        goToNextDiff();
+      })
+      .catch((error) => {
+        toast.error(getErrorMessage(error));
+        // Keep the content so the user can retry.
+        setIsPending(false);
+      });
   };
+
   return (
     <Dialog size="medium">
       <DialogBody>
@@ -161,21 +205,39 @@ function RejectCommentDialog(props: {
           Let your team know why you're rejecting this snapshot. Your comment is
           added to your review and becomes visible once you submit it.
         </DialogText>
-        <StandaloneEditor
-          onSubmit={handleSubmit}
+        {diff ? (
+          <div className="border-thin bg-subtle mb-3 flex items-center gap-2.5 rounded-md p-2">
+            <ScreenshotDiffThumbnail
+              screenshotDiff={diff}
+              className="size-8"
+              iconClassName="size-5"
+              fit="cover"
+            />
+            <span className="min-w-0 flex-1 truncate text-sm font-medium">
+              {diff.name}
+            </span>
+          </div>
+        ) : null}
+        <Editor
+          onChange={setValue}
+          onSubmit={submit}
           mentions={mentions}
           placeholder="Leave a comment…"
-          submitLabel="Add to review"
-          emptyMessage={{
-            title: "Comment required",
-            description: "Please add a comment before submitting.",
-          }}
+          disabled={isPending}
           autoFocus
           aria-label="Rejection comment"
         />
       </DialogBody>
       <DialogFooter>
-        <DialogDismiss>Skip</DialogDismiss>
+        <DialogDismiss isDisabled={isPending}>Skip</DialogDismiss>
+        <Button
+          variant="primary"
+          isPending={isPending}
+          aria-disabled={isEmpty}
+          onPress={submit}
+        >
+          Add to review
+        </Button>
       </DialogFooter>
     </Dialog>
   );


### PR DESCRIPTION
## Summary

Reworks the **"Add a note about this rejection"** dialog (shown when rejecting a snapshot during build review) per ARG-444.

- **Normal button in the footer, not in the field** — replaces the editor's baked-in send button with a normal **"Add to review"** button in the dialog footer, next to **Skip**. ⌘/Ctrl+Enter still submits.
- **Snapshot shown on top of the field** — a thumbnail + name of the snapshot the note attaches to, so the reviewer sees what they're commenting on (mirrors the sidebar's snapshot reference).
- **Post-submit flow** — once the comment is added: the dialog closes, the right sidebar opens on the **Review** panel (so the new comment is visible), and the viewer advances to the next snapshot to keep reviewing.

Empty submit still surfaces the "Comment required" toast, and content is preserved on error. The provider/context/hook API is unchanged, so `TrackButtons`/`BuildPage` need no changes.

## Notes

- **Skip** closes without advancing (only submit advances), matching the issue wording.

## Test plan

- [ ] Reject a snapshot → dialog shows the snapshot thumbnail + name above the field, and an "Add to review" button in the footer
- [ ] Type a note and submit → comment is added, right sidebar opens on the Review panel showing the comment, viewer advances to the next snapshot
- [ ] Submit while empty → "Comment required" toast, no comment created
- [ ] Skip → dialog closes, snapshot stays rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
