### PR TITLE
fix(oauth): keep concurrent sessions logged in (ARG-466)

### DIFF
--- a/apps/backend/db/migrations/20260715120000_oauth-grants-per-device.js
+++ b/apps/backend/db/migrations/20260715120000_oauth-grants-per-device.js
@@ -1,0 +1,26 @@
+/**
+ * Make OAuth grants per-authorization (effectively per-device/session) instead of
+ * one shared record per (user, client).
+ *
+ * The original `oauth` migration enforced `unique(["userId", "oauthClientId"])`, so
+ * every `argos login` under one user reused a single grant and revoked the sibling
+ * session's tokens (last-login-wins). Dropping the constraint lets each login mint
+ * its own grant and refresh-token family, so two machines can stay authenticated at
+ * the same time. See ARG-466.
+ *
+ * @param {import('knex').Knex} knex
+ */
+export const up = async (knex) => {
+  await knex.schema.alterTable("oauth_grants", (table) => {
+    table.dropUnique(["userId", "oauthClientId"]);
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+export const down = async (knex) => {
+  await knex.schema.alterTable("oauth_grants", (table) => {
+    table.unique(["userId", "oauthClientId"]);
+  });
+};

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -3506,14 +3506,6 @@ ALTER TABLE ONLY public.oauth_grants
 
 
 --
--- Name: oauth_grants oauth_grants_userid_oauthclientid_unique; Type: CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.oauth_grants
-    ADD CONSTRAINT oauth_grants_userid_oauthclientid_unique UNIQUE ("userId", "oauthClientId");
-
-
---
 -- Name: oauth_refresh_tokens oauth_refresh_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
@@ -5625,3 +5617,4 @@ INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('2026062
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260709120000_github-installation-token-text.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260714120000_oauth.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260714130000_seed-argos-cli-oauth-client.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260715120000_oauth-grants-per-device.js', 1, NOW());

--- a/apps/backend/src/graphql/definitions/OAuthClient.ts
+++ b/apps/backend/src/graphql/definitions/OAuthClient.ts
@@ -6,7 +6,6 @@ import { createAuthorizationCode } from "@/oauth/authorization-code";
 import { getClientByClientId, validateRedirectUri } from "@/oauth/clients";
 import { getKnownApp } from "@/oauth/known-apps";
 import { isOAuthScope, OAUTH_SCOPES, parseScopeString } from "@/oauth/scopes";
-import { revokeGrantTokens } from "@/oauth/tokens";
 
 import type { IResolvers } from "../__generated__/resolver-types";
 import { getAccessibleAccounts } from "../services/account";
@@ -166,32 +165,19 @@ export const resolvers: IResolvers = {
         throw badUserInput("One or more organizations are not accessible");
       }
 
+      // Every authorization mints its own grant (and its own refresh-token
+      // family), so concurrent logins under one user — e.g. a laptop and a CI
+      // machine both running `argos login` — each get an independent session
+      // instead of revoking one another. A prior grant stays valid until its
+      // tokens expire or the user revokes that session in settings.
       const grant = await transaction(async (trx) => {
-        const existing = await OAuthGrant.query(trx).findOne({
+        const saved = await OAuthGrant.query(trx).insertAndFetch({
           userId,
           oauthClientId: client.id,
+          scopes: requestedScopes,
+          lastUsedAt: null,
+          revokedAt: null,
         });
-        const saved = existing
-          ? await existing
-              .$query(trx)
-              .patchAndFetch({ scopes: requestedScopes, revokedAt: null })
-          : await OAuthGrant.query(trx).insertAndFetch({
-              userId,
-              oauthClientId: client.id,
-              scopes: requestedScopes,
-              lastUsedAt: null,
-              revokedAt: null,
-            });
-        // Re-consent redefines scopes/orgs: revoke the grant's existing tokens
-        // so previously-issued (possibly broader) ones stop working now instead
-        // of lingering until they expire.
-        if (existing) {
-          await revokeGrantTokens(saved.id, trx);
-        }
-        // Replace the granted organizations with the freshly-consented set.
-        await OAuthGrantAccount.query(trx)
-          .where("oauthGrantId", saved.id)
-          .delete();
         await OAuthGrantAccount.query(trx).insert(
           accessibleAccounts.map((account) => ({
             oauthGrantId: saved.id,

--- a/apps/backend/src/graphql/tests/oauthAuthorize.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/oauthAuthorize.e2e.test.ts
@@ -124,28 +124,10 @@ describe("OAuth authorization flow", () => {
     expect(auth.scope.map((a) => a.id)).toEqual([userAccount.id]);
   });
 
-  it("revokes previously-issued tokens when the user re-consents", async () => {
+  it("mints an independent grant per authorization, leaving prior sessions alive", async () => {
     const userAccount = await factory.UserAccount.create();
     await userAccount.$fetchGraph("user");
     const client = await createTestClient();
-    const grant = await OAuthGrant.query().insertAndFetch({
-      userId: userAccount.userId!,
-      oauthClientId: client.id,
-      scopes: ["profile", "projects:read"],
-      lastUsedAt: null,
-      revokedAt: null,
-    });
-    await OAuthGrantAccount.query().insert({
-      oauthGrantId: grant.id,
-      accountId: userAccount.id,
-    });
-    // A broad token from the first authorization.
-    const old = await issueTokens({
-      grantId: grant.id,
-      scopes: ["profile", "projects:read"],
-      resource: null,
-    });
-    await getAuthPayloadFromOAuthAccessToken(old.accessToken);
 
     const app = await createApolloServerApp(
       apolloServer,
@@ -153,31 +135,110 @@ describe("OAuth authorization flow", () => {
       { user: userAccount.user!, account: userAccount },
     );
 
-    // Re-consent, this time dropping projects:read.
-    const res = await request(app)
-      .post("/graphql")
-      .send({
-        query: AuthorizeMutation,
-        variables: {
-          input: {
-            clientId: client.clientId,
-            redirectUri: ACTUAL_REDIRECT,
-            scopes: ["profile"],
-            accountIds: [userAccount.id],
-            codeChallenge: "challenge",
-            codeChallengeMethod: "S256",
+    // Run the consent mutation and resolve it down to the created grant.
+    const authorize = async () => {
+      const codeVerifier = "s".repeat(64);
+      const codeChallenge = createHash("sha256")
+        .update(codeVerifier)
+        .digest("base64url");
+      const res = await request(app)
+        .post("/graphql")
+        .send({
+          query: AuthorizeMutation,
+          variables: {
+            input: {
+              clientId: client.clientId,
+              redirectUri: ACTUAL_REDIRECT,
+              scopes: ["profile", "projects:read"],
+              accountIds: [userAccount.id],
+              codeChallenge,
+              codeChallengeMethod: "S256",
+            },
           },
-        },
+        });
+      expectNoGraphQLError(res);
+      const code = new URL(
+        res.body.data.authorizeOAuthConsent.redirectUri,
+      ).searchParams.get("code");
+      const payload = await consumeAuthorizationCode({
+        code: code!,
+        codeVerifier,
+        clientId: client.clientId,
+        redirectUri: ACTUAL_REDIRECT,
       });
-    expectNoGraphQLError(res);
+      expect(payload).not.toBeNull();
+      return payload!;
+    };
 
-    // The old broad token is dead, but the grant itself stays active.
-    await expect(
-      getAuthPayloadFromOAuthAccessToken(old.accessToken),
-    ).rejects.toThrow();
-    const refreshed = await OAuthGrant.query().findById(grant.id);
-    expect(refreshed?.revokedAt).toBeNull();
-    expect(refreshed?.scopes).toEqual(["profile"]);
+    // Machine A logs in and gets a token.
+    const a = await authorize();
+    const aTokens = await issueTokens({
+      grantId: a.grantId,
+      scopes: ["profile", "projects:read"],
+      resource: null,
+    });
+    await getAuthPayloadFromOAuthAccessToken(aTokens.accessToken);
+
+    // Machine B logs in under the same user + client.
+    const b = await authorize();
+
+    // Each login is its own grant, so B does not disturb A.
+    expect(b.grantId).not.toBe(a.grantId);
+    expect(
+      await OAuthGrant.query().where({ userId: userAccount.userId! }),
+    ).toHaveLength(2);
+
+    // Machine A's token keeps working after B logs in.
+    const auth = await getAuthPayloadFromOAuthAccessToken(aTokens.accessToken);
+    expect(auth.grantId).toBe(a.grantId);
+  });
+
+  it("keeps a sibling session alive when another session refreshes (ARG-466)", async () => {
+    const userAccount = await factory.UserAccount.create();
+    await userAccount.$fetchGraph("user");
+    const client = await createTestClient();
+
+    // Two independent sessions (grants) for the same user + client.
+    const openSession = async () => {
+      const grant = await OAuthGrant.query().insertAndFetch({
+        userId: userAccount.userId!,
+        oauthClientId: client.id,
+        scopes: ["profile"],
+        lastUsedAt: null,
+        revokedAt: null,
+      });
+      await OAuthGrantAccount.query().insert({
+        oauthGrantId: grant.id,
+        accountId: userAccount.id,
+      });
+      return issueTokens({
+        grantId: grant.id,
+        scopes: ["profile"],
+        resource: null,
+      });
+    };
+    const a = await openSession();
+    const b = await openSession();
+
+    // Machine B refreshes, rotating only its own refresh-token family.
+    const rotated = await rotateRefreshToken({
+      refreshToken: b.refreshToken,
+      clientId: client.clientId,
+      requestedScopes: null,
+      resource: null,
+    });
+    expect(rotated.ok).toBe(true);
+
+    // Machine A is untouched: its access token still authenticates and its
+    // refresh token still rotates.
+    await getAuthPayloadFromOAuthAccessToken(a.accessToken);
+    const aRotated = await rotateRefreshToken({
+      refreshToken: a.refreshToken,
+      clientId: client.clientId,
+      requestedScopes: null,
+      resource: null,
+    });
+    expect(aRotated.ok).toBe(true);
   });
 
   it("rejects an unregistered redirect_uri at consent", async () => {

--- a/apps/backend/src/oauth/tokens.ts
+++ b/apps/backend/src/oauth/tokens.ts
@@ -184,10 +184,9 @@ export async function rotateRefreshToken(params: {
 
 /**
  * Revoke all live access + refresh tokens for a grant, leaving the grant itself
- * untouched. Used on re-consent so previously-issued (possibly broader) tokens
- * stop working immediately rather than lingering until they expire.
+ * untouched. Helper behind `revokeGrant`.
  */
-export async function revokeGrantTokens(
+async function revokeGrantTokens(
   grantId: string,
   trx?: TransactionOrKnex,
 ): Promise<void> {


### PR DESCRIPTION
## Problem

Two machines logged in under the **same user** couldn't stay authenticated simultaneously — logging in on a second machine silently logged the first one out (last-login-wins). Surfaced while reviewing the OAuth 2.1 CLI login (ARG-426).

The backend keyed OAuth grants one-per-`(user, client)` (a DB unique constraint plus a find-and-reuse in the consent handler), and every `argos login` uses the same first-party `argos-cli` client. On re-consent the handler reused the existing grant and called `revokeGrantTokens`, killing the other machine's access + refresh tokens. The two machines then ping-ponged and could never both be authenticated.

## Fix

Make grants **per-authorization** (effectively per-device/session):

- **Drop** the `unique(["userId", "oauthClientId"])` constraint on `oauth_grants` (new migration; keeps the `userId` index).
- **`authorizeOAuthConsent`** now always inserts a fresh grant with its own refresh-token family instead of finding/reusing one and revoking its tokens. Concurrent logins each get an independent session and never evict one another.

This drops the ARG-426 "revoke on re-consent" behavior — a prior authorization stays valid until its tokens expire or the user revokes that session in settings (standard OAuth semantics, and the tradeoff proposed in the issue).

### Scope

Applies to **all** clients, not just the CLI. Dynamically-registered MCP/LLM clients already get a distinct `clientId` per registration (so they already had separate grants), meaning the acute last-login-wins problem was CLI-specific; per-session grants mostly add robustness for MCP (two agent sessions no longer evict each other).

The one property intentionally given up is "re-consenting with narrower scopes instantly kills the older broad tokens." In practice the window is small (access-token TTL is 1h, the orphaned refresh token is never exercised, and the session is revocable in settings).

### Settings UX

Unchanged: the "Authorized applications" list stays **one row per grant/session**, so users can view and revoke individual sessions. No frontend change.

## Testing

- New migration applied to the test DB.
- `oauthAuthorize` e2e suite: **8/8 passing**, including two new tests:
  - authorizing twice for the same user+client mints two distinct grants and leaves the first session's token working;
  - refreshing one session does not revoke a sibling session (the ARG-466 regression).
- `tsc --noEmit` and eslint clean on changed files.

Closes ARG-466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)