### PR TITLE
fix(frontend): land on the next diff to review after reapplying approvals

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: verify
+description: Build, launch, and drive the Argos app locally to verify frontend/backend changes end-to-end against the test database.
+---
+
+# Verifying Argos changes end-to-end
+
+## Build
+
+```bash
+pnpm --filter @argos/frontend build   # vite → apps/frontend/dist (~40s)
+pnpm --filter @argos/backend build    # swc → apps/backend/dist (~10s)
+```
+
+The web server (`apps/backend/dist/processes/proc/web.js`) serves the built
+frontend — rebuild the frontend after every source change you want to observe.
+
+## Environment
+
+- Docker provides Postgres (5432) and Redis (6380): `docker compose up -d`
+  (containers `argos-postgres-1`, `argos-redis-1`).
+- Test DB: `cd apps/backend && NODE_ENV=test pnpm db:migrate:latest`.
+- Node: repo pins 24 (`.nvmrc`), shell may have 26 via mise —
+  run node things with `mise exec node@24 -- <cmd>`.
+
+## Gotcha: stock Playwright e2e does NOT run locally
+
+`pnpm test:e2e` fails on any locally-installed Node (24/22/26, checked
+2026-07) at two levels:
+
+1. Loading `playwright.config.mts` → imports `apps/backend/src/config` →
+   convict → semver → Node ERR_INTERNAL_ASSERTION "Unexpected module status 3".
+2. Even with a CJS config, test files importing backend `src/` TS die in
+   Playwright's resolve hook: `context.conditions?.includes is not a function`.
+
+CI works because it runs inside `mcr.microsoft.com/playwright:v1.61.0-jammy`.
+
+## Local workaround that works
+
+1. **Seed via a plain `.mjs` script importing from `apps/backend/dist/`**
+   (compiled JS — no transform involved), run with
+   `NODE_ENV=test mise exec node@24 -- node seed.mjs`. Reuse
+   `createUserAccount` / `createTeamAccount` / `createProject` /
+   `createBuildScenario` from `dist/database/seeds.js`, `truncateAll` from
+   `dist/database/testing/index.js`, and `createSession` from
+   `dist/auth/session.js`. Print JSON (slugs, build number, session
+   `rawToken`) for the spec.
+2. **Write a self-contained spec** (no backend imports) that logs in by
+   setting cookies `argos_session=<rawToken>` (httpOnly) and
+   `argos_logged_in=1` on `http://localhost:3000`, reading the seed JSON from
+   an env var.
+3. **Minimal CJS Playwright config inside the repo root** (module resolution
+   fails outside it): baseURL `http://localhost:3000`, webServer command
+   `node <repo>/apps/backend/dist/processes/proc/web.js` with env
+   `NODE_ENV=test` and
+   `CSP_SCRIPT_SRC` = `` `${getCSPScriptHash()},'unsafe-eval'` `` from
+   `require("@argos-ci/playwright")`.
+4. Run: `NODE_ENV=test TZ=utc mise exec node@24 -- pnpm exec playwright test
+<spec> --config=<cjs-config> --project=chromium`.
+
+## Useful facts
+
+- Build scenario: build 6 = "changes detected" (2 failures, 6 changed,
+  8 added, 2 removed, 2 unchanged), build 7 = accepted, build 8 = rejected.
+  All buckets branch `main`, bucket name `default`.
+- To trigger "previous approvals" (`branchApprovedDiffs`): earlier build on
+  same bucket name+branch with conclusion `changes-detected`, an approved
+  non-dismissed `BuildReview` with the viewer's `userId`, matching
+  `ScreenshotDiffReview` rows, and matching `fingerprint` on the diffs of
+  both builds (seed diffs have no fileIds, so fingerprints are the way).
+- IconButtons don't expose accessible names from tooltips; locate them via
+  lucide icon classes, e.g. `button:has(.lucide-thumbs-up)`.

