### PR TITLE
fix(backend): raise comment JSON byte limit to 40kb

### DIFF
--- a/apps/backend/src/comment/validate.test.ts
+++ b/apps/backend/src/comment/validate.test.ts
@@ -379,7 +379,7 @@ describe("isCommentTooLarge", () => {
               marks: [
                 {
                   type: "link",
-                  attrs: { href: `https://example.com/${"a".repeat(25_000)}` },
+                  attrs: { href: `https://example.com/${"a".repeat(45_000)}` },
                 },
               ],
             },

--- a/apps/backend/src/comment/validate.ts
+++ b/apps/backend/src/comment/validate.ts
@@ -169,7 +169,7 @@ export function isCommentEmpty(value: JSONContent): boolean {
  * - depth protects recursive rendering from pathological nesting.
  */
 const MAX_COMMENT_CHARACTERS = 2_000;
-const MAX_COMMENT_JSON_BYTES = 20_000;
+const MAX_COMMENT_JSON_BYTES = 40_000;
 const MAX_COMMENT_NODES = 300;
 const MAX_COMMENT_DEPTH = 12;
 


### PR DESCRIPTION
## Summary
- Raise `MAX_COMMENT_JSON_BYTES` from 20kb to ~40kb in the comment content validation guard.

## Why
Allow larger comment documents while still guarding storage/bandwidth from abuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)