### PR TITLE
fix(backend): raise /graphql body limit to 1mb (ARG-449)

### DIFF
--- a/apps/backend/src/web/app-router.ts
+++ b/apps/backend/src/web/app-router.ts
@@ -127,7 +127,7 @@ export const installAppRouter = async (app: express.Application) => {
       }
       next();
     },
-    express.json(),
+    express.json({ limit: "1mb" }),
     helmet({
       // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
       contentSecurityPolicy: {


### PR DESCRIPTION
## Problem

The `/graphql` route parsed request bodies with `express.json()` using the default **100 kB** limit. Legitimate large requests (big mutations / large `variables` payloads) were rejected with a 413 "Payload Too Large" error thrown by `express.json()` before the request even reached Apollo.

## Fix

Raise the limit to `1mb`:

```ts
express.json({ limit: "1mb" })
```

Related: #2342 ensures any remaining 413s are reported to Sentry at `error` level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)