### PR TITLE
fix(frontend): disable review submit until all diffs load (ARG-450)

### DIFF
--- a/apps/frontend/src/pages/Build/BuildReviewForm.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewForm.tsx
@@ -15,9 +15,11 @@ import { Form, handleFormError } from "@/ui/Form";
 import { FormRootError } from "@/ui/FormRootError";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 import { ModalActionContext } from "@/ui/Modal";
+import { Tooltip } from "@/ui/Tooltip";
 import { getMentionUser } from "@/ui/UserCard";
 import { lowTextColorClassNames } from "@/util/colors";
 
+import { useBuildDiffState } from "./BuildDiffState";
 import { useCreateBuildReviewMutation } from "./BuildReviewAction";
 import { BUILD_REVIEW_EVENT_DEFINITIONS } from "./BuildReviewEvents";
 import { useBuildReviewSummary } from "./BuildReviewState";
@@ -79,6 +81,11 @@ export function BuildReviewForm(props: {
     },
   });
 
+  // Block submission until every diff has been fetched: the review progression
+  // and the accept/reject counts are computed from the loaded diffs, so
+  // submitting mid-load could approve or reject an incomplete set of changes.
+  const { isLoading } = useBuildDiffState();
+
   // Tracks the action currently being submitted: drives the per-button spinner
   // and disables the rest of the form while the review is in flight.
   const [pendingEvent, setPendingEvent] = useState<BuildReviewEvent | null>(
@@ -102,6 +109,9 @@ export function BuildReviewForm(props: {
     : BuildReviewEvent.Approve;
 
   const submitReview = async (event: BuildReviewEvent) => {
+    if (isLoading) {
+      return;
+    }
     const { body } = form.getValues();
     if (event === BuildReviewEvent.Comment && !hasEditorContent(body)) {
       form.setError("body", {
@@ -187,40 +197,50 @@ export function BuildReviewForm(props: {
       </div>
       <div className="flex flex-col gap-2 p-3">
         <FormRootError control={form.control} />
-        <div className="flex justify-end gap-2">
-          {SUBMIT_EVENTS.map((event) => {
-            const definition = BUILD_REVIEW_EVENT_DEFINITIONS[event];
-            const Icon = definition.icon;
-            const isDefault = event === defaultEvent;
-            return (
-              <Button
-                key={event}
-                variant={definition.variant}
-                rounded
-                size="small"
-                className="shrink-0"
-                isPending={pendingEvent === event}
-                isDisabled={isSubmitting && pendingEvent !== event}
-                autoFocus={isDefault}
-                // Keep the ring on the focused button (not only keyboard focus)
-                // so the default action Enter triggers stays visible.
-                showFocusRing
-                onAction={() => submitReview(event)}
-              >
-                <ButtonIcon>
-                  <Icon
-                    className={
-                      definition.iconColor
-                        ? lowTextColorClassNames[definition.iconColor]
-                        : undefined
-                    }
-                  />
-                </ButtonIcon>
-                {definition.label}
-              </Button>
-            );
-          })}
-        </div>
+        <Tooltip
+          content={
+            isLoading
+              ? "Waiting for all changes to load before you can submit a review…"
+              : null
+          }
+        >
+          <div className="flex justify-end gap-2">
+            {SUBMIT_EVENTS.map((event) => {
+              const definition = BUILD_REVIEW_EVENT_DEFINITIONS[event];
+              const Icon = definition.icon;
+              const isDefault = event === defaultEvent;
+              return (
+                <Button
+                  key={event}
+                  variant={definition.variant}
+                  rounded
+                  size="small"
+                  className="shrink-0"
+                  isPending={pendingEvent === event}
+                  isDisabled={
+                    isLoading || (isSubmitting && pendingEvent !== event)
+                  }
+                  autoFocus={isDefault}
+                  // Keep the ring on the focused button (not only keyboard focus)
+                  // so the default action Enter triggers stays visible.
+                  showFocusRing
+                  onAction={() => submitReview(event)}
+                >
+                  <ButtonIcon>
+                    <Icon
+                      className={
+                        definition.iconColor
+                          ? lowTextColorClassNames[definition.iconColor]
+                          : undefined
+                      }
+                    />
+                  </ButtonIcon>
+                  {definition.label}
+                </Button>
+              );
+            })}
+          </div>
+        </Tooltip>
       </div>
     </Form>
   );


### PR DESCRIPTION
## Problem

A reviewer could submit an Approve/Reject/Comment review while the build's screenshot diffs were still being fetched (paginated load). The review progression (`X / Y reviewed`) and the accept/reject counts are computed from the diffs loaded *so far*, so submitting mid-load could approve or reject an incomplete set of changes.

## Fix

In `BuildReviewForm`, read `isLoading` from `useBuildDiffState()` (true while more diff pages remain) and:

- Disable the three submit buttons (Comment / Reject / Approve) while loading.
- Guard `submitReview` so the implicit submit paths (Enter on the focused button, Cmd+Enter in the editor) are no-ops while loading.
- Wrap the button group in a tooltip explaining the wait: _"Waiting for all changes to load before you can submit a review…"_.

The editor stays enabled so the reviewer can draft a summary while diffs finish loading.

Closes ARG-450

🤖 Generated with [Claude Code](https://claude.com/claude-code)