### PR TITLE
fix(backend): report 413 errors to Sentry at error level

### DIFF
--- a/apps/backend/src/sentry/index.ts
+++ b/apps/backend/src/sentry/index.ts
@@ -35,6 +35,13 @@ export function setup() {
         "statusCode" in error &&
         typeof error.statusCode === "number"
       ) {
+        // Keep 413 "Payload Too Large" at error level: we always want to be
+        // notified when a request body exceeds the configured limit.
+        if (error.statusCode === 413) {
+          event.level = "error";
+          return event;
+        }
+
         // Set level to info for 4xx errors
         if (error.statusCode >= 400 && error.statusCode < 500) {
           event.level = "info";


### PR DESCRIPTION
## Problem

The Sentry `beforeSend` hook downgraded **every** 4xx error (400–499) to `info` level. This bucketed 413 "Payload Too Large" errors alongside benign user errors, making them easy to miss — including 413s thrown by `express.json()` on the `/graphql` API when a request body exceeds the (default 100kb) limit.

## Fix

Add a dedicated branch in `beforeSend` that keeps 413 at `error` level and always sends it to Sentry, so we're notified whenever a request body exceeds the configured limit.

This is the single global filter for the backend Sentry client, so it covers `/graphql` and all other routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)