### PR TITLE
fix(frontend): stack review submit error above buttons (ARG-448)

### DIFF
--- a/apps/frontend/src/pages/Build/BuildReviewForm.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewForm.tsx
@@ -185,39 +185,42 @@ export function BuildReviewForm(props: {
           </ErrorMessage>
         ) : null}
       </div>
-      <div className="flex justify-end gap-2 p-3">
-        <FormRootError control={form.control} className="flex-1" />
-        {SUBMIT_EVENTS.map((event) => {
-          const definition = BUILD_REVIEW_EVENT_DEFINITIONS[event];
-          const Icon = definition.icon;
-          const isDefault = event === defaultEvent;
-          return (
-            <Button
-              key={event}
-              variant={definition.variant}
-              rounded
-              size="small"
-              isPending={pendingEvent === event}
-              isDisabled={isSubmitting && pendingEvent !== event}
-              autoFocus={isDefault}
-              // Keep the ring on the focused button (not only keyboard focus)
-              // so the default action Enter triggers stays visible.
-              showFocusRing
-              onAction={() => submitReview(event)}
-            >
-              <ButtonIcon>
-                <Icon
-                  className={
-                    definition.iconColor
-                      ? lowTextColorClassNames[definition.iconColor]
-                      : undefined
-                  }
-                />
-              </ButtonIcon>
-              {definition.label}
-            </Button>
-          );
-        })}
+      <div className="flex flex-col gap-2 p-3">
+        <FormRootError control={form.control} />
+        <div className="flex justify-end gap-2">
+          {SUBMIT_EVENTS.map((event) => {
+            const definition = BUILD_REVIEW_EVENT_DEFINITIONS[event];
+            const Icon = definition.icon;
+            const isDefault = event === defaultEvent;
+            return (
+              <Button
+                key={event}
+                variant={definition.variant}
+                rounded
+                size="small"
+                className="shrink-0"
+                isPending={pendingEvent === event}
+                isDisabled={isSubmitting && pendingEvent !== event}
+                autoFocus={isDefault}
+                // Keep the ring on the focused button (not only keyboard focus)
+                // so the default action Enter triggers stays visible.
+                showFocusRing
+                onAction={() => submitReview(event)}
+              >
+                <ButtonIcon>
+                  <Icon
+                    className={
+                      definition.iconColor
+                        ? lowTextColorClassNames[definition.iconColor]
+                        : undefined
+                    }
+                  />
+                </ButtonIcon>
+                {definition.label}
+              </Button>
+            );
+          })}
+        </div>
       </div>
     </Form>
   );


### PR DESCRIPTION
## Problem

The submit review popover footer placed the root error message and the Comment/Reject/Approve buttons on the same flex row (`<FormRootError className="flex-1" />` alongside the buttons). Since the three buttons already fill most of the ~448px popover width, the error was squeezed into a narrow column and wrapped to 3 lines — the broken layout reported in ARG-448.

## Fix

- Changed the footer container from `flex justify-end gap-2` to `flex flex-col gap-2` so the error renders full-width on its own row **above** the buttons. `FormRootError` returns `null` when there's no error, so no extra spacing appears in the normal case.
- Wrapped the buttons in their own `flex justify-end gap-2` row.
- Added `shrink-0` to the buttons so they never collapse.

Typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)