### PR TITLE
fix(backend): scope automatic reviews per project and team

### DIFF
--- a/apps/backend/src/build/approval.e2e.test.ts
+++ b/apps/backend/src/build/approval.e2e.test.ts
@@ -395,6 +395,35 @@ describe("getPreviousApproverUserIds", () => {
     const userIds = await getPreviousApproverUserIds({ build, compareBucket });
     expect(userIds.sort()).toEqual([userA.id, userB.id].sort());
   });
+
+  test("ignores approvals from a same-named build in another project", async ({
+    build,
+    compareBucket,
+  }) => {
+    // A build in a different project (and therefore a different team) that
+    // shares the same bucket name and branch must never contribute approvers.
+    const otherProject = await factory.Project.create();
+    const otherBucket = await factory.ScreenshotBucket.create({
+      projectId: otherProject.id,
+      branch: compareBucket.branch,
+      name: compareBucket.name,
+    });
+    const otherBuild = await factory.Build.create({
+      compareScreenshotBucketId: otherBucket.id,
+      conclusion: "changes-detected",
+      projectId: otherProject.id,
+      createdAt: new Date(Date.now() - 1000).toISOString(),
+    });
+    const otherUser = await factory.User.create();
+    await factory.BuildReview.create({
+      buildId: otherBuild.id,
+      state: "approved",
+      userId: otherUser.id,
+    });
+
+    const userIds = await getPreviousApproverUserIds({ build, compareBucket });
+    expect(userIds).toEqual([]);
+  });
 });
 
 describe("getBuildReviewableDiffIds", () => {

--- a/apps/backend/src/build/approval.ts
+++ b/apps/backend/src/build/approval.ts
@@ -92,6 +92,12 @@ function getPreviousBuildsQuery(args: {
   const buildQuery = Build.query()
     .select("builds.id")
     .joinRelated("compareScreenshotBucket")
+    // Scope to the current build's project. Bucket names ("default", …) are
+    // only unique within a project, so without this a build could inherit
+    // approvals from a same-named build in another project — and therefore
+    // another team. Scoping by project keeps automatic reviews isolated per
+    // project and per team.
+    .where("builds.projectId", build.projectId)
     .where("builds.createdAt", "<", build.createdAt)
     .where("builds.mode", build.mode)
     .where("builds.conclusion", "changes-detected")


### PR DESCRIPTION
## Problem

The automatic review system (the "reapply previous approvals" flow, where reviews are marked `automatic`) was **not scoped per project or per team**.

Candidate previous builds all flow through a single query, `getPreviousBuildsQuery`, which matched only on bucket `name` + `branch` + `mode` (+ PR). Since `ScreenshotBucket.name` equals the build name and is only unique *within a project* (e.g. `"default"`), a build could inherit approvals from a same-named build in **another project — and therefore another team**.

## Fix

Add `.where("builds.projectId", build.projectId)` to `getPreviousBuildsQuery`. This is the single source of truth for previous builds (used by `getPreviousBuildIds`, `getPreviousApproverUserIds`, and `getPreviousDiffApprovals`), so scoping it here isolates the entire automatic-review flow. Because a project belongs to exactly one account (team), scoping by `projectId` guarantees both per-project **and** per-team isolation.

## Test

Added a regression test asserting that an approved build in a different project sharing the same bucket name/branch contributes no approvers.

All `approval` (8) and `autoApproveBuild` (7) e2e tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)