### PR TITLE
fix(frontend): size text snapshot editor to content (ARG-454)

### DIFF
--- a/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
@@ -1508,11 +1508,17 @@ type SnapshotProps = { url: string; contentType: string };
 
 function SuspendedSnapshot(props: SnapshotProps) {
   const [text] = useTextContent([props.url]);
+  // Size the editor to its content instead of stretching to fill the flex row:
+  // `self-start` opts out of the row's default `align-items: stretch` so a short
+  // snapshot (e.g. a one-line ARIA tree) stays short, while the outer panel
+  // (`overflow-y-auto`) scrolls when the content is tall.
   return (
-    <Editor
-      value={text}
-      language={getLanguageFromContentType(props.contentType)}
-    />
+    <div className="w-full self-start">
+      <Editor
+        value={text}
+        language={getLanguageFromContentType(props.contentType)}
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
## Problem

In the build review, a text/ARIA snapshot editor stretched to fill the entire viewport height even when it contained just one line (e.g. `button "Click me"`), leaving a large empty bordered box.

## Root cause

The single text snapshot editor (`Snapshot` → `Editor`, used for `Added`/`Unchanged`/baseline text diffs) is rendered inside a **row** flex container (`flex ... justify-center`). The default `align-items: stretch` stretched the bordered `@pierre/diffs` viewer to the full panel height. The multi-line *Changed* diff didn't have this issue because it lives in a column flex, where it already sizes to content.

## Fix

Wrapped the editor in a `w-full self-start` div so it opts out of the row's vertical stretch and sizes to its content. The outer detail panel is already `overflow-y-auto`, so tall snapshots still scroll — matching how the Changed diff already behaves.

Resolves ARG-454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)