### PR TITLE
feat(frontend): make the whole comment card clickable to open its snapshot (ARG-446)

### DIFF
--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -392,7 +392,7 @@ export function CommentCard(props: {
         // Interactive children keep their own cursor (UA styles on buttons,
         // links, editors), so the pointer only shows where a click navigates.
         cardNavigates &&
-          "group/comment-card cursor-pointer **:data-no-card-nav:cursor-auto",
+          "hover:border-hover cursor-pointer **:data-no-card-nav:cursor-auto",
       )}
     >
       {!hideScreenshotReference && comment.screenshotDiff ? (

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -392,7 +392,7 @@ export function CommentCard(props: {
         // Interactive children keep their own cursor (UA styles on buttons,
         // links, editors), so the pointer only shows where a click navigates.
         cardNavigates &&
-          "hover:border-hover cursor-pointer **:data-no-card-nav:cursor-auto",
+          "hover:ring-primary-hover cursor-pointer hover:ring-1 **:data-no-card-nav:cursor-auto",
       )}
     >
       {!hideScreenshotReference && comment.screenshotDiff ? (

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -39,6 +39,7 @@ import {
 } from "./CommentReactions";
 import {
   CommentScreenshotReference,
+  useGoToCommentDiff,
   type CommentAnchor,
 } from "./CommentScreenshotReference";
 import { DeleteCommentDialog } from "./DeleteCommentDialog";
@@ -47,6 +48,20 @@ import { useCollapsedThread } from "./useCollapsedThread";
 
 // Shared id so copying a comment link reuses a single toast instead of stacking.
 const COPY_TOAST_ID = "comment-link-copied";
+
+/**
+ * Elements whose clicks must not trigger the card-level "go to snapshot"
+ * navigation: interactive controls handle their own clicks, and zones marked
+ * `data-no-card-nav` (composer, comment being edited) are input surfaces where
+ * a missed click must not teleport the user away.
+ */
+const CARD_NAV_EXCLUDE_SELECTOR =
+  'a, button, input, select, textarea, [role="button"], [contenteditable="true"], [tabindex], [data-no-card-nav]';
+
+function isSelectionCollapsed() {
+  const selection = window.getSelection();
+  return !selection || selection.isCollapsed;
+}
 
 // Detailed date format used in the date tooltip, e.g. "Thu May 21, 2026, 15:47:43".
 const DETAILED_DATE_FORMAT = "ddd MMM D, YYYY, HH:mm:ss";
@@ -253,6 +268,42 @@ export function CommentCard(props: {
       },
     });
 
+  const anchor = (comment.anchor as CommentAnchor | null) ?? null;
+  const goToDiff = useGoToCommentDiff({
+    commentId: comment.id,
+    screenshotDiff: comment.screenshotDiff ?? null,
+    anchor,
+  });
+  // The whole card navigates to the referenced snapshot, not just the
+  // reference header — but only where that header is shown; on the screenshot
+  // itself (`hideScreenshotReference`) there is nowhere to go.
+  const cardNavigates = !hideScreenshotReference && goToDiff != null;
+  // Whether a text selection existed at mousedown: the browser collapses the
+  // selection before `click` fires, and a click that merely dismisses a
+  // selection must not also navigate.
+  const hadSelectionRef = useRef(false);
+  const handleCardMouseDown = () => {
+    hadSelectionRef.current = !isSelectionCollapsed();
+  };
+  const handleCardClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (!goToDiff || !(event.target instanceof Element)) {
+      return;
+    }
+    // Clicks bubbling in from portaled content (menus, dialogs, hover cards)
+    // are not on the card itself.
+    if (!event.currentTarget.contains(event.target)) {
+      return;
+    }
+    if (event.target.closest(CARD_NAV_EXCLUDE_SELECTOR)) {
+      return;
+    }
+    // Selecting comment text must not navigate.
+    if (hadSelectionRef.current || !isSelectionCollapsed()) {
+      return;
+    }
+    goToDiff();
+  };
+
   const resolved = Boolean(comment.resolvedAt);
   // `collapsed` is the stored preference and drives the header label and toggle.
   const [collapsed, setCollapsed] = useCollapsedThread(comment.id, resolved);
@@ -333,13 +384,23 @@ export function CommentCard(props: {
   const onToggleResolved = canReply ? toggleResolved : undefined;
 
   return (
-    <div className={clsx(!embedded && "border-thin bg-app -mx-2.5 rounded-md")}>
+    <div
+      onMouseDown={cardNavigates ? handleCardMouseDown : undefined}
+      onClick={cardNavigates ? handleCardClick : undefined}
+      className={clsx(
+        !embedded && "border-thin bg-app -mx-2.5 rounded-md",
+        // Interactive children keep their own cursor (UA styles on buttons,
+        // links, editors), so the pointer only shows where a click navigates.
+        cardNavigates &&
+          "group/comment-card cursor-pointer **:data-no-card-nav:cursor-auto",
+      )}
+    >
       {!hideScreenshotReference && comment.screenshotDiff ? (
         <div className="border-b-thin">
           <CommentScreenshotReference
             commentId={comment.id}
             screenshotDiff={comment.screenshotDiff}
-            anchor={(comment.anchor as CommentAnchor | null) ?? null}
+            anchor={anchor}
           />
         </div>
       ) : null}
@@ -605,7 +666,10 @@ function CommentMessage(props: {
             />
           </div>
         </div>
-        <div className="text-default px-1 pb-2 text-sm select-text">
+        <div
+          className="text-default px-1 pb-2 text-sm select-text"
+          data-no-card-nav={isEditing ? "" : undefined}
+        >
           {isEditing ? (
             <StandaloneEditor
               variant="plain"
@@ -695,7 +759,7 @@ function ReplyComposer(props: {
   };
 
   return (
-    <div className="border-t-thin px-2 py-1">
+    <div className="border-t-thin px-2 py-1" data-no-card-nav="">
       <div className="flex items-start gap-1.5">
         <Editor
           key={editorKey}

--- a/apps/frontend/src/pages/Build/sidebar/CommentScreenshotReference.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentScreenshotReference.tsx
@@ -111,9 +111,9 @@ export function CommentScreenshotReference(props: {
       <Button
         onPress={goToDiff}
         aria-label={`Go to snapshot ${screenshotDiff.name}`}
-        // `group-hover` mirrors the hover styles when hovering anywhere on the
-        // surrounding card, which shares this button's navigation (ARG-446).
-        className="text-low hover:bg-hover hover:text-default group-hover/comment-card:bg-hover group-hover/comment-card:text-default rac-focus flex w-full items-center gap-2 rounded-t-md px-2 py-1.5 text-left text-xs transition select-none"
+        // No hover style or default cursor of its own: the surrounding card
+        // shares this button's navigation and carries the hover affordance.
+        className="text-low rac-focus flex w-full cursor-pointer items-center gap-2 rounded-t-md px-2 py-1.5 text-left text-xs select-none"
       >
         <ScreenshotDiffThumbnail
           screenshotDiff={screenshotDiff}

--- a/apps/frontend/src/pages/Build/sidebar/CommentScreenshotReference.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentScreenshotReference.tsx
@@ -8,7 +8,6 @@ import {
   requestedScreenshotCommentIdAtom,
 } from "@/containers/Build/CommentTool";
 import { DocumentType, graphql } from "@/gql";
-import { Tooltip } from "@/ui/Tooltip";
 
 import { useBuildDiffState } from "../BuildDiffState";
 import { ScreenshotDiffThumbnail } from "./ScreenshotDiffThumbnail";
@@ -107,32 +106,27 @@ export function CommentScreenshotReference(props: {
   const isPoint = anchor?.__typename === "CommentPointAnchor";
 
   return (
-    <Tooltip content="Go to this snapshot">
-      <Button
-        onPress={goToDiff}
-        aria-label={`Go to snapshot ${screenshotDiff.name}`}
-        // No hover style or default cursor of its own: the surrounding card
-        // shares this button's navigation and carries the hover affordance.
-        className="text-low rac-focus flex w-full cursor-pointer items-center gap-2 rounded-t-md px-2 py-1.5 text-left text-xs select-none"
-      >
-        <ScreenshotDiffThumbnail
-          screenshotDiff={screenshotDiff}
-          className="size-6"
-          iconClassName="size-4"
-        />
-        <span className="min-w-0 flex-1 truncate font-medium">
-          {screenshotDiff.name}
-        </span>
-        {isPoint ? (
-          <MapPinIcon
-            className="size-3.5 shrink-0"
-            aria-label="Pinned comment"
-          />
-        ) : null}
-        {linesLabel ? (
-          <span className="shrink-0 tabular-nums">{linesLabel}</span>
-        ) : null}
-      </Button>
-    </Tooltip>
+    <Button
+      onPress={goToDiff}
+      aria-label={`Go to snapshot ${screenshotDiff.name}`}
+      // No hover style or default cursor of its own: the surrounding card
+      // shares this button's navigation and carries the hover affordance.
+      className="text-low rac-focus flex w-full cursor-pointer items-center gap-2 rounded-t-md px-2 py-1.5 text-left text-xs select-none"
+    >
+      <ScreenshotDiffThumbnail
+        screenshotDiff={screenshotDiff}
+        className="size-6"
+        iconClassName="size-4"
+      />
+      <span className="min-w-0 flex-1 truncate font-medium">
+        {screenshotDiff.name}
+      </span>
+      {isPoint ? (
+        <MapPinIcon className="size-3.5 shrink-0" aria-label="Pinned comment" />
+      ) : null}
+      {linesLabel ? (
+        <span className="shrink-0 tabular-nums">{linesLabel}</span>
+      ) : null}
+    </Button>
   );
 }

--- a/apps/frontend/src/pages/Build/sidebar/CommentScreenshotReference.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentScreenshotReference.tsx
@@ -1,3 +1,4 @@
+import { invariant } from "@argos/util/invariant";
 import { useSetAtom } from "jotai/react";
 import { MapPinIcon } from "lucide-react";
 import { Button } from "react-aria-components";
@@ -49,24 +50,27 @@ function getAnchorLabel(anchor: CommentAnchor | null): string | null {
 }
 
 /**
- * A quote of the screenshot a comment is anchored to, shown at the top of the
- * comment thread. Clicking it navigates to that diff in the viewer.
+ * Navigate to the diff a comment is anchored to, or `null` when the comment
+ * has no linked snapshot. The diff may not be in the current list (filtered
+ * out, or not yet loaded), in which case the callback leaves the view
+ * untouched.
  */
-export function CommentScreenshotReference(props: {
+export function useGoToCommentDiff(input: {
   commentId: string;
-  screenshotDiff: ScreenshotDiff;
+  screenshotDiff: ScreenshotDiff | null;
   anchor: CommentAnchor | null;
-}) {
-  const { commentId, screenshotDiff, anchor } = props;
+}): (() => void) | null {
+  const { commentId, screenshotDiff, anchor } = input;
   const { allDiffs, setActiveDiff } = useBuildDiffState();
   const setCommentsVisible = useSetAtom(commentsVisibleAtom);
   const requestOpenComment = useSetAtom(requestedScreenshotCommentIdAtom);
-  const linesLabel = getAnchorLabel(anchor);
   const isPoint = anchor?.__typename === "CommentPointAnchor";
 
-  // Jump to the referenced diff. It may not be in the current list (filtered
-  // out, or not yet loaded), in which case we leave the view untouched.
-  const goToDiff = () => {
+  if (!screenshotDiff) {
+    return null;
+  }
+
+  return () => {
     const diff = allDiffs.find(
       (candidate) => candidate.id === screenshotDiff.id,
     );
@@ -83,13 +87,33 @@ export function CommentScreenshotReference(props: {
       requestOpenComment(commentId);
     }
   };
+}
+
+/**
+ * A quote of the screenshot a comment is anchored to, shown at the top of the
+ * comment thread. Clicking it navigates to that diff in the viewer; the whole
+ * card shares that behavior (see {@link useGoToCommentDiff} in `CommentCard`),
+ * this button remains the keyboard-accessible control for it.
+ */
+export function CommentScreenshotReference(props: {
+  commentId: string;
+  screenshotDiff: ScreenshotDiff;
+  anchor: CommentAnchor | null;
+}) {
+  const { commentId, screenshotDiff, anchor } = props;
+  const goToDiff = useGoToCommentDiff({ commentId, screenshotDiff, anchor });
+  invariant(goToDiff, "always navigable: screenshotDiff is provided");
+  const linesLabel = getAnchorLabel(anchor);
+  const isPoint = anchor?.__typename === "CommentPointAnchor";
 
   return (
     <Tooltip content="Go to this snapshot">
       <Button
         onPress={goToDiff}
         aria-label={`Go to snapshot ${screenshotDiff.name}`}
-        className="text-low hover:bg-hover hover:text-default rac-focus flex w-full items-center gap-2 rounded-t-md px-2 py-1.5 text-left text-xs transition select-none"
+        // `group-hover` mirrors the hover styles when hovering anywhere on the
+        // surrounding card, which shares this button's navigation (ARG-446).
+        className="text-low hover:bg-hover hover:text-default group-hover/comment-card:bg-hover group-hover/comment-card:text-default rac-focus flex w-full items-center gap-2 rounded-t-md px-2 py-1.5 text-left text-xs transition select-none"
       >
         <ScreenshotDiffThumbnail
           screenshotDiff={screenshotDiff}

--- a/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
@@ -456,7 +456,7 @@ function ActivityEntryRow(props: {
   if (entry.kind === "comment") {
     return (
       <motion.div
-        className={spacing}
+        className={clsx("pb-px", spacing)}
         style={{ overflowY: "clip" }}
         exit={{ height: 0, paddingTop: 0, opacity: 0 }}
         transition={{


### PR DESCRIPTION
## ARG-446

In the build review sidebar, a comment linked to a snapshot showed a clickable snapshot-reference strip at the top, while the rest of the card was inert. The whole comment card is now clickable: clicking anywhere on it navigates to the referenced diff.

## Changes

- **`CommentScreenshotReference.tsx`** — the navigation logic (find the diff, `setActiveDiff`, reveal point-anchored comment threads) is extracted into an exported `useGoToCommentDiff` hook. The header button still uses it and remains the keyboard-accessible control, but it no longer has a hover style or default cursor of its own — the card is one clickable unit.
- **`CommentCard.tsx`** — the card root gets a click handler and `cursor-pointer` when the reference header is shown (`!hideScreenshotReference && screenshotDiff` — the on-screenshot popover is unaffected), and hovering anywhere on it outlines the card via `hover:border-hover`, matching other clickable cards (ProjectList). Card-level navigation is suppressed for:
  - clicks on interactive elements (`a`, `button`, inputs, `[role="button"]`, editable editors, `[tabindex]` hover-card triggers);
  - clicks bubbling in from portaled content (menus, dialogs, hover cards), told apart by DOM containment;
  - zones marked `data-no-card-nav` — the reply composer and the comment body while editing — where a missed click must not teleport the user away (these also keep the default cursor);
  - text selection: a non-collapsed selection at click time, or one that existed at mousedown (the browser collapses it before `click` fires), so selecting or dismissing a selection never navigates.

## Verification

Drove the built app end-to-end (seeded e2e server + Playwright, throwaway spec): rejected a diff with a note, then from another diff clicked the comment body → navigated back to the referenced diff. Probes: reference header still navigates and shows a pointer cursor with no hover style of its own; the card border outlines on hover identically from the body or the header; composer padding and copy-link button don't navigate; drag-selecting text doesn't, nor does the click dismissing the selection, while the next plain click does.

- `tsc --noEmit` — no errors
- ESLint / Prettier — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)