### PR TITLE
feat(frontend): redesign toasts and emphasize repeated ones

### DIFF
--- a/apps/frontend/eslint.config.mjs
+++ b/apps/frontend/eslint.config.mjs
@@ -5,4 +5,21 @@ import { defineConfig, globalIgnores } from "eslint/config";
 export default defineConfig(
   globalIgnores(["src/gql/**/*", "storybook-static"]),
   ...config,
+  {
+    ignores: ["src/ui/Toaster.tsx"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "sonner",
+              message:
+                'Import { toast, Toaster } from "@/ui/Toaster" instead, it handles theming and emphasizes duplicate toasts.',
+            },
+          ],
+        },
+      ],
+    },
+  },
 );

--- a/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
@@ -29,7 +29,6 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { useObjectRef } from "react-aria";
-import { toast } from "sonner";
 import { useClipboard } from "use-clipboard-copy";
 
 import { DocumentType, graphql } from "@/gql";
@@ -49,6 +48,7 @@ import {
 } from "@/ui/Menu";
 import { Popover } from "@/ui/Popover";
 import { Time } from "@/ui/Time";
+import { toast } from "@/ui/Toaster";
 import { Tooltip } from "@/ui/Tooltip";
 import { useEventCallback } from "@/ui/useEventCallback";
 import { useResizeObserver } from "@/ui/useResizeObserver";

--- a/apps/frontend/src/containers/Project/GitRepository.tsx
+++ b/apps/frontend/src/containers/Project/GitRepository.tsx
@@ -1,6 +1,5 @@
 import { useApolloClient, useMutation } from "@apollo/client/react";
 import { SubmitHandler, useForm } from "react-hook-form";
-import { toast } from "sonner";
 
 import { DocumentType, graphql } from "@/gql";
 import { ProjectGitRepository_ProjectFragment } from "@/gql/graphql";
@@ -10,6 +9,7 @@ import { Form } from "@/ui/Form";
 import { FormCardFooter } from "@/ui/FormCardFooter";
 import { FormSwitch } from "@/ui/FormSwitch";
 import { Link } from "@/ui/Link";
+import { toast } from "@/ui/Toaster";
 import { getErrorMessage } from "@/util/error";
 
 import { RepositoryIcons } from "../Repository";

--- a/apps/frontend/src/containers/Team/Domains.tsx
+++ b/apps/frontend/src/containers/Team/Domains.tsx
@@ -1,7 +1,6 @@
 import { useApolloClient, useMutation } from "@apollo/client/react";
 import { PlusIcon, Trash2Icon } from "lucide-react";
 import { useForm, type SubmitHandler } from "react-hook-form";
-import { toast } from "sonner";
 
 import { graphql, type DocumentType } from "@/gql";
 import { Button, ButtonIcon } from "@/ui/Button";
@@ -30,6 +29,7 @@ import { FormTextInput } from "@/ui/FormTextInput";
 import { IconButton } from "@/ui/IconButton";
 import { List, ListRow } from "@/ui/List";
 import { Modal } from "@/ui/Modal";
