### PR TITLE
fix(frontend): advance to next diff after rejection note + session opt-out (ARG-447)

### DIFF
--- a/apps/frontend/src/pages/Build/BuildReviewState.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewState.tsx
@@ -118,8 +118,10 @@ export function useAcknowledgeMarkedDiff(options?: UseGetNextDiffOptions) {
   const diffStatusesRef = useRef<Record<string, EvaluationStatus> | null>(null);
   const nextDiffRef = useRef<Diff | null>(null);
 
-  const acknowledge = useEventCallback(() => {
-    const nextDiff = nextDiffRef.current;
+  // Navigate to the next diff to review, or show the review dialog once every
+  // diff has been reviewed. `reviewStatus` is read fresh at call time, so the
+  // diff that was just marked is already accounted for.
+  const acknowledgeNextDiff = useEventCallback((nextDiff: Diff | null) => {
     if (reviewStatus === "complete") {
       reviewDialog.show();
     } else if (
@@ -128,6 +130,10 @@ export function useAcknowledgeMarkedDiff(options?: UseGetNextDiffOptions) {
     ) {
       setActiveDiff(nextDiff, true);
     }
+  });
+
+  const acknowledge = useEventCallback(() => {
+    acknowledgeNextDiff(nextDiffRef.current);
   });
 
   useEffect(() => {
@@ -142,11 +148,20 @@ export function useAcknowledgeMarkedDiff(options?: UseGetNextDiffOptions) {
     nextDiffRef.current = getNextDiff();
   });
 
+  // Snapshot the next diff to review *now* — before marking re-sorts the list —
+  // but defer the navigation to the returned callback instead of firing it on
+  // the next render. Used by the reject-note dialog so moving to the next diff
+  // waits until the reviewer submits or skips the note.
+  const planDeferredAck = useEventCallback(() => {
+    const nextDiff = getNextDiff();
+    return () => acknowledgeNextDiff(nextDiff);
+  });
+
   const checkIsPending = useEventCallback(() => {
     return Boolean(diffStatusesRef.current);
   });
 
-  return [checkIsPending, planAck] as const;
+  return [checkIsPending, planAck, planDeferredAck] as const;
 }
 
 /**

--- a/apps/frontend/src/pages/Build/RejectCommentDialog.tsx
+++ b/apps/frontend/src/pages/Build/RejectCommentDialog.tsx
@@ -14,6 +14,7 @@ import { toast } from "sonner";
 import { DocumentType, graphql } from "@/gql";
 import { useProjectParams } from "@/pages/Project/ProjectParams";
 import { Button } from "@/ui/Button";
+import { Checkbox } from "@/ui/Checkbox";
 import {
   Dialog,
   DialogBody,
@@ -27,10 +28,15 @@ import { hasEditorContent } from "@/ui/Editor/util";
 import { Modal, ModalActionContext } from "@/ui/Modal";
 import { getMentionUser } from "@/ui/UserCard";
 import { getErrorMessage } from "@/util/error";
+import * as sessionStorage from "@/util/session-storage";
 
-import { useBuildDiffState, useGoToNextDiff } from "./BuildDiffState";
+import { useBuildDiffState } from "./BuildDiffState";
 import { useOpenReviewSidebar } from "./RightSidebarState";
 import { ScreenshotDiffThumbnail } from "./sidebar/ScreenshotDiffThumbnail";
+
+// Key used to remember, for the current session, that the reviewer opted out of
+// the reject-note prompt (mirrors the "ignore change" dialog's opt-out).
+const dontAskAgainKey = "rejectCommentDontShowAgain";
 
 const _BuildFragment = graphql(`
   fragment RejectCommentDialog_Build on Build {
@@ -68,10 +74,16 @@ const AddBuildCommentMutation = graphql(`
 /**
  * Returns a function to invite the user to comment on why they're rejecting a
  * snapshot. It opens the dialog only when no pending comment already exists on
- * that snapshot, returning whether it did so — callers use this to skip the
- * usual auto-advance while the dialog is open. Null when no provider is mounted.
+ * that snapshot and the reviewer hasn't opted out for the session, returning
+ * whether it did so — callers use this to skip the usual auto-advance while the
+ * dialog is open. When it opens, `onProceed` is invoked once the reviewer
+ * submits or skips the note, so the caller can advance to the next diff.
+ * Null when no provider is mounted.
  */
-type PromptRejectComment = (screenshotDiffId: string) => boolean;
+type PromptRejectComment = (
+  screenshotDiffId: string,
+  onProceed: () => void,
+) => boolean;
 
 const RejectCommentDialogContext = createContext<PromptRejectComment | null>(
   null,
@@ -86,11 +98,18 @@ export function RejectCommentDialogProvider(props: {
   children: React.ReactNode;
 }) {
   const { build, children } = props;
-  const [diffId, setDiffId] = useState<string | null>(null);
+  const [state, setState] = useState<{
+    diffId: string;
+    onProceed: () => void;
+  } | null>(null);
 
   const comments = build?.comments;
   const promptRejectComment = useCallback<PromptRejectComment>(
-    (screenshotDiffId) => {
+    (screenshotDiffId, onProceed) => {
+      // Respect the session-wide opt-out, just like the "ignore change" dialog.
+      if (sessionStorage.getItem(dontAskAgainKey) === "true") {
+        return false;
+      }
       const hasPendingComment = (comments ?? []).some(
         (comment) =>
           comment.pending && comment.screenshotDiff?.id === screenshotDiffId,
@@ -98,7 +117,7 @@ export function RejectCommentDialogProvider(props: {
       if (hasPendingComment) {
         return false;
       }
-      setDiffId(screenshotDiffId);
+      setState({ diffId: screenshotDiffId, onProceed });
       return true;
     },
     [comments],
@@ -109,19 +128,20 @@ export function RejectCommentDialogProvider(props: {
       {children}
       {build ? (
         <Modal
-          isOpen={diffId != null}
+          isOpen={state != null}
           onOpenChange={(open) => {
             if (!open) {
-              setDiffId(null);
+              setState(null);
             }
           }}
           isDismissable
         >
-          {diffId ? (
+          {state ? (
             <RejectCommentDialog
               build={build}
-              screenshotDiffId={diffId}
-              onClose={() => setDiffId(null)}
+              screenshotDiffId={state.diffId}
+              onProceed={state.onProceed}
+              onClose={() => setState(null)}
             />
           ) : (
             <span />
@@ -135,13 +155,13 @@ export function RejectCommentDialogProvider(props: {
 function RejectCommentDialog(props: {
   build: Build;
   screenshotDiffId: string;
+  onProceed: () => void;
   onClose: () => void;
 }) {
-  const { build, screenshotDiffId, onClose } = props;
+  const { build, screenshotDiffId, onProceed, onClose } = props;
   const projectParams = useProjectParams();
   invariant(projectParams);
   const { diffs, allDiffs } = useBuildDiffState();
-  const goToNextDiff = useGoToNextDiff();
   const openReviewSidebar = useOpenReviewSidebar();
   // The snapshot the note will be attached to, shown above the field so the
   // reviewer sees what they're commenting on (the reject flow always acts on a
@@ -197,10 +217,10 @@ function RejectCommentDialog(props: {
       })
       .then(() => {
         // Close, reveal the new comment in the review panel, and move on to the
-        // next snapshot so the reviewer can keep going.
+        // next snapshot to review so the reviewer can keep going.
         onClose();
         openReviewSidebar();
-        goToNextDiff();
+        onProceed();
       })
       .catch((error) => {
         toast.error(getErrorMessage(error));
@@ -246,8 +266,25 @@ function RejectCommentDialog(props: {
         />
       </DialogBody>
       <DialogFooter>
-        {/* DialogDismiss disables itself while the modal action is pending. */}
-        <DialogDismiss>Skip</DialogDismiss>
+        <div className="flex flex-1">
+          <Checkbox
+            onChange={(value) => {
+              if (value) {
+                sessionStorage.setItem(dontAskAgainKey, "true");
+              } else {
+                sessionStorage.removeItem(dontAskAgainKey);
+              }
+            }}
+          >
+            Don’t ask again for this session
+          </Checkbox>
+        </div>
+        {/*
+          DialogDismiss disables itself while the modal action is pending and
+          closes the dialog after `onPress`. Skipping still advances to the next
+          diff to review, matching a submitted note.
+        */}
+        <DialogDismiss onPress={onProceed}>Skip</DialogDismiss>
         <Button
           variant="primary"
           isPending={isPending}

--- a/apps/frontend/src/pages/Build/TrackButtons.tsx
+++ b/apps/frontend/src/pages/Build/TrackButtons.tsx
@@ -22,7 +22,8 @@ function useEvaluationToggle(props: {
   target: EvaluationStatus;
 }) {
   const { diffId, diffGroup, target } = props;
-  const [checkIsPending, acknowledge] = useAcknowledgeMarkedDiff();
+  const [checkIsPending, acknowledge, planDeferredAck] =
+    useAcknowledgeMarkedDiff();
   const promptRejectComment = useRejectCommentInvite();
   const { diffs } = useBuildDiffState();
   const [status, setStatus] = useBuildDiffStatusState({
@@ -39,13 +40,15 @@ function useEvaluationToggle(props: {
     if (nextStatus !== EvaluationStatus.Pending) {
       // On a fresh rejection with no note yet, invite the reviewer to explain
       // why. A whole-group rejection anchors the note to the group's first
-      // snapshot. When the dialog opens we skip the usual auto-advance/review
-      // dialog so it isn't buried; otherwise proceed as normal.
+      // snapshot. When the dialog opens we hand it a deferred advance (captured
+      // before the rejection re-sorts the list) so it runs once the reviewer
+      // submits or skips the note; otherwise proceed as normal.
       if (target === EvaluationStatus.Rejected) {
         const rejectDiffId = diffGroup
           ? (diffs.find((diff) => diff.group === diffGroup)?.id ?? diffId)
           : diffId;
-        if (promptRejectComment?.(rejectDiffId)) {
+        const proceed = planDeferredAck();
+        if (promptRejectComment?.(rejectDiffId, proceed)) {
           return;
         }
       }


### PR DESCRIPTION
## ARG-447 — Add a comment when rejected

Fixes two issues in the reject-note flow:

### 1. Submit/Skip didn't advance to the next diff
Rejecting a diff flips its status to `Rejected`, which **re-sorts** the diff list — the snapshot jumps from the "Changed/Added" group down to the "Rejected" group. The dialog's `goToNextDiff()` computed "next" from the active diff's *current* index, which after the re-sort points into the Rejected group, so navigation landed in the wrong place. **Skip** did nothing at all.

Now we snapshot the next diff to review *before* the re-sort (`planDeferredAck` in `useAcknowledgeMarkedDiff`) and defer navigation until the reviewer **submits or skips** the note — reusing the same two-phase mechanism the rest of the review flow relies on. If the rejection completed the review, it surfaces the review dialog instead, consistent with a normal reject.

### 2. Session-wide opt-out
Added a **"Don't ask again for this session"** checkbox in the dialog footer, backed by `sessionStorage`, mirroring the ignore-change dialog opt-out. When set, `promptRejectComment` returns `false` so a reject just marks-and-advances without the prompt.

### Notes
- The explicit **Skip** button advances; Escape/backdrop dismissal just closes without advancing (treated as "cancel"). Happy to change if any dismissal should advance.
- Typecheck + ESLint pass. Not yet driven end-to-end in a live build — worth a manual pass on a build with several pending diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)