### PR TITLE
feat(frontend): show previous approvals dialog on overview (ARG-443)

### DIFF
--- a/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
@@ -34,7 +34,6 @@ import { useClipboard } from "use-clipboard-copy";
 
 import { DocumentType, graphql } from "@/gql";
 import { BuildType, ScreenshotDiffStatus } from "@/gql/graphql";
-import { BuildDialogs } from "@/pages/Build/BuildDialogs";
 import { DiffCommentLayer } from "@/pages/Build/diffComments/DiffCommentLayer";
 import { ScreenshotCommentLayer } from "@/pages/Build/screenshotComments/ScreenshotCommentLayer";
 import { Code } from "@/ui/Code";
@@ -104,7 +103,6 @@ const _BuildFragment = graphql(`
     pullRequest {
       merged
     }
-    ...BuildDialogs_Build
     ...ScreenshotCommentLayer_Build
     ...DiffCommentLayer_Build
   }
@@ -1637,10 +1635,7 @@ export function BuildDiffDetail(props: {
       )}
     >
       {diff ? (
-        <>
-          <BuildScreenshots build={build} diff={diff} />
-          <BuildDialogs build={build} />
-        </>
+        <BuildScreenshots build={build} diff={diff} />
       ) : build.type === BuildType.Skipped ? (
         <Centered>
           <SkippedBuildEmptyState />

--- a/apps/frontend/src/pages/Build/BuildOverview/index.tsx
+++ b/apps/frontend/src/pages/Build/BuildOverview/index.tsx
@@ -1,6 +1,7 @@
 import { useBuildHotkey } from "@/containers/Build/BuildHotkeys";
 import { DocumentType, graphql } from "@/gql";
 
+import { BuildDialogs } from "../BuildDialogs";
 import { useGoToNextDiff } from "../BuildDiffState";
 import { ReviewActivitySection } from "../sidebar/ReviewActivitySection";
 import { ReviewersSection } from "../sidebar/ReviewersSection";
@@ -22,6 +23,7 @@ const _BuildFragment = graphql(`
     ...DeploymentSection_Build
     ...ReviewersSection_Build
     ...ReviewActivitySection_Build
+    ...BuildDialogs_Build
   }
 `);
 
@@ -40,6 +42,7 @@ export function BuildOverview(props: { build: Build; repoUrl: string | null }) {
   const showDeployment = Boolean(build.deployment) || build.storybook;
   return (
     <div className="min-h-0 min-w-0 flex-1 overflow-y-auto">
+      <BuildDialogs build={build} />
       <div className="flex flex-col gap-10 p-6 lg:flex-row lg:gap-8">
         <div className="flex min-w-0 flex-1 justify-center">
           <main className="flex w-full max-w-3xl flex-col gap-10">


### PR DESCRIPTION
## ARG-443

The "Previous approvals detected" dialog was only shown once the user entered the review flow. It now appears as soon as the user arrives on the build **overview**.

The dialog logic itself was already correct — it opens only when there are previous branch approvals to reapply, the viewer hasn't submitted a review, and no diffs have been marked yet; and on **Reapply** it reapplies the approvals and redirects to the first still-pending snapshot. The only issue was where it was mounted.

### Changes
- **BuildDiffDetail.tsx** — removed the `<BuildDialogs>` render, its import, and the `...BuildDialogs_Build` fragment spread (this is what delayed the dialog until review mode).
- **BuildOverview/index.tsx** — mounted `<BuildDialogs>` here and added `...BuildDialogs_Build` to the `BuildOverview_Build` fragment.

### Behavior
- Arrive on overview with previous approvals → dialog shows immediately.
- **Accept** → approvals reapplied + redirected to the first snapshot for review.
- **Cancel** → dialog closes, user stays on the overview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)