### PR TITLE
fix(backend): widen and encrypt github_installations.githubToken

### DIFF
--- a/apps/backend/db/migrations/20260709120000_github-installation-token-text.js
+++ b/apps/backend/db/migrations/20260709120000_github-installation-token-text.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ */
+export async function up(knex) {
+  // GitHub installation access tokens have grown beyond 255 characters, which
+  // overflowed the default varchar(255) column. Widen it to text.
+  await knex.schema.alterTable("github_installations", (table) => {
+    table.text("githubToken").alter();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+export async function down(knex) {
+  await knex.schema.alterTable("github_installations", (table) => {
+    table.string("githubToken").alter();
+  });
+}

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -944,7 +944,7 @@ CREATE TABLE public.github_installations (
     "updatedAt" timestamp with time zone NOT NULL,
     "githubId" integer NOT NULL,
     deleted boolean DEFAULT false NOT NULL,
-    "githubToken" character varying(255),
+    "githubToken" text,
     "githubTokenExpiresAt" timestamp with time zone,
     app text DEFAULT 'main'::text NOT NULL,
     proxy boolean DEFAULT false NOT NULL,
@@ -5200,3 +5200,4 @@ INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('2026062
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260625120000_project-ignore-config.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260627120000_add-screenshots-has-parent-index.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260628120000_build-review-automatic.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260709120000_github-installation-token-text.js', 1, NOW());

--- a/apps/backend/src/database/models/GithubInstallation.ts
+++ b/apps/backend/src/database/models/GithubInstallation.ts
@@ -4,6 +4,8 @@ import { timestampsSchema } from "../util/schemas";
 export class GithubInstallation extends Model {
   static override tableName = "github_installations";
 
+  static override encryptedAttributes = ["githubToken"];
+
   static override jsonSchema = {
     allOf: [
       timestampsSchema,


### PR DESCRIPTION
## Problem

Sentry [`DataError`](https://argos-server.sentry.io/issues/7601173049): `value too long for type character varying(255)` when patching `github_installations`.

GitHub installation access tokens have grown beyond 255 characters, overflowing the `varchar(255)` `githubToken` column. It's the only string-typed column in the failing UPDATE. It was also missed when the recent `encrypt-sensitive-data` migration widened the other token columns to `text`.

Fix ARGOS-SERVER-ZK8

## Changes

1. **Migration** — widen `github_installations.githubToken` from `varchar(255)` → `text`.
2. **Model** — declare `githubToken` as an `encryptedAttribute` (random IV, same as `GithubAccount.accessToken`). The token is never looked up by value, so deterministic encryption isn't needed.

## Retro-compatibility / deploy order

Designed for **migration-first, code-second** deploy:

- The `Model` base always encrypts on write and, on read, `decrypt()` returns not-yet-encrypted values unchanged — so legacy plaintext rows still read correctly during the transition window.
- The column must be widened *before* the code deploys, since the encrypted blob (~444 chars for a 300-char token) far exceeds 255.
- No backfill needed: installation tokens are short-lived (~1h) and constantly rewritten, so existing plaintext rows re-encrypt naturally on refresh.

## Verification

- Typecheck passes.
- Migration runs cleanly on dev + test DBs.
- Verified `decrypt(encrypt(token)) === token` and `decrypt(legacyPlaintext) === token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)