### PR TITLE
refactor(backend): remove per-job "Done" log to reduce Sentry log volume

### DIFF
--- a/apps/backend/src/job-core/createJob.ts
+++ b/apps/backend/src/job-core/createJob.ts
@@ -244,22 +244,8 @@ export const createJob = <TValue extends string | number>(
           redisLock.acquire(
             [queue, id],
             async () => {
-              const performStart = performance.now();
               await consumer.perform(id, ctx);
-              const performEnd = performance.now();
-              const completeStart = performance.now();
               await consumer.complete?.(id, ctx);
-              const completeEnd = performance.now();
-              const duration = performEnd - performStart;
-              const completingDuration = completeEnd - completeStart;
-              ctx.logger.info(
-                {
-                  duration,
-                  completingDuration,
-                  totalDuration: duration + completingDuration,
-                },
-                "Done",
-              );
             },
             { timeout },
           ),


### PR DESCRIPTION
## Problem

Sentry logs are at ~4GB/5GB. The bulk of them are the per-job `"Done"` info log emitted on every completed job in the job-core consumer.

## Change

Removes the per-job `"Done"` info log (and the surrounding `performance.now()` timing bookkeeping that only fed it) in `createJob.ts`. The `perform`/`complete` calls are unchanged.

Error and timeout logging is untouched, so job failures remain visible in Sentry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)