--- a/apps/frontend/src/pages/Build/BuildDiffState.tsx
+++ b/apps/frontend/src/pages/Build/BuildDiffState.tsx
@@ -267,8 +267,8 @@ export function useHasNextDiff() {
 
 export interface UseGetNextDiffOptions {
   /**
-   * The index to start searching from.
-   * Default to the active diff index.
+   * The search starts after this index; pass -1 to search from the top of
+   * the list. Default to the active diff index.
    */
   fromIndex?: number;
 }
@@ -277,13 +277,12 @@ export function useGetNextDiff(
   predicate?: (diff: Diff) => boolean,
   options?: UseGetNextDiffOptions,
 ) {
-  const hasNextDiff = useHasNextDiff();
   const { searchMode } = useSearchModeState();
   const { diffs, activeDiff, expanded } = useBuildDiffState();
   const activeDiffIndex = useActiveDiffIndex();
   const fromIndex = options?.fromIndex ?? activeDiffIndex;
   return useEventCallback(() => {
-    if (!hasNextDiff) {
+    if (fromIndex >= diffs.length - 1) {
       return null;
     }
 

--- a/apps/frontend/src/pages/Build/BuildPreviousReviewDialog.tsx
+++ b/apps/frontend/src/pages/Build/BuildPreviousReviewDialog.tsx
@@ -11,7 +11,9 @@ import {
   DialogTitle,
   useOverlayTriggerState,
 } from "@/ui/Dialog";
+import { toast } from "@/ui/Toaster";
 
+import { useBuildDiffState } from "./BuildDiffState";
 import {
   useAcknowledgeMarkedDiff,
   useBuildReviewAPI,
@@ -93,6 +95,7 @@ function ReapplyPreviousApprovalsButton(props: {
     reviewState,
     "Review state should exist if this dialog is displayed",
   );
+  const { stats, isSubsetBuild } = useBuildDiffState();
   const { close } = useOverlayTriggerState();
   return (
     <Button
@@ -111,6 +114,24 @@ function ReapplyPreviousApprovalsButton(props: {
             {},
           ),
         }));
+        const count = branchApprovedDiffs.length;
+        const total = stats
+          ? stats.added + stats.changed + (isSubsetBuild ? 0 : stats.removed)
+          : null;
+        const remaining = total !== null ? Math.max(0, total - count) : null;
+        toast.success(
+          count === 1
+            ? "1 previous approval reapplied"
+            : `${count} previous approvals reapplied`,
+          {
+            description:
+              remaining === null
+                ? undefined
+                : remaining === 0
+                  ? "All changes are reviewed — you're ready to submit your review."
+                  : `${remaining === 1 ? "1 change" : `${remaining} changes`} left to review — taking you to the first one.`,
+          },
+        );
         acknowledge();
         close();
       }}

--- a/apps/frontend/src/pages/Build/BuildPreviousReviewDialog.tsx
+++ b/apps/frontend/src/pages/Build/BuildPreviousReviewDialog.tsx
@@ -81,8 +81,13 @@ function ReapplyPreviousApprovalsButton(props: {
   const { branchApprovedDiffs } = props;
   const api = useBuildReviewAPI();
   const reviewState = useBuildReviewState();
+  // After reapplying, land on the first diff that still needs a review,
+  // starting from the top of the list. The next diff has to be resolved after
+  // the approvals are applied — resolving it now would still see the reapplied
+  // diffs as pending and navigate to one of them.
   const [checkIsPending, acknowledge] = useAcknowledgeMarkedDiff({
-    fromIndex: 0,
+    fromIndex: -1,
+    resolveNextDiffOnAck: true,
   });
   invariant(
     reviewState,

--- a/apps/frontend/src/pages/Build/BuildReviewState.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewState.tsx
@@ -102,16 +102,30 @@ export function useBuildReviewAPI(): BuildReviewAPI | null {
 /**
  * Acknowledge the current diff and move to the next diff or show the review dialog.
  */
-export function useAcknowledgeMarkedDiff(options?: UseGetNextDiffOptions) {
+export function useAcknowledgeMarkedDiff(
+  options?: UseGetNextDiffOptions & {
+    /**
+     * Resolve the next diff once the status update has landed instead of
+     * snapshotting it at plan time. Required when marking several diffs at
+     * once: a plan-time snapshot still sees them as pending and would
+     * navigate to one of them.
+     */
+    resolveNextDiffOnAck?: boolean;
+  },
+) {
   const getDiffStatus = useGetDiffEvaluationStatus();
+  const reviewStatus = useReviewStatus();
+  const { setActiveDiff, isSubsetBuild, diffs, isLoading } =
+    useBuildDiffState();
   const getNextDiff = useGetNextDiff((diff) => {
     if (!getDiffStatus) {
       return false;
     }
-    return getDiffStatus(diff.id) === EvaluationStatus.Pending;
+    return (
+      checkDiffCanBeReviewed(diff.status, { isSubsetBuild }) &&
+      getDiffStatus(diff.id) === EvaluationStatus.Pending
+    );
   }, options);
-  const reviewStatus = useReviewStatus();
-  const { setActiveDiff, isSubsetBuild } = useBuildDiffState();
   const reviewDialog = useReviewDialog();
   const state = use(BuildReviewStateContext);
   const diffStatuses = state?.diffStatuses ?? null;
@@ -132,20 +146,40 @@ export function useAcknowledgeMarkedDiff(options?: UseGetNextDiffOptions) {
     }
   });
 
+  const resolveNextDiffOnAck = options?.resolveNextDiffOnAck ?? false;
+
   const acknowledge = useEventCallback(() => {
-    acknowledgeNextDiff(nextDiffRef.current);
+    // With `resolveNextDiffOnAck`, the updated statuses and re-sorted list are
+    // committed by the time this runs, so the next diff is computed against
+    // them rather than read from the plan-time snapshot.
+    acknowledgeNextDiff(
+      resolveNextDiffOnAck ? getNextDiff() : nextDiffRef.current,
+    );
   });
 
   useEffect(() => {
     if (diffStatusesRef.current && diffStatuses !== diffStatusesRef.current) {
+      // In resolve-on-ack mode the next diff to review may simply not be
+      // loaded yet — hold the acknowledgment until more of the list arrives
+      // (`diffs` is a dependency) or it is fully loaded.
+      if (resolveNextDiffOnAck && isLoading && !getNextDiff()) {
+        return;
+      }
       diffStatusesRef.current = null;
       acknowledge();
     }
-  }, [diffStatuses, acknowledge]);
+  }, [
+    diffStatuses,
+    acknowledge,
+    resolveNextDiffOnAck,
+    isLoading,
+    getNextDiff,
+    diffs,
+  ]);
 
   const planAck = useEventCallback(() => {
     diffStatusesRef.current = diffStatuses;
-    nextDiffRef.current = getNextDiff();
+    nextDiffRef.current = resolveNextDiffOnAck ? null : getNextDiff();
   });
 
   // Snapshot the next diff to review *now* — before marking re-sorts the list —


### PR DESCRIPTION
Closes [ARG-464](https://linear.app/argos/issue/ARG-464)

## Problem

Clicking **Reapply previous approvals** navigated to an already-approved snapshot (or nowhere at all). The reapply button snapshotted the "next diff to review" *before* the approvals were committed, so its pending-predicate still saw the reapplied diffs as pending and picked one of them — or a non-reviewable failure diff, in which case nothing navigated.

## Fix

- New `resolveNextDiffOnAck` mode on `useAcknowledgeMarkedDiff`: the next diff is resolved once the status update has landed, against the updated statuses and re-sorted list. The single-mark flows (accept/reject buttons) keep their snapshot-early behavior, which is correct there.
- The dialog searches from the top of the list (`fromIndex: -1`; the old `fromIndex: 0` silently skipped index 0), and `useGetNextDiff`'s guard now derives from `fromIndex` instead of the active diff index.
- The pending-predicate now requires `checkDiffCanBeReviewed`, so failure/unchanged diffs are skipped instead of stalling navigation.
- If the paginated diff list hasn't fully loaded when the update lands, the acknowledgment is held until the next diff appears or the list is fully loaded.
- A success toast describes the resulting state after reapplying: how many approvals were reapplied, and either how many changes are left to review (with the app taking the reviewer to the first one) or that everything is reviewed and ready to submit.

## Verification

Verified end-to-end with a seeded scenario (previous approved build on the same branch with matching fingerprints): after reapplying, the toast shows "6 previous approvals reapplied — 10 changes left to review — taking you to the first one" and the app navigates to the first snapshot still to review — skipping failures and the reapplied diffs — and the dialog doesn't reappear on reload. A negative control against the pre-fix build reproduces the reported behavior. Also adds `.claude/skills/verify/SKILL.md` documenting the local verification recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)