+import { toast } from "@/ui/Toaster";
 
 const _TeamFragment = graphql(`
   fragment TeamDomains_Team on Team {

--- a/apps/frontend/src/containers/Team/SAMLSSO.tsx
+++ b/apps/frontend/src/containers/Team/SAMLSSO.tsx
@@ -16,7 +16,6 @@ import {
   type Control,
   type SubmitHandler,
 } from "react-hook-form";
-import { toast } from "sonner";
 import z from "zod";
 
 import { CONTACT_HREF } from "@/constants";
@@ -53,6 +52,7 @@ import { Popover } from "@/ui/Popover";
 import { Separator } from "@/ui/Separator";
 import { Switch } from "@/ui/Switch";
 import { TextInput, TextInputAddon, TextInputGroup } from "@/ui/TextInput";
+import { toast } from "@/ui/Toaster";
 import { Tooltip } from "@/ui/Tooltip";
 import { useEventCallback } from "@/ui/useEventCallback";
 import { getErrorMessage } from "@/util/error";

--- a/apps/frontend/src/containers/Team/members/InviteDialog.tsx
+++ b/apps/frontend/src/containers/Team/members/InviteDialog.tsx
@@ -3,7 +3,6 @@ import { invariant } from "@argos/util/invariant";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { PlusCircleIcon } from "lucide-react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
-import { toast } from "sonner";
 import { z } from "zod";
 
 import { DocumentType, graphql } from "@/gql";
@@ -24,6 +23,7 @@ import { FormSubmit } from "@/ui/FormSubmit";
 import { FormTextInput } from "@/ui/FormTextInput";
 import { Label } from "@/ui/Label";
 import { Separator } from "@/ui/Separator";
+import { toast } from "@/ui/Toaster";
 
 import { MemberLevelSelect } from "./MemberLevelSelect";
 

--- a/apps/frontend/src/containers/Team/members/InvitesList.tsx
+++ b/apps/frontend/src/containers/Team/members/InvitesList.tsx
@@ -9,7 +9,6 @@ import {
   MoreVerticalIcon,
 } from "lucide-react";
 import { Heading, MenuTrigger, Text } from "react-aria-components";
-import { toast } from "sonner";
 
 import { AccountAvatar } from "@/containers/AccountAvatar";
 import { TeamMemberLabel } from "@/containers/UserList";
@@ -23,6 +22,7 @@ import { List, ListLoadMore, ListRow } from "@/ui/List";
 import { Menu, MenuItem, MenuItemIcon } from "@/ui/Menu";
 import { Modal } from "@/ui/Modal";
 import { Popover } from "@/ui/Popover";
+import { toast } from "@/ui/Toaster";
 
 import { InviteDialog } from "./InviteDialog";
 import { SearchFilter } from "./SearchFilter";

--- a/apps/frontend/src/containers/User/Auth.tsx
+++ b/apps/frontend/src/containers/User/Auth.tsx
@@ -3,7 +3,6 @@ import { invariant } from "@argos/util/invariant";
 import { MonitorIcon, SmartphoneIcon } from "lucide-react";
 import moment from "moment";
 import { Button as RACButton } from "react-aria-components";
-import { toast } from "sonner";
 
 import { logout } from "@/containers/Auth";
 import { DocumentType, graphql } from "@/gql";
@@ -24,6 +23,7 @@ import { ErrorMessage } from "@/ui/ErrorMessage";
 import { List, ListRow } from "@/ui/List";
 import { Modal } from "@/ui/Modal";
 import { Time } from "@/ui/Time";
+import { toast } from "@/ui/Toaster";
 
 import { EmailAuth } from "./providers/EmailAuth";
 import { GitHubAuth } from "./providers/GitHubAuth";

--- a/apps/frontend/src/containers/User/Emails.tsx
+++ b/apps/frontend/src/containers/User/Emails.tsx
@@ -2,7 +2,6 @@ import { useApolloClient } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { MoreVerticalIcon, PlusIcon } from "lucide-react";
 import { DialogTrigger, MenuTrigger } from "react-aria-components";
-import { toast } from "sonner";
 
 import { DocumentType, graphql } from "@/gql";
 import { Button, ButtonIcon } from "@/ui/Button";
@@ -20,6 +19,7 @@ import { List, ListRow } from "@/ui/List";
 import { Menu, MenuItem, MenuItemTooltip } from "@/ui/Menu";
 import { Modal } from "@/ui/Modal";
 import { Popover } from "@/ui/Popover";
+import { toast } from "@/ui/Toaster";
 import { getErrorMessage } from "@/util/error";
 
 import { AddUserEmailDialog } from "./emails/AddUserEmailDialog";

--- a/apps/frontend/src/containers/User/NotificationPreferences.tsx
+++ b/apps/frontend/src/containers/User/NotificationPreferences.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 import { useApolloClient } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
-import { toast } from "sonner";
 
 import { DocumentType, graphql } from "@/gql";
 import { Card, CardBody, CardParagraph, CardTitle } from "@/ui/Card";
 import { Switch } from "@/ui/Switch";
+import { toast } from "@/ui/Toaster";
 import { getErrorMessage } from "@/util/error";
 
 const _AccountFragment = graphql(`

--- a/apps/frontend/src/containers/User/emails/AddUserEmailDialog.tsx
+++ b/apps/frontend/src/containers/User/emails/AddUserEmailDialog.tsx
@@ -1,7 +1,6 @@
 import { useApolloClient } from "@apollo/client/react";
 import { InfoIcon } from "lucide-react";
 import { useForm, type SubmitHandler } from "react-hook-form";
-import { toast } from "sonner";
 import { z } from "zod";
 
 import { logout } from "@/containers/Auth";
@@ -22,6 +21,7 @@ import { FormCheckbox } from "@/ui/FormCheckbox";
 import { FormRootError } from "@/ui/FormRootError";
 import { FormSubmit } from "@/ui/FormSubmit";
 import { FormTextInput } from "@/ui/FormTextInput";
+import { toast } from "@/ui/Toaster";
 
 const AddUserEmailMutation = graphql(`
   mutation AddUserEmailMutation($email: String!) {

--- a/apps/frontend/src/containers/User/emails/DeleteUserEmailDialog.tsx
+++ b/apps/frontend/src/containers/User/emails/DeleteUserEmailDialog.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from "@apollo/client/react";
-import { toast } from "sonner";
 
 import { graphql } from "@/gql";
 import { Button } from "@/ui/Button";
@@ -13,6 +12,7 @@ import {
   useOverlayTriggerState,
 } from "@/ui/Dialog";
 import { ErrorMessage } from "@/ui/ErrorMessage";
+import { toast } from "@/ui/Toaster";
 
 type DeleteUserEmailDialogProps = {
   email: string;

--- a/apps/frontend/src/containers/User/emails/SendUserEmailVerificationButton.tsx
+++ b/apps/frontend/src/containers/User/emails/SendUserEmailVerificationButton.tsx
@@ -1,8 +1,8 @@
 import { useMutation } from "@apollo/client/react";
-import { toast } from "sonner";
 
 import { graphql } from "@/gql";
 import { Button } from "@/ui/Button";
+import { toast } from "@/ui/Toaster";
 import { getErrorMessage } from "@/util/error";
 
 type SendUserEmailVerificationButtonProps = {

--- a/apps/frontend/src/containers/User/tokens/DeleteTokenDialog.tsx
+++ b/apps/frontend/src/containers/User/tokens/DeleteTokenDialog.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from "@apollo/client/react";
-import { toast } from "sonner";
 
 import { graphql } from "@/gql";
 import { Button } from "@/ui/Button";
@@ -13,6 +12,7 @@ import {
   useOverlayTriggerState,
 } from "@/ui/Dialog";
 import { ErrorMessage } from "@/ui/ErrorMessage";
+import { toast } from "@/ui/Toaster";
 
 const DeleteUserAccessTokenMutation = graphql(`
   mutation DeleteUserAccessToken($input: DeleteUserAccessTokenInput!) {

--- a/apps/frontend/src/containers/User/tokens/EditTokenDialog.tsx
+++ b/apps/frontend/src/containers/User/tokens/EditTokenDialog.tsx
@@ -1,6 +1,5 @@
 import { useApolloClient } from "@apollo/client/react";
 import { useForm, type SubmitHandler } from "react-hook-form";
-import { toast } from "sonner";
 
 import { graphql } from "@/gql";
 import {
@@ -16,6 +15,7 @@ import { Form } from "@/ui/Form";
 import { FormRootError } from "@/ui/FormRootError";
 import { FormSubmit } from "@/ui/FormSubmit";
 import { FormTextInput } from "@/ui/FormTextInput";
+import { toast } from "@/ui/Toaster";
 
 const UpdateUserAccessTokenMutation = graphql(`
   mutation UpdateUserAccessToken($input: UpdateUserAccessTokenInput!) {

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -352,6 +352,34 @@
   }
 }
 
+/*
+ * Sonner only hides the content of collapsed (stacked) toasts when they are
+ * styled; replicate it for our unstyled toasts. Kept out of any layer so it
+ * competes with the stylesheet sonner injects at runtime.
+ */
+[data-sonner-toast][data-expanded="false"][data-front="false"] > * {
+  opacity: 0;
+}
+
+/*
+ * Restate sonner's toast transition list to add `scale`, which the Toaster
+ * toggles through the `toast-emphasized` class when a toast is triggered
+ * again while visible. The selector is doubled to win over the stylesheet
+ * sonner injects at runtime.
+ */
+[data-sonner-toast][data-sonner-toast] {
+  transition:
+    transform 0.4s,
+    opacity 0.4s,
+    height 0.4s,
+    box-shadow 0.2s,
+    scale 0.25s;
+}
+
+[data-sonner-toast].toast-emphasized {
+  scale: 1.05;
+}
+
 @layer base {
   *,
   ::after,

--- a/apps/frontend/src/pages/Account/NewProject.tsx
+++ b/apps/frontend/src/pages/Account/NewProject.tsx
@@ -5,7 +5,6 @@ import { Heading, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
-import { toast } from "sonner";
 
 import { ConnectRepository } from "@/containers/Project/ConnectRepository";
 import { graphql } from "@/gql";
@@ -21,6 +20,7 @@ import {
   PageHeaderContent,
 } from "@/ui/Layout";
 import { Separator } from "@/ui/Separator";
+import { toast } from "@/ui/Toaster";
 import { getErrorMessage } from "@/util/error";
 
 import { useAccountParams } from "./AccountParams";

--- a/apps/frontend/src/pages/Automation/AutomationTestNotification.tsx
+++ b/apps/frontend/src/pages/Automation/AutomationTestNotification.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef, useState } from "react";
 import { useMutation } from "@apollo/client/react";
 import { CheckIcon } from "lucide-react";
-import { toast } from "sonner";
 
 import { graphql } from "@/gql";
 import { Button, ButtonIcon } from "@/ui/Button";
 import { handleFormError } from "@/ui/Form";
+import { toast } from "@/ui/Toaster";
 
 import type { AutomationForm } from "./AutomationForm";
 

--- a/apps/frontend/src/pages/Build/RejectCommentDialog.tsx
+++ b/apps/frontend/src/pages/Build/RejectCommentDialog.tsx
@@ -9,7 +9,6 @@ import {
 } from "react";
 import { useApolloClient } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
-import { toast } from "sonner";
 
 import { DocumentType, graphql } from "@/gql";
 import { useProjectParams } from "@/pages/Project/ProjectParams";
@@ -26,6 +25,7 @@ import {
 import { Editor, type EditorValue } from "@/ui/Editor/Editor";
 import { hasEditorContent } from "@/ui/Editor/util";
 import { Modal, ModalActionContext } from "@/ui/Modal";
+import { toast } from "@/ui/Toaster";
 import { getMentionUser } from "@/ui/UserCard";
 import { getErrorMessage } from "@/util/error";
 import * as sessionStorage from "@/util/session-storage";

--- a/apps/frontend/src/pages/Build/diffComments/DiffCommentDraft.tsx
+++ b/apps/frontend/src/pages/Build/diffComments/DiffCommentDraft.tsx
@@ -1,6 +1,5 @@
 import { useId, useState } from "react";
 import { MessageSquarePlusIcon } from "lucide-react";
-import { toast } from "sonner";
 
 import { AccountAvatar } from "@/containers/AccountAvatar";
 import { Button, ButtonIcon } from "@/ui/Button";
@@ -8,6 +7,7 @@ import { Editor, type EditorValue } from "@/ui/Editor/Editor";
 import { MOD } from "@/ui/Editor/EditorToolbar.shortcuts";
 import { hasEditorContent } from "@/ui/Editor/util";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
+import { toast } from "@/ui/Toaster";
 import { useAltKeyHeld } from "@/ui/useAltKeyHeld";
 
 import { useMentionableUsers } from "../sidebar/MentionableUsersContext";

--- a/apps/frontend/src/pages/Build/diffComments/DiffCommentLayer.tsx
+++ b/apps/frontend/src/pages/Build/diffComments/DiffCommentLayer.tsx
@@ -7,7 +7,6 @@ import type {
   SupportedLanguages,
 } from "@pierre/diffs/react";
 import { useAtomValue } from "jotai/react";
-import { toast } from "sonner";
 
 import { useAuthTokenPayload } from "@/containers/Auth";
 import { CommentsEnabledContext } from "@/containers/Build/CommentsContext";
@@ -18,6 +17,7 @@ import { DocumentType, graphql } from "@/gql";
 import { ProjectPermission } from "@/gql/graphql";
 import { useProjectParams } from "@/pages/Project/ProjectParams";
 import { type EditorValue } from "@/ui/Editor/Editor";
+import { toast } from "@/ui/Toaster";
 import { getMentionUser } from "@/ui/UserCard";
 import { getErrorMessage } from "@/util/error";
 

--- a/apps/frontend/src/pages/Build/screenshotComments/CommentDraftPopover.tsx
+++ b/apps/frontend/src/pages/Build/screenshotComments/CommentDraftPopover.tsx
@@ -1,8 +1,8 @@
 import { useId, useState } from "react";
-import { toast } from "sonner";
 
 import { Editor, type EditorValue } from "@/ui/Editor/Editor";
 import { hasEditorContent } from "@/ui/Editor/util";
+import { toast } from "@/ui/Toaster";
 import { useAltKeyHeld } from "@/ui/useAltKeyHeld";
 
 import { ReviewCommentSubmitButton } from "../ReviewCommentSubmitButton";

--- a/apps/frontend/src/pages/Build/screenshotComments/ScreenshotCommentLayer.tsx
+++ b/apps/frontend/src/pages/Build/screenshotComments/ScreenshotCommentLayer.tsx
@@ -10,7 +10,6 @@ import {
 import { useApolloClient } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { useAtom, useAtomValue } from "jotai/react";
-import { toast } from "sonner";
 
 import { useAuthTokenPayload } from "@/containers/Auth";
 import { CommentsEnabledContext } from "@/containers/Build/CommentsContext";
@@ -28,6 +27,7 @@ import { DocumentType, graphql } from "@/gql";
 import { ProjectPermission } from "@/gql/graphql";
 import { useProjectParams } from "@/pages/Project/ProjectParams";
 import { type EditorValue } from "@/ui/Editor/Editor";
+import { toast } from "@/ui/Toaster";
 import { getMentionUser } from "@/ui/UserCard";
 import { getErrorMessage } from "@/util/error";
 

--- a/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
@@ -4,12 +4,12 @@ import { invariant } from "@argos/util/invariant";
 import { clsx } from "clsx";
 import { EyeOffIcon } from "lucide-react";
 import { Button } from "react-aria-components";
-import { toast } from "sonner";
 
 import { DocumentType, graphql } from "@/gql";
 import { useProjectParams } from "@/pages/Project/ProjectParams";
 import { type EditorValue } from "@/ui/Editor/Editor";
 import { StandaloneEditor } from "@/ui/Editor/StandaloneEditor";
+import { toast } from "@/ui/Toaster";
 import { Tooltip } from "@/ui/Tooltip";
 import { useAltKeyHeld } from "@/ui/useAltKeyHeld";
 import { getErrorMessage } from "@/util/error";

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -11,7 +11,6 @@ import {
 import moment from "moment";
 import { AnimatePresence, motion } from "motion/react";
 import { Button } from "react-aria-components";
-import { toast } from "sonner";
 import { useClipboard } from "use-clipboard-copy";
 
 import { AccountAvatar } from "@/containers/AccountAvatar";
@@ -28,6 +27,7 @@ import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 import { IconButton } from "@/ui/IconButton";
 import { Modal } from "@/ui/Modal";
 import { Time } from "@/ui/Time";
+import { toast } from "@/ui/Toaster";
 import { Tooltip } from "@/ui/Tooltip";
 import { getMentionUser, getUserCardData, UserHoverCard } from "@/ui/UserCard";
 import { getErrorMessage } from "@/util/error";

--- a/apps/frontend/src/pages/Build/sidebar/CommentReactions.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentReactions.tsx
@@ -2,13 +2,13 @@ import { useApolloClient } from "@apollo/client/react";
 import { clsx } from "clsx";
 import { SmilePlusIcon } from "lucide-react";
 import { Button } from "react-aria-components";
-import { toast } from "sonner";
 
 import { useProjectPermission } from "@/containers/Project/PermissionsContext";
 import { DocumentType, graphql } from "@/gql";
 import { ProjectPermission } from "@/gql/graphql";
 import { EmojiPickerPopover, EmojiPickerTrigger } from "@/ui/EmojiPicker";
 import { IconButton } from "@/ui/IconButton";
+import { toast } from "@/ui/Toaster";
 import { Tooltip } from "@/ui/Tooltip";
 import { getErrorMessage } from "@/util/error";
 import { formatNameListText } from "@/util/nameList";

--- a/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
@@ -12,7 +12,6 @@ import {
 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
-import { toast } from "sonner";
 
 import { useProjectPermission } from "@/containers/Project/PermissionsContext";
 import { DocumentType, graphql } from "@/gql";
@@ -26,6 +25,7 @@ import type { MentionUser } from "@/ui/Editor/mention";
 import { IconButton } from "@/ui/IconButton";
 import { Panel, PanelHeader, PanelTitle } from "@/ui/Panel";
 import { Time } from "@/ui/Time";
+import { toast } from "@/ui/Toaster";
 import { Tooltip } from "@/ui/Tooltip";
 import { useLiveRef } from "@/ui/useLiveRef";
 import { getMentionUser, getUserCardData, UserHoverCard } from "@/ui/UserCard";

--- a/apps/frontend/src/pages/Invite.tsx
+++ b/apps/frontend/src/pages/Invite.tsx
@@ -3,7 +3,6 @@ import { invariant } from "@argos/util/invariant";
 import { Heading, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
 import { useNavigate, useParams } from "react-router-dom";
-import { toast } from "sonner";
 
 import { useIsLoggedIn } from "@/containers/Auth";
 import {
@@ -15,6 +14,7 @@ import {
 import { graphql } from "@/gql";
 import { Button, type ButtonProps } from "@/ui/Button";
 import { PageLoader } from "@/ui/PageLoader";
+import { toast } from "@/ui/Toaster";
 import { getErrorMessage } from "@/util/error";
 
 import { getAccountURL } from "./Account/AccountParams";

--- a/apps/frontend/src/pages/VerifyEmail.tsx
+++ b/apps/frontend/src/pages/VerifyEmail.tsx
@@ -1,13 +1,13 @@
 import { useMutation } from "@apollo/client/react";
 import { Helmet } from "react-helmet";
 import { useSearchParams } from "react-router-dom";
-import { toast } from "sonner";
 
 import { Layout } from "@/containers/Layout";
 import { graphql } from "@/gql";
 import { Button } from "@/ui/Button";
 import { Code } from "@/ui/Code";
 import { Container } from "@/ui/Container";
+import { toast } from "@/ui/Toaster";
 import { getErrorMessage } from "@/util/error";
 
 export function Component() {

--- a/apps/frontend/src/ui/Button.tsx
+++ b/apps/frontend/src/ui/Button.tsx
@@ -6,8 +6,8 @@ import {
   Link as RACLink,
   LinkProps as RACLinkProps,
 } from "react-aria-components";
-import { toast } from "sonner";
 
+import { toast } from "@/ui/Toaster";
 import { getErrorMessage } from "@/util/error";
 
 import { Loader } from "./Loader";

--- a/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
+++ b/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
@@ -1,7 +1,8 @@
 import { useId, useState } from "react";
 import clsx from "clsx";
 import { ArrowUpIcon } from "lucide-react";
-import { toast } from "sonner";
+
+import { toast } from "@/ui/Toaster";
 
 import { Button } from "../Button";
 import { HotkeyTooltip } from "../HotkeyTooltip";

--- a/apps/frontend/src/ui/FormRootError.tsx
+++ b/apps/frontend/src/ui/FormRootError.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useFormState, type Control, type FieldValues } from "react-hook-form";
-import { toast } from "sonner";
+
+import { toast } from "@/ui/Toaster";
 
 import { ErrorMessage } from "./ErrorMessage";
 

--- a/apps/frontend/src/ui/Toaster.stories.tsx
+++ b/apps/frontend/src/ui/Toaster.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Button } from "./Button";
+import { ColorModeProvider } from "./ColorMode";
+import { toast, Toaster } from "./Toaster";
+
+const meta: Meta<typeof Toaster> = {
+  title: "UI/Toaster",
+  component: Toaster,
+  decorators: [
+    (Story) => (
+      <ColorModeProvider>
+        <Story />
+        <Toaster />
+      </ColorModeProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Button
+        variant="secondary"
+        onPress={() => toast("Issue URL copied to clipboard")}
+      >
+        Default
+      </Button>
+      <Button
+        variant="secondary"
+        onPress={() => toast.info("A new version of Argos is available")}
+      >
+        Info
+      </Button>
+      <Button
+        variant="secondary"
+        onPress={() => toast.success("Invitations sent successfully")}
+      >
+        Success
+      </Button>
+      <Button
+        variant="secondary"
+        onPress={() => toast.error("Something went wrong, please try again")}
+      >
+        Danger
+      </Button>
+      <Button
+        variant="secondary"
+        onPress={() => toast.warning("Your trial expires in 3 days")}
+      >
+        Warning
+      </Button>
+      <Button
+        variant="secondary"
+        onPress={() =>
+          toast("greg/arg-462-expose-all-flakiness-stats-in-the-apicli", {
+            description:
+              "Branch name copied to clipboard. Paste it into your favorite git client.",
+          })
+        }
+      >
+        With description
+      </Button>
+      <Button
+        variant="secondary"
+        onPress={() =>
+          toast.success("Build #4821 approved", {
+            description: "12 screenshots changed",
+            action: {
+              label: "View",
+              onClick: () => {},
+            },
+          })
+        }
+      >
+        With action
+      </Button>
+      <Button
+        variant="secondary"
+        onPress={() =>
+          toast.promise(
+            new Promise((resolve) => {
+              setTimeout(resolve, 2000);
+            }),
+            {
+              loading: "Uploading screenshots…",
+              success: "Screenshots uploaded",
+              error: "Failed to upload screenshots",
+            },
+          )
+        }
+      >
+        Promise
+      </Button>
+      <Button
+        variant="secondary"
+        onPress={() =>
+          toast('"ARG-462" copied to clipboard', { id: "copy-issue-id" })
+        }
+      >
+        Same id (zoom when repeated)
+      </Button>
+    </div>
+  ),
+};

--- a/apps/frontend/src/ui/Toaster.tsx
+++ b/apps/frontend/src/ui/Toaster.tsx
@@ -1,14 +1,137 @@
-import { Toaster as Sonner, ToasterProps } from "sonner";
+import {
+  CircleCheckIcon,
+  CircleXIcon,
+  InfoIcon,
+  TriangleAlertIcon,
+  XIcon,
+} from "lucide-react";
+import {
+  ExternalToast,
+  Toaster as Sonner,
+  toast as sonnerToast,
+  ToasterProps,
+} from "sonner";
 
 import { useColorMode } from "@/ui/ColorMode";
+import { Loader } from "@/ui/Loader";
 
 export function Toaster(props: ToasterProps) {
   const { colorMode } = useColorMode();
   return (
     <Sonner
       theme={colorMode ?? "system"}
-      className="toaster group"
+      closeButton
+      icons={{
+        info: (
+          <InfoIcon className="size-4 text-(--gray-1) [&_circle]:fill-(--gray-12) [&_circle]:stroke-(--gray-12)" />
+        ),
+        success: (
+          <CircleCheckIcon className="size-4 text-white [&_circle]:fill-(--grass-9) [&_circle]:stroke-(--grass-9)" />
+        ),
+        warning: (
+          <TriangleAlertIcon className="size-4 text-white [&_path:first-child]:fill-(--orange-9) [&_path:first-child]:stroke-(--orange-9)" />
+        ),
+        error: (
+          <CircleXIcon className="size-4 text-white [&_circle]:fill-(--tomato-9) [&_circle]:stroke-(--tomato-9)" />
+        ),
+        loading: <Loader delay={0} className="text-low size-4" />,
+        close: <XIcon className="size-3.5" />,
+      }}
+      toastOptions={{
+        unstyled: true,
+        classNames: {
+          toast:
+            "bg-subtle border-thin flex w-(--width) items-start gap-2.5 rounded-xl bg-clip-padding p-3 text-sm shadow-lg",
+          content: "flex min-w-0 flex-1 flex-col gap-0.5",
+          title: "text-default font-medium",
+          description: "text-low",
+          icon: "relative mt-0.5 flex size-4 shrink-0 items-center justify-center",
+          // Sonner positions the loader relative to the whole toast; pin it
+          // inside the icon slot instead.
+          loader: "absolute! inset-0! transform-none!",
+          closeButton:
+            "text-low hover:text-default hover:bg-hover order-last -mt-1 -mr-1 flex size-6 shrink-0 items-center justify-center rounded-md",
+          actionButton:
+            "bg-primary-solid hover:bg-primary-solid-hover active:bg-primary-solid-active self-center rounded-sm border border-transparent px-2 py-1 text-xs font-medium text-white",
+          cancelButton:
+            "text-default hover:bg-hover hover:border-hover active:bg-active self-center rounded-sm border bg-transparent px-2 py-1 text-xs font-medium",
+        },
+      }}
       {...props}
     />
   );
 }
+
+const EMPHASIS_DURATION = 300;
+const emphasisTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+/**
+ * Scale up a visible toast for a moment to draw attention to it. The `scale`
+ * transition declared in index.css animates both legs, so repeated calls
+ * hold the toast scaled up instead of replaying the effect from scratch.
+ */
+function emphasizeToast(testId: string) {
+  const element = document.querySelector(
+    `[data-sonner-toast][data-testid="${CSS.escape(testId)}"]`,
+  );
+  if (!(element instanceof HTMLElement)) {
+    return;
+  }
+  element.classList.add("toast-emphasized");
+  clearTimeout(emphasisTimers.get(testId));
+  emphasisTimers.set(
+    testId,
+    setTimeout(() => {
+      emphasisTimers.delete(testId);
+      element.classList.remove("toast-emphasized");
+    }, EMPHASIS_DURATION),
+  );
+}
+
+type ToastCreator = (
+  message: React.ReactNode | (() => React.ReactNode),
+  data?: ExternalToast,
+) => string | number;
+
+/**
+ * Wrap a sonner toast creator so that calling it with the id of a toast
+ * already on screen zooms that toast instead of just swapping its content.
+ */
+function withEmphasis<T extends ToastCreator>(create: T): T {
+  const wrapped: ToastCreator = (message, data) => {
+    if (data?.id == null) {
+      return create(message, data);
+    }
+    const testId = data.testId ?? `toast-${data.id}`;
+    const alreadyVisible = sonnerToast
+      .getToasts()
+      .some((toast) => toast.id === data.id);
+    const id = create(message, { ...data, testId });
+    if (alreadyVisible) {
+      emphasizeToast(testId);
+    }
+    return id;
+  };
+  return wrapped as T;
+}
+
+/**
+ * Same API as sonner's `toast`, but calling it with the id of a toast that is
+ * already visible emphasizes it with a zoom animation.
+ */
+export const toast: typeof sonnerToast = Object.assign(
+  withEmphasis(sonnerToast),
+  {
+    success: withEmphasis(sonnerToast.success),
+    info: withEmphasis(sonnerToast.info),
+    warning: withEmphasis(sonnerToast.warning),
+    error: withEmphasis(sonnerToast.error),
+    message: withEmphasis(sonnerToast.message),
+    loading: withEmphasis(sonnerToast.loading),
+    custom: sonnerToast.custom,
+    promise: sonnerToast.promise,
+    dismiss: sonnerToast.dismiss,
+    getHistory: sonnerToast.getHistory,
+    getToasts: sonnerToast.getToasts,
+  },
+);

--- a/apps/frontend/src/ui/Toaster.tsx
+++ b/apps/frontend/src/ui/Toaster.tsx
@@ -120,7 +120,11 @@ function withEmphasis<T extends ToastCreator>(create: T): T {
  * already visible emphasizes it with a zoom animation.
  */
 export const toast: typeof sonnerToast = Object.assign(
-  withEmphasis(sonnerToast),
+  // Sonner's bare `toast()` skips its `create()` logic: with an explicit id
+  // it appends duplicate entries and never revives a dismissed id, so
+  // `getToasts()` misses it once it has been dismissed. `message()` renders
+  // the same untyped toast but goes through `create()`.
+  withEmphasis(sonnerToast.message),
   {
     success: withEmphasis(sonnerToast.success),
     info: withEmphasis(sonnerToast.info),


### PR DESCRIPTION
## Summary

- Redesign toasts (Linear-style): unstyled sonner toasts restyled from our design tokens — `bg-subtle` elevated card, hairline border, `rounded-xl`, medium-weight title, `text-low` description, in-card close button.
- Colored filled icons per severity: green check disc (success), red cross disc (danger), orange triangle (warning), neutral dark info disc that inverts in dark mode. Loading uses the app `Loader`, pinned inside the icon slot.
- New `UI/Toaster` Storybook story covering default, info, success, danger, warning, description, action, promise, and repeated same-id toasts.
- `@/ui/Toaster` now exports a wrapped `toast` (same API as sonner's): re-firing a toast whose `id` is still visible scales it up briefly (`scale` transition, so stacking transforms are untouched and repeated triggers extend the hold instead of replaying). Direct `sonner` imports are banned via ESLint so everything gets theming + emphasis; all 31 call sites migrated.
- Toasts with an `id` render a `data-testid="toast-<id>"` hook, used by the emphasis and available to e2e tests.

## Test plan

- `check-types` and `lint` pass across the workspace; the new story passes the Storybook vitest project.
- Driven in Storybook with Playwright (Chromium + WebKit): all variants light/dark, promise loading→success, collapsed stack, close button, and the emphasis (computed `scale` reaches 1.05, settles back, single toast for duplicate ids, holds under rapid re-triggers, disabled under `prefers-reduced-motion` via sonner's media rule).
- The Argos build of this PR includes the new story for visual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)