### PR TITLE
feat: improve account analytics with build conclusions and reviews (ARG-461)

### DIFF
--- a/apps/backend/src/graphql/definitions/Account.ts
+++ b/apps/backend/src/graphql/definitions/Account.ts
@@ -93,6 +93,33 @@ export const typeDefs = gql`
     projects: JSONObject!
   }
 
+  type AccountBuildsMetricDataPoint {
+    ts: Timestamp!
+    total: Int!
+    projects: JSONObject!
+    "Builds concluded with changes detected"
+    changesDetected: Int!
+    "Builds concluded with no changes"
+    noChanges: Int!
+    "Builds with changes detected, accepted by a reviewer"
+    accepted: Int!
+    "Builds with changes detected, rejected by a reviewer"
+    rejected: Int!
+  }
+
+  type AccountBuildsMetricData {
+    total: Int!
+    projects: JSONObject!
+    "Builds concluded with changes detected"
+    changesDetected: Int!
+    "Builds concluded with no changes"
+    noChanges: Int!
+    "Builds with changes detected, accepted by a reviewer"
+    accepted: Int!
+    "Builds with changes detected, rejected by a reviewer"
+    rejected: Int!
+  }
+
   type AccountScreenshotMetrics {
     series: [AccountMetricDataPoint!]!
     all: AccountMetricData!
@@ -100,8 +127,8 @@ export const typeDefs = gql`
   }
 
   type AccountBuildsMetrics {
-    series: [AccountMetricDataPoint!]!
-    all: AccountMetricData!
+    series: [AccountBuildsMetricDataPoint!]!
+    all: AccountBuildsMetricData!
     projects: [Project!]!
   }
 

--- a/apps/backend/src/metrics/__snapshots__/account.e2e.test.ts.snap
+++ b/apps/backend/src/metrics/__snapshots__/account.e2e.test.ts.snap
@@ -3,443 +3,695 @@
 exports[`getAccountBuildMetrics > with groupBy day > with projectIds > returns the count of builds 1`] = `
 [
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1606780800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1606867200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1606953600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607040000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607126400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607212800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607299200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607385600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607472000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607558400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607644800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607731200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607817600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607904000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607990400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608076800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608163200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608249600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608336000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608422400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608508800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608595200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608681600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608768000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608854400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608940800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609027200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609113600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609200000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609286400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609372800000,
   },
   {
+    "accepted": 1,
+    "changesDetected": 1,
+    "noChanges": 1,
     "projects": {
       "1000000": 2,
     },
+    "rejected": 0,
     "total": 2,
     "ts": 1609459200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 1,
+    "noChanges": 0,
     "projects": {
       "1000000": 1,
     },
+    "rejected": 1,
     "total": 1,
     "ts": 1609545600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 1,
+    "noChanges": 0,
     "projects": {
       "1000000": 1,
     },
+    "rejected": 0,
     "total": 1,
     "ts": 1609632000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609718400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609804800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609891200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609977600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610064000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610150400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610236800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610323200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610409600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610496000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610582400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610668800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610755200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610841600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610928000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611014400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611100800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611187200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611273600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611360000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611446400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611532800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611619200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611705600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611792000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611878400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611964800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1612051200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1612137600000,
   },
@@ -448,9 +700,13 @@ exports[`getAccountBuildMetrics > with groupBy day > with projectIds > returns t
 
 exports[`getAccountBuildMetrics > with groupBy day > with projectIds > returns the count of builds 2`] = `
 {
+  "accepted": 1,
+  "changesDetected": 3,
+  "noChanges": 1,
   "projects": {
     "1000000": 4,
   },
+  "rejected": 1,
   "total": 4,
 }
 `;
