### PR TITLE
refactor(frontend): use client.mutate where useMutation result is unused

### DIFF
--- a/apps/frontend/src/containers/Build/toolbar/IgnoreButton.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/IgnoreButton.tsx
@@ -1,5 +1,5 @@
 import { memo, useState } from "react";
-import { useMutation } from "@apollo/client/react";
+import { useApolloClient } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { FlagOffIcon } from "lucide-react";
 import { DialogTrigger } from "react-aria-components";
@@ -66,77 +66,83 @@ function EnabledIgnoreButton(props: {
   const isIgnored = diff.change.ignored;
   const [dialog, setDialog] = useState<"ignore" | "unignore" | null>(null);
   const authPayload = useAuthTokenPayload();
-  const [mutateIgnoreChange] = useMutation(IgnoreChangeMutation, {
-    variables: {
-      accountSlug: params.accountSlug,
-      changeId: diff.change.id,
-    },
-    optimisticResponse: {
-      ignoreChange: {
-        __typename: "TestChange",
-        id: diff.change.id,
-        ignored: true,
-      },
-    },
-    update: (cache) => {
-      if (diff.test) {
-        invariant(authPayload, "User should be logged in");
-        addAuditTrailEntry({
-          cache,
-          action: "files.ignored",
-          authPayload,
-          testId: diff.test.id,
-          accountSlug: params.accountSlug,
-          projectName: params.projectName,
-        });
-      }
-    },
-  });
+  const client = useApolloClient();
+  const changeId = diff.change.id;
 
   const ignoreChange = () => {
     const auditTrailId =
       typeof crypto !== "undefined" && "randomUUID" in crypto
         ? crypto.randomUUID()
         : `local-audit-trail-${Date.now()}`;
-    mutateIgnoreChange({ context: { auditTrailId } }).catch(() => {
-      // Optimistic response will handle this
-    });
+    client
+      .mutate({
+        mutation: IgnoreChangeMutation,
+        variables: {
+          accountSlug: params.accountSlug,
+          changeId,
+        },
+        optimisticResponse: {
+          ignoreChange: {
+            __typename: "TestChange",
+            id: changeId,
+            ignored: true,
+          },
+        },
+        update: (cache) => {
+          if (diff.test) {
+            invariant(authPayload, "User should be logged in");
+            addAuditTrailEntry({
+              cache,
+              action: "files.ignored",
+              authPayload,
+              testId: diff.test.id,
+              accountSlug: params.accountSlug,
+              projectName: params.projectName,
+            });
+          }
+        },
+        context: { auditTrailId },
+      })
+      .catch(() => {
+        // Optimistic response will handle this
+      });
     onIgnoreChange?.();
     setDialog(null);
   };
 
-  const [mutateUnignoreChange] = useMutation(UnignoreChangeMutation, {
-    variables: {
-      accountSlug: params.accountSlug,
-      changeId: diff.change.id,
-    },
-    optimisticResponse: {
-      unignoreChange: {
-        __typename: "TestChange",
-        id: diff.change.id,
-        ignored: false,
-      },
-    },
-    update: (cache) => {
-      if (diff.test) {
-        invariant(authPayload, "User should be logged in");
-        addAuditTrailEntry({
-          cache,
-          action: "files.unignored",
-          authPayload,
-          testId: diff.test.id,
-          accountSlug: params.accountSlug,
-          projectName: params.projectName,
-        });
-      }
-    },
-  });
   const unignoreChange = () => {
     const auditTrailId =
       typeof crypto !== "undefined" && "randomUUID" in crypto
         ? crypto.randomUUID()
         : `local-audit-trail-${Date.now()}`;
-    mutateUnignoreChange({ context: { auditTrailId } });
+    client.mutate({
+      mutation: UnignoreChangeMutation,
+      variables: {
+        accountSlug: params.accountSlug,
+        changeId,
+      },
+      optimisticResponse: {
+        unignoreChange: {
+          __typename: "TestChange",
+          id: changeId,
+          ignored: false,
+        },
+      },
+      update: (cache) => {
+        if (diff.test) {
+          invariant(authPayload, "User should be logged in");
+          addAuditTrailEntry({
+            cache,
+            action: "files.unignored",
+            authPayload,
+            testId: diff.test.id,
+            accountSlug: params.accountSlug,
+            projectName: params.projectName,
+          });
+        }
+      },
+      context: { auditTrailId },
+    });
     setDialog(null);
   };
   const toggle = () => {

--- a/apps/frontend/src/containers/Project/Contributors/ProjectContributorLevelSelect.tsx
+++ b/apps/frontend/src/containers/Project/Contributors/ProjectContributorLevelSelect.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from "@apollo/client/react";
+import { useApolloClient } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import clsx from "clsx";
 
@@ -37,7 +37,7 @@ export function ProjectContributorLevelSelect(props: {
   userId: string;
   level: ProjectUserLevel | "";
 }) {
-  const [addOrUpdateContributor] = useMutation(AddOrUpdateContributorMutation);
+  const client = useApolloClient();
 
   return (
     <Select
@@ -45,7 +45,8 @@ export function ProjectContributorLevelSelect(props: {
       value={props.level}
       onChange={(value) => {
         invariant(typeof value === "string");
-        addOrUpdateContributor({
+        client.mutate({
+          mutation: AddOrUpdateContributorMutation,
           variables: {
             projectId: props.projectId,
             userAccountId: props.userId,

--- a/apps/frontend/src/containers/Project/GitRepository.tsx
+++ b/apps/frontend/src/containers/Project/GitRepository.tsx
@@ -102,17 +102,20 @@ const UpdateEnablePrCommentMutation = graphql(`
 function UnlinkGithubRepositoryButton(props: {
   project: ProjectGitRepository_ProjectFragment;
 }) {
-  const [unlink] = useMutation(UnlinkGithubRepositoryMutation, {
-    variables: {
-      projectId: props.project.id,
-    },
-    optimisticResponse: {
-      unlinkGithubRepository: {
-        id: props.project.id,
-        repository: null,
-      } as ProjectGitRepository_ProjectFragment,
-    },
-  });
+  const client = useApolloClient();
+  const unlink = () =>
+    client.mutate({
+      mutation: UnlinkGithubRepositoryMutation,
+      variables: {
+        projectId: props.project.id,
+      },
+      optimisticResponse: {
+        unlinkGithubRepository: {
+          id: props.project.id,
+          repository: null,
+        } as ProjectGitRepository_ProjectFragment,
+      },
+    });
   return (
     <Button
       variant="secondary"
@@ -128,17 +131,20 @@ function UnlinkGithubRepositoryButton(props: {
 const UnlinkGitlabProjectButton = (props: {
   project: ProjectGitRepository_ProjectFragment;
 }) => {
-  const [unlink] = useMutation(UnlinkGitlabProjectMutation, {
-    variables: {
-      projectId: props.project.id,
-    },
-    optimisticResponse: {
-      unlinkGitlabProject: {
-        id: props.project.id,
-        repository: null,
-      } as ProjectGitRepository_ProjectFragment,
-    },
-  });
+  const client = useApolloClient();
+  const unlink = () =>
+    client.mutate({
+      mutation: UnlinkGitlabProjectMutation,
+      variables: {
+        projectId: props.project.id,
+      },
+      optimisticResponse: {
+        unlinkGitlabProject: {
+          id: props.project.id,
+          repository: null,
+        } as ProjectGitRepository_ProjectFragment,
+      },
+    });
   return (
     <Button
       variant="secondary"

--- a/apps/frontend/src/containers/Team/SAMLSSO.tsx
+++ b/apps/frontend/src/containers/Team/SAMLSSO.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/refs */
 import { useId } from "react";
-import { useApolloClient, useMutation } from "@apollo/client/react";
+import { useApolloClient } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import {
   CheckCircle2Icon,
@@ -132,10 +132,11 @@ export function TeamSAMLSSO(props: {
 }) {
   const { team } = props;
   const hasSamlIncluded = team.plan?.samlIncluded;
-  const [update] = useMutation(ConfigureTeamSamlMutation);
+  const apolloClient = useApolloClient();
   const toggleEnable = (enabled: boolean) => {
     invariant(team.samlSso);
-    update({
+    apolloClient.mutate({
+      mutation: ConfigureTeamSamlMutation,
       variables: {
         input: {
           teamAccountId: team.id,
@@ -151,18 +152,20 @@ export function TeamSAMLSSO(props: {
       },
     });
   };
-  const [remove] = useMutation(RemoveTeamSamlMutation, {
-    variables: {
-      teamAccountId: team.id,
-    },
-    optimisticResponse: {
-      removeTeamSaml: {
-        __typename: "Team",
-        id: team.id,
-        samlSso: null,
+  const remove = () =>
+    apolloClient.mutate({
+      mutation: RemoveTeamSamlMutation,
+      variables: {
+        teamAccountId: team.id,
       },
-    },
-  });
+      optimisticResponse: {
+        removeTeamSaml: {
+          __typename: "Team",
+          id: team.id,
+          samlSso: null,
+        },
+      },
+    });
 
   return (
     <Card>
@@ -246,7 +249,8 @@ export function TeamSAMLSSO(props: {
                   isSelected={team.samlSso.enforced}
                   onChange={(isSelected) => {
                     invariant(team.samlSso);
-                    update({
+                    apolloClient.mutate({
+                      mutation: ConfigureTeamSamlMutation,
                       variables: {
                         input: {
                           teamAccountId: team.id,

--- a/apps/frontend/src/containers/Team/Slack.tsx
+++ b/apps/frontend/src/containers/Team/Slack.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from "@apollo/client/react";
+import { useApolloClient } from "@apollo/client/react";
 import {
   ExternalLinkIcon,
   MoreVerticalIcon,
@@ -45,15 +45,18 @@ export function TeamSlack(props: {
   const { account } = props;
   const { permissions } = useAccountContext();
   const hasAdminPermission = permissions.includes(AccountPermission.Admin);
-  const [uninstallSlack] = useMutation(UninstallSlackMutation, {
-    variables: { accountId: props.account.id },
-    optimisticResponse: {
-      uninstallSlack: {
-        ...props.account,
-        slackInstallation: null,
-      } as TeamSlack_AccountFragment,
-    },
-  });
+  const client = useApolloClient();
+  const uninstallSlack = () =>
+    client.mutate({
+      mutation: UninstallSlackMutation,
+      variables: { accountId: props.account.id },
+      optimisticResponse: {
+        uninstallSlack: {
+          ...props.account,
+          slackInstallation: null,
+        } as TeamSlack_AccountFragment,
+      },
+    });
   const authURL = getSlackAuthURL({ accountId: props.account.id });
   return (
     <Card id="slack">

--- a/apps/frontend/src/containers/Team/members/InvitesList.tsx
+++ b/apps/frontend/src/containers/Team/members/InvitesList.tsx
@@ -1,6 +1,6 @@
 import { useDeferredValue, useState } from "react";
 import type { Reference } from "@apollo/client";
-import { useMutation, useSuspenseQuery } from "@apollo/client/react";
+import { useApolloClient, useSuspenseQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import {
   CircleXIcon,
@@ -93,8 +93,7 @@ const ResendInviteMutation = graphql(`
 export function TeamInvitesList(props: TeamInvitesListProps) {
   const [search, setSearch] = useState("");
   const deferredSearch = useDeferredValue(search);
-  const [cancelInvite] = useMutation(TeamInviteCancelMutation);
-  const [resendInvite] = useMutation(ResendInviteMutation);
+  const client = useApolloClient();
   const { data, fetchMore } = useSuspenseQuery(TeamInvitesQuery, {
     variables: {
       id: props.team.id,
@@ -158,7 +157,8 @@ export function TeamInvitesList(props: TeamInvitesListProps) {
                           variant="danger"
                           onAction={() => {
                             toast.promise(
-                              cancelInvite({
+                              client.mutate({
+                                mutation: TeamInviteCancelMutation,
                                 variables: { teamInviteId: invite.id },
                                 update(cache, { data }) {
                                   if (data?.cancelInvite) {
@@ -208,7 +208,8 @@ export function TeamInvitesList(props: TeamInvitesListProps) {
                         <MenuItem
                           onAction={() => {
                             toast.promise(
-                              resendInvite({
+                              client.mutate({
+                                mutation: ResendInviteMutation,
                                 variables: {
                                   input: {
                                     teamAccountId: props.team.id,

--- a/apps/frontend/src/containers/Team/members/MemberLevelEditor.tsx
+++ b/apps/frontend/src/containers/Team/members/MemberLevelEditor.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from "@apollo/client/react";
+import { useApolloClient } from "@apollo/client/react";
 
 import { DocumentType, graphql } from "@/gql";
 import { TeamUserLevel } from "@/gql/graphql";
@@ -40,7 +40,7 @@ export function MemberLevelEditor(props: {
   member: DocumentType<typeof _TeamMemberFragment>;
 }) {
   const { member, hasFineGrainedAccessControl } = props;
-  const [setTeamMemberLevel] = useMutation(SetTeamMemberLevelMutation);
+  const client = useApolloClient();
 
   return (
     <MemberLevelSelect
@@ -49,7 +49,8 @@ export function MemberLevelEditor(props: {
       hasFineGrainedAccessControl={hasFineGrainedAccessControl}
       value={member.level}
       onChange={(value) => {
-        setTeamMemberLevel({
+        client.mutate({
+          mutation: SetTeamMemberLevelMutation,
           variables: {
             teamAccountId: props.teamId,
             userAccountId: member.user.id,

--- a/apps/frontend/src/containers/User/providers/GitHubAuth.tsx
+++ b/apps/frontend/src/containers/User/providers/GitHubAuth.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from "@apollo/client/react";
+import { useApolloClient } from "@apollo/client/react";
 import { MarkGithubIcon } from "@primer/octicons-react";
 import { ExternalLinkIcon } from "lucide-react";
 import { MenuTrigger } from "react-aria-components";
@@ -45,18 +45,21 @@ export function GitHubAuth(props: {
   account: DocumentType<typeof _AccountFragment>;
 }) {
   const { account } = props;
-  const [disconnect] = useMutation(DisconnectGitHubMutation, {
-    variables: {
-      accountId: account.id,
-    },
-    optimisticResponse: {
-      disconnectGitHubAuth: {
-        __typename: "User",
-        id: account.id,
-        githubAccount: null,
-      } as GitHubAuth_AccountFragment,
-    },
-  });
+  const client = useApolloClient();
+  const disconnect = () =>
+    client.mutate({
+      mutation: DisconnectGitHubMutation,
+      variables: {
+        accountId: account.id,
+      },
+      optimisticResponse: {
+        disconnectGitHubAuth: {
+          __typename: "User",
+          id: account.id,
+          githubAccount: null,
+        } as GitHubAuth_AccountFragment,
+      },
+    });
   return (
     <ProviderCard>
       {account.githubAccount ? (

--- a/apps/frontend/src/containers/User/providers/GitLabAuth.tsx
+++ b/apps/frontend/src/containers/User/providers/GitLabAuth.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from "@apollo/client/react";
+import { useApolloClient } from "@apollo/client/react";
 import { ExternalLinkIcon } from "lucide-react";
 import { MenuTrigger } from "react-aria-components";
 
@@ -43,18 +43,21 @@ export function GitLabAuth(props: {
   account: DocumentType<typeof _AccountFragment>;
 }) {
   const { account } = props;
-  const [disconnect] = useMutation(DisconnectGitLabMutation, {
-    variables: {
-      accountId: account.id,
-    },
-    optimisticResponse: {
-      disconnectGitLabAuth: {
-        __typename: "User",
-        id: account.id,
-        gitlabUser: null,
-      } as GitLabAuth_AccountFragment,
-    },
-  });
+  const client = useApolloClient();
+  const disconnect = () =>
+    client.mutate({
+      mutation: DisconnectGitLabMutation,
+      variables: {
+        accountId: account.id,
+      },
+      optimisticResponse: {
+        disconnectGitLabAuth: {
+          __typename: "User",
+          id: account.id,
+          gitlabUser: null,
+        } as GitLabAuth_AccountFragment,
+      },
+    });
   return (
     <ProviderCard>
       {account.gitlabUser ? (

--- a/apps/frontend/src/containers/User/providers/GoogleAuth.tsx
+++ b/apps/frontend/src/containers/User/providers/GoogleAuth.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from "@apollo/client/react";
+import { useApolloClient } from "@apollo/client/react";
 import { ExternalLinkIcon } from "lucide-react";
 import { MenuTrigger } from "react-aria-components";
 
@@ -40,18 +40,21 @@ export function GoogleAuth(props: {
   account: DocumentType<typeof _AccountFragment>;
 }) {
   const { account } = props;
-  const [disconnect] = useMutation(DisconnectGoogleMutation, {
-    variables: {
-      accountId: account.id,
-    },
-    optimisticResponse: {
-      disconnectGoogleAuth: {
-        __typename: "User",
-        id: account.id,
-        googleUser: null,
+  const client = useApolloClient();
+  const disconnect = () =>
+    client.mutate({
+      mutation: DisconnectGoogleMutation,
+      variables: {
+        accountId: account.id,
       },
-    },
-  });
+      optimisticResponse: {
+        disconnectGoogleAuth: {
+          __typename: "User",
+          id: account.id,
+          googleUser: null,
+        },
+      },
+    });
   return (
     <ProviderCard>
       {account.googleUser ? (

--- a/apps/frontend/src/pages/Automation/DeleteAutomation.tsx
+++ b/apps/frontend/src/pages/Automation/DeleteAutomation.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from "@apollo/client/react";
+import { useApolloClient } from "@apollo/client/react";
 
 import { graphql } from "@/gql";
 import { Button } from "@/ui/Button";
@@ -25,48 +25,52 @@ export function DeleteAutomationDialog(props: {
   onCompleted?: () => void;
 }) {
   const { automationRuleId, projectId, onCompleted } = props;
-  const [deactivateAutomationRule] = useMutation(
-    DeactivateAutomationRuleMutation,
-    {
-      variables: { id: automationRuleId },
-      onCompleted,
-      update(cache, { data }) {
-        if (!data?.deactivateAutomationRule?.id) {
-          return;
-        }
-        const { id } = data.deactivateAutomationRule;
-        // Find the project id in the cache
-        const projectGqlID = cache.identify({
-          __typename: "Project",
-          id: projectId,
-        });
-
-        if (projectGqlID) {
-          cache.modify({
-            id: projectGqlID,
-            fields: {
-              automationRules(existingAutomationRules = {}, { readField }) {
-                if (!existingAutomationRules.edges) {
-                  return existingAutomationRules;
-                }
-
-                return {
-                  ...existingAutomationRules,
-                  edges: existingAutomationRules.edges.filter(
-                    (ruleRef: any) => readField("id", ruleRef) !== id,
-                  ),
-                  pageInfo: {
-                    ...existingAutomationRules.pageInfo,
-                    totalCount: existingAutomationRules.pageInfo.totalCount - 1,
-                  },
-                };
-              },
-            },
+  const client = useApolloClient();
+  const deactivateAutomationRule = () =>
+    client
+      .mutate({
+        mutation: DeactivateAutomationRuleMutation,
+        variables: { id: automationRuleId },
+        update(cache, { data }) {
+          if (!data?.deactivateAutomationRule?.id) {
+            return;
+          }
+          const { id } = data.deactivateAutomationRule;
+          // Find the project id in the cache
+          const projectGqlID = cache.identify({
+            __typename: "Project",
+            id: projectId,
           });
-        }
-      },
-    },
-  );
+
+          if (projectGqlID) {
+            cache.modify({
+              id: projectGqlID,
+              fields: {
+                automationRules(existingAutomationRules = {}, { readField }) {
+                  if (!existingAutomationRules.edges) {
+                    return existingAutomationRules;
+                  }
+
+                  return {
+                    ...existingAutomationRules,
+                    edges: existingAutomationRules.edges.filter(
+                      (ruleRef: any) => readField("id", ruleRef) !== id,
+                    ),
+                    pageInfo: {
+                      ...existingAutomationRules.pageInfo,
+                      totalCount:
+                        existingAutomationRules.pageInfo.totalCount - 1,
+                    },
+                  };
+                },
+              },
+            });
+          }
+        },
+      })
+      .then(() => {
+        onCompleted?.();
+      });
   return (
     <Dialog size="medium">
       <DialogBody>

--- a/apps/frontend/src/pages/Build/BuildReviewAction.ts
+++ b/apps/frontend/src/pages/Build/BuildReviewAction.ts
@@ -1,14 +1,9 @@
-import { useMutation } from "@apollo/client/react";
+import { useApolloClient } from "@apollo/client/react";
 import { assertNever } from "@argos/util/assertNever";
 import { invariant } from "@argos/util/invariant";
 
 import { DocumentType, graphql } from "@/gql";
-import {
-  BuildReviewEvent,
-  ScreenshotDiffReviewState,
-  type BuildReviewAction_CreateBuildReviewMutation,
-  type BuildReviewAction_CreateBuildReviewMutationVariables,
-} from "@/gql/graphql";
+import { BuildReviewEvent, ScreenshotDiffReviewState } from "@/gql/graphql";
 import { useProjectParams } from "@/pages/Project/ProjectParams";
 import { EditorValue } from "@/ui/Editor/Editor";
 import { useEventCallback } from "@/ui/useEventCallback";
@@ -49,20 +44,12 @@ const _BuildFragment = graphql(`
 
 export function useCreateBuildReviewMutation(
   build: DocumentType<typeof _BuildFragment>,
-  options?: Pick<
-    useMutation.Options<
-      BuildReviewAction_CreateBuildReviewMutation,
-      BuildReviewAction_CreateBuildReviewMutationVariables
-    >,
-    "onCompleted"
-  >,
+  options?: { onCompleted?: () => void },
 ) {
   const api = useBuildReviewAPI();
   const openReviewSidebar = useOpenReviewSidebar();
   const projectParams = useProjectParams();
-  const [mutate, data] = useMutation(CreateBuildReviewMutation, {
-    ...options,
-  });
+  const client = useApolloClient();
 
   const getReviewedDiffStatuses = useGetReviewedDiffStatuses();
   const createReview = useEventCallback(
@@ -86,7 +73,8 @@ export function useCreateBuildReviewMutation(
           };
         })
         .filter((x) => x !== null);
-      const result = await mutate({
+      const result = await client.mutate({
+        mutation: CreateBuildReviewMutation,
         variables: {
           input: {
             buildId: build.id,
@@ -98,13 +86,14 @@ export function useCreateBuildReviewMutation(
           projectName: projectParams.projectName,
         },
       });
+      options?.onCompleted?.();
       api.setDiffStatuses(diffStatuses);
       openReviewSidebar();
       return result;
     },
   );
 
-  return [createReview, data] as const;
+  return [createReview] as const;
 }
 
 /**

--- a/apps/frontend/src/pages/Build/diffComments/DiffCommentLayer.tsx
+++ b/apps/frontend/src/pages/Build/diffComments/DiffCommentLayer.tsx
@@ -1,5 +1,5 @@
 import { use, useCallback, useMemo, useState } from "react";
-import { useMutation } from "@apollo/client/react";
+import { useApolloClient } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import type {
   DiffLineAnnotation,
@@ -113,7 +113,7 @@ export function DiffCommentLayer(props: {
   const { accountSlug, projectName } = useProjectParams() ?? {};
   invariant(accountSlug && projectName, "Missing project route params");
   const accountId = useAuthTokenPayload()?.account.id;
-  const [addBuildComment] = useMutation(AddBuildCommentMutation);
+  const client = useApolloClient();
 
   const [draft, setDraft] = useState<LineRange | null>(null);
   // The range being drag-selected right now (before it's committed to a draft).
@@ -210,7 +210,8 @@ export function DiffCommentLayer(props: {
         return;
       }
       try {
-        await addBuildComment({
+        await client.mutate({
+          mutation: AddBuildCommentMutation,
           variables: {
             input: {
               buildId: build.id,
@@ -231,7 +232,7 @@ export function DiffCommentLayer(props: {
       }
     },
     [
-      addBuildComment,
+      client,
       build.id,
       draft,
       screenshotDiffId,

--- a/apps/frontend/src/pages/Build/screenshotComments/ScreenshotCommentLayer.tsx
+++ b/apps/frontend/src/pages/Build/screenshotComments/ScreenshotCommentLayer.tsx
@@ -7,7 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { useMutation } from "@apollo/client/react";
+import { useApolloClient } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { useAtom, useAtomValue } from "jotai/react";
 import { toast } from "sonner";
@@ -129,7 +129,7 @@ export function ScreenshotCommentLayer(props: {
   const { accountSlug, projectName } = useProjectParams() ?? {};
   invariant(accountSlug && projectName, "Missing project route params");
   const accountId = useAuthTokenPayload()?.account.id;
-  const [addBuildComment] = useMutation(AddBuildCommentMutation);
+  const client = useApolloClient();
 
   const { toScreen, toNormalized, ready } = useScreenshotProjection({
     paneSize,
@@ -323,7 +323,8 @@ export function ScreenshotCommentLayer(props: {
       }
       const priorIds = new Set(build.comments.map((comment) => comment.id));
       try {
-        const result = await addBuildComment({
+        const result = await client.mutate({
+          mutation: AddBuildCommentMutation,
           variables: {
             input: {
               buildId: build.id,
@@ -350,7 +351,7 @@ export function ScreenshotCommentLayer(props: {
       }
     },
     [
-      addBuildComment,
+      client,
       build.comments,
       build.id,
       draft,

--- a/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
@@ -1,5 +1,5 @@
 import { ComponentProps, useState } from "react";
-import { useMutation } from "@apollo/client/react";
+import { useApolloClient } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { clsx } from "clsx";
 import { EyeOffIcon } from "lucide-react";
@@ -110,10 +110,11 @@ export function AddCommentForm(props: {
   const attachedDiff = detached ? null : activeDiff;
   const canAddToReview = useCanAddToReview(build);
   const altHeld = useAltKeyHeld();
-  const [addBuildComment] = useMutation(AddBuildCommentMutation);
+  const client = useApolloClient();
   const handleSubmit = async (body: EditorValue) => {
     try {
-      await addBuildComment({
+      await client.mutate({
+        mutation: AddBuildCommentMutation,
         variables: {
           input: {
             buildId: build.id,

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useRef, useState } from "react";
-import { useMutation } from "@apollo/client/react";
+import { useApolloClient } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { clsx } from "clsx";
 import {
@@ -203,10 +203,10 @@ export function CommentCard(props: {
   } = props;
   const projectParams = useProjectParams();
   invariant(projectParams);
-  const [addReply] = useMutation(AddReplyMutation);
-  const [subscribeToCommentThread] = useMutation(
-    SubscribeToCommentThreadMutation,
-    {
+  const client = useApolloClient();
+  const subscribeToCommentThread = () =>
+    client.mutate({
+      mutation: SubscribeToCommentThreadMutation,
       variables: { input: { commentId: comment.id } },
       optimisticResponse: {
         subscribeToCommentThread: {
@@ -215,11 +215,10 @@ export function CommentCard(props: {
           threadSubscribed: true,
         },
       },
-    },
-  );
-  const [unsubscribeFromCommentThread] = useMutation(
-    UnsubscribeFromCommentThreadMutation,
-    {
+    });
+  const unsubscribeFromCommentThread = () =>
+    client.mutate({
+      mutation: UnsubscribeFromCommentThreadMutation,
       variables: { input: { commentId: comment.id } },
       optimisticResponse: {
         unsubscribeFromCommentThread: {
@@ -228,28 +227,31 @@ export function CommentCard(props: {
           threadSubscribed: false,
         },
       },
-    },
-  );
-  const [resolveCommentThread] = useMutation(ResolveCommentThreadMutation, {
-    variables: { input: { commentId: comment.id } },
-    optimisticResponse: {
-      resolveCommentThread: {
-        __typename: "Comment",
-        id: comment.id,
-        resolvedAt: new Date().toISOString(),
+    });
+  const resolveCommentThread = () =>
+    client.mutate({
+      mutation: ResolveCommentThreadMutation,
+      variables: { input: { commentId: comment.id } },
+      optimisticResponse: {
+        resolveCommentThread: {
+          __typename: "Comment",
+          id: comment.id,
+          resolvedAt: new Date().toISOString(),
+        },
       },
-    },
-  });
-  const [unresolveCommentThread] = useMutation(UnresolveCommentThreadMutation, {
-    variables: { input: { commentId: comment.id } },
-    optimisticResponse: {
-      unresolveCommentThread: {
-        __typename: "Comment",
-        id: comment.id,
-        resolvedAt: null,
+    });
+  const unresolveCommentThread = () =>
+    client.mutate({
+      mutation: UnresolveCommentThreadMutation,
+      variables: { input: { commentId: comment.id } },
+      optimisticResponse: {
+        unresolveCommentThread: {
+          __typename: "Comment",
+          id: comment.id,
+          resolvedAt: null,
+        },
       },
-    },
-  });
+    });
 
   const resolved = Boolean(comment.resolvedAt);
   // `collapsed` is the stored preference and drives the header label and toggle.
@@ -270,7 +272,8 @@ export function CommentCard(props: {
 
   const handleReplySubmit = async (body: EditorValue) => {
     try {
-      await addReply({
+      await client.mutate({
+        mutation: AddReplyMutation,
         variables: {
           input: { buildId, threadId: comment.id, body },
           accountSlug: projectParams.accountSlug,
@@ -470,7 +473,7 @@ function CommentMessage(props: {
   const mentionedUsers = comment.mentionedUsers.map(getMentionUser);
   const [isEditing, setIsEditing] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-  const [updateComment] = useMutation(UpdateCommentMutation);
+  const client = useApolloClient();
 
   useEffect(() => {
     if (highlighted && ref.current) {
@@ -490,7 +493,8 @@ function CommentMessage(props: {
 
   const handleEditSubmit = async (body: EditorValue) => {
     try {
-      await updateComment({
+      await client.mutate({
+        mutation: UpdateCommentMutation,
         variables: {
           input: { id: comment.id, body },
           accountSlug: projectParams.accountSlug,

--- a/apps/frontend/src/pages/Build/sidebar/CommentReactions.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentReactions.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from "@apollo/client/react";
+import { useApolloClient } from "@apollo/client/react";
 import { clsx } from "clsx";
 import { SmilePlusIcon } from "lucide-react";
 import { Button } from "react-aria-components";
@@ -65,22 +65,27 @@ function useCanReact(): boolean {
  * and the reaction pills mutate the same comment.
  */
 function useReactionActions(commentId: string) {
-  const [addReaction] = useMutation(AddCommentReactionMutation);
-  const [removeReaction] = useMutation(RemoveCommentReactionMutation);
+  const client = useApolloClient();
+  const addReaction = (emoji: string) =>
+    client.mutate({
+      mutation: AddCommentReactionMutation,
+      variables: { input: { commentId, emoji } },
+    });
+  const removeReaction = (emoji: string) =>
+    client.mutate({
+      mutation: RemoveCommentReactionMutation,
+      variables: { input: { commentId, emoji } },
+    });
 
   const react = (emoji: string) => {
-    addReaction({
-      variables: { input: { commentId, emoji } },
-    }).catch((error) => {
+    addReaction(emoji).catch((error) => {
       toast.error(getErrorMessage(error));
     });
   };
 
   const toggle = (group: ReactionGroup) => {
     const mutation = group.reactedByMe ? removeReaction : addReaction;
-    mutation({
-      variables: { input: { commentId, emoji: group.emoji } },
-    }).catch((error) => {
+    mutation(group.emoji).catch((error) => {
       toast.error(getErrorMessage(error));
     });
   };

--- a/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo } from "react";
 import type { Reference } from "@apollo/client";
-import { useMutation, useSubscription } from "@apollo/client/react";
+import { useApolloClient, useSubscription } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import clsx from "clsx";
 import {
@@ -383,26 +383,31 @@ export function ReviewActivitySection(props: { build: Build }) {
 
 function SubscribeToggleButton(props: { build: Build }) {
   const { build } = props;
-  const [subscribeToBuild] = useMutation(SubscribeToBuildMutation, {
-    variables: { input: { buildId: build.id } },
-    optimisticResponse: {
-      subscribeToBuild: {
-        __typename: "Build",
-        id: build.id,
-        subscribed: true,
+  const client = useApolloClient();
+  const subscribeToBuild = () =>
+    client.mutate({
+      mutation: SubscribeToBuildMutation,
+      variables: { input: { buildId: build.id } },
+      optimisticResponse: {
+        subscribeToBuild: {
+          __typename: "Build",
+          id: build.id,
+          subscribed: true,
+        },
       },
-    },
-  });
-  const [unsubscribeFromBuild] = useMutation(UnsubscribeFromBuildMutation, {
-    variables: { input: { buildId: build.id } },
-    optimisticResponse: {
-      unsubscribeFromBuild: {
-        __typename: "Build",
-        id: build.id,
-        subscribed: false,
+    });
+  const unsubscribeFromBuild = () =>
+    client.mutate({
+      mutation: UnsubscribeFromBuildMutation,
+      variables: { input: { buildId: build.id } },
+      optimisticResponse: {
+        unsubscribeFromBuild: {
+          __typename: "Build",
+          id: build.id,
+          subscribed: false,
+        },
       },
-    },
-  });
+    });
   const subscribed = build.subscribed;
   const label = subscribed ? "Unsubscribe" : "Subscribe";
   const handlePress = () => {

--- a/apps/frontend/src/pages/Build/sidebar/ReviewersSection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewersSection.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { useMutation } from "@apollo/client/react";
+import { useApolloClient, useMutation } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import clsx from "clsx";
 import {
@@ -256,8 +256,7 @@ function RequestReviewersMenu(props: { build: Build }) {
   const { contains } = useFilter({ sensitivity: "base" });
   const [isOpen, setIsOpen] = useState(false);
   const hotkey = useBuildHotkey("requestReviewers", () => setIsOpen(true));
-  const [addReviewers] = useMutation(AddBuildReviewersMutation);
-  const [removeReviewers] = useMutation(RemoveBuildReviewersMutation);
+  const client = useApolloClient();
 
   // You can't request yourself as a reviewer, so exclude the current user from
   // the picker (the server enforces this too).
@@ -325,22 +324,28 @@ function RequestReviewersMenu(props: { build: Build }) {
     setRequested(next);
     const revert = () => setRequested(new Set(requestedKeys));
     if (added.length > 0) {
-      addReviewers({
-        variables: {
-          input: { buildId: build.id, userIds: added },
-          accountSlug: projectParams.accountSlug,
-          projectName: projectParams.projectName,
-        },
-      }).catch(revert);
+      client
+        .mutate({
+          mutation: AddBuildReviewersMutation,
+          variables: {
+            input: { buildId: build.id, userIds: added },
+            accountSlug: projectParams.accountSlug,
+            projectName: projectParams.projectName,
+          },
+        })
+        .catch(revert);
     }
     if (removed.length > 0) {
-      removeReviewers({
-        variables: {
-          input: { buildId: build.id, userIds: removed },
-          accountSlug: projectParams.accountSlug,
-          projectName: projectParams.projectName,
-        },
-      }).catch(revert);
+      client
+        .mutate({
+          mutation: RemoveBuildReviewersMutation,
+          variables: {
+            input: { buildId: build.id, userIds: removed },
+            accountSlug: projectParams.accountSlug,
+            projectName: projectParams.projectName,
+          },
+        })
+        .catch(revert);
     }
   };
 


### PR DESCRIPTION
## Summary

Follow-up cleanup from #2336: eliminate the `useMutation`-without-result anti-pattern across the frontend.

`useMutation` subscribes the component to the mutation's own `loading`/`data`/`error` state and **re-renders it while the request is in flight even when that state is never read**. Where a call site only needs to fire the mutation (it tracks pending itself, or not at all), that's wasted work. Those are replaced with `useApolloClient().mutate()`, which doesn't subscribe.

This is the guideline documented in `apps/frontend/AGENTS.md` (added in #2336).

## Scope

**31 call sites across 19 files** converted — behavior preserved:

- Call-site `variables` / `optimisticResponse` / `update` / `context` folded into the single `client.mutate({ mutation, ... })` object.
- `DeleteAutomation` and the `useCreateBuildReviewMutation` hook: `onCompleted` → `.then()`.
- `BuildReviewAction` no longer returns its unused mutation result (its one caller already destructured it away).

Areas touched: auth disconnects (GitHub/GitLab/Google), Slack, GitRepository (unlink), SAMLSSO, contributor/member level selects, InvitesList, IgnoreButton, DeleteAutomation, comment composers (AddCommentForm, CommentCard, ScreenshotCommentLayer, DiffCommentLayer), optimistic toggles (CommentReactions, ReviewActivitySection subscribe, ReviewersSection request), and the review-action hook.

**Left as-is:** the 25 `useMutation` usages that genuinely render from `loading`/`data`/`error` (dialogs with spinners, invite/verify screens, etc.).

## Verification

- `pnpm check-types` — 0 errors
- `pnpm lint` — clean
- `pnpm check-format` — clean
- Every remaining `useMutation(` call reads its result state (verified by grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
