### PR TITLE
fix(frontend): make text diff viewer scrollable (ARG-454)

### DIFF
--- a/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
@@ -1513,11 +1513,19 @@ function SuspendedSnapshot(props: SnapshotProps) {
   // snapshot (e.g. a one-line ARIA tree) stays short, while the outer panel
   // (`overflow-y-auto`) scrolls when the content is tall.
   return (
-    <div className="w-full self-start">
+    <EditorContainer>
       <Editor
         value={text}
         language={getLanguageFromContentType(props.contentType)}
       />
+    </EditorContainer>
+  );
+}
+
+function EditorContainer(props: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-0 w-full flex-1 flex-col overflow-auto rounded border">
+      {props.children}
     </div>
   );
 }
@@ -1531,14 +1539,8 @@ function DiffSnapshots(props: {
 }) {
   const { base, head, renderSideBySide, build, screenshotDiffId } = props;
   const [baseText, headText] = useTextContent([base.url, head.url]);
-  // Size the diff to its content instead of stretching to fill the flex column.
-  // The diff viewer's root is `overflow-hidden`, so as a shrinkable flex child it
-  // gets clamped to the panel height and clips (rather than scrolls) a tall diff.
-  // Wrapping it in a plain `w-full self-start` div restores content sizing, so the
-  // outer panel (`overflow-y-auto`) scrolls tall diffs and short ones stay short —
-  // mirroring the single-snapshot viewer above.
   return (
-    <div className="w-full self-start">
+    <EditorContainer>
       <DiffCommentLayer
         build={build}
         screenshotDiffId={screenshotDiffId}
@@ -1548,7 +1550,7 @@ function DiffSnapshots(props: {
         modifiedLanguage={getLanguageFromContentType(head.contentType)}
         renderSideBySide={renderSideBySide}
       />
-    </div>
+    </EditorContainer>
   );
 }
 

--- a/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
@@ -1531,16 +1531,24 @@ function DiffSnapshots(props: {
 }) {
   const { base, head, renderSideBySide, build, screenshotDiffId } = props;
   const [baseText, headText] = useTextContent([base.url, head.url]);
+  // Size the diff to its content instead of stretching to fill the flex column.
+  // The diff viewer's root is `overflow-hidden`, so as a shrinkable flex child it
+  // gets clamped to the panel height and clips (rather than scrolls) a tall diff.
+  // Wrapping it in a plain `w-full self-start` div restores content sizing, so the
+  // outer panel (`overflow-y-auto`) scrolls tall diffs and short ones stay short —
+  // mirroring the single-snapshot viewer above.
   return (
-    <DiffCommentLayer
-      build={build}
-      screenshotDiffId={screenshotDiffId}
-      original={baseText}
-      originalLanguage={getLanguageFromContentType(base.contentType)}
-      modified={headText}
-      modifiedLanguage={getLanguageFromContentType(head.contentType)}
-      renderSideBySide={renderSideBySide}
-    />
+    <div className="w-full self-start">
+      <DiffCommentLayer
+        build={build}
+        screenshotDiffId={screenshotDiffId}
+        original={baseText}
+        originalLanguage={getLanguageFromContentType(base.contentType)}
+        modified={headText}
+        modifiedLanguage={getLanguageFromContentType(head.contentType)}
+        renderSideBySide={renderSideBySide}
+      />
+    </div>
   );
 }
 

--- a/apps/frontend/src/containers/Build/DiffEditor.tsx
+++ b/apps/frontend/src/containers/Build/DiffEditor.tsx
@@ -35,8 +35,6 @@ const BASE_OPTIONS = {
   preferredHighlighter: "shiki-js",
 } satisfies BaseCodeOptions;
 
-const CLASS_NAME = "overflow-hidden rounded border";
-
 // Styling for the gutter "+", injected into the viewer's shadow DOM via
 // `unsafeCSS` (its `unsafe` cascade layer outranks the library's own rules).
 const GUTTER_UTILITY_CSS =
@@ -148,7 +146,6 @@ export function DiffEditor<LAnnotation = undefined>(props: {
           lang: modifiedLanguage,
         }}
         options={options}
-        className={CLASS_NAME}
         lineAnnotations={comments?.lineAnnotations}
         selectedLines={comments?.selectedLines}
         renderAnnotation={comments?.renderAnnotation}
@@ -164,7 +161,6 @@ export function Editor(props: { value: string; language: SupportedLanguages }) {
       <File
         file={{ name: "snapshot", contents: props.value, lang: props.language }}
         options={{ ...BASE_OPTIONS, themeType }}
-        className={CLASS_NAME}
       />
     </Suspense>
   );


### PR DESCRIPTION
## Problem

The text **snapshot** and **diff** viewers weren't scrollable when their content was taller than the panel — tall snapshots/diffs got clipped with no way to reach the hidden lines.

The single-snapshot case was first addressed in #2350; this PR fixes the diff viewer too and unifies both behind one scrollable container.

## Cause

The viewer's root element (`File` / `MultiFileDiff`) carried `overflow-hidden rounded border` (`DiffEditor.tsx`). As a shrinkable flex child of the panel column, `overflow-hidden` makes its `min-height: auto` resolve to `0`, so with the default `flex: 0 1 auto` the item **shrinks to fit** the panel and clips its overflow — clipping tall content instead of scrolling it.

## Fix

Introduce a shared `EditorContainer` that wraps both the single-snapshot `Editor` and the diff `DiffCommentLayer`:

```
flex min-h-0 w-full flex-1 flex-col overflow-auto rounded border
```

The container owns the border and is itself the scroll region — `flex-1` to fill the panel, `overflow-auto` + `min-h-0` to scroll — so tall snapshots and diffs scroll **inside** the bordered viewer. The `overflow-hidden rounded border` class is removed from the viewers themselves (moved into the container) so they no longer clamp and clip content.

## Testing

- `tsc --noEmit` passes.
- Verified scroll behavior locally against a long text diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
