### PR TITLE
test(backend): stub the Discord notification in project-creation tests

### DIFF
--- a/apps/backend/src/api/handlers/createProject.e2e.test.ts
+++ b/apps/backend/src/api/handlers/createProject.e2e.test.ts
@@ -1,5 +1,5 @@
 import request from "supertest";
-import { test as base, beforeAll, describe, expect } from "vitest";
+import { test as base, beforeAll, describe, expect, vi } from "vitest";
 import z from "zod";
 
 import {
@@ -13,6 +13,10 @@ import { factory, setupDatabase } from "@/database/testing";
 
 import { createTestHandlerApp } from "../test-util";
 import { createProject } from "./createProject";
+
+// The Discord webhook is configured in the test env; stub it so creating a
+// project here doesn't post a real notification.
+vi.mock("@/discord", () => ({ notifyDiscord: vi.fn(() => Promise.resolve()) }));
 
 const app = createTestHandlerApp(createProject);
 

--- a/apps/backend/src/database/services/project.e2e.test.ts
+++ b/apps/backend/src/database/services/project.e2e.test.ts
@@ -1,11 +1,15 @@
 import { invariant } from "@argos/util/invariant";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Project } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
 import { HTTPError } from "@/util/error";
 
 import { createProject } from "./project";
+
+// The Discord webhook is configured in the test env; stub it so creating a
+// project here doesn't post a real notification.
+vi.mock("@/discord", () => ({ notifyDiscord: vi.fn(() => Promise.resolve()) }));
 
 /**
  * Create a team account with an owner (admin) user and its personal account.

--- a/apps/backend/src/graphql/tests/createProject.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/createProject.e2e.test.ts
@@ -1,6 +1,6 @@
 import { invariant } from "@argos/util/invariant";
 import request from "supertest";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Project } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
@@ -8,6 +8,10 @@ import { factory, setupDatabase } from "@/database/testing";
 import { apolloServer, createApolloMiddleware } from "../apollo";
 import { expectNoGraphQLError } from "../testing";
 import { createApolloServerApp } from "./util";
+
+// The Discord webhook is configured in the test env; stub it so creating a
+// project here doesn't post a real notification.
+vi.mock("@/discord", () => ({ notifyDiscord: vi.fn(() => Promise.resolve()) }));
 
 const CreateProjectMutation = `
   mutation CreateProject($input: CreateProjectInput!) {


### PR DESCRIPTION
## What

The test env has a live `DISCORD_WEBHOOK_URL`, so tests that create a project were posting **real** notifications to the team's Discord on every run.

This mocks `@/discord` in the three project-creation test suites so runs no longer fire the webhook:
- `database/services/project.e2e.test.ts` (service)
- `api/handlers/createProject.e2e.test.ts` (REST handler)
- `graphql/tests/createProject.e2e.test.ts` (GraphQL mutation)

The mock returns a resolved promise so `notifyProjectCreation`'s `.catch(...)` still works.

## Not changed

The production `notifyProjectCreation` (and its Discord webhook) is intentionally left as-is — only the tests are stubbed.

Follow-up to #2352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