@@ -458,443 +714,695 @@ exports[`getAccountBuildMetrics > with groupBy day > with projectIds > returns t
 exports[`getAccountBuildMetrics > with groupBy day > without projectIds > returns the count of builds 1`] = `
 [
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1606780800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1606867200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1606953600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607040000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607126400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607212800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607299200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607385600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607472000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607558400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607644800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607731200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607817600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607904000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607990400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608076800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608163200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608249600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608336000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608422400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608508800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608595200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608681600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608768000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608854400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608940800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609027200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609113600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609200000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609286400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609372800000,
   },
   {
+    "accepted": 1,
+    "changesDetected": 1,
+    "noChanges": 1,
     "projects": {
       "1000000": 2,
     },
+    "rejected": 0,
     "total": 2,
     "ts": 1609459200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 1,
+    "noChanges": 0,
     "projects": {
       "1000000": 1,
     },
+    "rejected": 1,
     "total": 1,
     "ts": 1609545600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 1,
+    "noChanges": 0,
     "projects": {
       "1000000": 1,
     },
+    "rejected": 0,
     "total": 1,
     "ts": 1609632000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609718400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609804800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609891200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609977600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610064000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610150400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610236800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610323200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610409600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610496000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610582400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610668800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610755200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610841600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610928000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611014400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611100800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611187200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611273600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611360000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611446400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611532800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611619200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611705600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611792000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611878400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611964800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1612051200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1612137600000,
   },
@@ -903,9 +1411,13 @@ exports[`getAccountBuildMetrics > with groupBy day > without projectIds > return
 
 exports[`getAccountBuildMetrics > with groupBy day > without projectIds > returns the count of builds 2`] = `
 {
+  "accepted": 1,
+  "changesDetected": 3,
+  "noChanges": 1,
   "projects": {
     "1000000": 4,
   },
+  "rejected": 1,
   "total": 4,
 }
 `;
@@ -913,23 +1425,35 @@ exports[`getAccountBuildMetrics > with groupBy day > without projectIds > return
 exports[`getAccountBuildMetrics > with groupBy month > with projectIds > returns the count of builds 1`] = `
 [
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1606780800000,
   },
   {
+    "accepted": 1,
+    "changesDetected": 3,
+    "noChanges": 1,
     "projects": {
       "1000000": 4,
     },
+    "rejected": 1,
     "total": 4,
     "ts": 1609459200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1612137600000,
   },
@@ -938,9 +1462,13 @@ exports[`getAccountBuildMetrics > with groupBy month > with projectIds > returns
 
 exports[`getAccountBuildMetrics > with groupBy month > with projectIds > returns the count of builds 2`] = `
 {
+  "accepted": 1,
+  "changesDetected": 3,
+  "noChanges": 1,
   "projects": {
     "1000000": 4,
   },
+  "rejected": 1,
   "total": 4,
 }
 `;
@@ -948,23 +1476,35 @@ exports[`getAccountBuildMetrics > with groupBy month > with projectIds > returns
 exports[`getAccountBuildMetrics > with groupBy month > without projectIds > returns the count of builds 1`] = `
 [
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1606780800000,
   },
   {
+    "accepted": 1,
+    "changesDetected": 3,
+    "noChanges": 1,
     "projects": {
       "1000000": 4,
     },
+    "rejected": 1,
     "total": 4,
     "ts": 1609459200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1612137600000,
   },
@@ -973,9 +1513,13 @@ exports[`getAccountBuildMetrics > with groupBy month > without projectIds > retu
 
 exports[`getAccountBuildMetrics > with groupBy month > without projectIds > returns the count of builds 2`] = `
 {
+  "accepted": 1,
+  "changesDetected": 3,
+  "noChanges": 1,
   "projects": {
     "1000000": 4,
   },
+  "rejected": 1,
   "total": 4,
 }
 `;
@@ -983,72 +1527,112 @@ exports[`getAccountBuildMetrics > with groupBy month > without projectIds > retu
 exports[`getAccountBuildMetrics > with groupBy week > with projectIds > returns the count of builds 1`] = `
 [
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1606694400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607299200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607904000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608508800000,
   },
   {
+    "accepted": 1,
+    "changesDetected": 3,
+    "noChanges": 1,
     "projects": {
       "1000000": 4,
     },
+    "rejected": 1,
     "total": 4,
     "ts": 1609113600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609718400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610323200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610928000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611532800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1612137600000,
   },
@@ -1057,9 +1641,13 @@ exports[`getAccountBuildMetrics > with groupBy week > with projectIds > returns 
 
 exports[`getAccountBuildMetrics > with groupBy week > with projectIds > returns the count of builds 2`] = `
 {
+  "accepted": 1,
+  "changesDetected": 3,
+  "noChanges": 1,
   "projects": {
     "1000000": 4,
   },
+  "rejected": 1,
   "total": 4,
 }
 `;
@@ -1067,72 +1655,112 @@ exports[`getAccountBuildMetrics > with groupBy week > with projectIds > returns 
 exports[`getAccountBuildMetrics > with groupBy week > without projectIds > returns the count of builds 1`] = `
 [
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1606694400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607299200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1607904000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1608508800000,
   },
   {
+    "accepted": 1,
+    "changesDetected": 3,
+    "noChanges": 1,
     "projects": {
       "1000000": 4,
     },
+    "rejected": 1,
     "total": 4,
     "ts": 1609113600000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1609718400000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610323200000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1610928000000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1611532800000,
   },
   {
+    "accepted": 0,
+    "changesDetected": 0,
+    "noChanges": 0,
     "projects": {
       "1000000": 0,
     },
+    "rejected": 0,
     "total": 0,
     "ts": 1612137600000,
   },
@@ -1141,9 +1769,13 @@ exports[`getAccountBuildMetrics > with groupBy week > without projectIds > retur
 
 exports[`getAccountBuildMetrics > with groupBy week > without projectIds > returns the count of builds 2`] = `
 {
+  "accepted": 1,
+  "changesDetected": 3,
+  "noChanges": 1,
   "projects": {
     "1000000": 4,
   },
+  "rejected": 1,
   "total": 4,
 }
 `;

--- a/apps/backend/src/metrics/account.e2e.test.ts
+++ b/apps/backend/src/metrics/account.e2e.test.ts
@@ -83,22 +83,52 @@ describe("getAccountBuildMetrics", () => {
       id: "1000000",
       githubRepositoryId: null,
     });
-    await factory.Build.createMany(4, [
+    const [, approvedBuild, rejectedBuild, dismissedBuild] =
+      await factory.Build.createMany(4, [
+        {
+          createdAt: new Date("2021-01-01").toISOString(),
+          projectId: project.id,
+          conclusion: "no-changes",
+        },
+        {
+          createdAt: new Date("2021-01-01").toISOString(),
+          projectId: project.id,
+          conclusion: "changes-detected",
+        },
+        {
+          createdAt: new Date("2021-01-02").toISOString(),
+          projectId: project.id,
+          conclusion: "changes-detected",
+        },
+        {
+          createdAt: new Date("2021-01-03").toISOString(),
+          projectId: project.id,
+          conclusion: "changes-detected",
+        },
+      ]);
+    const user = await factory.User.create();
+    await factory.BuildReview.createMany(4, [
+      // Approved build.
+      { buildId: approvedBuild!.id, state: "approved" },
+      // Approved then rejected by the same user, only the latest counts.
       {
-        createdAt: new Date("2021-01-01").toISOString(),
-        projectId: project.id,
+        buildId: rejectedBuild!.id,
+        userId: user.id,
+        state: "approved",
+        createdAt: new Date("2021-01-02T10:00:00Z").toISOString(),
       },
       {
-        createdAt: new Date("2021-01-01").toISOString(),
-        projectId: project.id,
+        buildId: rejectedBuild!.id,
+        userId: user.id,
+        state: "rejected",
+        createdAt: new Date("2021-01-02T11:00:00Z").toISOString(),
       },
+      // Dismissed reviews are ignored.
       {
-        createdAt: new Date("2021-01-02").toISOString(),
-        projectId: project.id,
-      },
-      {
-        createdAt: new Date("2021-01-03").toISOString(),
-        projectId: project.id,
+        buildId: dismissedBuild!.id,
+        state: "approved",
+        dismissedAt: new Date("2021-01-03T10:00:00Z").toISOString(),
+        dismissedById: user.id,
       },
     ]);
   });

--- a/apps/backend/src/metrics/account.ts
+++ b/apps/backend/src/metrics/account.ts
@@ -129,9 +129,26 @@ export async function getAccountBuildMetrics(input: {
     SELECT
       date_trunc(:groupBy, b."createdAt") AS date,
       p.id AS "projectId",
-      COUNT(b.id) AS value
+      COUNT(b.id) AS value,
+      COUNT(b.id) FILTER (WHERE b.conclusion = 'changes-detected') AS "changesDetected",
+      COUNT(b.id) FILTER (WHERE b.conclusion = 'no-changes') AS "noChanges",
+      COUNT(b.id) FILTER (WHERE b.conclusion = 'changes-detected' AND r.approved AND NOT r.rejected) AS accepted,
+      COUNT(b.id) FILTER (WHERE b.conclusion = 'changes-detected' AND r.rejected) AS rejected
     FROM builds b
     LEFT JOIN projects p ON b."projectId" = p.id
+    LEFT JOIN LATERAL (
+      SELECT
+        bool_or(lr.state = 'approved') AS approved,
+        bool_or(lr.state = 'rejected') AS rejected
+      FROM (
+        SELECT DISTINCT ON (br."userId") br.state, br."dismissedAt"
+        FROM build_reviews br
+        WHERE br."buildId" = b.id
+        ORDER BY br."userId", br."createdAt" DESC, br.id DESC
+      ) lr
+      WHERE lr."dismissedAt" IS NULL
+        AND lr.state IN ('approved', 'rejected')
+    ) r ON TRUE
     WHERE p."accountId" = :accountId
       AND b."createdAt" >= date_trunc(:groupBy, :from::timestamp)
       AND b."createdAt" <= :to
@@ -154,7 +171,11 @@ export async function getAccountBuildMetrics(input: {
   SELECT
     s.date,
     jsonb_object_agg(a."projectId", COALESCE(a.value, 0))
-      FILTER (WHERE a."projectId" IS NOT NULL) AS counts
+      FILTER (WHERE a."projectId" IS NOT NULL) AS counts,
+    COALESCE(SUM(a."changesDetected"), 0)::int AS "changesDetected",
+    COALESCE(SUM(a."noChanges"), 0)::int AS "noChanges",
+    COALESCE(SUM(a.accepted), 0)::int AS accepted,
+    COALESCE(SUM(a.rejected), 0)::int AS rejected
   FROM series s
   LEFT JOIN aggregated a
     ON s.date = a.date
@@ -169,7 +190,14 @@ export async function getAccountBuildMetrics(input: {
   }
   const [result, inputProjects] = await Promise.all([
     knex.raw<{
-      rows: { date: number; counts: Record<string, number> | null }[];
+      rows: {
+        date: number;
+        counts: Record<string, number> | null;
+        changesDetected: number;
+        noChanges: number;
+        accepted: number;
+        rejected: number;
+      }[];
     }>(query, {
       accountId: input.accountId,
       projectIds: input.projectIds,
@@ -203,21 +231,40 @@ export async function getAccountBuildMetrics(input: {
       ts: new Date(row.date).getTime(),
       projects: projectCounts,
       total,
+      changesDetected: row.changesDetected,
+      noChanges: row.noChanges,
+      accepted: row.accepted,
+      rejected: row.rejected,
     };
   });
 
   const all = series.reduce<{
     total: number;
     projects: Record<string, number>;
+    changesDetected: number;
+    noChanges: number;
+    accepted: number;
+    rejected: number;
   }>(
     (acc, serie) => {
       acc.total += serie.total;
+      acc.changesDetected += serie.changesDetected;
+      acc.noChanges += serie.noChanges;
+      acc.accepted += serie.accepted;
+      acc.rejected += serie.rejected;
       Object.entries(serie.projects).forEach(([projectId, count]) => {
         acc.projects[projectId] = (acc.projects[projectId] ?? 0) + count;
       });
       return acc;
     },
-    { total: 0, projects: {} },
+    {
+      total: 0,
+      projects: {},
+      changesDetected: 0,
+      noChanges: 0,
+      accepted: 0,
+      rejected: 0,
+    },
   );
 
   return { series, all, projects };

--- a/apps/frontend/src/pages/Account/Analytics.stories.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.stories.tsx
@@ -5,8 +5,10 @@ import { TimeSeriesGroupBy } from "@/gql/graphql";
 import { AnalyticsDashboard } from "./Analytics";
 
 const PROJECTS = [
-  { __typename: "Project" as const, id: "1", name: "website" },
-  { __typename: "Project" as const, id: "2", name: "design-system" },
+  { __typename: "Project" as const, id: "1", name: "argos" },
+  { __typename: "Project" as const, id: "2", name: "argos-ci.com" },
+  { __typename: "Project" as const, id: "3", name: "argos-javascript" },
+  { __typename: "Project" as const, id: "4", name: "storybook" },
 ];
 
 const DAY = 24 * 60 * 60 * 1000;
@@ -31,13 +33,41 @@ function buildFixture() {
     projects: {} as Record<string, number>,
   };
 
+  // Builds per project per bucket, roughly matching real relative volumes.
+  const buildWeights: Record<string, number> = {
+    "1": 6,
+    "2": 2,
+    "3": 3,
+    "4": 2,
+  };
+  // Screenshots per build for each project.
+  const screenshotWeights: Record<string, number> = {
+    "1": 42,
+    "2": 27,
+    "3": 31,
+    "4": 55,
+  };
+
   for (let i = 0; i < POINTS; i++) {
     const ts = START + i * DAY;
     // Deterministic wave so the charts look alive without randomness.
     const wave = 1 + Math.sin(i / 3) * 0.5;
-    const p1 = Math.round(6 * wave) + 2;
-    const p2 = Math.round(3 * wave) + 1;
-    const total = p1 + p2;
+    const buildCounts: Record<string, number> = {};
+    const screenshotCounts: Record<string, number> = {};
+    let total = 0;
+    let sTotal = 0;
+    for (const project of PROJECTS) {
+      const builds = Math.round(buildWeights[project.id]! * wave) + 1;
+      const screenshots = builds * screenshotWeights[project.id]!;
+      buildCounts[project.id] = builds;
+      screenshotCounts[project.id] = screenshots;
+      total += builds;
+      sTotal += screenshots;
+      buildsAll.projects[project.id] =
+        (buildsAll.projects[project.id] ?? 0) + builds;
+      screenshotsAll.projects[project.id] =
+        (screenshotsAll.projects[project.id] ?? 0) + screenshots;
+    }
     const changesDetected = Math.round(total * 0.35);
     const noChanges = total - changesDetected;
     const accepted = Math.round(changesDetected * 0.7);
@@ -50,32 +80,25 @@ function buildFixture() {
       __typename: "AccountBuildsMetricDataPoint" as const,
       ts,
       total,
-      projects: { "1": p1, "2": p2 },
+      projects: buildCounts,
       changesDetected,
       noChanges,
       accepted,
       rejected,
     });
     buildsAll.total += total;
-    buildsAll.projects["1"] = (buildsAll.projects["1"] ?? 0) + p1;
-    buildsAll.projects["2"] = (buildsAll.projects["2"] ?? 0) + p2;
     buildsAll.changesDetected += changesDetected;
     buildsAll.noChanges += noChanges;
     buildsAll.accepted += accepted;
     buildsAll.rejected += rejected;
 
-    const s1 = p1 * 42;
-    const s2 = p2 * 27;
-    const sTotal = s1 + s2;
     screenshotsSeries.push({
       __typename: "AccountMetricDataPoint" as const,
       ts,
       total: sTotal,
-      projects: { "1": s1, "2": s2 },
+      projects: screenshotCounts,
     });
     screenshotsAll.total += sTotal;
-    screenshotsAll.projects["1"] = (screenshotsAll.projects["1"] ?? 0) + s1;
-    screenshotsAll.projects["2"] = (screenshotsAll.projects["2"] ?? 0) + s2;
   }
 
   return {

--- a/apps/frontend/src/pages/Account/Analytics.stories.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.stories.tsx
@@ -1,0 +1,154 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { TimeSeriesGroupBy } from "@/gql/graphql";
+
+import { AnalyticsDashboard } from "./Analytics";
+
+const PROJECTS = [
+  { __typename: "Project" as const, id: "1", name: "website" },
+  { __typename: "Project" as const, id: "2", name: "design-system" },
+];
+
+const DAY = 24 * 60 * 60 * 1000;
+const START = new Date("2026-06-01T00:00:00Z").getTime();
+const POINTS = 30;
+
+function buildFixture() {
+  const buildsSeries = [];
+  const screenshotsSeries = [];
+  const buildsAll = {
+    __typename: "AccountBuildsMetricData" as const,
+    total: 0,
+    projects: {} as Record<string, number>,
+    changesDetected: 0,
+    noChanges: 0,
+    accepted: 0,
+    rejected: 0,
+  };
+  const screenshotsAll = {
+    __typename: "AccountMetricData" as const,
+    total: 0,
+    projects: {} as Record<string, number>,
+  };
+
+  for (let i = 0; i < POINTS; i++) {
+    const ts = START + i * DAY;
+    // Deterministic wave so the charts look alive without randomness.
+    const wave = 1 + Math.sin(i / 3) * 0.5;
+    const p1 = Math.round(6 * wave) + 2;
+    const p2 = Math.round(3 * wave) + 1;
+    const total = p1 + p2;
+    const changesDetected = Math.round(total * 0.35);
+    const noChanges = total - changesDetected;
+    const accepted = Math.round(changesDetected * 0.7);
+    const rejected = Math.max(
+      0,
+      changesDetected - accepted - (i % 3 === 0 ? 1 : 0),
+    );
+
+    buildsSeries.push({
+      __typename: "AccountBuildsMetricDataPoint" as const,
+      ts,
+      total,
+      projects: { "1": p1, "2": p2 },
+      changesDetected,
+      noChanges,
+      accepted,
+      rejected,
+    });
+    buildsAll.total += total;
+    buildsAll.projects["1"] = (buildsAll.projects["1"] ?? 0) + p1;
+    buildsAll.projects["2"] = (buildsAll.projects["2"] ?? 0) + p2;
+    buildsAll.changesDetected += changesDetected;
+    buildsAll.noChanges += noChanges;
+    buildsAll.accepted += accepted;
+    buildsAll.rejected += rejected;
+
+    const s1 = p1 * 42;
+    const s2 = p2 * 27;
+    const sTotal = s1 + s2;
+    screenshotsSeries.push({
+      __typename: "AccountMetricDataPoint" as const,
+      ts,
+      total: sTotal,
+      projects: { "1": s1, "2": s2 },
+    });
+    screenshotsAll.total += sTotal;
+    screenshotsAll.projects["1"] = (screenshotsAll.projects["1"] ?? 0) + s1;
+    screenshotsAll.projects["2"] = (screenshotsAll.projects["2"] ?? 0) + s2;
+  }
+
+  return {
+    __typename: "AccountMetrics" as const,
+    builds: {
+      __typename: "AccountBuildsMetrics" as const,
+      all: buildsAll,
+      series: buildsSeries,
+      projects: PROJECTS,
+    },
+    screenshots: {
+      __typename: "AccountScreenshotMetrics" as const,
+      all: screenshotsAll,
+      series: screenshotsSeries,
+      projects: PROJECTS,
+    },
+  };
+}
+
+const meta: Meta<typeof AnalyticsDashboard> = {
+  title: "Pages/AnalyticsDashboard",
+  component: AnalyticsDashboard,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <div className="bg-subtle min-h-screen p-10">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    accountSlug: "acme",
+    metrics: buildFixture(),
+    from: new Date(START),
+    to: new Date(START + POINTS * DAY),
+    groupBy: TimeSeriesGroupBy.Day,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    accountSlug: "acme",
+    metrics: {
+      __typename: "AccountMetrics",
+      builds: {
+        __typename: "AccountBuildsMetrics",
+        all: {
+          __typename: "AccountBuildsMetricData",
+          total: 0,
+          projects: {},
+          changesDetected: 0,
+          noChanges: 0,
+          accepted: 0,
+          rejected: 0,
+        },
+        series: [],
+        projects: [],
+      },
+      screenshots: {
+        __typename: "AccountScreenshotMetrics",
+        all: { __typename: "AccountMetricData", total: 0, projects: {} },
+        series: [],
+        projects: [],
+      },
+    },
+    from: new Date(START),
+    to: new Date(START + POINTS * DAY),
+    groupBy: TimeSeriesGroupBy.Day,
+  },
+};

--- a/apps/frontend/src/pages/Account/Analytics.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.tsx
@@ -1,10 +1,16 @@
-import { Suspense, useCallback, useEffect, useMemo } from "react";
+import { Suspense, useCallback, useEffect, useId, useMemo } from "react";
 import { useSuspenseQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { getLocalTimeZone, today } from "@internationalized/date";
 import NumberFlow from "@number-flow/react";
 import clsx from "clsx";
-import { FileDownIcon } from "lucide-react";
+import {
+  FileDownIcon,
+  GitCompareArrowsIcon,
+  ImagesIcon,
+  LayersIcon,
+  ThumbsUpIcon,
+} from "lucide-react";
 import moment from "moment";
 import { Heading, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
@@ -20,7 +26,10 @@ import {
 } from "recharts";
 
 import { graphql } from "@/gql";
-import { TimeSeriesGroupBy } from "@/gql/graphql";
+import {
+  TimeSeriesGroupBy,
+  type AccountUsage_AccountQuery,
+} from "@/gql/graphql";
 import { Card } from "@/ui/Card";
 import {
   ChartConfig,
@@ -233,18 +242,43 @@ function Charts(props: {
   });
 
   const metrics = data.account?.metrics;
-  const concludedBuilds = metrics
-    ? metrics.builds.all.changesDetected + metrics.builds.all.noChanges
-    : 0;
-  const reviewedBuilds = metrics
-    ? metrics.builds.all.accepted + metrics.builds.all.rejected
-    : 0;
+  if (!metrics) {
+    return <Navigate to="/" />;
+  }
 
-  const screenshotByBuildSeries: Metric | null = useMemo(() => {
-    if (!metrics) {
-      return null;
-    }
+  return (
+    <AnalyticsDashboard
+      accountSlug={accountSlug}
+      metrics={metrics}
+      from={from}
+      to={to}
+      groupBy={groupBy}
+    />
+  );
+}
 
+type DashboardMetrics = NonNullable<
+  NonNullable<AccountUsage_AccountQuery["account"]>["metrics"]
+>;
+
+/**
+ * The presentational analytics dashboard. Kept free of data fetching so it can
+ * be rendered in isolation (e.g. Storybook) with fixture metrics.
+ */
+export function AnalyticsDashboard(props: {
+  accountSlug: string;
+  metrics: DashboardMetrics;
+  from: Date;
+  to: Date;
+  groupBy: TimeSeriesGroupBy;
+}) {
+  const { accountSlug, metrics, from, to, groupBy } = props;
+  const concludedBuilds =
+    metrics.builds.all.changesDetected + metrics.builds.all.noChanges;
+  const reviewedBuilds =
+    metrics.builds.all.accepted + metrics.builds.all.rejected;
+
+  const screenshotByBuildSeries: Metric = useMemo(() => {
     const series = metrics.screenshots.series.reduce<Metric["series"]>(
       (acc, serie, index) => {
         const screenshots = serie;
@@ -291,22 +325,143 @@ function Charts(props: {
     };
   }, [metrics]);
 
-  if (data && !metrics) {
-    return <Navigate to="/" />;
-  }
+  const groupByLabel = GroupByLabels[groupBy].toLowerCase();
+  const buildsPerPeriod = metrics.builds.series.length
+    ? Math.round(metrics.builds.all.total / metrics.builds.series.length)
+    : 0;
+  const screenshotsPerPeriod = metrics.screenshots.series.length
+    ? Math.round(
+        metrics.screenshots.all.total / metrics.screenshots.series.length,
+      )
+    : 0;
+  const screenshotsPerBuild = metrics.builds.all.total
+    ? Math.round(metrics.screenshots.all.total / metrics.builds.all.total)
+    : 0;
 
   return (
-    <div className="grid grid-cols-12 gap-6 lg:flex-row">
-      <Card className="group col-span-12 flex flex-col lg:col-span-6">
-        <ChartCardHeader className="flex items-start justify-between gap-6">
-          <div>
-            <ChartCardDescription>Builds</ChartCardDescription>
-            <Count count={metrics?.builds.all.total ?? null} />
-          </div>
-          <Tooltip content="Export to CSV">
-            <IconButton
+    <div className="flex flex-col gap-10">
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatTile
+          icon={LayersIcon}
+          color="primary"
+          label="Builds"
+          value={metrics?.builds.all.total ?? null}
+          hint={
+            buildsPerPeriod !== null
+              ? `${buildsPerPeriod.toLocaleString()} avg / ${groupByLabel}`
+              : null
+          }
+          visual={
+            metrics && metrics.builds.all.total > 0 ? (
+              <Sparkline data={metrics.builds.series} color="var(--violet-9)" />
+            ) : null
+          }
+        />
+        <StatTile
+          icon={ImagesIcon}
+          color="storybook"
+          label="Screenshots"
+          value={metrics?.screenshots.all.total ?? null}
+          hint={
+            screenshotsPerPeriod !== null
+              ? `${screenshotsPerPeriod.toLocaleString()} avg / ${groupByLabel}`
+              : null
+          }
+          visual={
+            metrics && metrics.screenshots.all.total > 0 ? (
+              <Sparkline
+                data={metrics.screenshots.series}
+                color="var(--pink-9)"
+              />
+            ) : null
+          }
+        />
+        <StatTile
+          icon={GitCompareArrowsIcon}
+          color="warning"
+          label="Change rate"
+          value={
+            metrics && concludedBuilds > 0
+              ? metrics.builds.all.changesDetected / concludedBuilds
+              : metrics
+                ? null
+                : undefined
+          }
+          format="percent"
+          hint={
+            metrics && concludedBuilds > 0
+              ? `${metrics.builds.all.changesDetected.toLocaleString()} of ${concludedBuilds.toLocaleString()} builds`
+              : "No completed builds yet"
+          }
+          visual={
+            metrics && concludedBuilds > 0 ? (
+              <SplitBar
+                segments={[
+                  {
+                    label: "Changes detected",
+                    value: metrics.builds.all.changesDetected,
+                    color: STATUS_COLORS.changesDetected,
+                  },
+                  {
+                    label: "No changes",
+                    value: metrics.builds.all.noChanges,
+                    color: STATUS_COLORS.noChanges,
+                  },
+                ]}
+              />
+            ) : null
+          }
+        />
+        <StatTile
+          icon={ThumbsUpIcon}
+          color="success"
+          label="Approval rate"
+          value={
+            metrics && reviewedBuilds > 0
+              ? metrics.builds.all.accepted / reviewedBuilds
+              : metrics
+                ? null
+                : undefined
+          }
+          format="percent"
+          hint={
+            metrics && reviewedBuilds > 0
+              ? `${metrics.builds.all.accepted.toLocaleString()} of ${reviewedBuilds.toLocaleString()} reviewed`
+              : "No builds reviewed yet"
+          }
+          visual={
+            metrics && reviewedBuilds > 0 ? (
+              <SplitBar
+                segments={[
+                  {
+                    label: "Approved",
+                    value: metrics.builds.all.accepted,
+                    color: STATUS_COLORS.accepted,
+                  },
+                  {
+                    label: "Rejected",
+                    value: metrics.builds.all.rejected,
+                    color: STATUS_COLORS.rejected,
+                  },
+                ]}
+              />
+            ) : null
+          }
+        />
+      </div>
+
+      <Section
+        title="Activity"
+        description="How much visual testing ran over the period."
+      >
+        <ChartCard
+          className="col-span-12 lg:col-span-6"
+          title="Builds"
+          description="Builds created, by project."
+          action={
+            <ExportButton
               isDisabled={!metrics}
-              onPress={() => {
+              onExport={() => {
                 invariant(metrics);
                 exportToCSV({
                   metric: metrics.builds,
@@ -328,13 +483,10 @@ function Charts(props: {
                   ],
                 });
               }}
-            >
-              <FileDownIcon />
-            </IconButton>
-          </Tooltip>
-        </ChartCardHeader>
-        <ChartCardBody>
-          {metrics?.builds ? (
+            />
+          }
+        >
+          {metrics ? (
             metrics.builds.all.total === 0 ? (
               <EmptyStateBuilds />
             ) : (
@@ -347,18 +499,15 @@ function Charts(props: {
               />
             )
           ) : null}
-        </ChartCardBody>
-      </Card>
-      <Card className="col-span-12 flex flex-col lg:col-span-6">
-        <ChartCardHeader className="flex items-start justify-between gap-6">
-          <div>
-            <ChartCardDescription>Screenshots</ChartCardDescription>
-            <Count count={metrics?.screenshots.all.total ?? null} />
-          </div>
-          <Tooltip content="Export to CSV">
-            <IconButton
+        </ChartCard>
+        <ChartCard
+          className="col-span-12 lg:col-span-6"
+          title="Screenshots"
+          description="Screenshots captured, by project."
+          action={
+            <ExportButton
               isDisabled={!metrics}
-              onPress={() => {
+              onExport={() => {
                 invariant(metrics);
                 exportToCSV({
                   metric: metrics.screenshots,
@@ -371,12 +520,9 @@ function Charts(props: {
                   }),
                 });
               }}
-            >
-              <FileDownIcon />
-            </IconButton>
-          </Tooltip>
-        </ChartCardHeader>
-        <ChartCardBody>
+            />
+          }
+        >
           {metrics ? (
             metrics.screenshots.all.total === 0 ? (
               <EmptyStateScreenshots />
@@ -390,26 +536,18 @@ function Charts(props: {
               />
             )
           ) : null}
-        </ChartCardBody>
-      </Card>
-      <Card className="col-span-12 flex flex-col lg:col-span-6">
-        <ChartCardHeader>
-          <ChartCardDescription>Changes detected</ChartCardDescription>
-          <div className="flex items-baseline gap-2">
-            <Count
-              count={metrics ? metrics.builds.all.changesDetected : null}
-            />
-            {metrics && concludedBuilds > 0 ? (
-              <span className="text-low text-sm font-medium">
-                {formatPercent(
-                  metrics.builds.all.changesDetected / concludedBuilds,
-                )}{" "}
-                of completed builds
-              </span>
-            ) : null}
-          </div>
-        </ChartCardHeader>
-        <ChartCardBody>
+        </ChartCard>
+      </Section>
+
+      <Section
+        title="Build outcomes"
+        description="What builds concluded, and how reviewers responded."
+      >
+        <ChartCard
+          className="col-span-12 lg:col-span-6"
+          title="Changes detected"
+          description="Completed builds, split by conclusion."
+        >
           {metrics ? (
             concludedBuilds === 0 ? (
               <EmptyStateBuilds />
@@ -424,22 +562,12 @@ function Charts(props: {
               />
             )
           ) : null}
-        </ChartCardBody>
-      </Card>
-      <Card className="col-span-12 flex flex-col lg:col-span-6">
-        <ChartCardHeader>
-          <ChartCardDescription>Reviewed builds</ChartCardDescription>
-          <div className="flex items-baseline gap-2">
-            <Count count={metrics ? reviewedBuilds : null} />
-            {metrics && reviewedBuilds > 0 ? (
-              <span className="text-low text-sm font-medium">
-                {formatPercent(metrics.builds.all.accepted / reviewedBuilds)}{" "}
-                approved
-              </span>
-            ) : null}
-          </div>
-        </ChartCardHeader>
-        <ChartCardBody>
+        </ChartCard>
+        <ChartCard
+          className="col-span-12 lg:col-span-6"
+          title="Reviewed builds"
+          description="Builds with changes, split by review decision."
+        >
           {metrics ? (
             reviewedBuilds === 0 ? (
               <EmptyStateReviews />
@@ -454,13 +582,18 @@ function Charts(props: {
               />
             )
           ) : null}
-        </ChartCardBody>
-      </Card>
-      <Card className="col-span-12 flex flex-col lg:col-span-4">
-        <ChartCardHeader>
-          <ChartCardHeading>Screenshots by Project</ChartCardHeading>
-        </ChartCardHeader>
-        <ChartCardBody>
+        </ChartCard>
+      </Section>
+
+      <Section
+        title="Breakdown"
+        description="Where screenshots come from, and how dense each build is."
+      >
+        <ChartCard
+          className="col-span-12 lg:col-span-5"
+          title="Screenshots by project"
+          description="Share of screenshots across projects."
+        >
           {metrics ? (
             metrics.screenshots.all.total > 0 ? (
               <ProjectPieChart metric={metrics.screenshots} />
@@ -468,61 +601,16 @@ function Charts(props: {
               <EmptyStateScreenshots />
             )
           ) : null}
-        </ChartCardBody>
-      </Card>
-      <div className="col-span-12 flex flex-col gap-[inherit] lg:col-span-3">
-        <Card className="p-6">
-          <ChartCardHeading className="mb-4">
-            Usage by {GroupByLabels[groupBy]}
-          </ChartCardHeading>
-          <div className="flex flex-col gap-4">
-            <div>
-              <ChartCardDescription>Builds</ChartCardDescription>
-              <Count
-                count={
-                  metrics
-                    ? Math.round(
-                        metrics.builds.all.total / metrics.builds.series.length,
-                      )
-                    : null
-                }
-              />
-            </div>
-            <div>
-              <ChartCardDescription>Screenshots</ChartCardDescription>
-              <Count
-                count={
-                  metrics
-                    ? Math.round(
-                        metrics.screenshots.all.total /
-                          metrics.screenshots.series.length,
-                      )
-                    : null
-                }
-              />
-            </div>
-          </div>
-        </Card>
-      </div>
-      <Card className="col-span-12 flex flex-col lg:col-span-5">
-        <ChartCardHeader>
-          <ChartCardHeading className="mb-4">
-            Screenshots by Build
-          </ChartCardHeading>
-          <ChartCardDescription>Screenshots</ChartCardDescription>
-          <Count
-            count={
-              metrics
-                ? metrics.screenshots.all.total
-                  ? Math.round(
-                      metrics.screenshots.all.total / metrics.builds.all.total,
-                    )
-                  : 0
-                : null
-            }
-          />
-        </ChartCardHeader>
-        <ChartCardBody>
+        </ChartCard>
+        <ChartCard
+          className="col-span-12 lg:col-span-7"
+          title="Screenshots per build"
+          description={
+            screenshotsPerBuild !== null
+              ? `${screenshotsPerBuild.toLocaleString()} on average across the period.`
+              : "Average screenshots captured per build."
+          }
+        >
           {screenshotByBuildSeries ? (
             screenshotByBuildSeries.all.total === 0 ? (
               <EmptyStateScreenshots />
@@ -536,8 +624,8 @@ function Charts(props: {
               />
             )
           ) : null}
-        </ChartCardBody>
-      </Card>
+        </ChartCard>
+      </Section>
     </div>
   );
 }
@@ -626,26 +714,26 @@ function EmptyStateReviews() {
   );
 }
 
-function formatPercent(ratio: number) {
-  return ratio.toLocaleString(navigator.language, {
-    style: "percent",
-    maximumFractionDigits: 0,
-  });
-}
-
 // Colors match the build status colors (warning / success / danger).
+const STATUS_COLORS = {
+  changesDetected: "var(--orange-9)",
+  noChanges: "var(--grass-9)",
+  accepted: "var(--grass-9)",
+  rejected: "var(--tomato-9)",
+};
+
 const BuildOutcomeChartKeys: EvolutionChartKey[] = [
   {
     id: "changesDetected",
     label: "Changes detected",
-    color: "var(--orange-9)",
+    color: STATUS_COLORS.changesDetected,
   },
-  { id: "noChanges", label: "No changes", color: "var(--grass-9)" },
+  { id: "noChanges", label: "No changes", color: STATUS_COLORS.noChanges },
 ];
 
 const BuildReviewChartKeys: EvolutionChartKey[] = [
-  { id: "rejected", label: "Rejected", color: "var(--tomato-9)" },
-  { id: "accepted", label: "Approved", color: "var(--grass-9)" },
+  { id: "rejected", label: "Rejected", color: STATUS_COLORS.rejected },
+  { id: "accepted", label: "Approved", color: STATUS_COLORS.accepted },
 ];
 
 type Metric = {
@@ -661,49 +749,179 @@ type Metric = {
   }[];
 };
 
-function ChartCardHeader(props: {
-  children: React.ReactNode;
-  className?: string;
+const StatTileChipStyles: Record<StatTileColor, string> = {
+  primary: "bg-primary-ui text-primary-low",
+  storybook: "bg-storybook-ui text-storybook-low",
+  warning: "bg-warning-ui text-warning-low",
+  success: "bg-success-ui text-success-low",
+};
+
+type StatTileColor = "primary" | "storybook" | "warning" | "success";
+
+/**
+ * A single KPI in the summary band: an icon, a headline value, a supporting
+ * line, and an optional inline visual (sparkline or split bar).
+ *
+ * `value` is `undefined` while loading (skeleton), `null` when there is no
+ * meaningful figure to show (rendered as an em dash), otherwise the number.
+ */
+function StatTile(props: {
+  icon: React.ComponentType<{ className?: string }>;
+  color: StatTileColor;
+  label: string;
+  value: number | null | undefined;
+  format?: "number" | "percent";
+  hint?: React.ReactNode;
+  visual?: React.ReactNode;
 }) {
-  return <div className={clsx("p-6", props.className)}>{props.children}</div>;
+  const { icon: Icon, value, format = "number" } = props;
+  const isLoading = value === undefined;
+  return (
+    <Card className="flex flex-col gap-4 p-5">
+      <div className="flex items-center gap-2.5">
+        <div
+          className={clsx(
+            "flex size-7 shrink-0 items-center justify-center rounded-md",
+            StatTileChipStyles[props.color],
+          )}
+        >
+          <Icon className="size-4" />
+        </div>
+        <span className="text-low text-sm font-medium">{props.label}</span>
+      </div>
+      <div>
+        <div className="relative text-3xl font-black tabular-nums">
+          {value === undefined ? (
+            <div className="bg-subtle h-[1em] w-24 rounded-sm" />
+          ) : value === null ? (
+            <span className="text-low">—</span>
+          ) : format === "percent" ? (
+            <NumberFlow
+              value={value}
+              format={{ style: "percent", maximumFractionDigits: 0 }}
+            />
+          ) : (
+            <NumberFlow value={value} />
+          )}
+        </div>
+        {props.hint ? (
+          <p className="text-low mt-1 h-4 text-sm">
+            {isLoading ? null : props.hint}
+          </p>
+        ) : null}
+      </div>
+      {props.visual ? <div className="mt-auto">{props.visual}</div> : null}
+    </Card>
+  );
 }
 
-function Count(props: { count: number | null }) {
-  const isLoading = props.count === null;
+function Sparkline(props: {
+  data: { ts: number; total: number }[];
+  color: string;
+}) {
+  const gradientId = useId();
   return (
-    <div className="relative text-4xl font-black">
-      <NumberFlow
-        value={props.count ?? 0}
-        className={isLoading ? "invisible" : undefined}
-      />
+    <div className="h-9 w-full">
+      <ChartContainer config={{}} className="size-full">
+        <AreaChart
+          data={props.data}
+          margin={{ top: 2, bottom: 0, left: 0, right: 0 }}
+        >
+          <defs>
+            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={props.color} stopOpacity={0.3} />
+              <stop offset="100%" stopColor={props.color} stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <Area
+            dataKey="total"
+            type="monotone"
+            stroke={props.color}
+            strokeWidth={1.5}
+            fill={`url(#${gradientId})`}
+            dot={false}
+            isAnimationActive={false}
+          />
+        </AreaChart>
+      </ChartContainer>
+    </div>
+  );
+}
 
-      {isLoading && (
-        <div className="bg-subtle absolute top-2 left-0 h-[1em] w-32 rounded-sm" />
+function SplitBar(props: {
+  segments: { label: string; value: number; color: string }[];
+}) {
+  const total = props.segments.reduce((sum, segment) => sum + segment.value, 0);
+  return (
+    <div className="flex h-1.5 w-full gap-0.5 overflow-hidden rounded-full">
+      {props.segments.map((segment) =>
+        segment.value > 0 ? (
+          <div
+            key={segment.label}
+            className="h-full first:rounded-l-full last:rounded-r-full"
+            style={{
+              width: `${(segment.value / total) * 100}%`,
+              backgroundColor: segment.color,
+            }}
+            aria-label={`${segment.label}: ${segment.value}`}
+          />
+        ) : null,
       )}
     </div>
   );
 }
 
-function ChartCardHeading(props: {
+/**
+ * A titled group of chart cards laid out on a 12-column grid.
+ */
+function Section(props: {
+  title: string;
+  description: string;
   children: React.ReactNode;
-  className?: string;
 }) {
   return (
-    <h2 className={clsx("text-2xl font-bold", props.className)}>
-      {props.children}
-    </h2>
+    <section className="flex flex-col gap-4">
+      <div>
+        <h2 className="text-base font-semibold">{props.title}</h2>
+        <p className="text-low text-sm">{props.description}</p>
+      </div>
+      <div className="grid grid-cols-12 gap-6">{props.children}</div>
+    </section>
   );
 }
 
-function ChartCardDescription(props: { children: React.ReactNode }) {
-  return <p className="text-low text-sm font-medium">{props.children}</p>;
+function ChartCard(props: {
+  className?: string;
+  title: string;
+  description?: React.ReactNode;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card className={clsx("flex flex-col", props.className)}>
+      <div className="flex items-start justify-between gap-4 p-5 pb-0">
+        <div>
+          <h3 className="font-semibold">{props.title}</h3>
+          {props.description ? (
+            <p className="text-low text-sm">{props.description}</p>
+          ) : null}
+        </div>
+        {props.action ? <div className="shrink-0">{props.action}</div> : null}
+      </div>
+      <div className="flex min-h-72 flex-1 items-center justify-center p-5">
+        {props.children}
+      </div>
+    </Card>
+  );
 }
 
-function ChartCardBody(props: { children: React.ReactNode }) {
+function ExportButton(props: { isDisabled: boolean; onExport: () => void }) {
   return (
-    <div className="flex min-h-80 flex-1 items-center justify-center p-6 pt-0">
-      {props.children}
-    </div>
+    <Tooltip content="Export to CSV">
+      <IconButton isDisabled={props.isDisabled} onPress={props.onExport}>
+        <FileDownIcon />
+      </IconButton>
+    </Tooltip>
   );
 }
 
@@ -741,16 +959,34 @@ function ProjectPieChart(props: { metric: Metric }) {
     return acc;
   }, []);
   return (
-    <ChartContainer config={chartConfig} className="size-full">
-      <PieChart>
-        <ChartTooltip
-          cursor={false}
-          content={<ChartTooltipContent hideLabel />}
-        />
-        <Pie data={data} dataKey="screenshots" nameKey="project" />
-        <ChartLegend content={<ChartLegendContent />} />
-      </PieChart>
-    </ChartContainer>
+    <div className="relative size-full">
+      <div className="pointer-events-none absolute inset-x-0 top-1/2 z-10 flex -translate-y-[calc(50%+1.25rem)] flex-col items-center">
+        <span className="text-2xl font-black tabular-nums">
+          {props.metric.all.total.toLocaleString(navigator.language, {
+            notation: "compact",
+          })}
+        </span>
+        <span className="text-low text-xs">screenshots</span>
+      </div>
+      <ChartContainer config={chartConfig} className="size-full">
+        <PieChart>
+          <ChartTooltip
+            cursor={false}
+            content={<ChartTooltipContent hideLabel />}
+          />
+          <Pie
+            data={data}
+            dataKey="screenshots"
+            nameKey="project"
+            innerRadius="55%"
+            outerRadius="80%"
+            paddingAngle={2}
+            strokeWidth={2}
+          />
+          <ChartLegend content={<ChartLegendContent nameKey="project" />} />
+        </PieChart>
+      </ChartContainer>
+    </div>
   );
 }
 
@@ -882,6 +1118,7 @@ function EvolutionChart(props: {
               fillOpacity={0.4}
               stroke={key.color}
               stackId="group"
+              isAnimationActive={false}
             />
           );
         })}

--- a/apps/frontend/src/pages/Account/Analytics.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.tsx
@@ -848,6 +848,7 @@ function Sparkline(props: {
             </linearGradient>
           </defs>
           <ChartTooltip
+            isAnimationActive={false}
             cursor={{ strokeDasharray: "3 3" }}
             position={{ y: -56 }}
             allowEscapeViewBox={{ y: true }}
@@ -866,7 +867,7 @@ function Sparkline(props: {
             dataKey="total"
             type="monotone"
             stroke={props.color}
-            strokeWidth={1.5}
+            strokeWidth={1}
             fill={`url(#${gradientId})`}
             dot={false}
             isAnimationActive={false}
@@ -1157,6 +1158,7 @@ function EvolutionChart(props: {
           }}
         />
         <ChartTooltip
+          isAnimationActive={false}
           content={
             <ChartTooltipContent
               labelFormatter={(_value, payload) => {

--- a/apps/frontend/src/pages/Account/Analytics.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.tsx
@@ -9,10 +9,19 @@ import {
   GitCompareArrowsIcon,
   ImagesIcon,
   LayersIcon,
+  SearchIcon,
   ThumbsUpIcon,
 } from "lucide-react";
 import moment from "moment";
-import { Heading, MenuTrigger, Text } from "react-aria-components";
+import { useFilter } from "react-aria";
+import {
+  Autocomplete,
+  Heading,
+  Input,
+  MenuTrigger,
+  SearchField,
+  Text,
+} from "react-aria-components";
 import { Helmet } from "react-helmet";
 import { Navigate, useSearchParams } from "react-router-dom";
 import {
@@ -922,6 +931,7 @@ function SplitBar(props: {
     <Tooltip
       delay={150}
       placement="top"
+      disableAnimation
       content={
         <div className="flex min-w-40 flex-col gap-1 py-0.5">
           {props.segments.map((segment) => (
@@ -1332,12 +1342,37 @@ function ProjectFilter(props: {
   const { data } = useSuspenseQuery(ProjectsQuery, {
     variables: { slug: props.accountSlug },
   });
-  const projects = [...(data.account?.projects.edges ?? [])].sort((a, b) =>
-    a.name.localeCompare(b.name),
-  );
+  const projects = data.account?.projects.edges ?? [];
   if (projects.length < 2) {
     return null;
   }
+  return (
+    <ProjectFilterMenu
+      projects={projects}
+      value={props.value}
+      onChange={props.onChange}
+    />
+  );
+}
+
+/**
+ * Number of projects above which the project filter shows a search field.
+ */
+const PROJECT_SEARCH_THRESHOLD = 5;
+
+/**
+ * The project filter UI, decoupled from data fetching so it can be rendered
+ * in isolation (e.g. Storybook).
+ */
+export function ProjectFilterMenu(props: {
+  projects: { id: string; name: string }[];
+  value: string[];
+  onChange: (value: string[]) => void;
+}) {
+  const { contains } = useFilter({ sensitivity: "base" });
+  const projects = [...props.projects].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
   const selected = props.value.filter((id) =>
     projects.some((project) => project.id === id),
   );
@@ -1347,9 +1382,37 @@ function ProjectFilter(props: {
       : selected.length === 1
         ? projects.find((project) => project.id === selected[0])?.name
         : `${selected.length} projects`;
+  const searchable = projects.length > PROJECT_SEARCH_THRESHOLD;
+  const menu = (
+    <Menu
+      aria-label="Projects"
+      selectionMode="multiple"
+      selectedKeys={selected}
+      className={searchable ? "max-h-72" : undefined}
+      renderEmptyState={() => (
+        <div className="text-low px-3 py-1.5 text-sm">No projects found</div>
+      )}
+      onSelectionChange={(keys) => {
+        if (keys === "all") {
+          return;
+        }
+        props.onChange(
+          projects
+            .filter((project) => keys.has(project.id))
+            .map((project) => project.id),
+        );
+      }}
+    >
+      {projects.map((project) => (
+        <MenuItem key={project.id} id={project.id} textValue={project.name}>
+          {project.name}
+        </MenuItem>
+      ))}
+    </Menu>
+  );
   return (
     <MenuTrigger>
-      <SelectButton className="text-sm">
+      <SelectButton className="shrink-0 text-sm whitespace-nowrap">
         {label}
         {selected.length > 1 ? (
           <Badge>
@@ -1358,27 +1421,26 @@ function ProjectFilter(props: {
         ) : null}
       </SelectButton>
       <Popover>
-        <Menu
-          aria-label="Projects"
-          selectionMode="multiple"
-          selectedKeys={selected}
-          onSelectionChange={(keys) => {
-            if (keys === "all") {
-              return;
-            }
-            props.onChange(
-              projects
-                .filter((project) => keys.has(project.id))
-                .map((project) => project.id),
-            );
-          }}
-        >
-          {projects.map((project) => (
-            <MenuItem key={project.id} id={project.id} textValue={project.name}>
-              {project.name}
-            </MenuItem>
-          ))}
-        </Menu>
+        {searchable ? (
+          <Autocomplete filter={contains}>
+            <div className="flex w-56 flex-col">
+              <SearchField
+                aria-label="Search projects"
+                autoFocus
+                className="flex items-center gap-2 border-b px-3 py-2"
+              >
+                <SearchIcon className="text-low size-4 shrink-0" />
+                <Input
+                  placeholder="Search projects…"
+                  className="placeholder:text-placeholder search-cancel:hidden w-full bg-transparent text-sm outline-hidden"
+                />
+              </SearchField>
+              {menu}
+            </div>
+          </Autocomplete>
+        ) : (
+          menu
+        )}
       </Popover>
     </MenuTrigger>
   );
@@ -1394,7 +1456,7 @@ function PeriodSelect(props: {
       value={props.value}
       onChange={(value) => props.onChange(value as Period)}
     >
-      <SelectButton className="w-full text-sm">
+      <SelectButton className="w-full shrink-0 text-sm whitespace-nowrap">
         {PeriodLabels[props.value]}
       </SelectButton>
       <Popover>

--- a/apps/frontend/src/pages/Account/Analytics.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.tsx
@@ -19,6 +19,7 @@ import {
   Area,
   AreaChart,
   CartesianGrid,
+  Label,
   Pie,
   PieChart,
   XAxis,
@@ -353,7 +354,12 @@ export function AnalyticsDashboard(props: {
           }
           visual={
             metrics && metrics.builds.all.total > 0 ? (
-              <Sparkline data={metrics.builds.series} color="var(--violet-9)" />
+              <Sparkline
+                label="Builds"
+                data={metrics.builds.series}
+                color="var(--violet-9)"
+                groupBy={groupBy}
+              />
             ) : null
           }
         />
@@ -370,8 +376,10 @@ export function AnalyticsDashboard(props: {
           visual={
             metrics && metrics.screenshots.all.total > 0 ? (
               <Sparkline
+                label="Screenshots"
                 data={metrics.screenshots.series}
                 color="var(--pink-9)"
+                groupBy={groupBy}
               />
             ) : null
           }
@@ -790,7 +798,7 @@ function StatTile(props: {
         <span className="text-low text-sm font-medium">{props.label}</span>
       </div>
       <div>
-        <div className="relative text-3xl font-black tabular-nums">
+        <div className="relative text-3xl leading-none font-black tabular-nums">
           {value === undefined ? (
             <div className="bg-subtle h-[1em] w-24 rounded-sm" />
           ) : value === null ? (
@@ -805,7 +813,7 @@ function StatTile(props: {
           )}
         </div>
         {props.hint ? (
-          <p className="text-low mt-1 h-4 text-sm">
+          <p className="text-low mt-0.5 h-4 text-sm">
             {isLoading ? null : props.hint}
           </p>
         ) : null}
@@ -816,13 +824,19 @@ function StatTile(props: {
 }
 
 function Sparkline(props: {
+  label: string;
   data: { ts: number; total: number }[];
   color: string;
+  groupBy: TimeSeriesGroupBy;
 }) {
+  const { groupBy } = props;
   const gradientId = useId();
   return (
     <div className="h-9 w-full">
-      <ChartContainer config={{}} className="size-full">
+      <ChartContainer
+        config={{ total: { label: props.label } }}
+        className="size-full"
+      >
         <AreaChart
           data={props.data}
           margin={{ top: 2, bottom: 0, left: 0, right: 0 }}
@@ -833,6 +847,21 @@ function Sparkline(props: {
               <stop offset="100%" stopColor={props.color} stopOpacity={0} />
             </linearGradient>
           </defs>
+          <ChartTooltip
+            cursor={{ strokeDasharray: "3 3" }}
+            position={{ y: -56 }}
+            allowEscapeViewBox={{ y: true }}
+            content={
+              <ChartTooltipContent
+                color={props.color}
+                labelFormatter={(_value, payload) => {
+                  const firstItem = payload[0];
+                  invariant(firstItem, "payload[0] is undefined");
+                  return formatSeriesDateLabel(firstItem.payload.ts, groupBy);
+                }}
+              />
+            }
+          />
           <Area
             dataKey="total"
             type="monotone"
@@ -853,21 +882,45 @@ function SplitBar(props: {
 }) {
   const total = props.segments.reduce((sum, segment) => sum + segment.value, 0);
   return (
-    <div className="flex h-1.5 w-full gap-0.5 overflow-hidden rounded-full">
-      {props.segments.map((segment) =>
-        segment.value > 0 ? (
-          <div
-            key={segment.label}
-            className="h-full first:rounded-l-full last:rounded-r-full"
-            style={{
-              width: `${(segment.value / total) * 100}%`,
-              backgroundColor: segment.color,
-            }}
-            aria-label={`${segment.label}: ${segment.value}`}
-          />
-        ) : null,
-      )}
-    </div>
+    <Tooltip
+      delay={150}
+      placement="top"
+      content={
+        <div className="flex min-w-40 flex-col gap-1 py-0.5">
+          {props.segments.map((segment) => (
+            <div key={segment.label} className="flex items-center gap-1.5">
+              <div
+                className="size-2 shrink-0 rounded-xs"
+                style={{ backgroundColor: segment.color }}
+              />
+              <span className="text-low">{segment.label}</span>
+              <span className="ml-auto font-medium tabular-nums">
+                {segment.value.toLocaleString()}
+              </span>
+            </div>
+          ))}
+        </div>
+      }
+    >
+      {/* Padding enlarges the hover target beyond the 6px bar. */}
+      <div className="-my-1.5 w-full cursor-default py-1.5">
+        <div className="flex h-1.5 w-full gap-0.5 overflow-hidden rounded-full">
+          {props.segments.map((segment) =>
+            segment.value > 0 ? (
+              <div
+                key={segment.label}
+                className="h-full first:rounded-l-full last:rounded-r-full"
+                style={{
+                  width: `${(segment.value / total) * 100}%`,
+                  backgroundColor: segment.color,
+                }}
+                aria-label={`${segment.label}: ${segment.value}`}
+              />
+            ) : null,
+          )}
+        </div>
+      </div>
+    </Tooltip>
   );
 }
 
@@ -959,34 +1012,51 @@ function ProjectPieChart(props: { metric: Metric }) {
     return acc;
   }, []);
   return (
-    <div className="relative size-full">
-      <div className="pointer-events-none absolute inset-x-0 top-1/2 z-10 flex -translate-y-[calc(50%+1.25rem)] flex-col items-center">
-        <span className="text-2xl font-black tabular-nums">
-          {props.metric.all.total.toLocaleString(navigator.language, {
-            notation: "compact",
-          })}
-        </span>
-        <span className="text-low text-xs">screenshots</span>
-      </div>
-      <ChartContainer config={chartConfig} className="size-full">
-        <PieChart>
-          <ChartTooltip
-            cursor={false}
-            content={<ChartTooltipContent hideLabel />}
+    <ChartContainer config={chartConfig} className="size-full">
+      <PieChart>
+        <Pie
+          data={data}
+          dataKey="screenshots"
+          nameKey="project"
+          innerRadius="55%"
+          outerRadius="80%"
+          paddingAngle={2}
+          strokeWidth={2}
+          isAnimationActive={false}
+        >
+          <Label
+            content={({ viewBox }) => {
+              if (!viewBox || !("cx" in viewBox) || !("cy" in viewBox)) {
+                return null;
+              }
+              const cx = Number(viewBox.cx);
+              const cy = Number(viewBox.cy);
+              return (
+                <text x={cx} y={cy} textAnchor="middle">
+                  <tspan
+                    x={cx}
+                    y={cy - 4}
+                    className="fill-(--text-color-default) text-2xl font-black tabular-nums"
+                  >
+                    {props.metric.all.total.toLocaleString(navigator.language, {
+                      notation: "compact",
+                    })}
+                  </tspan>
+                  <tspan
+                    x={cx}
+                    y={cy + 14}
+                    className="fill-(--text-color-low) text-xs"
+                  >
+                    screenshots
+                  </tspan>
+                </text>
+              );
+            }}
           />
-          <Pie
-            data={data}
-            dataKey="screenshots"
-            nameKey="project"
-            innerRadius="55%"
-            outerRadius="80%"
-            paddingAngle={2}
-            strokeWidth={2}
-          />
-          <ChartLegend content={<ChartLegendContent nameKey="project" />} />
-        </PieChart>
-      </ChartContainer>
-    </div>
+        </Pie>
+        <ChartLegend content={<ChartLegendContent nameKey="project" />} />
+      </PieChart>
+    </ChartContainer>
   );
 }
 
@@ -1082,27 +1152,7 @@ function EvolutionChart(props: {
               labelFormatter={(_value, payload) => {
                 const firstItem = payload[0];
                 invariant(firstItem, "payload[0] is undefined");
-                const date = new Date(firstItem.payload.ts);
-                switch (groupBy) {
-                  case TimeSeriesGroupBy.Day:
-                    return date.toLocaleDateString(navigator.language, {
-                      month: "short",
-                      day: "numeric",
-                    });
-                  case TimeSeriesGroupBy.Week: {
-                    const startOfWeek = moment(date)
-                      .startOf("week")
-                      .format("MMM D");
-                    const endOfWeek = moment(date)
-                      .endOf("week")
-                      .format("MMM D");
-                    return `${startOfWeek} - ${endOfWeek}`;
-                  }
-                  case TimeSeriesGroupBy.Month:
-                    return date.toLocaleDateString(navigator.language, {
-                      month: "short",
-                    });
-                }
+                return formatSeriesDateLabel(firstItem.payload.ts, groupBy);
               }}
             />
           }
@@ -1183,6 +1233,26 @@ const GroupByLabels: Record<TimeSeriesGroupBy, string> = {
   [TimeSeriesGroupBy.Week]: "Week",
   [TimeSeriesGroupBy.Month]: "Month",
 };
+
+function formatSeriesDateLabel(ts: number, groupBy: TimeSeriesGroupBy) {
+  const date = new Date(ts);
+  switch (groupBy) {
+    case TimeSeriesGroupBy.Day:
+      return date.toLocaleDateString(navigator.language, {
+        month: "short",
+        day: "numeric",
+      });
+    case TimeSeriesGroupBy.Week: {
+      const startOfWeek = moment(date).startOf("week").format("MMM D");
+      const endOfWeek = moment(date).endOf("week").format("MMM D");
+      return `${startOfWeek} - ${endOfWeek}`;
+    }
+    case TimeSeriesGroupBy.Month:
+      return date.toLocaleDateString(navigator.language, {
+        month: "short",
+      });
+  }
+}
 
 function PeriodSelect(props: {
   value: Period;

--- a/apps/frontend/src/pages/Account/Analytics.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.tsx
@@ -988,17 +988,6 @@ function EmptyState(props: { title: string; description: string }) {
 }
 
 function ProjectPieChart(props: { metric: Metric }) {
-  const chartConfig = props.metric.projects.reduce<ChartConfig>(
-    (config, project, index) => {
-      config[project.name] = {
-        label: project.name,
-        count: props.metric.all.projects[project.id],
-        color: getChartColorFromIndex(index),
-      };
-      return config;
-    },
-    { screenshots: { label: "Screenshots" } },
-  );
   const data = props.metric.projects.reduce<
     { project: string; screenshots: number; fill: string }[]
   >((acc, project, index) => {
@@ -1012,51 +1001,72 @@ function ProjectPieChart(props: { metric: Metric }) {
     return acc;
   }, []);
   return (
-    <ChartContainer config={chartConfig} className="size-full">
-      <PieChart>
-        <Pie
-          data={data}
-          dataKey="screenshots"
-          nameKey="project"
-          innerRadius="55%"
-          outerRadius="80%"
-          paddingAngle={2}
-          strokeWidth={2}
-          isAnimationActive={false}
-        >
-          <Label
-            content={({ viewBox }) => {
-              if (!viewBox || !("cx" in viewBox) || !("cy" in viewBox)) {
-                return null;
-              }
-              const cx = Number(viewBox.cx);
-              const cy = Number(viewBox.cy);
-              return (
-                <text x={cx} y={cy} textAnchor="middle">
-                  <tspan
-                    x={cx}
-                    y={cy - 4}
-                    className="fill-(--text-color-default) text-2xl font-black tabular-nums"
-                  >
-                    {props.metric.all.total.toLocaleString(navigator.language, {
-                      notation: "compact",
-                    })}
-                  </tspan>
-                  <tspan
-                    x={cx}
-                    y={cy + 14}
-                    className="fill-(--text-color-low) text-xs"
-                  >
-                    screenshots
-                  </tspan>
-                </text>
-              );
-            }}
-          />
-        </Pie>
-        <ChartLegend content={<ChartLegendContent nameKey="project" />} />
-      </PieChart>
-    </ChartContainer>
+    <div className="flex size-full flex-col">
+      {/* The legend lives outside the SVG: when it participates in the
+          chart layout, the pie ring shifts up but the center label viewBox
+          does not, leaving the label off-center. */}
+      <ChartContainer config={{}} className="min-h-0 flex-1">
+        <PieChart>
+          <Pie
+            data={data}
+            dataKey="screenshots"
+            nameKey="project"
+            innerRadius="55%"
+            outerRadius="80%"
+            paddingAngle={2}
+            strokeWidth={2}
+            isAnimationActive={false}
+          >
+            <Label
+              content={({ viewBox }) => {
+                if (!viewBox || !("cx" in viewBox) || !("cy" in viewBox)) {
+                  return null;
+                }
+                const cx = Number(viewBox.cx);
+                const cy = Number(viewBox.cy);
+                return (
+                  <text x={cx} y={cy} textAnchor="middle">
+                    <tspan
+                      x={cx}
+                      y={cy - 4}
+                      className="fill-(--text-color-default) text-2xl font-black tabular-nums"
+                    >
+                      {props.metric.all.total.toLocaleString(
+                        navigator.language,
+                        { notation: "compact" },
+                      )}
+                    </tspan>
+                    <tspan
+                      x={cx}
+                      y={cy + 14}
+                      className="fill-(--text-color-low) text-xs"
+                    >
+                      screenshots
+                    </tspan>
+                  </text>
+                );
+              }}
+            />
+          </Pie>
+        </PieChart>
+      </ChartContainer>
+      <div className="flex flex-wrap items-start justify-center gap-x-6 gap-y-2 pt-3 text-xs">
+        {props.metric.projects.map((project, index) => (
+          <div key={project.id}>
+            <div className="flex items-center gap-1.5">
+              <div
+                className="size-2 shrink-0 rounded-xs"
+                style={{ backgroundColor: getChartColorFromIndex(index) }}
+              />
+              {project.name}
+            </div>
+            <div className="mt-1 text-base font-bold tabular-nums">
+              {props.metric.all.projects[project.id]?.toLocaleString()}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/apps/frontend/src/pages/Account/Analytics.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.tsx
@@ -79,11 +79,19 @@ const AccountQuery = graphql(`
           all {
             total
             projects
+            changesDetected
+            noChanges
+            accepted
+            rejected
           }
           series {
             ts
             total
             projects
+            changesDetected
+            noChanges
+            accepted
+            rejected
           }
           projects {
             id
@@ -225,6 +233,12 @@ function Charts(props: {
   });
 
   const metrics = data.account?.metrics;
+  const concludedBuilds = metrics
+    ? metrics.builds.all.changesDetected + metrics.builds.all.noChanges
+    : 0;
+  const reviewedBuilds = metrics
+    ? metrics.builds.all.accepted + metrics.builds.all.rejected
+    : 0;
 
   const screenshotByBuildSeries: Metric | null = useMemo(() => {
     if (!metrics) {
@@ -303,6 +317,15 @@ function Charts(props: {
                     to,
                     groupBy,
                   }),
+                  extraColumns: [
+                    {
+                      label: "Changes detected",
+                      get: (serie) => serie.changesDetected,
+                    },
+                    { label: "No changes", get: (serie) => serie.noChanges },
+                    { label: "Approved", get: (serie) => serie.accepted },
+                    { label: "Rejected", get: (serie) => serie.rejected },
+                  ],
                 });
               }}
             >
@@ -316,7 +339,8 @@ function Charts(props: {
               <EmptyStateBuilds />
             ) : (
               <EvolutionChart
-                metric={metrics.builds}
+                series={metrics.builds.series}
+                keys={getProjectChartKeys(metrics.builds.projects)}
                 from={from}
                 to={to}
                 groupBy={groupBy}
@@ -337,7 +361,7 @@ function Charts(props: {
               onPress={() => {
                 invariant(metrics);
                 exportToCSV({
-                  metric: metrics.builds,
+                  metric: metrics.screenshots,
                   name: getCSVName({
                     account: accountSlug,
                     unit: "screenshots",
@@ -358,10 +382,75 @@ function Charts(props: {
               <EmptyStateScreenshots />
             ) : (
               <EvolutionChart
-                metric={metrics.screenshots}
+                series={metrics.screenshots.series}
+                keys={getProjectChartKeys(metrics.screenshots.projects)}
                 from={from}
                 to={to}
                 groupBy={groupBy}
+              />
+            )
+          ) : null}
+        </ChartCardBody>
+      </Card>
+      <Card className="col-span-12 flex flex-col lg:col-span-6">
+        <ChartCardHeader>
+          <ChartCardDescription>Changes detected</ChartCardDescription>
+          <div className="flex items-baseline gap-2">
+            <Count
+              count={metrics ? metrics.builds.all.changesDetected : null}
+            />
+            {metrics && concludedBuilds > 0 ? (
+              <span className="text-low text-sm font-medium">
+                {formatPercent(
+                  metrics.builds.all.changesDetected / concludedBuilds,
+                )}{" "}
+                of completed builds
+              </span>
+            ) : null}
+          </div>
+        </ChartCardHeader>
+        <ChartCardBody>
+          {metrics ? (
+            concludedBuilds === 0 ? (
+              <EmptyStateBuilds />
+            ) : (
+              <EvolutionChart
+                series={metrics.builds.series}
+                keys={BuildOutcomeChartKeys}
+                from={from}
+                to={to}
+                groupBy={groupBy}
+                legend
+              />
+            )
+          ) : null}
+        </ChartCardBody>
+      </Card>
+      <Card className="col-span-12 flex flex-col lg:col-span-6">
+        <ChartCardHeader>
+          <ChartCardDescription>Reviewed builds</ChartCardDescription>
+          <div className="flex items-baseline gap-2">
+            <Count count={metrics ? reviewedBuilds : null} />
+            {metrics && reviewedBuilds > 0 ? (
+              <span className="text-low text-sm font-medium">
+                {formatPercent(metrics.builds.all.accepted / reviewedBuilds)}{" "}
+                approved
+              </span>
+            ) : null}
+          </div>
+        </ChartCardHeader>
+        <ChartCardBody>
+          {metrics ? (
+            reviewedBuilds === 0 ? (
+              <EmptyStateReviews />
+            ) : (
+              <EvolutionChart
+                series={metrics.builds.series}
+                keys={BuildReviewChartKeys}
+                from={from}
+                to={to}
+                groupBy={groupBy}
+                legend
               />
             )
           ) : null}
@@ -439,7 +528,8 @@ function Charts(props: {
               <EmptyStateScreenshots />
             ) : (
               <EvolutionChart
-                metric={screenshotByBuildSeries}
+                series={screenshotByBuildSeries.series}
+                keys={getProjectChartKeys(screenshotByBuildSeries.projects)}
                 from={from}
                 to={to}
                 groupBy={groupBy}
@@ -465,11 +555,20 @@ function getCSVName(props: {
   return `${account}-${unit}-${fromStr}-${toStr}-${groupBy}.csv`;
 }
 
-function exportToCSV(props: { metric: Metric; name: string }) {
-  const { metric } = props;
+function exportToCSV<TSerie extends Metric["series"][number]>(props: {
+  metric: Omit<Metric, "series"> & { series: TSerie[] };
+  name: string;
+  extraColumns?: { label: string; get: (serie: TSerie) => number }[];
+}) {
+  const { metric, extraColumns = [] } = props;
 
   const rows: (string | number)[][] = [
-    ["Date", "Total", ...metric.projects.map((p) => p.name)],
+    [
+      "Date",
+      "Total",
+      ...metric.projects.map((p) => p.name),
+      ...extraColumns.map((column) => column.label),
+    ],
   ];
 
   metric.series.forEach((serie) => {
@@ -477,6 +576,7 @@ function exportToCSV(props: { metric: Metric; name: string }) {
       new Date(serie.ts).toISOString(),
       serie.total,
       ...metric.projects.map((p) => serie.projects[p.id] ?? 0),
+      ...extraColumns.map((column) => column.get(serie)),
     ];
     rows.push(row);
   });
@@ -516,6 +616,37 @@ function EmptyStateBuilds() {
     />
   );
 }
+
+function EmptyStateReviews() {
+  return (
+    <EmptyState
+      title="No reviews"
+      description="No builds have been reviewed for this period."
+    />
+  );
+}
+
+function formatPercent(ratio: number) {
+  return ratio.toLocaleString(navigator.language, {
+    style: "percent",
+    maximumFractionDigits: 0,
+  });
+}
+
+// Colors match the build status colors (warning / success / danger).
+const BuildOutcomeChartKeys: EvolutionChartKey[] = [
+  {
+    id: "changesDetected",
+    label: "Changes detected",
+    color: "var(--orange-9)",
+  },
+  { id: "noChanges", label: "No changes", color: "var(--grass-9)" },
+];
+
+const BuildReviewChartKeys: EvolutionChartKey[] = [
+  { id: "rejected", label: "Rejected", color: "var(--tomato-9)" },
+  { id: "accepted", label: "Approved", color: "var(--grass-9)" },
+];
 
 type Metric = {
   all: {
@@ -623,16 +754,34 @@ function ProjectPieChart(props: { metric: Metric }) {
   );
 }
 
+type EvolutionChartKey = {
+  id: string;
+  label: string;
+  color: string;
+};
+
+function getProjectChartKeys(
+  projects: { id: string; name: string }[],
+): EvolutionChartKey[] {
+  return projects.map((project, index) => ({
+    id: `projects.${project.id}`,
+    label: project.name,
+    color: getChartColorFromIndex(index),
+  }));
+}
+
 function EvolutionChart(props: {
-  metric: Metric;
+  series: { ts: number }[];
+  keys: EvolutionChartKey[];
   from: Date;
   to: Date;
   groupBy: TimeSeriesGroupBy;
+  legend?: boolean;
 }) {
-  const { metric, from, to, groupBy } = props;
-  const chartConfig = metric.projects.reduce<ChartConfig>((config, project) => {
-    config[`projects.${project.id}`] = {
-      label: project.name,
+  const { series, keys, from, to, groupBy } = props;
+  const chartConfig = keys.reduce<ChartConfig>((config, key) => {
+    config[key.id] = {
+      label: key.label,
     };
     return config;
   }, {});
@@ -651,7 +800,7 @@ function EvolutionChart(props: {
       <AreaChart
         margin={{ left: -12, right: 12 }}
         accessibilityLayer
-        data={metric.series}
+        data={series}
         syncId="evolution"
       >
         <CartesianGrid vertical={false} strokeDasharray="5 5" />
@@ -722,16 +871,16 @@ function EvolutionChart(props: {
             />
           }
         />
-        {metric.projects.map((project, index) => {
-          const color = getChartColorFromIndex(index);
+        {props.legend ? <ChartLegend content={<ChartLegendContent />} /> : null}
+        {keys.map((key) => {
           return (
             <Area
-              key={project.id}
-              dataKey={`projects.${project.id}`}
+              key={key.id}
+              dataKey={key.id}
               type="monotone"
-              fill={color}
+              fill={key.color}
               fillOpacity={0.4}
-              stroke={color}
+              stroke={key.color}
               stackId="group"
             />
           );

--- a/apps/frontend/src/pages/Account/Analytics.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.tsx
@@ -178,15 +178,15 @@ export function Component() {
     [setSearchParams],
   );
 
-  const projectIds = parseProjectIds(searchParams);
-  const setProjectIds = useCallback(
-    (ids: string[]) => {
+  const projectNames = parseProjectNames(searchParams);
+  const setProjectNames = useCallback(
+    (names: string[]) => {
       setSearchParams((prev) => {
         const next = new URLSearchParams(prev);
-        if (ids.length === 0) {
+        if (names.length === 0) {
           next.delete("projects");
         } else {
-          next.set("projects", ids.join(","));
+          next.set("projects", names.join(","));
         }
         return next;
       });
@@ -217,8 +217,8 @@ export function Component() {
               <Suspense fallback={null}>
                 <ProjectFilter
                   accountSlug={accountSlug}
-                  value={projectIds}
-                  onChange={setProjectIds}
+                  value={projectNames}
+                  onChange={setProjectNames}
                 />
               </Suspense>
               <PeriodSelect value={period} onChange={setPeriod} />
@@ -260,7 +260,7 @@ export function Component() {
             accountSlug={accountSlug}
             period={period}
             customPeriod={customPeriod}
-            projectIds={projectIds}
+            projectNames={projectNames}
           />
         </Suspense>
       </PageContainer>
@@ -272,10 +272,21 @@ function Charts(props: {
   accountSlug: string;
   period: Period;
   customPeriod: { from: Date; to: Date } | null;
-  projectIds: string[];
+  projectNames: string[];
 }) {
-  const { accountSlug, period, customPeriod, projectIds } = props;
+  const { accountSlug, period, customPeriod, projectNames } = props;
   const { from, to, groupBy } = getPeriodSettings(period, customPeriod);
+
+  // The metrics input takes project ids; resolve the names from the URL.
+  // Deduplicated with the ProjectFilter query by Apollo cache.
+  const { data: projectsData } = useSuspenseQuery(ProjectsQuery, {
+    variables: { slug: accountSlug },
+  });
+  const accountProjects = projectsData.account?.projects.edges ?? [];
+  const projectIds = projectNames.flatMap((name) => {
+    const project = accountProjects.find((project) => project.name === name);
+    return project ? [project.id] : [];
+  });
 
   const { data } = useSuspenseQuery(AccountQuery, {
     variables: {
@@ -929,7 +940,7 @@ function SplitBar(props: {
   const total = props.segments.reduce((sum, segment) => sum + segment.value, 0);
   return (
     <Tooltip
-      delay={150}
+      delay={0}
       placement="top"
       disableAnimation
       content={
@@ -1326,7 +1337,7 @@ const ProjectsQuery = graphql(`
   }
 `);
 
-function parseProjectIds(searchParams: URLSearchParams): string[] {
+function parseProjectNames(searchParams: URLSearchParams): string[] {
   const value = searchParams.get("projects");
   if (!value) {
     return [];
@@ -1373,14 +1384,14 @@ export function ProjectFilterMenu(props: {
   const projects = [...props.projects].sort((a, b) =>
     a.name.localeCompare(b.name),
   );
-  const selected = props.value.filter((id) =>
-    projects.some((project) => project.id === id),
+  const selected = props.value.filter((name) =>
+    projects.some((project) => project.name === name),
   );
   const label =
     selected.length === 0
       ? "All projects"
       : selected.length === 1
-        ? projects.find((project) => project.id === selected[0])?.name
+        ? selected[0]
         : `${selected.length} projects`;
   const searchable = projects.length > PROJECT_SEARCH_THRESHOLD;
   const menu = (
@@ -1398,13 +1409,13 @@ export function ProjectFilterMenu(props: {
         }
         props.onChange(
           projects
-            .filter((project) => keys.has(project.id))
-            .map((project) => project.id),
+            .filter((project) => keys.has(project.name))
+            .map((project) => project.name),
         );
       }}
     >
       {projects.map((project) => (
-        <MenuItem key={project.id} id={project.id} textValue={project.name}>
+        <MenuItem key={project.id} id={project.name} textValue={project.name}>
           {project.name}
         </MenuItem>
       ))}

--- a/apps/frontend/src/pages/Account/Analytics.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.tsx
@@ -12,7 +12,7 @@ import {
   ThumbsUpIcon,
 } from "lucide-react";
 import moment from "moment";
-import { Heading, Text } from "react-aria-components";
+import { Heading, MenuTrigger, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
 import { Navigate, useSearchParams } from "react-router-dom";
 import {
@@ -31,6 +31,7 @@ import {
   TimeSeriesGroupBy,
   type AccountUsage_AccountQuery,
 } from "@/gql/graphql";
+import { Badge } from "@/ui/Badge";
 import { Card } from "@/ui/Card";
 import {
   ChartConfig,
@@ -52,6 +53,7 @@ import {
   PageHeaderContent,
 } from "@/ui/Layout";
 import { ListBox, ListBoxItem, ListBoxItemLabel } from "@/ui/ListBox";
+import { Menu, MenuItem } from "@/ui/Menu";
 import { PageLoader } from "@/ui/PageLoader";
 import { Popover } from "@/ui/Popover";
 import { Select, SelectButton } from "@/ui/Select";
@@ -65,11 +67,19 @@ const AccountQuery = graphql(`
     $from: DateTime!
     $to: DateTime!
     $groupBy: TimeSeriesGroupBy!
+    $projectIds: [ID!]
   ) {
     account(slug: $slug) {
       id
       permissions
-      metrics(input: { from: $from, to: $to, groupBy: $groupBy }) {
+      metrics(
+        input: {
+          from: $from
+          to: $to
+          groupBy: $groupBy
+          projectIds: $projectIds
+        }
+      ) {
         screenshots {
           all {
             total
@@ -159,6 +169,22 @@ export function Component() {
     [setSearchParams],
   );
 
+  const projectIds = parseProjectIds(searchParams);
+  const setProjectIds = useCallback(
+    (ids: string[]) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        if (ids.length === 0) {
+          next.delete("projects");
+        } else {
+          next.set("projects", ids.join(","));
+        }
+        return next;
+      });
+    },
+    [setSearchParams],
+  );
+
   useEffect(() => {
     setPeriod(period);
   }, [setPeriod, period]);
@@ -179,6 +205,13 @@ export function Component() {
           </PageHeaderContent>
           <PageHeaderActions>
             <div className="flex items-center gap-2">
+              <Suspense fallback={null}>
+                <ProjectFilter
+                  accountSlug={accountSlug}
+                  value={projectIds}
+                  onChange={setProjectIds}
+                />
+              </Suspense>
               <PeriodSelect value={period} onChange={setPeriod} />
               {period === "custom" && customPeriod ? (
                 <DateRangePicker
@@ -218,6 +251,7 @@ export function Component() {
             accountSlug={accountSlug}
             period={period}
             customPeriod={customPeriod}
+            projectIds={projectIds}
           />
         </Suspense>
       </PageContainer>
@@ -229,8 +263,9 @@ function Charts(props: {
   accountSlug: string;
   period: Period;
   customPeriod: { from: Date; to: Date } | null;
+  projectIds: string[];
 }) {
-  const { accountSlug, period, customPeriod } = props;
+  const { accountSlug, period, customPeriod, projectIds } = props;
   const { from, to, groupBy } = getPeriodSettings(period, customPeriod);
 
   const { data } = useSuspenseQuery(AccountQuery, {
@@ -239,6 +274,7 @@ function Charts(props: {
       from: from.toISOString(),
       to: to.toISOString(),
       groupBy,
+      projectIds: projectIds.length > 0 ? projectIds : null,
     },
   });
 
@@ -1264,6 +1300,88 @@ function formatSeriesDateLabel(ts: number, groupBy: TimeSeriesGroupBy) {
         month: "short",
       });
   }
+}
+
+const ProjectsQuery = graphql(`
+  query AccountAnalyticsProjects_account($slug: String!) {
+    account(slug: $slug) {
+      id
+      projects(first: 100, after: 0) {
+        edges {
+          id
+          name
+        }
+      }
+    }
+  }
+`);
+
+function parseProjectIds(searchParams: URLSearchParams): string[] {
+  const value = searchParams.get("projects");
+  if (!value) {
+    return [];
+  }
+  return value.split(",").filter(Boolean);
+}
+
+function ProjectFilter(props: {
+  accountSlug: string;
+  value: string[];
+  onChange: (value: string[]) => void;
+}) {
+  const { data } = useSuspenseQuery(ProjectsQuery, {
+    variables: { slug: props.accountSlug },
+  });
+  const projects = [...(data.account?.projects.edges ?? [])].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+  if (projects.length < 2) {
+    return null;
+  }
+  const selected = props.value.filter((id) =>
+    projects.some((project) => project.id === id),
+  );
+  const label =
+    selected.length === 0
+      ? "All projects"
+      : selected.length === 1
+        ? projects.find((project) => project.id === selected[0])?.name
+        : `${selected.length} projects`;
+  return (
+    <MenuTrigger>
+      <SelectButton className="text-sm">
+        {label}
+        {selected.length > 1 ? (
+          <Badge>
+            {selected.length}/{projects.length}
+          </Badge>
+        ) : null}
+      </SelectButton>
+      <Popover>
+        <Menu
+          aria-label="Projects"
+          selectionMode="multiple"
+          selectedKeys={selected}
+          onSelectionChange={(keys) => {
+            if (keys === "all") {
+              return;
+            }
+            props.onChange(
+              projects
+                .filter((project) => keys.has(project.id))
+                .map((project) => project.id),
+            );
+          }}
+        >
+          {projects.map((project) => (
+            <MenuItem key={project.id} id={project.id} textValue={project.name}>
+              {project.name}
+            </MenuItem>
+          ))}
+        </Menu>
+      </Popover>
+    </MenuTrigger>
+  );
 }
 
 function PeriodSelect(props: {

--- a/apps/frontend/src/pages/Account/AnalyticsProjectFilter.stories.tsx
+++ b/apps/frontend/src/pages/Account/AnalyticsProjectFilter.stories.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ProjectFilterMenu } from "./Analytics";
+
+function ProjectFilterPlayground(props: { count: number }) {
+  const projects = Array.from({ length: props.count }, (_, i) => ({
+    id: String(i + 1),
+    name: [
+      "argos",
+      "argos-ci.com",
+      "argos-javascript",
+      "storybook",
+      "design-system",
+      "marketing-site",
+      "mobile-app",
+      "docs",
+    ][i]!,
+  }));
+  const [value, setValue] = useState<string[]>([]);
+  return (
+    <div className="p-10">
+      <ProjectFilterMenu
+        projects={projects}
+        value={value}
+        onChange={setValue}
+      />
+    </div>
+  );
+}
+
+const meta: Meta<typeof ProjectFilterPlayground> = {
+  title: "Pages/AnalyticsProjectFilter",
+  component: ProjectFilterPlayground,
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithSearch: Story = {
+  args: { count: 8 },
+};
+
+export const WithoutSearch: Story = {
+  args: { count: 4 },
+};

--- a/apps/frontend/src/pages/Test/ChangesChart.tsx
+++ b/apps/frontend/src/pages/Test/ChangesChart.tsx
@@ -76,6 +76,7 @@ export function ChangesChart(props: {
     >
       <ComposedChart data={transformedSeries}>
         <ChartTooltip
+          isAnimationActive={false}
           cursor={false}
           content={
             <ChartTooltipContent
@@ -121,18 +122,21 @@ export function ChangesChart(props: {
           type="monotone"
           fill="var(--gray-7)"
           stroke=""
+          isAnimationActive={false}
         />
         <Bar
           dataKey="uniqueChanges"
           xAxisId="changes"
           stackId="changes"
           fill="var(--blue-10)"
+          isAnimationActive={false}
         />
         <Bar
           dataKey="nonUniqueChanges"
           xAxisId="changes"
           stackId="changes"
           fill="var(--amber-10)"
+          isAnimationActive={false}
         />
         <XAxis
           dataKey="ts"

--- a/apps/frontend/src/ui/Tooltip.tsx
+++ b/apps/frontend/src/ui/Tooltip.tsx
@@ -24,6 +24,7 @@ export type TooltipProps = {
   variant?: TooltipVariant;
   placement?: RACTooltipProps["placement"];
   disableHoverableContent?: boolean;
+  disableAnimation?: boolean;
   isOpen?: TooltipTriggerComponentProps["isOpen"];
   onOpenChange?: TooltipTriggerComponentProps["onOpenChange"];
   delay?: TooltipTriggerComponentProps["delay"];
@@ -72,6 +73,7 @@ type TooltipOverlayProps = RACTooltipProps & {
   ref?: React.Ref<HTMLDivElement>;
   variant?: TooltipVariant;
   disableHoverableContent?: boolean;
+  disableAnimation?: boolean;
   children: React.ReactNode;
 };
 
@@ -79,6 +81,7 @@ function TooltipOverlay({
   className,
   variant = "default",
   disableHoverableContent = true,
+  disableAnimation = false,
   children,
   ...props
 }: TooltipOverlayProps) {
@@ -92,7 +95,7 @@ function TooltipOverlay({
         clsx(
           "bg-subtle text-default overflow-hidden rounded-md border shadow-md",
           disableHoverableContent && "pointer-events-none",
-          getTooltipAnimationClassName(props),
+          !disableAnimation && getTooltipAnimationClassName(props),
           variantClassName,
           className,
         )
@@ -146,6 +149,7 @@ export function Tooltip(props: TooltipProps) {
         variant={props.variant}
         placement={props.placement}
         disableHoverableContent={props.disableHoverableContent}
+        disableAnimation={props.disableAnimation}
       >
         {props.content}
       </TooltipOverlay>


### PR DESCRIPTION
Closes [ARG-461](https://linear.app/argos/issue/ARG-461)


<img width="2830" height="2472" alt="app argos-ci dev_4002_argos-ci_~_analytics" src="https://github.com/user-attachments/assets/ed70f3a1-dc42-4e31-8e5f-8134bf01f7cb" />

## What

Now that builds carry a `conclusion`, the account analytics page exposes richer, more actionable analytics, and the page has been redesigned around a scan-then-explore hierarchy.

### New metrics (backend + GraphQL)

- `getAccountBuildMetrics` now also counts, per time bucket:
  - `changesDetected` / `noChanges` — from `builds.conclusion`
  - `accepted` / `rejected` — review outcome, matching `Build.getReviewStatuses` semantics exactly (latest non-dismissed review per user, rejection wins), computed in SQL via a lateral join.
- New `AccountBuildsMetricDataPoint` / `AccountBuildsMetricData` GraphQL types expose these on `account.metrics.builds`.
- e2e coverage: approved build, approve-then-reject by the same user, dismissed review.

### Redesigned analytics page

- **KPI summary band**: Builds and Screenshots (with sparklines), Change rate and Approval rate (with split bars).
- **Themed sections**: Activity (builds/screenshots by project), Build outcomes (changes detected + reviewed builds, using build status colors), Breakdown (screenshots by project donut + screenshots per build).
- Project pie is now a donut with a center total; fixed its legend showing "Screenshots" instead of project names.
- Builds CSV export gains Changes detected / No changes / Approved / Rejected columns; fixed the Screenshots card exporting the builds metric.
- Extracted a pure `AnalyticsDashboard` component with a Storybook story (default + empty fixtures).

## Notes

- Chart mount animation is disabled for instant, consistent rendering (matches the KPI sparklines).
- Phase 2 of ARG-461 (exposing these analytics in the REST API/CLI) is intentionally left for a follow-up.

## Test plan

- `apps/backend/src/metrics/account.e2e.test.ts` (12 tests, snapshots assert the conclusion/review counts).
- Typecheck + ESLint + Prettier pass on backend and frontend.
- Verified visually via the new Storybook story: light, dark, and empty states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)