### PR TITLE
feat(mcp): add MCP server derived from the OpenAPI document

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,7 @@ jobs:
           environment-variables: |
             NODE_ENV=production
             API_BASE_URL=https://api.argos-ci.com
+            MCP_BASE_URL=https://mcp.argos-ci.com
             SERVER_URL=https://app.argos-ci.com
             SENTRY_RELEASE_VERSION=${{ github.sha }}
           secrets: |

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -41,6 +41,7 @@
     "@aws-sdk/s3-request-presigner": "^3.1081.0",
     "@gitbeaker/rest": "^43.8.0",
     "@graphql-tools/schema": "^10.0.35",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@octokit/auth-app": "^8.2.0",
     "@octokit/core": "^7.0.6",
     "@octokit/openapi-types": "^27.0.0",

--- a/apps/backend/src/api/auth/project.ts
+++ b/apps/backend/src/api/auth/project.ts
@@ -4,7 +4,10 @@ import {
   getAuthHeaderFromExpressReq,
   parseBearerFromHeader,
 } from "@/auth/auth-header";
-import { getAuthPayloadFromOAuthAccessToken } from "@/auth/oauth-access-token";
+import {
+  getAcceptedOAuthResources,
+  getAuthPayloadFromOAuthAccessToken,
+} from "@/auth/oauth-access-token";
 import type {
   AuthOAuthPayload,
   AuthPATPayload,
@@ -100,7 +103,9 @@ export async function getAuthPayloadFromExpressReq(
   const authHeader = getAuthHeaderFromExpressReq(request);
   const bearer = parseBearerFromHeader(authHeader);
   const auth = OAuthAccessToken.isOAuthAccessToken(bearer)
-    ? await getAuthPayloadFromOAuthAccessToken(bearer)
+    ? await getAuthPayloadFromOAuthAccessToken(bearer, {
+        acceptedResources: getAcceptedOAuthResources(request),
+      })
     : UserAccessToken.isValidUserAccessToken(bearer)
       ? await getAuthPayloadFromUserAccessToken(bearer)
       : await getAuthProjectPayloadFromBearerToken(bearer);

--- a/apps/backend/src/api/auth/project.ts
+++ b/apps/backend/src/api/auth/project.ts
@@ -7,6 +7,7 @@ import {
 import {
   getAcceptedOAuthResources,
   getAuthPayloadFromOAuthAccessToken,
+  getSkipUsageTracking,
 } from "@/auth/oauth-access-token";
 import type {
   AuthOAuthPayload,
@@ -102,12 +103,14 @@ export async function getAuthPayloadFromExpressReq(
 ) {
   const authHeader = getAuthHeaderFromExpressReq(request);
   const bearer = parseBearerFromHeader(authHeader);
+  const trackUsage = !getSkipUsageTracking(request);
   const auth = OAuthAccessToken.isOAuthAccessToken(bearer)
     ? await getAuthPayloadFromOAuthAccessToken(bearer, {
         acceptedResources: getAcceptedOAuthResources(request),
+        trackUsage,
       })
     : UserAccessToken.isValidUserAccessToken(bearer)
-      ? await getAuthPayloadFromUserAccessToken(bearer)
+      ? await getAuthPayloadFromUserAccessToken(bearer, { trackUsage })
       : await getAuthProjectPayloadFromBearerToken(bearer);
   assertAuthAttributes(auth, attributes);
   return auth;

--- a/apps/backend/src/api/handlers/getBuild.e2e.test.ts
+++ b/apps/backend/src/api/handlers/getBuild.e2e.test.ts
@@ -1,16 +1,24 @@
 import { invariant } from "@argos/util/invariant";
+import express from "express";
 import request from "supertest";
 import { test as base, beforeAll, describe, expect } from "vitest";
 import z from "zod";
 
-import type {
-  Account,
-  Build,
-  Project,
-  ScreenshotBucket,
+import {
+  OAuthClient,
+  OAuthGrant,
+  OAuthGrantAccount,
+  type Account,
+  type Build,
+  type Project,
+  type ScreenshotBucket,
 } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
+import { getApiResourceUrl, getMcpResourceUrl } from "@/oauth/metadata";
+import type { OAuthScope } from "@/oauth/scopes";
+import { issueTokens } from "@/oauth/tokens";
 
+import { openAPIRouter } from "../index";
 import { createTestHandlerApp } from "../test-util";
 import { getBuild } from "./getBuild";
 
@@ -136,6 +144,111 @@ describe("getBuild", () => {
           },
         });
       });
+  });
+
+  describe("with an OAuth access token", () => {
+    // The full router: OAuth scope failures surface through the shared
+    // `errorHandler`, unlike `createTestHandlerApp`'s bare fallback.
+    const oauthApp = express();
+    oauthApp.use(openAPIRouter);
+
+    async function createOAuthAccessToken(
+      account: Account,
+      scopes: OAuthScope[],
+      options?: { resource?: string },
+    ) {
+      const user = await factory.User.create();
+      await factory.UserAccount.create({ userId: user.id });
+      invariant(account.teamId);
+      await factory.TeamUser.create({
+        teamId: account.teamId,
+        userId: user.id,
+      });
+      const client = await OAuthClient.query().insertAndFetch({
+        clientId: "test-client",
+        clientName: "Test Client",
+        redirectUris: ["http://localhost/callback"],
+        grantTypes: ["authorization_code", "refresh_token"],
+        responseTypes: ["code"],
+        tokenEndpointAuthMethod: "none",
+        isFirstParty: false,
+        verified: false,
+      });
+      const grant = await OAuthGrant.query().insertAndFetch({
+        userId: user.id,
+        oauthClientId: client.id,
+        scopes,
+        lastUsedAt: null,
+        revokedAt: null,
+      });
+      await OAuthGrantAccount.query().insert({
+        oauthGrantId: grant.id,
+        accountId: account.id,
+      });
+      const tokens = await issueTokens({
+        grantId: grant.id,
+        scopes,
+        resource: options?.resource ?? null,
+      });
+      return tokens.accessToken;
+    }
+
+    test("returns a build with the projects:read scope", async ({
+      account,
+      build,
+    }) => {
+      const token = await createOAuthAccessToken(account, ["projects:read"]);
+      await request(oauthApp)
+        .get(`/projects/acme/web/builds/${build.number}`)
+        .set("Authorization", `Bearer ${token}`)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.id).toBe(build.id);
+        });
+    });
+
+    test("returns 403 without the projects:read scope", async ({
+      account,
+      build,
+    }) => {
+      const token = await createOAuthAccessToken(account, ["profile"]);
+      await request(oauthApp)
+        .get(`/projects/acme/web/builds/${build.number}`)
+        .set("Authorization", `Bearer ${token}`)
+        .expect(403)
+        .expect((res) => {
+          expect(res.body.error).toContain("Insufficient scope");
+        });
+    });
+
+    test("accepts a token bound to the REST API resource", async ({
+      account,
+      build,
+    }) => {
+      const token = await createOAuthAccessToken(account, ["projects:read"], {
+        resource: getApiResourceUrl(),
+      });
+      await request(oauthApp)
+        .get(`/projects/acme/web/builds/${build.number}`)
+        .set("Authorization", `Bearer ${token}`)
+        .expect(200);
+    });
+
+    test("rejects a token bound to the MCP resource (audience isolation)", async ({
+      account,
+      build,
+    }) => {
+      const token = await createOAuthAccessToken(account, ["projects:read"], {
+        resource: getMcpResourceUrl(),
+      });
+      await request(oauthApp)
+        .get(`/projects/acme/web/builds/${build.number}`)
+        .set("Authorization", `Bearer ${token}`)
+        .expect(401)
+        .expect((res) => {
+          expect(res.body.error).toContain("not issued for this resource");
+        });
+    });
   });
 
   test("returns a build without base info and uses the compare bucket sha when prHeadCommit is null", async ({

--- a/apps/backend/src/api/handlers/getBuild.e2e.test.ts
+++ b/apps/backend/src/api/handlers/getBuild.e2e.test.ts
@@ -231,7 +231,10 @@ describe("getBuild", () => {
       await request(oauthApp)
         .get(`/projects/acme/web/builds/${build.number}`)
         .set("Authorization", `Bearer ${token}`)
-        .expect(200);
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.id).toBe(build.id);
+        });
     });
 
     test("rejects a token bound to the MCP resource (audience isolation)", async ({

--- a/apps/backend/src/api/handlers/getBuild.ts
+++ b/apps/backend/src/api/handlers/getBuild.ts
@@ -18,7 +18,7 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
-import { anyTokenAuth } from "../security";
+import { anyTokenOrOAuthAuth } from "../security";
 import { CreateAPIHandler } from "../util";
 
 export const getBuildOperation = {
@@ -27,7 +27,7 @@ export const getBuildOperation = {
   description:
     "Retrieve a single build by its number within a project, including its status and metadata.",
   tags: ["Builds"],
-  security: anyTokenAuth,
+  security: anyTokenOrOAuthAuth(["projects:read"]),
   requestParams: {
     path: z.object({
       owner: AccountSlug,

--- a/apps/backend/src/api/handlers/getMe.e2e.test.ts
+++ b/apps/backend/src/api/handlers/getMe.e2e.test.ts
@@ -55,7 +55,10 @@ const test = base.extend<{
 });
 
 describe("getMe", () => {
-  test("returns the authenticated user", async ({ userAccount, patToken }) => {
+  test("returns the authenticated user and its accessible accounts", async ({
+    userAccount,
+    patToken,
+  }) => {
     await request(app)
       .get("/me")
       .set("Authorization", `Bearer ${patToken}`)
@@ -65,7 +68,53 @@ describe("getMe", () => {
           id: userAccount.id,
           slug: "jane-doe",
           name: "Jane Doe",
+          accounts: [
+            {
+              id: userAccount.id,
+              slug: "jane-doe",
+              name: "Jane Doe",
+              type: "user",
+            },
+          ],
         });
+      });
+  });
+
+  test("includes team accounts the token is scoped to", async ({
+    user,
+    userAccount,
+  }) => {
+    const teamAccount = await factory.TeamAccount.create({
+      slug: "acme",
+      name: "ACME",
+    });
+    await factory.TeamUser.create({
+      teamId: teamAccount.teamId!,
+      userId: user.id,
+    });
+    const token = `arp_${"t".repeat(36)}`;
+    const userAccessToken = await factory.UserAccessToken.create({
+      userId: user.id,
+      token: hashToken(token),
+    });
+    await UserAccessTokenScope.query().insert([
+      { userAccessTokenId: userAccessToken.id, accountId: userAccount.id },
+      { userAccessTokenId: userAccessToken.id, accountId: teamAccount.id },
+    ]);
+
+    await request(app)
+      .get("/me")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+      .expect((res) => {
+        expect(
+          res.body.accounts.map((account: { slug: string }) => account.slug),
+        ).toEqual(expect.arrayContaining(["jane-doe", "acme"]));
+        expect(
+          res.body.accounts.find(
+            (account: { slug: string }) => account.slug === "acme",
+          ),
+        ).toMatchObject({ type: "team", name: "ACME" });
       });
   });
 

--- a/apps/backend/src/api/handlers/getMe.ts
+++ b/apps/backend/src/api/handlers/getMe.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { ZodOpenApiOperationObject } from "zod-openapi";
 
 import { serializeUser, UserSchema } from "../schema/primitives/user";
@@ -5,12 +6,33 @@ import { serverError, unauthorized } from "../schema/util/error";
 import { patOrOAuthAuth } from "../security";
 import { CreateAPIHandler } from "../util";
 
+const MeAccountSchema = z
+  .object({
+    id: z.string(),
+    slug: z
+      .string()
+      .meta({ description: "Account slug, used as the `owner` in API paths." }),
+    name: z.string().nullable(),
+    type: z.enum(["user", "team"]),
+  })
+  .meta({
+    description: "An account (personal or team) accessible to the token.",
+    id: "MeAccount",
+  });
+
+const MeSchema = UserSchema.extend({
+  accounts: z.array(MeAccountSchema).meta({
+    description:
+      "The accounts this token can access: the personal account and the teams selected when the token was created or authorized.",
+  }),
+}).meta({ description: "The authenticated user.", id: "Me" });
+
 const responses = {
   "200": {
     description: "The authenticated user",
     content: {
       "application/json": {
-        schema: UserSchema,
+        schema: MeSchema,
       },
     },
   },
@@ -22,7 +44,7 @@ export const getMeOperation = {
   operationId: "getMe",
   summary: "Get the current user",
   description:
-    "Retrieve the user associated with the token used to authenticate the request.",
+    "Retrieve the user associated with the token used to authenticate the request, with the accounts (personal and teams) the token can access. Account slugs are the `owner` used in other API paths.",
   tags: ["Users"],
   security: patOrOAuthAuth(["profile"]),
   responses,
@@ -32,6 +54,14 @@ export const getMe: CreateAPIHandler = ({ get }) => {
   get("/me", async (req, res) => {
     const auth = await req.ctx.auth();
 
-    res.send(serializeUser(auth.account));
+    res.send({
+      ...serializeUser(auth.account),
+      accounts: auth.scope.map((account) => ({
+        id: account.id,
+        slug: account.slug,
+        name: account.displayName,
+        type: account.type,
+      })),
+    });
   });
 };

--- a/apps/backend/src/api/handlers/getProject.ts
+++ b/apps/backend/src/api/handlers/getProject.ts
@@ -14,7 +14,7 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
-import { anyTokenAuth } from "../security";
+import { anyTokenOrOAuthAuth } from "../security";
 import { CreateAPIHandler } from "../util";
 
 export const getProjectOperation = {
@@ -23,7 +23,7 @@ export const getProjectOperation = {
   description:
     "Retrieve a project by its owner (account slug) and project name.",
   tags: ["Projects"],
-  security: anyTokenAuth,
+  security: anyTokenOrOAuthAuth(["projects:read"]),
   requestParams: {
     path: z.object({
       owner: AccountSlug,

--- a/apps/backend/src/api/handlers/listBuildDiffs.ts
+++ b/apps/backend/src/api/handlers/listBuildDiffs.ts
@@ -23,7 +23,7 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
-import { anyTokenAuth } from "../security";
+import { anyTokenOrOAuthAuth } from "../security";
 import { CreateAPIHandler } from "../util";
 
 const ListBuildDiffsParams = PageParamsSchema.extend({
@@ -53,7 +53,7 @@ export const listBuildDiffsOperation = {
   description:
     "List the screenshot diffs of a build, with pagination. Each diff compares a baseline screenshot to the one captured by the build. Each diff also carries its test's flakiness metrics and, when it is a change, its ignore state and occurrence count — so you can tell whether a change is worth reviewing or is just a flaky one. Use `needsReview` to return only the diffs that require review.",
   tags: ["Builds"],
-  security: anyTokenAuth,
+  security: anyTokenOrOAuthAuth(["projects:read"]),
   requestParams: {
     path: z.object({
       owner: AccountSlug,

--- a/apps/backend/src/api/handlers/listBuilds.ts
+++ b/apps/backend/src/api/handlers/listBuilds.ts
@@ -17,7 +17,7 @@ import {
   serverError,
   unauthorized,
 } from "../schema/util/error";
-import { anyTokenAuth } from "../security";
+import { anyTokenOrOAuthAuth } from "../security";
 import { CreateAPIHandler } from "../util";
 
 export const listBuildsOperation = {
@@ -26,7 +26,7 @@ export const listBuildsOperation = {
   description:
     "List the builds of a project, most recent first. Results are paginated. Use `search` to match builds by name, branch or commit, and `distinctName` to return only the latest build per name and commit.",
   tags: ["Builds"],
-  security: anyTokenAuth,
+  security: anyTokenOrOAuthAuth(["projects:read"]),
   requestParams: {
     path: z.object({
       owner: AccountSlug,

--- a/apps/backend/src/api/handlers/listProjects.e2e.test.ts
+++ b/apps/backend/src/api/handlers/listProjects.e2e.test.ts
@@ -1,0 +1,148 @@
+import request from "supertest";
+import { test as base, beforeAll, describe, expect } from "vitest";
+import z from "zod";
+
+import {
+  Account,
+  Project,
+  User,
+  UserAccessTokenScope,
+} from "@/database/models";
+import { hashToken } from "@/database/services/crypto";
+import { factory, setupDatabase } from "@/database/testing";
+
+import { createTestHandlerApp } from "../test-util";
+import { listProjects } from "./listProjects";
+
+const app = createTestHandlerApp(listProjects);
+
+const test = base.extend<{
+  user: User;
+  teamAccount: Account;
+  projects: Project[];
+  patToken: string;
+}>({
+  user: async ({}, use) => {
+    await setupDatabase();
+    const user = await factory.User.create();
+    await factory.UserAccount.create({ userId: user.id });
+    await use(user);
+  },
+  teamAccount: async ({ user }, use) => {
+    const teamAccount = await factory.TeamAccount.create({ slug: "acme" });
+    await factory.TeamUser.create({
+      teamId: teamAccount.teamId!,
+      userId: user.id,
+      userLevel: "member",
+    });
+    await use(teamAccount);
+  },
+  projects: async ({ teamAccount }, use) => {
+    const projects = await factory.Project.createMany(2, [
+      { accountId: teamAccount.id, name: "web" },
+      { accountId: teamAccount.id, name: "mobile" },
+    ]);
+    await use(projects);
+  },
+  patToken: async ({ user, teamAccount }, use) => {
+    const token = `arp_${"e".repeat(36)}`;
+    const userAccessToken = await factory.UserAccessToken.create({
+      userId: user.id,
+      token: hashToken(token),
+    });
+    await UserAccessTokenScope.query().insert({
+      userAccessTokenId: userAccessToken.id,
+      accountId: teamAccount.id,
+    });
+    await use(token);
+  },
+});
+
+describe("listProjects", () => {
+  beforeAll(() => {
+    z.globalRegistry.clear();
+  });
+
+  test("lists the account's projects, paginated", async ({
+    projects,
+    patToken,
+  }) => {
+    await request(app)
+      .get("/accounts/acme/projects")
+      .set("Authorization", `Bearer ${patToken}`)
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.pageInfo).toEqual({ total: 2, page: 1, perPage: 30 });
+        expect(
+          res.body.results.map((project: { name: string }) => project.name),
+        ).toEqual(expect.arrayContaining(["web", "mobile"]));
+        const [first] = res.body.results;
+        expect(first).toMatchObject({
+          id: expect.any(String),
+          account: { slug: "acme" },
+        });
+        void projects;
+      });
+  });
+
+  test("paginates with page and perPage", async ({
+    projects: _projects,
+    patToken,
+  }) => {
+    const res = await request(app)
+      .get("/accounts/acme/projects?perPage=1&page=2")
+      .set("Authorization", `Bearer ${patToken}`)
+      .expect(200);
+    expect(res.body.pageInfo).toEqual({ total: 2, page: 2, perPage: 1 });
+    expect(res.body.results).toHaveLength(1);
+  });
+
+  test("hides projects a contributor cannot see", async ({
+    teamAccount,
+    projects,
+    patToken: _patToken,
+  }) => {
+    // A contributor with no project membership and no default level sees
+    // nothing — the same visibility rules as the GraphQL API.
+    const contributor = await factory.User.create();
+    await factory.UserAccount.create({ userId: contributor.id });
+    await factory.TeamUser.create({
+      teamId: teamAccount.teamId!,
+      userId: contributor.id,
+      userLevel: "contributor",
+    });
+    const token = `arp_${"c".repeat(36)}`;
+    const userAccessToken = await factory.UserAccessToken.create({
+      userId: contributor.id,
+      token: hashToken(token),
+    });
+    await UserAccessTokenScope.query().insert({
+      userAccessTokenId: userAccessToken.id,
+      accountId: teamAccount.id,
+    });
+
+    const res = await request(app)
+      .get("/accounts/acme/projects")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200);
+    expect(res.body.pageInfo.total).toBe(0);
+    expect(res.body.results).toEqual([]);
+    void projects;
+  });
+
+  test("returns 401 for an account outside the token scope", async ({
+    projects: _projects,
+    patToken,
+  }) => {
+    await factory.TeamAccount.create({ slug: "other" });
+    await request(app)
+      .get("/accounts/other/projects")
+      .set("Authorization", `Bearer ${patToken}`)
+      .expect(401)
+      .expect((res) => {
+        expect(res.body.error).toContain(
+          "You do not have access to this account",
+        );
+      });
+  });
+});

--- a/apps/backend/src/api/handlers/listProjects.ts
+++ b/apps/backend/src/api/handlers/listProjects.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+import { ZodOpenApiOperationObject } from "zod-openapi";
+
+import { queryAccountProjects } from "@/database/services/project";
+
+import { getAccountForAuth } from "../auth/project";
+import { PageParamsSchema, paginated } from "../schema/primitives/pagination";
+import {
+  AccountSlug,
+  ProjectSchema,
+  serializeProject,
+} from "../schema/primitives/project";
+import {
+  forbidden,
+  invalidParameters,
+  serverError,
+  unauthorized,
+} from "../schema/util/error";
+import { patOrOAuthAuth } from "../security";
+import { CreateAPIHandler } from "../util";
+
+export const listProjectsOperation = {
+  operationId: "listProjects",
+  summary: "List an account's projects",
+  description:
+    "List the projects of an account that are visible to the authenticated user, most recently active first. Results are paginated. The token must be scoped to the account.",
+  tags: ["Projects"],
+  security: patOrOAuthAuth(["projects:read"]),
+  requestParams: {
+    path: z.object({
+      accountSlug: AccountSlug.meta({
+        description: "Slug of the account to list projects for.",
+      }),
+    }),
+    query: PageParamsSchema,
+  },
+  responses: {
+    "200": {
+      description: "List of projects",
+      content: {
+        "application/json": {
+          schema: paginated(ProjectSchema),
+        },
+      },
+    },
+    "400": invalidParameters,
+    "401": unauthorized,
+    "403": forbidden,
+    "500": serverError,
+  },
+} satisfies ZodOpenApiOperationObject;
+
+export const listProjects: CreateAPIHandler = ({ get }) => {
+  get("/accounts/{accountSlug}/projects", async (req, res) => {
+    const { page, perPage } = req.ctx.query;
+    const auth = await req.ctx.auth();
+
+    // The token scope is the authorization boundary: it must cover the target
+    // account. Resolves the in-scope account or throws 401.
+    const account = getAccountForAuth(auth, {
+      slug: req.ctx.params.accountSlug,
+    });
+
+    // Shared with the GraphQL API — same visibility rules, same ordering.
+    const query = queryAccountProjects({ account, user: auth.user });
+    if (!query) {
+      res.send({ results: [], pageInfo: { total: 0, page, perPage } });
+      return;
+    }
+
+    const projects = await query.range(
+      (page - 1) * perPage,
+      page * perPage - 1,
+    );
+    const results = await Promise.all(projects.results.map(serializeProject));
+    res.send({
+      results,
+      pageInfo: { total: projects.total, page, perPage },
+    });
+  });
+};

--- a/apps/backend/src/api/index.ts
+++ b/apps/backend/src/api/index.ts
@@ -28,6 +28,7 @@ import { ignoreChange, unignoreChange } from "./handlers/ignoreChange";
 import { listBuildDiffs } from "./handlers/listBuildDiffs";
 import { listBuilds } from "./handlers/listBuilds";
 import { listComments } from "./handlers/listComments";
+import { listProjects } from "./handlers/listProjects";
 import { listReviews } from "./handlers/listReviews";
 import { removeCommentReaction } from "./handlers/removeCommentReaction";
 import {
@@ -102,6 +103,7 @@ registerHandler(router, ignoreChange);
 registerHandler(router, unignoreChange);
 registerHandler(router, getProject);
 registerHandler(router, listBuilds);
+registerHandler(router, listProjects);
 registerHandler(router, resolveDeploymentDomain);
 registerHandler(router, updateBuild);
 

--- a/apps/backend/src/api/schema.ts
+++ b/apps/backend/src/api/schema.ts
@@ -2,6 +2,7 @@ import { createDocument, ZodOpenApiObject } from "zod-openapi";
 
 import config from "@/config";
 import { isMcpEligible } from "@/mcp/eligibility";
+import { getMcpResourceUrl } from "@/oauth/metadata";
 
 import { addCommentReactionOperation } from "./handlers/addCommentReaction";
 import { createBuildOperation } from "./handlers/createBuild";
@@ -59,6 +60,9 @@ export const zodSchema = {
     },
     termsOfService: "https://argos-ci.com/terms",
   },
+  // Advertise the MCP server to GitBook and other tooling reading the spec;
+  // per-operation availability is stamped via `x-gitbook-mcp`.
+  "x-gitbook-mcp-url": getMcpResourceUrl(),
   externalDocs: {
     description: "Argos API reference",
     url: "https://argos-ci.com/docs/api-reference",

--- a/apps/backend/src/api/schema.ts
+++ b/apps/backend/src/api/schema.ts
@@ -31,6 +31,7 @@ import {
 import { listBuildDiffsOperation } from "./handlers/listBuildDiffs";
 import { listBuildsOperation } from "./handlers/listBuilds";
 import { listCommentsOperation } from "./handlers/listComments";
+import { listProjectsOperation } from "./handlers/listProjects";
 import { listReviewsOperation } from "./handlers/listReviews";
 import { removeCommentReactionOperation } from "./handlers/removeCommentReaction";
 import {
@@ -125,6 +126,9 @@ export const zodSchema = {
   paths: {
     "/accounts/{accountSlug}/analytics": {
       get: getAccountAnalyticsOperation,
+    },
+    "/accounts/{accountSlug}/projects": {
+      get: listProjectsOperation,
     },
     "/builds": {
       post: createBuildOperation,

--- a/apps/backend/src/api/schema.ts
+++ b/apps/backend/src/api/schema.ts
@@ -1,6 +1,7 @@
 import { createDocument, ZodOpenApiObject } from "zod-openapi";
 
 import config from "@/config";
+import { isMcpEligible } from "@/mcp/eligibility";
 
 import { addCommentReactionOperation } from "./handlers/addCommentReaction";
 import { createBuildOperation } from "./handlers/createBuild";
@@ -223,5 +224,27 @@ export const zodSchema = {
   },
 } satisfies ZodOpenApiObject;
 
-export const schema: ReturnType<typeof createDocument> =
-  createDocument(zodSchema);
+/**
+ * Stamp `x-gitbook-mcp` on every operation exposed on the MCP server. The
+ * marker is *computed* from each operation's declared `security` (the same
+ * predicate the MCP server derives its tools from), never set by hand, so the
+ * published OpenAPI document can't get out of sync with the MCP tool surface.
+ */
+function markMcpOperations(
+  document: ReturnType<typeof createDocument>,
+): ReturnType<typeof createDocument> {
+  const methods = ["get", "post", "put", "patch", "delete"] as const;
+  for (const pathItem of Object.values(document.paths ?? {})) {
+    for (const method of methods) {
+      const operation = pathItem[method];
+      if (operation && isMcpEligible(operation)) {
+        Object.assign(operation, { "x-gitbook-mcp": true });
+      }
+    }
+  }
+  return document;
+}
+
+export const schema: ReturnType<typeof createDocument> = markMcpOperations(
+  createDocument(zodSchema),
+);

--- a/apps/backend/src/api/schema/primitives/build.ts
+++ b/apps/backend/src/api/schema/primitives/build.ts
@@ -107,7 +107,12 @@ export const BuildNumber = z
 export const BuildSchema = z
   .object({
     id: BuildIdSchema,
-    number: BuildNumber,
+    // Not `BuildNumber`: that schema parses the *path parameter* (a string
+    // transformed into a number) and cannot describe a response field.
+    number: z.int().min(1).meta({
+      description: "The build number",
+      example: 42,
+    }),
     head: BuildGitReferenceSchema.meta({
       description: "The head reference of the build",
     }),

--- a/apps/backend/src/api/security.test.ts
+++ b/apps/backend/src/api/security.test.ts
@@ -5,7 +5,7 @@ import type { AuthPATPayload, AuthProjectPayload } from "@/auth/payload";
 
 import { getAuthPayloadFromExpressReq } from "./auth/project";
 import {
-  anyTokenAuth,
+  anyTokenOrOAuthAuth,
   authenticateRequest,
   noAuth,
   personalAccessTokenAuth,
@@ -54,9 +54,10 @@ describe("security definitions", () => {
   it("declares the expected requirement shapes", () => {
     expect(projectTokenAuth).toEqual([{ projectToken: [] }]);
     expect(personalAccessTokenAuth).toEqual([{ personalAccessToken: [] }]);
-    expect(anyTokenAuth).toEqual([
+    expect(anyTokenOrOAuthAuth(["projects:read"])).toEqual([
       { projectToken: [] },
       { personalAccessToken: [] },
+      { oauth2: ["projects:read"] },
     ]);
     expect(noAuth).toEqual([]);
   });
@@ -103,13 +104,15 @@ describe("authenticateRequest", () => {
   });
 
   it("accepts either token kind on an any-token endpoint", async () => {
+    const security = anyTokenOrOAuthAuth(["projects:read"]);
+
     resolveAs(patPayload);
-    await expect(authenticateRequest(request, anyTokenAuth)).resolves.toBe(
+    await expect(authenticateRequest(request, security)).resolves.toBe(
       patPayload,
     );
 
     resolveAs(projectPayload);
-    await expect(authenticateRequest(request, anyTokenAuth)).resolves.toBe(
+    await expect(authenticateRequest(request, security)).resolves.toBe(
       projectPayload,
     );
   });

--- a/apps/backend/src/api/security.ts
+++ b/apps/backend/src/api/security.ts
@@ -133,12 +133,19 @@ export const personalAccessTokenAuth: SecurityRequirement<AuthPATPayload> = [
 ];
 
 /**
- * Accept **either** a project token or a personal access token. Used by
- * read-only endpoints that are reachable from both CI and a user.
+ * Accept a project token, a personal access token, or an OAuth access token
+ * with the given scopes. Used by read-only endpoints that are reachable from
+ * CI, a user, and OAuth clients (CLI, MCP agents).
  */
-export const anyTokenAuth: SecurityRequirement<
-  AuthProjectPayload | AuthPATPayload
-> = [{ projectToken: [] }, { personalAccessToken: [] }];
+export function anyTokenOrOAuthAuth(
+  scopes: OAuthScope[],
+): SecurityRequirement<AuthProjectPayload | AuthPATPayload | AuthOAuthPayload> {
+  return [
+    { projectToken: [] },
+    { personalAccessToken: [] },
+    { oauth2: scopes },
+  ];
+}
 
 /**
  * Accept **either** a personal access token or an OAuth access token with the

--- a/apps/backend/src/auth/oauth-access-token.ts
+++ b/apps/backend/src/auth/oauth-access-token.ts
@@ -5,7 +5,7 @@ import type { Request } from "express";
 import { waitUntil } from "@/api/request-context";
 import { Account, OAuthAccessToken, OAuthGrant } from "@/database/models";
 import { hashToken } from "@/database/services/crypto";
-import { getApiResourceUrl } from "@/oauth/metadata";
+import { getApiResourceUrl, normalizeResource } from "@/oauth/metadata";
 
 import { boom } from "../util/error";
 import type { AuthOAuthPayload } from "./payload";
@@ -87,11 +87,14 @@ export async function getAuthPayloadFromOAuthAccessToken(
   // Audience binding (RFC 8707): a token issued for another resource must not
   // be accepted here. The REST API only accepts its own audience; the MCP
   // server marks its requests as also accepting the MCP audience. Tokens with
-  // no bound resource are unscoped and accepted everywhere.
+  // no bound resource are unscoped and accepted everywhere. Comparison is
+  // normalized: clients canonicalize resource URLs (trailing slash).
   const acceptedResources = options?.acceptedResources ?? [getApiResourceUrl()];
   if (
     accessToken.resource &&
-    !acceptedResources.includes(accessToken.resource)
+    !acceptedResources
+      .map(normalizeResource)
+      .includes(normalizeResource(accessToken.resource))
   ) {
     throw boom(401, "Access token was not issued for this resource");
   }

--- a/apps/backend/src/auth/oauth-access-token.ts
+++ b/apps/backend/src/auth/oauth-access-token.ts
@@ -31,8 +31,24 @@ export function getAcceptedOAuthResources(
   return (request as MarkedRequest)[kAcceptedOAuthResources];
 }
 
+/**
+ * Request-scoped marker telling the token resolvers to skip `lastUsedAt`
+ * bookkeeping. Set on the MCP loopback dispatch requests, whose outer request
+ * has already recorded usage, so a single tool call doesn't write it twice.
+ */
+const kSkipUsageTracking = Symbol("skipUsageTracking");
+
+export function markSkipUsageTracking(request: Request): void {
+  (request as MarkedRequest)[kSkipUsageTracking] = true;
+}
+
+export function getSkipUsageTracking(request: Request): boolean {
+  return (request as MarkedRequest)[kSkipUsageTracking] === true;
+}
+
 type MarkedRequest = Request & {
   [kAcceptedOAuthResources]?: readonly string[];
+  [kSkipUsageTracking]?: boolean;
 };
 
 /**
@@ -44,7 +60,10 @@ type MarkedRequest = Request & {
  */
 export async function getAuthPayloadFromOAuthAccessToken(
   token: string,
-  options?: { acceptedResources?: readonly string[] | undefined },
+  options?: {
+    acceptedResources?: readonly string[] | undefined;
+    trackUsage?: boolean | undefined;
+  },
 ): Promise<AuthOAuthPayload> {
   if (!OAuthAccessToken.isOAuthAccessToken(token)) {
     throw boom(400, "Invalid OAuth access token");
@@ -119,16 +138,19 @@ export async function getAuthPayloadFromOAuthAccessToken(
     );
   }
 
-  // Bookkeeping — see the note in `getAuthPayloadFromUserAccessToken`.
-  const now = new Date().toISOString();
-  await waitUntil(
-    Promise.all([
-      OAuthAccessToken.query()
-        .patch({ lastUsedAt: now })
-        .findById(accessToken.id),
-      OAuthGrant.query().patch({ lastUsedAt: now }).findById(grant.id),
-    ]),
-  );
+  // Bookkeeping — see the note in `getAuthPayloadFromUserAccessToken`. Skipped
+  // when the caller already recorded usage (the MCP loopback re-auth).
+  if (options?.trackUsage !== false) {
+    const now = new Date().toISOString();
+    await waitUntil(
+      Promise.all([
+        OAuthAccessToken.query()
+          .patch({ lastUsedAt: now })
+          .findById(accessToken.id),
+        OAuthGrant.query().patch({ lastUsedAt: now }).findById(grant.id),
+      ]),
+    );
+  }
 
   return {
     type: "oauth",

--- a/apps/backend/src/auth/oauth-access-token.ts
+++ b/apps/backend/src/auth/oauth-access-token.ts
@@ -1,5 +1,6 @@
 import { assertNever } from "@argos/util/assertNever";
 import { invariant } from "@argos/util/invariant";
+import type { Request } from "express";
 
 import { waitUntil } from "@/api/request-context";
 import { Account, OAuthAccessToken, OAuthGrant } from "@/database/models";
@@ -10,6 +11,31 @@ import { boom } from "../util/error";
 import type { AuthOAuthPayload } from "./payload";
 
 /**
+ * Request-scoped marker listing the resource identifiers (RFC 8707 audiences)
+ * accepted by the surface handling the request. Symbol-keyed so it can only be
+ * set by our own middleware, never by external input. Absent on public REST
+ * API requests, which keep the strict default audience.
+ */
+const kAcceptedOAuthResources = Symbol("acceptedOAuthResources");
+
+export function markAcceptedOAuthResources(
+  request: Request,
+  resources: readonly string[],
+): void {
+  (request as MarkedRequest)[kAcceptedOAuthResources] = resources;
+}
+
+export function getAcceptedOAuthResources(
+  request: Request,
+): readonly string[] | undefined {
+  return (request as MarkedRequest)[kAcceptedOAuthResources];
+}
+
+type MarkedRequest = Request & {
+  [kAcceptedOAuthResources]?: readonly string[];
+};
+
+/**
  * Resolve an OAuth access token to an auth payload.
  *
  * Like personal access tokens, the token's account scope is re-validated
@@ -18,6 +44,7 @@ import type { AuthOAuthPayload } from "./payload";
  */
 export async function getAuthPayloadFromOAuthAccessToken(
   token: string,
+  options?: { acceptedResources?: readonly string[] | undefined },
 ): Promise<AuthOAuthPayload> {
   if (!OAuthAccessToken.isOAuthAccessToken(token)) {
     throw boom(400, "Invalid OAuth access token");
@@ -38,10 +65,15 @@ export async function getAuthPayloadFromOAuthAccessToken(
   if (new Date(accessToken.expiresAt) <= new Date()) {
     throw boom(401, "Access token has expired");
   }
-  // Audience binding (RFC 8707): a token issued for another resource server
-  // (e.g. a future MCP server) must not be accepted by the REST API. Tokens
-  // with no bound resource are unscoped and accepted everywhere.
-  if (accessToken.resource && accessToken.resource !== getApiResourceUrl()) {
+  // Audience binding (RFC 8707): a token issued for another resource must not
+  // be accepted here. The REST API only accepts its own audience; the MCP
+  // server marks its requests as also accepting the MCP audience. Tokens with
+  // no bound resource are unscoped and accepted everywhere.
+  const acceptedResources = options?.acceptedResources ?? [getApiResourceUrl()];
+  if (
+    accessToken.resource &&
+    !acceptedResources.includes(accessToken.resource)
+  ) {
     throw boom(401, "Access token was not issued for this resource");
   }
 

--- a/apps/backend/src/auth/user-access-token.ts
+++ b/apps/backend/src/auth/user-access-token.ts
@@ -13,6 +13,7 @@ import type { AuthPATPayload } from "./payload";
  */
 export async function getAuthPayloadFromUserAccessToken(
   token: string,
+  options?: { trackUsage?: boolean | undefined },
 ): Promise<AuthPATPayload> {
   if (!UserAccessToken.isValidUserAccessToken(token)) {
     throw boom(400, "Invalid user access token");
@@ -71,12 +72,15 @@ export async function getAuthPayloadFromUserAccessToken(
   // Refreshing `lastUsedAt` is bookkeeping, not part of the auth decision, so
   // don't make the request wait on it: within an API request it runs in the
   // background (awaited before the response is flushed), and elsewhere it runs
-  // directly.
-  await waitUntil(
-    UserAccessToken.query()
-      .patch({ lastUsedAt: new Date().toISOString() })
-      .findById(userAccessToken.id),
-  );
+  // directly. Skipped when the caller already recorded usage (the MCP loopback
+  // re-auth).
+  if (options?.trackUsage !== false) {
+    await waitUntil(
+      UserAccessToken.query()
+        .patch({ lastUsedAt: new Date().toISOString() })
+        .findById(userAccessToken.id),
+    );
+  }
 
   return { type: "pat", account: user.account, user, scope: scopeAccounts };
 }

--- a/apps/backend/src/config/index.ts
+++ b/apps/backend/src/config/index.ts
@@ -156,6 +156,14 @@ export function createConfig() {
         },
       },
     },
+    mcp: {
+      baseUrl: {
+        doc: "The MCP server base URL",
+        format: String,
+        default: "https://mcp.argos-ci.dev:4001",
+        env: "MCP_BASE_URL",
+      },
+    },
     api: {
       baseUrl: {
         doc: "The API base URL",

--- a/apps/backend/src/database/services/project.ts
+++ b/apps/backend/src/database/services/project.ts
@@ -1,11 +1,15 @@
 import { ProjectNameSchema } from "@argos/schemas/project";
+import { assertNever } from "@argos/util/assertNever";
 import * as Sentry from "@sentry/node";
+import type { QueryBuilder } from "objection";
 
 import { notifyDiscord } from "@/discord";
 import { boom } from "@/util/error";
 
 import type { Account } from "../models/Account";
 import { Project } from "../models/Project";
+import { ProjectUser } from "../models/ProjectUser";
+import { TeamUser } from "../models/TeamUser";
 import type { User } from "../models/User";
 
 const RESERVED_PROJECT_NAMES = ["new", "settings"];
@@ -44,6 +48,92 @@ export const resolveProjectName = async (args: {
 
   return name;
 };
+
+/**
+ * Apply the project-visibility rules for a user to a `Project` query, returning
+ * the filtered query — or `null` when the user can see no project at all, so the
+ * caller can decide whether to throw or return an empty result.
+ *
+ * This is the single source of truth shared by the GraphQL API
+ * (`Account.projects`, `getVisibleProjectIds`) and the public REST API
+ * (`GET /accounts/{accountSlug}/projects`):
+ * - staff see every project
+ * - on a user account, only the owner
+ * - on a team, owners/members see all; contributors see projects they are a
+ *   contributor on (or that expose a default user level)
+ */
+export function applyProjectVisibility<R>(
+  query: QueryBuilder<Project, R>,
+  args: { account: Account; user: { id: string; staff: boolean } },
+): QueryBuilder<Project, R> | null {
+  const { account, user } = args;
+
+  // Staff can view all projects
+  if (user.staff) {
+    return query;
+  }
+
+  switch (account.type) {
+    case "user":
+      return account.userId === user.id ? query : null;
+    case "team": {
+      const teamUserQuery = TeamUser.query().where({
+        teamId: account.teamId,
+        userId: user.id,
+      });
+      return query.where((qb) => {
+        // User is a team member or owner
+        qb.whereExists(
+          teamUserQuery
+            .select(1)
+            .clone()
+            .whereIn("userLevel", ["owner", "member"]),
+        ).orWhere((qb) => {
+          // User is a contributor
+          qb.whereExists(
+            teamUserQuery.select(1).clone().where("userLevel", "contributor"),
+          ).where((qb) => {
+            // And is a contributor to the project
+            qb.whereExists(
+              ProjectUser.query()
+                .select(1)
+                .whereRaw(`projects.id = project_users."projectId"`)
+                .where("userId", user.id),
+            )
+              // Or where there is a default user level set on the project
+              .orWhereNotNull("projects.defaultUserLevel");
+          });
+        });
+      });
+    }
+    default:
+      return assertNever(account.type);
+  }
+}
+
+/**
+ * Query the projects of an account visible to a user, most recently active
+ * first (latest created project or build). Returns `null` when the user can
+ * see no project at all. Callers apply their own pagination.
+ *
+ * Shared by the GraphQL API (`Account.projects`) and the public REST API
+ * (`GET /accounts/{accountSlug}/projects`) so both list the exact same
+ * projects in the exact same order.
+ */
+export function queryAccountProjects(args: {
+  account: Account;
+  user: { id: string; staff: boolean };
+}): QueryBuilder<Project, Project[]> | null {
+  return applyProjectVisibility(
+    Project.query()
+      .where("accountId", args.account.id)
+      // Sort by most recently created project or build
+      .orderByRaw(
+        `greatest(projects."createdAt", (select max("createdAt") from builds where builds."projectId" = projects.id)) desc`,
+      ),
+    args,
+  );
+}
 
 /** Where a project creation originated, used in the creation notification. */
 export type ProjectCreationSource = "GitHub" | "GitLab" | null;

--- a/apps/backend/src/graphql/definitions/Account.ts
+++ b/apps/backend/src/graphql/definitions/Account.ts
@@ -8,13 +8,14 @@ import { disconnectGitHubAuth } from "@/auth/github";
 import { disconnectGitLabAuth } from "@/auth/gitlab";
 import { disconnectGoogleAuth } from "@/auth/google";
 import { startSession } from "@/auth/login";
-import { Account, Project } from "@/database/models";
+import { Account } from "@/database/models";
 import {
   authenticateWithEmail,
   checkAccountSlug,
   requestEmailSignin,
   requestEmailSignup,
 } from "@/database/services/account";
+import { queryAccountProjects } from "@/database/services/project";
 import { getSpendLimitThreshold } from "@/database/services/spend-limit";
 import { hasAutoInviteForUser } from "@/database/services/team-domain";
 import { isValidPgBigInt } from "@/database/util/biginteger";
@@ -37,10 +38,7 @@ import {
 import type { Context } from "../context";
 import { getAdminAccount } from "../services/account";
 import { getAccountAvatar } from "../services/avatar";
-import {
-  applyProjectVisibility,
-  getVisibleProjectIds,
-} from "../services/project";
+import { getVisibleProjectIds } from "../services/project";
 import { queryActiveTests } from "../services/test";
 import { badUserInput, unauthenticated } from "../util";
 import { paginateResult } from "./PageInfo";
@@ -290,20 +288,11 @@ export const commonAccountResolvers: IResolvers["Team"] = {
     if (!auth) {
       throw unauthenticated();
     }
-    const query = applyProjectVisibility(
-      Project.query()
-        .where("accountId", account.id)
-        // Sort by most recently created project or build
-        .orderByRaw(
-          `greatest(projects."createdAt", (select max("createdAt") from builds where builds."projectId" = projects.id)) desc`,
-        )
-        .range(args.after, args.after + args.first - 1),
-      { account, user: auth.user },
-    );
+    const query = queryAccountProjects({ account, user: auth.user });
     if (!query) {
       throw unauthenticated();
     }
-    const result = await query;
+    const result = await query.range(args.after, args.after + args.first - 1);
     return paginateResult({
       after: args.after,
       first: args.first,

--- a/apps/backend/src/graphql/definitions/OAuthClient.ts
+++ b/apps/backend/src/graphql/definitions/OAuthClient.ts
@@ -5,6 +5,7 @@ import { transaction } from "@/database/transaction";
 import { createAuthorizationCode } from "@/oauth/authorization-code";
 import { getClientByClientId, validateRedirectUri } from "@/oauth/clients";
 import { getKnownApp } from "@/oauth/known-apps";
+import { isKnownResource } from "@/oauth/metadata";
 import { isOAuthScope, OAUTH_SCOPES, parseScopeString } from "@/oauth/scopes";
 
 import type { IResolvers } from "../__generated__/resolver-types";
@@ -155,6 +156,11 @@ export const resolvers: IResolvers = {
         if (!requestedScopes.every((scope) => allowed.has(scope))) {
           throw badUserInput("Requested scope is not allowed for this client");
         }
+      }
+
+      // RFC 8707: only issue tokens for resources we actually serve.
+      if (resource && !isKnownResource(resource)) {
+        throw badUserInput("Unknown resource");
       }
 
       const accessibleAccounts = await getAccessibleAccounts({

--- a/apps/backend/src/graphql/definitions/OAuthClient.ts
+++ b/apps/backend/src/graphql/definitions/OAuthClient.ts
@@ -5,7 +5,7 @@ import { transaction } from "@/database/transaction";
 import { createAuthorizationCode } from "@/oauth/authorization-code";
 import { getClientByClientId, validateRedirectUri } from "@/oauth/clients";
 import { getKnownApp } from "@/oauth/known-apps";
-import { isKnownResource } from "@/oauth/metadata";
+import { isKnownResource, normalizeResource } from "@/oauth/metadata";
 import { isOAuthScope, OAUTH_SCOPES, parseScopeString } from "@/oauth/scopes";
 
 import type { IResolvers } from "../__generated__/resolver-types";
@@ -201,7 +201,7 @@ export const resolvers: IResolvers = {
         scopes: requestedScopes,
         accountIds: accessibleAccounts.map((account) => account.id),
         codeChallenge,
-        resource: resource ?? null,
+        resource: resource ? normalizeResource(resource) : null,
       });
 
       const url = new URL(redirectUri);

--- a/apps/backend/src/graphql/services/project.ts
+++ b/apps/backend/src/graphql/services/project.ts
@@ -1,6 +1,5 @@
-import { assertNever } from "@argos/util/assertNever";
 import { invariant } from "@argos/util/invariant";
-import { QueryBuilder, TransactionOrKnex } from "objection";
+import { TransactionOrKnex } from "objection";
 
 import {
   Account,
@@ -23,6 +22,7 @@ import {
   Test,
   User,
 } from "@/database/models";
+import { applyProjectVisibility } from "@/database/services/project";
 import { transaction } from "@/database/transaction";
 import { isValidPgBigInt } from "@/database/util/biginteger";
 import { sendNotification } from "@/notification";
@@ -89,67 +89,6 @@ export async function getAdminProject(args: {
   const permissions = await project.$getPermissions(args.user);
   invariant(permissions.includes("admin"), "not admin");
   return project;
-}
-
-/**
- * Apply the project-visibility rules for a user to a `Project` query, returning
- * the filtered query — or `null` when the user can see no project at all, so the
- * caller can decide whether to throw or return an empty result.
- *
- * This is the single source of truth shared by the `Account.projects` resolver
- * and {@link getVisibleProjectIds}:
- * - staff see every project
- * - on a user account, only the owner
- * - on a team, owners/members see all; contributors see projects they are a
- *   contributor on (or that expose a default user level)
- */
-export function applyProjectVisibility<R>(
-  query: QueryBuilder<Project, R>,
-  args: { account: Account; user: { id: string; staff: boolean } },
-): QueryBuilder<Project, R> | null {
-  const { account, user } = args;
-
-  // Staff can view all projects
-  if (user.staff) {
-    return query;
-  }
-
-  switch (account.type) {
-    case "user":
-      return account.userId === user.id ? query : null;
-    case "team": {
-      const teamUserQuery = TeamUser.query().where({
-        teamId: account.teamId,
-        userId: user.id,
-      });
-      return query.where((qb) => {
-        // User is a team member or owner
-        qb.whereExists(
-          teamUserQuery
-            .select(1)
-            .clone()
-            .whereIn("userLevel", ["owner", "member"]),
-        ).orWhere((qb) => {
-          // User is a contributor
-          qb.whereExists(
-            teamUserQuery.select(1).clone().where("userLevel", "contributor"),
-          ).where((qb) => {
-            // And is a contributor to the project
-            qb.whereExists(
-              ProjectUser.query()
-                .select(1)
-                .whereRaw(`projects.id = project_users."projectId"`)
-                .where("userId", user.id),
-            )
-              // Or where there is a default user level set on the project
-              .orWhereNotNull("projects.defaultUserLevel");
-          });
-        });
-      });
-    }
-    default:
-      return assertNever(account.type);
-  }
 }
 
 /**

--- a/apps/backend/src/graphql/tests/oauthAuthorize.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/oauthAuthorize.e2e.test.ts
@@ -12,7 +12,7 @@ import {
 } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
 import { consumeAuthorizationCode } from "@/oauth/authorization-code";
-import { getApiResourceUrl } from "@/oauth/metadata";
+import { getApiResourceUrl, getMcpResourceUrl } from "@/oauth/metadata";
 import { issueTokens, revokeGrant, rotateRefreshToken } from "@/oauth/tokens";
 
 import { apolloServer, createApolloMiddleware } from "../apollo";
@@ -191,6 +191,122 @@ describe("OAuth authorization flow", () => {
     // Machine A's token keeps working after B logs in.
     const auth = await getAuthPayloadFromOAuthAccessToken(aTokens.accessToken);
     expect(auth.grantId).toBe(a.grantId);
+  });
+
+  it("rejects a consent for a resource we do not serve (RFC 8707)", async () => {
+    const userAccount = await factory.UserAccount.create();
+    await userAccount.$fetchGraph("user");
+    const client = await createTestClient();
+
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user: userAccount.user!, account: userAccount },
+    );
+
+    const codeVerifier = "s".repeat(64);
+    const codeChallenge = createHash("sha256")
+      .update(codeVerifier)
+      .digest("base64url");
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: AuthorizeMutation,
+        variables: {
+          input: {
+            clientId: client.clientId,
+            redirectUri: ACTUAL_REDIRECT,
+            scopes: ["profile"],
+            accountIds: [userAccount.id],
+            codeChallenge,
+            codeChallengeMethod: "S256",
+            resource: "https://evil.example",
+          },
+        },
+      });
+    expect(res.body.errors?.[0]?.message).toBe("Unknown resource");
+  });
+
+  it("accepts a consent bound to the MCP resource", async () => {
+    const userAccount = await factory.UserAccount.create();
+    await userAccount.$fetchGraph("user");
+    const client = await createTestClient();
+
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user: userAccount.user!, account: userAccount },
+    );
+
+    const codeVerifier = "s".repeat(64);
+    const codeChallenge = createHash("sha256")
+      .update(codeVerifier)
+      .digest("base64url");
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: AuthorizeMutation,
+        variables: {
+          input: {
+            clientId: client.clientId,
+            redirectUri: ACTUAL_REDIRECT,
+            scopes: ["profile"],
+            accountIds: [userAccount.id],
+            codeChallenge,
+            codeChallengeMethod: "S256",
+            resource: getMcpResourceUrl(),
+          },
+        },
+      });
+    expectNoGraphQLError(res);
+    const code = new URL(
+      res.body.data.authorizeOAuthConsent.redirectUri,
+    ).searchParams.get("code");
+    const payload = await consumeAuthorizationCode({
+      code: code!,
+      codeVerifier,
+      clientId: client.clientId,
+      redirectUri: ACTUAL_REDIRECT,
+    });
+    expect(payload?.resource).toBe(getMcpResourceUrl());
+  });
+
+  it("refuses to rotate a refresh token onto an unknown resource (invalid_target)", async () => {
+    const userAccount = await factory.UserAccount.create();
+    const client = await createTestClient();
+    const grant = await OAuthGrant.query().insertAndFetch({
+      userId: userAccount.userId!,
+      oauthClientId: client.id,
+      scopes: ["profile"],
+      lastUsedAt: null,
+      revokedAt: null,
+    });
+    await OAuthGrantAccount.query().insert({
+      oauthGrantId: grant.id,
+      accountId: userAccount.id,
+    });
+    const tokens = await issueTokens({
+      grantId: grant.id,
+      scopes: ["profile"],
+      resource: null,
+    });
+
+    const rotated = await rotateRefreshToken({
+      refreshToken: tokens.refreshToken,
+      clientId: client.clientId,
+      requestedScopes: null,
+      resource: "https://evil.example",
+    });
+    expect(rotated).toEqual({ ok: false, error: "invalid_target" });
+
+    // The refused rotation must not have consumed the refresh token.
+    const retried = await rotateRefreshToken({
+      refreshToken: tokens.refreshToken,
+      clientId: client.clientId,
+      requestedScopes: null,
+      resource: getMcpResourceUrl(),
+    });
+    expect(retried.ok).toBe(true);
   });
 
   it("keeps a sibling session alive when another session refreshes (ARG-466)", async () => {

--- a/apps/backend/src/graphql/tests/oauthAuthorize.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/oauthAuthorize.e2e.test.ts
@@ -227,7 +227,7 @@ describe("OAuth authorization flow", () => {
     expect(res.body.errors?.[0]?.message).toBe("Unknown resource");
   });
 
-  it("accepts a consent bound to the MCP resource", async () => {
+  it("accepts a consent bound to the canonicalized MCP resource and normalizes it", async () => {
     const userAccount = await factory.UserAccount.create();
     await userAccount.$fetchGraph("user");
     const client = await createTestClient();
@@ -254,7 +254,9 @@ describe("OAuth authorization flow", () => {
             accountIds: [userAccount.id],
             codeChallenge,
             codeChallengeMethod: "S256",
-            resource: getMcpResourceUrl(),
+            // MCP clients canonicalize the server URL, adding a trailing
+            // slash — the exact form Claude Code sends.
+            resource: `${getMcpResourceUrl()}/`,
           },
         },
       });

--- a/apps/backend/src/mcp/README.md
+++ b/apps/backend/src/mcp/README.md
@@ -1,0 +1,71 @@
+# MCP Server
+
+The Argos MCP server exposes the public REST API to AI agents over the
+[Model Context Protocol](https://modelcontextprotocol.io). It is served on its
+own subdomain (`config.mcp.baseUrl`, `https://mcp.argos-ci.com` in production)
+and authenticates with **personal access tokens** and **OAuth 2.1 access
+tokens** (see `src/oauth/README.md`). Project tokens are rejected.
+
+## Architecture: derived from OpenAPI
+
+There is **no per-endpoint MCP code**. The whole surface is derived from the
+OpenAPI document and dispatched through the existing API stack:
+
+1. **Derivation** (`tools.ts`) — at module load, every operation in
+   `api/schema.ts` whose `security` accepts a personal access token or OAuth
+   (`isMcpEligible` in `eligibility.ts`) becomes a tool: name = `operationId`,
+   input schema = merged path + query + body Zod schemas, output schema = the
+   2xx response schema. Project-token-only CI operations, `x-internal` and
+   public operations are excluded. The generated OpenAPI document stamps
+   eligible operations with `x-gitbook-mcp` using the same predicate, so docs
+   and tools can never disagree.
+2. **Registration** (`server.ts`) — tools are registered on an SDK `McpServer`
+   with their Zod schemas; the SDK converts them to JSON Schema for
+   `tools/list` and validates arguments and structured results.
+3. **Dispatch** (`dispatch.ts`) — a tool call becomes an HTTP request to a
+   private loopback server running the `openAPIRouter`, forwarding the
+   caller's bearer. Validation, authentication, **scope enforcement**,
+   serialization and error formatting are the API's own; API errors surface
+   verbatim as `isError` tool results.
+4. **Transport** (`router.ts`) — stateless Streamable HTTP at `POST /` (a
+   fresh server + transport per request). Browsers hitting `GET /` are
+   redirected to the documentation.
+
+Adding a REST endpoint automatically adds the MCP tool. The unit test
+snapshot in `tools.test.ts` locks the tool surface; adding an endpoint updates
+that snapshot, which is the only MCP touchpoint in review.
+
+### `x-mcp` operation extension
+
+Operations can opt out or customize their projection:
+
+```ts
+"x-mcp": { enabled?: boolean; name?: string; description?: string }
+```
+
+No operation needs it by default — eligibility is computed from `security`.
+
+## Authentication and audience
+
+- Requests without a valid PAT/OAuth bearer get `401` +
+  `WWW-Authenticate: Bearer resource_metadata="…/.well-known/oauth-protected-resource"`,
+  which triggers the MCP client authorization flow (discovery → Dynamic Client
+  Registration → consent).
+- The MCP server is its own OAuth resource (RFC 8707 audience,
+  `getMcpResourceUrl()`). It accepts tokens bound to the MCP resource or to
+  the REST API resource; the public REST API keeps accepting only its own
+  audience (`markAcceptedOAuthResources` in `auth/oauth-access-token.ts`).
+- OAuth scopes are enforced per tool call by the API layer
+  (`assertOAuthScopes`); scope failures come back as `isError` tool results,
+  not HTTP 401s, so clients don't needlessly re-authenticate.
+
+## Local development
+
+The `mcp` subdomain must resolve to the backend (like `api` and `app`):
+add `mcp.argos-ci.dev` to `/etc/hosts` alongside the other Argos hosts.
+Requests need `Accept: application/json, text/event-stream` (MCP spec,
+enforced by the SDK transport).
+
+```sh
+claude mcp add --transport http argos https://mcp.argos-ci.dev:4001
+```

--- a/apps/backend/src/mcp/dispatch.ts
+++ b/apps/backend/src/mcp/dispatch.ts
@@ -1,0 +1,170 @@
+/**
+ * Executes MCP tool calls by routing HTTP requests through the existing
+ * OpenAPI Express router. The API layer stays the single source of truth:
+ * request validation, authentication, OAuth scope enforcement, serialization
+ * and error formatting are all reused verbatim.
+ *
+ * Requests go through a private HTTP server bound to the loopback interface
+ * (never exposed): it runs the OpenAPI router without the public `api`
+ * subdomain matching or the public `/v2` rate limiter (the MCP endpoint has
+ * its own), and every request re-authenticates with the caller's bearer.
+ */
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import express from "express";
+
+import { openAPIRouter } from "@/api/index";
+import { markAcceptedOAuthResources } from "@/auth/oauth-access-token";
+import { getApiResourceUrl, getMcpResourceUrl } from "@/oauth/metadata";
+
+import type { McpToolDefinition } from "./tools";
+
+function createInternalApp(): express.Express {
+  const app = express();
+  app.use((req, _res, next) => {
+    // Tool calls come from the MCP server, so tokens bound to either the MCP
+    // resource or the REST API resource are acceptable.
+    markAcceptedOAuthResources(req, [getMcpResourceUrl(), getApiResourceUrl()]);
+    next();
+  });
+  app.use(openAPIRouter);
+  app.use((_req, res) => {
+    res.status(404).json({ error: "Not found" });
+  });
+  app.use(
+    (
+      error: unknown,
+      _req: express.Request,
+      res: express.Response,
+      _next: express.NextFunction,
+    ) => {
+      const message =
+        error instanceof Error ? error.message : "Internal server error";
+      res.status(500).json({ error: message });
+    },
+  );
+  return app;
+}
+
+let internalBaseUrl: Promise<string> | null = null;
+
+/** Lazily start the loopback dispatch server, once per process. */
+function getInternalBaseUrl(): Promise<string> {
+  internalBaseUrl ??= new Promise((resolve, reject) => {
+    const server = createServer(createInternalApp());
+    // Never keep the process alive because of the dispatch server.
+    server.unref();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+  return internalBaseUrl;
+}
+
+function textResult(text: string, isError?: boolean): CallToolResult {
+  return {
+    content: [{ type: "text", text }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+/**
+ * Execute a tool call by routing it through the OpenAPI router with the
+ * caller's bearer token. Returns an MCP tool result; API errors become
+ * `isError` results carrying the API's own error message.
+ */
+export async function callTool(
+  tool: McpToolDefinition,
+  args: Record<string, unknown>,
+  authorization: string,
+): Promise<CallToolResult> {
+  // Build the URL from the OpenAPI path template.
+  let url = tool.path;
+  for (const key of tool.pathKeys) {
+    const value = args[key];
+    if (value === undefined || value === null || value === "") {
+      return textResult(`Missing required parameter "${key}".`, true);
+    }
+    url = url.replace(`{${key}}`, encodeURIComponent(String(value)));
+  }
+
+  const searchParams = new URLSearchParams();
+  for (const key of tool.queryKeys) {
+    const value = args[key];
+    if (value === undefined || value === null) {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        searchParams.append(key, String(item));
+      }
+    } else {
+      searchParams.append(key, String(value));
+    }
+  }
+  const queryString = searchParams.toString();
+  if (queryString) {
+    url += `?${queryString}`;
+  }
+
+  let body: unknown;
+  if (tool.hasBody) {
+    if (tool.bodyKeys === null) {
+      body = args["body"];
+    } else {
+      const picked: Record<string, unknown> = {};
+      for (const key of tool.bodyKeys) {
+        if (args[key] !== undefined) {
+          picked[key] = args[key];
+        }
+      }
+      body = picked;
+    }
+  }
+
+  const baseUrl = await getInternalBaseUrl();
+  const response = await fetch(`${baseUrl}${url}`, {
+    method: tool.method.toUpperCase(),
+    headers: {
+      authorization,
+      ...(body !== undefined ? { "content-type": "application/json" } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+  const payload = await response.text();
+
+  if (response.ok) {
+    if (!payload) {
+      return textResult(JSON.stringify({ success: true }));
+    }
+    return {
+      content: [{ type: "text", text: payload }],
+      ...(tool.outputSchema ? { structuredContent: JSON.parse(payload) } : {}),
+    };
+  }
+
+  return textResult(
+    `${tool.name} failed (HTTP ${response.status}): ${formatApiError(payload)}`,
+    true,
+  );
+}
+
+/** Format the API error payload (`{ error, details }`, see api/util.ts). */
+function formatApiError(payload: string): string {
+  try {
+    const parsed = JSON.parse(payload) as {
+      error?: string;
+      details?: { message?: string }[];
+    };
+    const message = parsed.error ?? payload;
+    const details = (parsed.details ?? [])
+      .map((detail) => detail.message)
+      .filter(Boolean);
+    return details.length > 0 ? `${message} — ${details.join("; ")}` : message;
+  } catch {
+    return payload || "Unknown error";
+  }
+}

--- a/apps/backend/src/mcp/dispatch.ts
+++ b/apps/backend/src/mcp/dispatch.ts
@@ -21,6 +21,8 @@ import { getApiResourceUrl, getMcpResourceUrl } from "@/oauth/metadata";
 import type { McpToolDefinition } from "./tools";
 
 function createInternalApp(): express.Express {
+  // No rate limiter here on purpose: this app binds to the loopback interface
+  // and is only reachable through the MCP endpoint, which is rate-limited.
   const app = express();
   app.use((req, _res, next) => {
     // Tool calls come from the MCP server, so tokens bound to either the MCP

--- a/apps/backend/src/mcp/dispatch.ts
+++ b/apps/backend/src/mcp/dispatch.ts
@@ -145,6 +145,16 @@ export async function callTool(
 
   if (response.ok) {
     if (!payload) {
+      // No response body (e.g. a 204). When the tool declares an output
+      // schema the MCP SDK requires a matching `structuredContent`, so an
+      // empty body is an anomaly we surface as an error rather than letting
+      // the SDK throw on a missing structured result.
+      if (tool.outputSchema) {
+        return textResult(
+          `${tool.name} returned an empty response body but declares structured output.`,
+          true,
+        );
+      }
       return textResult(JSON.stringify({ success: true }));
     }
     return {

--- a/apps/backend/src/mcp/dispatch.ts
+++ b/apps/backend/src/mcp/dispatch.ts
@@ -15,7 +15,10 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import express from "express";
 
 import { openAPIRouter } from "@/api/index";
-import { markAcceptedOAuthResources } from "@/auth/oauth-access-token";
+import {
+  markAcceptedOAuthResources,
+  markSkipUsageTracking,
+} from "@/auth/oauth-access-token";
 import { getApiResourceUrl, getMcpResourceUrl } from "@/oauth/metadata";
 
 import type { McpToolDefinition } from "./tools";
@@ -28,6 +31,9 @@ function createInternalApp(): express.Express {
     // Tool calls come from the MCP server, so tokens bound to either the MCP
     // resource or the REST API resource are acceptable.
     markAcceptedOAuthResources(req, [getMcpResourceUrl(), getApiResourceUrl()]);
+    // The outer MCP request already authenticated the same bearer and recorded
+    // its usage, so skip the redundant `lastUsedAt` writes on this re-auth.
+    markSkipUsageTracking(req);
     next();
   });
   app.use(openAPIRouter);

--- a/apps/backend/src/mcp/dispatch.ts
+++ b/apps/backend/src/mcp/dispatch.ts
@@ -53,7 +53,7 @@ let internalBaseUrl: Promise<string> | null = null;
 
 /** Lazily start the loopback dispatch server, once per process. */
 function getInternalBaseUrl(): Promise<string> {
-  internalBaseUrl ??= new Promise((resolve, reject) => {
+  internalBaseUrl ??= new Promise<string>((resolve, reject) => {
     const server = createServer(createInternalApp());
     // Never keep the process alive because of the dispatch server.
     server.unref();
@@ -62,6 +62,11 @@ function getInternalBaseUrl(): Promise<string> {
       const { port } = server.address() as AddressInfo;
       resolve(`http://127.0.0.1:${port}`);
     });
+  }).catch((error: unknown) => {
+    // Don't cache the failure: clearing the memo lets the next call retry
+    // instead of every future tool call awaiting the same rejected promise.
+    internalBaseUrl = null;
+    throw error;
   });
   return internalBaseUrl;
 }

--- a/apps/backend/src/mcp/dispatch.ts
+++ b/apps/backend/src/mcp/dispatch.ts
@@ -157,9 +157,24 @@ export async function callTool(
       }
       return textResult(JSON.stringify({ success: true }));
     }
+    if (!tool.outputSchema) {
+      return { content: [{ type: "text", text: payload }] };
+    }
+    let structuredContent: Record<string, unknown>;
+    try {
+      structuredContent = JSON.parse(payload) as Record<string, unknown>;
+    } catch {
+      // A 2xx body that isn't parseable JSON can't satisfy the declared
+      // output schema; return a clean error instead of throwing out of the
+      // tool handler.
+      return textResult(
+        `${tool.name} returned a response that could not be parsed as JSON.`,
+        true,
+      );
+    }
     return {
       content: [{ type: "text", text: payload }],
-      ...(tool.outputSchema ? { structuredContent: JSON.parse(payload) } : {}),
+      structuredContent,
     };
   }
 

--- a/apps/backend/src/mcp/eligibility.ts
+++ b/apps/backend/src/mcp/eligibility.ts
@@ -1,0 +1,55 @@
+/**
+ * MCP eligibility of an OpenAPI operation.
+ *
+ * Single source of truth shared by the MCP tool derivation (mcp/tools.ts) and
+ * the OpenAPI document generation (api/schema.ts), which stamps eligible
+ * operations with `x-gitbook-mcp`. Eligibility is *computed* from the
+ * operation's declared `security` — never marked by hand — so the OpenAPI
+ * document, the docs and the MCP tool surface can't get out of sync.
+ *
+ * This module is dependency-free on purpose: both sides import it without
+ * creating an import cycle.
+ */
+
+/**
+ * Optional `x-mcp` extension on an OpenAPI operation controlling how it is
+ * projected as an MCP tool.
+ */
+export type XMcpExtension = {
+  /** Set to `false` to exclude the operation from the MCP tool surface. */
+  enabled?: boolean;
+  /** Override the tool name (defaults to the operationId). */
+  name?: string;
+  /** Override the tool description (defaults to summary + description). */
+  description?: string;
+};
+
+type EligibilityFields = {
+  security?: readonly Record<string, unknown>[];
+  "x-internal"?: boolean;
+  "x-mcp"?: XMcpExtension;
+};
+
+/**
+ * An operation is exposed on the MCP server when a user-held token can call
+ * it: its security declares the `personalAccessToken` or `oauth2` scheme.
+ * Project-token-only operations (CI/SDK endpoints), public endpoints and
+ * internal operations are excluded, as are explicit `x-mcp: { enabled: false }`
+ * opt-outs.
+ */
+export function isMcpEligible(operation: EligibilityFields): boolean {
+  if (operation["x-internal"]) {
+    return false;
+  }
+  if (operation["x-mcp"]?.enabled === false) {
+    return false;
+  }
+  const security = operation.security;
+  if (!security || security.length === 0) {
+    return false;
+  }
+  return security.some(
+    (requirement) =>
+      "personalAccessToken" in requirement || "oauth2" in requirement,
+  );
+}

--- a/apps/backend/src/mcp/mcp.e2e.test.ts
+++ b/apps/backend/src/mcp/mcp.e2e.test.ts
@@ -1,0 +1,313 @@
+import express from "express";
+import request from "supertest";
+import { test as base, describe, expect } from "vitest";
+
+import {
+  Account,
+  OAuthClient,
+  OAuthGrant,
+  OAuthGrantAccount,
+  Project,
+  User,
+  UserAccessTokenScope,
+} from "@/database/models";
+import { hashToken } from "@/database/services/crypto";
+import { factory, setupDatabase } from "@/database/testing";
+import { getApiResourceUrl, getMcpResourceUrl } from "@/oauth/metadata";
+import type { OAuthScope } from "@/oauth/scopes";
+import { issueTokens } from "@/oauth/tokens";
+
+import { mcpRouter } from "./router";
+
+const app = express();
+app.use(mcpRouter);
+
+const ACCEPT = "application/json, text/event-stream";
+
+type RpcResponse = {
+  result?: {
+    tools?: { name: string }[];
+    content?: { type: string; text: string }[];
+    structuredContent?: Record<string, unknown>;
+    isError?: boolean;
+  };
+  error?: { code: number; message: string };
+};
+
+async function rpc(
+  token: string | null,
+  method: string,
+  params: Record<string, unknown> = {},
+) {
+  let req = request(app)
+    .post("/")
+    .set("Accept", ACCEPT)
+    .set("Content-Type", "application/json");
+  if (token) {
+    req = req.set("Authorization", `Bearer ${token}`);
+  }
+  return req.send({ jsonrpc: "2.0", id: 1, method, params });
+}
+
+async function createOAuthAccessToken(input: {
+  userAccount: Account;
+  scopes: OAuthScope[];
+  resource: string | null;
+}) {
+  const client = await OAuthClient.query().insertAndFetch({
+    clientId: "test-mcp-client",
+    clientName: "Test MCP Client",
+    redirectUris: ["http://localhost/callback"],
+    grantTypes: ["authorization_code", "refresh_token"],
+    responseTypes: ["code"],
+    tokenEndpointAuthMethod: "none",
+    isFirstParty: false,
+    verified: false,
+  });
+  const grant = await OAuthGrant.query().insertAndFetch({
+    userId: input.userAccount.userId!,
+    oauthClientId: client.id,
+    scopes: input.scopes,
+    lastUsedAt: null,
+    revokedAt: null,
+  });
+  await OAuthGrantAccount.query().insert({
+    oauthGrantId: grant.id,
+    accountId: input.userAccount.id,
+  });
+  const tokens = await issueTokens({
+    grantId: grant.id,
+    scopes: input.scopes,
+    resource: input.resource,
+  });
+  return tokens.accessToken;
+}
+
+const test = base.extend<{
+  user: User;
+  userAccount: Account;
+  patToken: string;
+  project: Project;
+}>({
+  user: async ({}, use) => {
+    await setupDatabase();
+    const user = await factory.User.create();
+    await use(user);
+  },
+  userAccount: async ({ user }, use) => {
+    const userAccount = await factory.UserAccount.create({
+      userId: user.id,
+      name: "Jane Doe",
+      slug: "jane-doe",
+    });
+    await use(userAccount);
+  },
+  patToken: async ({ user, userAccount }, use) => {
+    const token = `arp_${"e".repeat(36)}`;
+    const userAccessToken = await factory.UserAccessToken.create({
+      userId: user.id,
+      token: hashToken(token),
+    });
+    await UserAccessTokenScope.query().insert({
+      userAccessTokenId: userAccessToken.id,
+      accountId: userAccount.id,
+    });
+    await use(token);
+  },
+  project: async ({ userAccount }, use) => {
+    const project = await factory.Project.create({
+      accountId: userAccount.id,
+      name: "awesome-project",
+      token: "the-awesome-token",
+    });
+    await use(project);
+  },
+});
+
+describe("MCP server", () => {
+  test("responds 401 with the OAuth discovery handshake when unauthenticated", async ({
+    user: _user,
+  }) => {
+    const res = await rpc(null, "tools/list");
+    expect(res.status).toBe(401);
+    expect(res.headers["www-authenticate"]).toContain(
+      '/.well-known/oauth-protected-resource"',
+    );
+  });
+
+  test("rejects project tokens", async ({ project: _project }) => {
+    const res = await rpc("the-awesome-token", "tools/list");
+    expect(res.status).toBe(401);
+    expect(res.body.error).toContain("project tokens are not accepted");
+  });
+
+  test("serves the protected resource metadata", async () => {
+    const res = await request(app)
+      .get("/.well-known/oauth-protected-resource")
+      .expect(200);
+    expect(res.body.resource).toBe(getMcpResourceUrl());
+    expect(res.body.authorization_servers).toHaveLength(1);
+  });
+
+  test("redirects humans to the documentation", async () => {
+    const res = await request(app).get("/").set("Accept", "text/html");
+    expect(res.status).toBe(302);
+    expect(res.headers["location"]).toContain("argos-ci.com/docs");
+  });
+
+  test("responds 405 to MCP clients probing the SSE stream", async () => {
+    const res = await request(app).get("/").set("Accept", "text/event-stream");
+    expect(res.status).toBe(405);
+    expect(res.headers["allow"]).toBe("POST");
+  });
+
+  test("responds 405 to DELETE (stateless, no session to terminate)", async () => {
+    const res = await request(app).delete("/");
+    expect(res.status).toBe(405);
+    expect(res.headers["allow"]).toBe("POST");
+  });
+
+  test("lists the derived tools with a PAT", async ({ patToken }) => {
+    const res = await rpc(patToken, "tools/list");
+    expect(res.status).toBe(200);
+    const body = res.body as RpcResponse;
+    const names = body.result!.tools!.map((tool) => tool.name);
+    expect(names).toEqual(
+      expect.arrayContaining(["getMe", "listBuilds", "createReview"]),
+    );
+    expect(names).not.toContain("createBuild");
+  });
+
+  test("calls getMe with a PAT", async ({ patToken, userAccount }) => {
+    const res = await rpc(patToken, "tools/call", {
+      name: "getMe",
+      arguments: {},
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as RpcResponse;
+    expect(body.result!.isError).toBeUndefined();
+    expect(body.result!.structuredContent).toEqual({
+      id: userAccount.id,
+      slug: "jane-doe",
+      name: "Jane Doe",
+    });
+  });
+
+  test("calls listBuilds with a PAT", async ({
+    patToken,
+    project: _project,
+  }) => {
+    const res = await rpc(patToken, "tools/call", {
+      name: "listBuilds",
+      arguments: {
+        owner: "jane-doe",
+        project: "awesome-project",
+        perPage: "10",
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as RpcResponse;
+    expect(body.result!.isError).toBeUndefined();
+    expect(body.result!.structuredContent).toMatchObject({
+      results: [],
+      pageInfo: { total: 0, page: 1, perPage: 10 },
+    });
+  });
+
+  test("calls a write tool with a JSON body (createProject)", async ({
+    patToken,
+  }) => {
+    const res = await rpc(patToken, "tools/call", {
+      name: "createProject",
+      arguments: { name: "mcp-created", accountSlug: "jane-doe" },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as RpcResponse;
+    expect(body.result!.isError).toBeUndefined();
+    expect(body.result!.structuredContent).toMatchObject({
+      name: "mcp-created",
+    });
+    const project = await Project.query().findOne({ name: "mcp-created" });
+    expect(project).toBeDefined();
+  });
+
+  test("rejects invalid tool arguments", async ({ patToken }) => {
+    const res = await rpc(patToken, "tools/call", {
+      name: "listBuilds",
+      arguments: { owner: "jane-doe" },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as RpcResponse;
+    // The SDK validates arguments against the same Zod schemas as the API and
+    // surfaces failures as tool errors.
+    expect(body.result!.isError).toBe(true);
+    expect(body.result!.content![0]!.text).toMatch(/input validation error/i);
+  });
+
+  test("enforces OAuth scopes per tool call", async ({
+    userAccount,
+    project: _project,
+  }) => {
+    const token = await createOAuthAccessToken({
+      userAccount,
+      scopes: ["profile"],
+      resource: getMcpResourceUrl(),
+    });
+
+    // `getMe` requires `profile` — allowed.
+    const meRes = await rpc(token, "tools/call", {
+      name: "getMe",
+      arguments: {},
+    });
+    expect((meRes.body as RpcResponse).result!.isError).toBeUndefined();
+
+    // `listBuilds` requires `projects:read` — rejected by the API layer.
+    const buildsRes = await rpc(token, "tools/call", {
+      name: "listBuilds",
+      arguments: { owner: "jane-doe", project: "awesome-project" },
+    });
+    const body = buildsRes.body as RpcResponse;
+    expect(body.result!.isError).toBe(true);
+    expect(body.result!.content![0]!.text).toContain("Insufficient scope");
+    expect(body.result!.content![0]!.text).toContain("projects:read");
+  });
+
+  test("accepts OAuth tokens bound to the REST API resource", async ({
+    userAccount,
+  }) => {
+    const token = await createOAuthAccessToken({
+      userAccount,
+      scopes: ["profile"],
+      resource: getApiResourceUrl(),
+    });
+    const res = await rpc(token, "tools/list");
+    expect(res.status).toBe(200);
+  });
+
+  test("rejects OAuth tokens bound to a foreign resource", async ({
+    userAccount,
+  }) => {
+    const token = await createOAuthAccessToken({
+      userAccount,
+      scopes: ["profile"],
+      resource: "https://evil.example",
+    });
+    const res = await rpc(token, "tools/list");
+    expect(res.status).toBe(401);
+    expect(res.body.error).toContain("not issued for this resource");
+    expect(res.headers["www-authenticate"]).toContain(
+      "oauth-protected-resource",
+    );
+  });
+
+  test("returns an error for an unknown tool", async ({ patToken }) => {
+    const res = await rpc(patToken, "tools/call", {
+      name: "doesNotExist",
+      arguments: {},
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as RpcResponse;
+    expect(body.result!.isError).toBe(true);
+    expect(body.result!.content![0]!.text).toMatch(/not found/i);
+  });
+});

--- a/apps/backend/src/mcp/mcp.e2e.test.ts
+++ b/apps/backend/src/mcp/mcp.e2e.test.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import request from "supertest";
-import { test as base, describe, expect } from "vitest";
+import { test as base, describe, expect, vi } from "vitest";
 
 import {
   Account,
@@ -13,11 +13,14 @@ import {
 } from "@/database/models";
 import { hashToken } from "@/database/services/crypto";
 import { factory, setupDatabase } from "@/database/testing";
+import { notifyDiscord } from "@/discord";
 import { getApiResourceUrl, getMcpResourceUrl } from "@/oauth/metadata";
 import type { OAuthScope } from "@/oauth/scopes";
 import { issueTokens } from "@/oauth/tokens";
 
 import { mcpRouter } from "./router";
+
+vi.mock("@/discord", () => ({ notifyDiscord: vi.fn(() => Promise.resolve()) }));
 
 const app = express();
 app.use(mcpRouter);
@@ -229,6 +232,9 @@ describe("MCP server", () => {
     });
     const project = await Project.query().findOne({ name: "mcp-created" });
     expect(project).toBeDefined();
+    // Proves the module mock intercepts through the loopback dispatch — a
+    // real Discord webhook must never fire from tests.
+    expect(vi.mocked(notifyDiscord)).toHaveBeenCalled();
   });
 
   test("rejects invalid tool arguments", async ({ patToken }) => {

--- a/apps/backend/src/mcp/mcp.e2e.test.ts
+++ b/apps/backend/src/mcp/mcp.e2e.test.ts
@@ -152,6 +152,14 @@ describe("MCP server", () => {
     expect(res.body.authorization_servers).toHaveLength(1);
   });
 
+  test("mirrors the authorization server metadata for legacy MCP clients", async () => {
+    const res = await request(app)
+      .get("/.well-known/oauth-authorization-server")
+      .expect(200);
+    expect(res.body.issuer).toMatch(/^https?:\/\//);
+    expect(res.body.token_endpoint).toBe(`${res.body.issuer}/oauth/token`);
+  });
+
   test("redirects humans to the documentation", async () => {
     const res = await request(app).get("/").set("Accept", "text/html");
     expect(res.status).toBe(302);

--- a/apps/backend/src/mcp/mcp.e2e.test.ts
+++ b/apps/backend/src/mcp/mcp.e2e.test.ts
@@ -201,6 +201,14 @@ describe("MCP server", () => {
       id: userAccount.id,
       slug: "jane-doe",
       name: "Jane Doe",
+      accounts: [
+        {
+          id: userAccount.id,
+          slug: "jane-doe",
+          name: "Jane Doe",
+          type: "user",
+        },
+      ],
     });
   });
 

--- a/apps/backend/src/mcp/mcp.e2e.test.ts
+++ b/apps/backend/src/mcp/mcp.e2e.test.ts
@@ -298,6 +298,18 @@ describe("MCP server", () => {
     expect(res.status).toBe(200);
   });
 
+  test("accepts OAuth tokens with a canonicalized (trailing-slash) resource", async ({
+    userAccount,
+  }) => {
+    const token = await createOAuthAccessToken({
+      userAccount,
+      scopes: ["profile"],
+      resource: `${getMcpResourceUrl()}/`,
+    });
+    const res = await rpc(token, "tools/list");
+    expect(res.status).toBe(200);
+  });
+
   test("rejects OAuth tokens bound to a foreign resource", async ({
     userAccount,
   }) => {

--- a/apps/backend/src/mcp/router.ts
+++ b/apps/backend/src/mcp/router.ts
@@ -12,6 +12,7 @@
  * referencing the Protected Resource Metadata, which is what triggers the MCP
  * client authorization flow (DCR + consent).
  */
+import { invariant } from "@argos/util/invariant";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import cors from "cors";
@@ -119,11 +120,13 @@ router.post(
   express.json({ limit: "1mb" }),
   authenticate,
   asyncHandler(async (req: Request, res: Response) => {
+    // `authenticate` runs first and rejects any request without a resolvable
+    // bearer, so the header is guaranteed to be present here.
     const authorization = req.headers.authorization;
-    if (!authorization) {
-      sendUnauthorized(res, "Authentication required");
-      return;
-    }
+    invariant(
+      authorization,
+      "authenticated MCP request without a bearer token",
+    );
     // Stateless mode (no `sessionIdGenerator`): a fresh server + transport
     // pair per request, so concurrent requests never collide and no session
     // state has to be replicated across instances.

--- a/apps/backend/src/mcp/router.ts
+++ b/apps/backend/src/mcp/router.ts
@@ -1,0 +1,143 @@
+/**
+ * HTTP surface of the MCP server, served on its own subdomain
+ * (`mcp.argos-ci.com`):
+ *
+ * - `POST /` — the MCP endpoint (streamable HTTP transport, stateless).
+ * - `GET /` — humans and non-MCP clients are redirected to the documentation.
+ * - `GET /.well-known/oauth-protected-resource` — RFC 9728 metadata pointing
+ *   MCP clients at the Authorization Server (the OAuth discovery handshake).
+ *
+ * Requests are authenticated with a personal access token or an OAuth access
+ * token. Unauthenticated requests get a `401` with a `WWW-Authenticate` header
+ * referencing the Protected Resource Metadata, which is what triggers the MCP
+ * client authorization flow (DCR + consent).
+ */
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import cors from "cors";
+import express, { Router, type Request, type Response } from "express";
+import { rateLimit } from "express-rate-limit";
+
+import { getAuthPayloadFromExpressReq } from "@/api/auth/project";
+import { markAcceptedOAuthResources } from "@/auth/oauth-access-token";
+import config from "@/config";
+import {
+  getApiResourceUrl,
+  getMcpProtectedResourceMetadataUrl,
+  getMcpResourceUrl,
+  getProtectedResourceMetadata,
+} from "@/oauth/metadata";
+import { createRedisStore } from "@/util/rate-limit";
+
+import { asyncHandler } from "../web/util";
+import { createMcpServer } from "./server";
+
+const MCP_DOCS_URL = "https://argos-ci.com/docs/sdks-reference/argos-mcp";
+
+const router: Router = Router();
+
+router.use(
+  cors({
+    origin: "*",
+    exposedHeaders: ["WWW-Authenticate"],
+    allowedHeaders: [
+      "Content-Type",
+      "Authorization",
+      "Mcp-Session-Id",
+      "Mcp-Protocol-Version",
+    ],
+  }),
+);
+
+// RFC 9728 Protected Resource Metadata for the MCP server.
+router.get("/.well-known/oauth-protected-resource", (_req, res) => {
+  res.json(getProtectedResourceMetadata(getMcpResourceUrl()));
+});
+
+// Humans and non-MCP clients land here (the MCP protocol only POSTs).
+router.get("/", (req, res) => {
+  if (req.accepts(["text/event-stream", "html"]) === "text/event-stream") {
+    // An MCP client probing for the SSE stream: the endpoint is stateless.
+    res.set("Allow", "POST").sendStatus(405);
+    return;
+  }
+  res.redirect(302, MCP_DOCS_URL);
+});
+
+router.delete("/", (_req, res) => {
+  res.set("Allow", "POST").sendStatus(405);
+});
+
+const limiter = rateLimit({
+  windowMs: config.get("api.rateLimit.window"),
+  limit: config.get("api.rateLimit.limit"),
+  standardHeaders: "draft-8",
+  legacyHeaders: false,
+  store: createRedisStore("mcp"),
+});
+
+function sendUnauthorized(res: Response, message: string): void {
+  res.set(
+    "WWW-Authenticate",
+    `Bearer error="invalid_token", resource_metadata="${getMcpProtectedResourceMetadataUrl()}"`,
+  );
+  res.status(401).json({ error: message });
+}
+
+/**
+ * Authenticate the MCP request. Tool calls re-authenticate inside the API
+ * layer; this gate exists so unauthenticated clients get the `401` +
+ * `WWW-Authenticate` handshake before reaching the protocol, and so project
+ * tokens are rejected with a clear message.
+ */
+const authenticate = asyncHandler(async (req, res, next) => {
+  markAcceptedOAuthResources(req, [getMcpResourceUrl(), getApiResourceUrl()]);
+  try {
+    const auth = await getAuthPayloadFromExpressReq(req);
+    if (auth.type === "project") {
+      sendUnauthorized(
+        res,
+        "The MCP server requires a personal access token or an OAuth access token; project tokens are not accepted.",
+      );
+      return;
+    }
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Authentication required";
+    sendUnauthorized(res, message);
+    return;
+  }
+  next();
+});
+
+router.post(
+  "/",
+  limiter,
+  express.json({ limit: "1mb" }),
+  authenticate,
+  asyncHandler(async (req: Request, res: Response) => {
+    const authorization = req.headers.authorization;
+    if (!authorization) {
+      sendUnauthorized(res, "Authentication required");
+      return;
+    }
+    // Stateless mode (no `sessionIdGenerator`): a fresh server + transport
+    // pair per request, so concurrent requests never collide and no session
+    // state has to be replicated across instances.
+    const server = createMcpServer({ authorization });
+    const transport = new StreamableHTTPServerTransport({
+      enableJsonResponse: true,
+    });
+    res.on("close", () => {
+      void transport.close();
+      void server.close();
+    });
+    // Cast: the SDK types `onclose` as `(() => void) | undefined`, which is
+    // not assignable to the optional `onclose?` of `Transport` under
+    // `exactOptionalPropertyTypes`.
+    await server.connect(transport as unknown as Transport);
+    await transport.handleRequest(req, res, req.body);
+  }),
+);
+
+export { router as mcpRouter };

--- a/apps/backend/src/mcp/router.ts
+++ b/apps/backend/src/mcp/router.ts
@@ -24,6 +24,7 @@ import { markAcceptedOAuthResources } from "@/auth/oauth-access-token";
 import config from "@/config";
 import {
   getApiResourceUrl,
+  getAuthorizationServerMetadata,
   getMcpProtectedResourceMetadataUrl,
   getMcpResourceUrl,
   getProtectedResourceMetadata,
@@ -56,6 +57,13 @@ router.use(
 // RFC 9728 Protected Resource Metadata for the MCP server.
 router.get("/.well-known/oauth-protected-resource", (_req, res) => {
   res.json(getProtectedResourceMetadata(getMcpResourceUrl()));
+});
+
+// RFC 8414 Authorization Server Metadata, mirrored on the MCP origin: MCP
+// clients on the pre-2025-06-18 authorization spec look it up here instead of
+// following the Protected Resource Metadata to the AS.
+router.get("/.well-known/oauth-authorization-server", (_req, res) => {
+  res.json(getAuthorizationServerMetadata());
 });
 
 // Humans and non-MCP clients land here (the MCP protocol only POSTs).

--- a/apps/backend/src/mcp/router.ts
+++ b/apps/backend/src/mcp/router.ts
@@ -36,6 +36,9 @@ const MCP_DOCS_URL = "https://argos-ci.com/docs/agents/mcp-server";
 
 const router: Router = Router();
 
+// Permissive CORS is intentional: the MCP endpoint is a public API consumed
+// by arbitrary MCP clients, authenticated with bearer tokens and no cookies —
+// the same policy as the /oauth/* endpoints.
 router.use(
   cors({
     origin: "*",

--- a/apps/backend/src/mcp/router.ts
+++ b/apps/backend/src/mcp/router.ts
@@ -32,7 +32,7 @@ import { createRedisStore } from "@/util/rate-limit";
 import { asyncHandler } from "../web/util";
 import { createMcpServer } from "./server";
 
-const MCP_DOCS_URL = "https://argos-ci.com/docs/sdks-reference/argos-mcp";
+const MCP_DOCS_URL = "https://argos-ci.com/docs/agents/mcp-server";
 
 const router: Router = Router();
 

--- a/apps/backend/src/mcp/server.ts
+++ b/apps/backend/src/mcp/server.ts
@@ -13,6 +13,8 @@ import { mcpTools } from "./tools";
 
 const MCP_INSTRUCTIONS = `Argos is a visual testing platform: CI uploads screenshots as "builds", Argos diffs them against a baseline, and users review and approve or reject the detected changes.
 
+Call "getMe" first: it returns the authenticated user and the accounts (personal and teams) the token can access, whose slugs are the "owner" used by the other tools.
+
 Projects are identified by an "owner" (account slug) and a "project" (project name), as in the URL https://app.argos-ci.com/{owner}/{project}. Builds are identified by their per-project "buildNumber". List endpoints are paginated with "page" and "perPage" arguments.`;
 
 /**

--- a/apps/backend/src/mcp/server.ts
+++ b/apps/backend/src/mcp/server.ts
@@ -1,0 +1,44 @@
+/**
+ * The MCP server itself: registers the derived tool definitions and routes
+ * tool calls through the dispatch layer.
+ *
+ * Tools are registered with their Zod schemas: the SDK converts them to JSON
+ * Schema for `tools/list` and validates arguments and structured results, so
+ * MCP clients get the exact same validation the REST API applies.
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { callTool } from "./dispatch";
+import { mcpTools } from "./tools";
+
+const MCP_INSTRUCTIONS = `Argos is a visual testing platform: CI uploads screenshots as "builds", Argos diffs them against a baseline, and users review and approve or reject the detected changes.
+
+Projects are identified by an "owner" (account slug) and a "project" (project name), as in the URL https://app.argos-ci.com/{owner}/{project}. Builds are identified by their per-project "buildNumber". List endpoints are paginated with "page" and "perPage" arguments.`;
+
+/**
+ * Create an MCP server bound to the caller's authorization. One instance per
+ * request (the transport is stateless).
+ */
+export function createMcpServer(context: { authorization: string }): McpServer {
+  const server = new McpServer(
+    { name: "argos", title: "Argos", version: "2.0.0" },
+    { instructions: MCP_INSTRUCTIONS },
+  );
+
+  for (const tool of mcpTools) {
+    server.registerTool(
+      tool.name,
+      {
+        ...(tool.title ? { title: tool.title } : {}),
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+        ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
+        annotations: tool.annotations,
+      },
+      (args) =>
+        callTool(tool, args as Record<string, unknown>, context.authorization),
+    );
+  }
+
+  return server;
+}

--- a/apps/backend/src/mcp/tools.test.ts
+++ b/apps/backend/src/mcp/tools.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { schema } from "@/api/schema";
+
+import { buildMcpTools, mcpTools } from "./tools";
+
+describe("buildMcpTools", () => {
+  it("derives the tool surface from the OpenAPI document", () => {
+    // This snapshot locks the MCP tool surface: it changes whenever an
+    // operation is added to (or removed from) the OpenAPI document with a
+    // security declaration accepting a personal access token or OAuth.
+    expect(mcpTools.map((tool) => tool.name).sort()).toMatchInlineSnapshot(`
+      [
+        "addCommentReaction",
+        "createComment",
+        "createProject",
+        "createReview",
+        "deleteComment",
+        "dismissReview",
+        "getAccountAnalytics",
+        "getBuild",
+        "getComment",
+        "getMe",
+        "getProject",
+        "ignoreChange",
+        "listBuildDiffs",
+        "listBuilds",
+        "listComments",
+        "listReviews",
+        "removeCommentReaction",
+        "resolveCommentThread",
+        "subscribeCommentThread",
+        "unignoreChange",
+        "unresolveCommentThread",
+        "unsubscribeCommentThread",
+        "updateComment",
+      ]
+    `);
+  });
+
+  it("excludes project-token-only, internal and public operations", () => {
+    const names = new Set(mcpTools.map((tool) => tool.name));
+    for (const excluded of [
+      // Project-token-only (CI/SDK) operations.
+      "createBuild",
+      "updateBuild",
+      "finalizeBuilds",
+      "findBaseline",
+      "getAuthProject",
+      "createDeployment",
+      "finalizeDeployment",
+      "getDeployment",
+      // Internal token-exchange operations.
+      "exchangeCliToken",
+      "exchangeGitHubActionsOidcToken",
+      "exchangeGitHubActionsTokenlessToken",
+      // Public operations.
+      "resolveDeploymentDomain",
+    ]) {
+      expect(names.has(excluded), `${excluded} should be excluded`).toBe(false);
+    }
+  });
+
+  it("projects listBuilds with merged input schema and metadata", () => {
+    const tool = mcpTools.find((tool) => tool.name === "listBuilds");
+    expect(tool).toBeDefined();
+    expect(tool).toMatchObject({
+      method: "get",
+      path: "/projects/{owner}/{project}/builds",
+      pathKeys: ["owner", "project"],
+      requiredScopes: ["projects:read"],
+      hasBody: false,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    });
+    expect(tool!.description).toContain("projects:read");
+
+    // Convert like the MCP SDK does for `tools/list` (`io: "input"`).
+    const inputSchema = z.toJSONSchema(tool!.inputSchema, {
+      io: "input",
+      unrepresentable: "any",
+    }) as {
+      type: string;
+      properties: Record<string, { type?: string }>;
+      required?: string[];
+    };
+    expect(inputSchema.type).toBe("object");
+    expect(inputSchema.required).toEqual(
+      expect.arrayContaining(["owner", "project"]),
+    );
+    // Query params keep their HTTP wire type (strings), matching what the
+    // dispatch serializes into the query string.
+    expect(inputSchema.properties["page"]?.type).toBe("string");
+    expect(inputSchema.properties["perPage"]?.type).toBe("string");
+
+    expect(tool!.outputSchema).toBeInstanceOf(z.ZodObject);
+  });
+
+  it("nests body keys for operations with a JSON object body", () => {
+    const tool = mcpTools.find((tool) => tool.name === "createReview");
+    expect(tool).toBeDefined();
+    expect(tool!.hasBody).toBe(true);
+    expect(tool!.bodyKeys).toEqual(
+      expect.arrayContaining(["event", "conclusion"]),
+    );
+    // Path params and body keys are merged flat into a single argument object.
+    expect(Object.keys(tool!.inputSchema.shape)).toEqual(
+      expect.arrayContaining(["owner", "project", "buildNumber", "event"]),
+    );
+  });
+
+  it("throws on a parameter key collision", () => {
+    const operation = {
+      operationId: "collide",
+      summary: "Colliding operation",
+      security: [{ personalAccessToken: [] }],
+      requestParams: {
+        path: z.object({ owner: z.string() }),
+        query: z.object({ owner: z.string() }),
+      },
+      responses: {},
+    };
+    expect(() =>
+      buildMcpTools({ "/collide/{owner}": { get: operation } }),
+    ).toThrow(/parameter key collision on "owner"/);
+  });
+
+  it("throws on duplicate tool names", () => {
+    const operation = {
+      operationId: "dupe",
+      summary: "Duplicate operation",
+      security: [{ personalAccessToken: [] }],
+      responses: {},
+    };
+    expect(() =>
+      buildMcpTools({
+        "/a": { get: operation },
+        "/b": { get: operation },
+      }),
+    ).toThrow(/Duplicate MCP tool name "dupe"/);
+  });
+
+  it("respects the x-mcp opt-out", () => {
+    const operation = {
+      operationId: "hidden",
+      summary: "Hidden operation",
+      security: [{ personalAccessToken: [] }],
+      responses: {},
+      "x-mcp": { enabled: false },
+    };
+    expect(buildMcpTools({ "/hidden": { get: operation } })).toEqual([]);
+  });
+
+  it("applies x-mcp name and description overrides", () => {
+    const operation = {
+      operationId: "uglyInternalName",
+      summary: "Some operation",
+      description: "Original description.",
+      security: [{ personalAccessToken: [] }],
+      responses: {},
+      "x-mcp": { name: "niceName", description: "Agent-facing description." },
+    };
+    const [tool] = buildMcpTools({ "/thing": { get: operation } });
+    expect(tool!.name).toBe("niceName");
+    expect(tool!.description).toBe("Agent-facing description.");
+  });
+});
+
+describe("x-gitbook-mcp stamping", () => {
+  it("marks exactly the MCP-eligible operations in the OpenAPI document", () => {
+    const methods = ["get", "post", "put", "patch", "delete"] as const;
+    const marked: string[] = [];
+    for (const [path, pathItem] of Object.entries(schema.paths ?? {})) {
+      for (const method of methods) {
+        const operation = pathItem[method] as
+          { operationId?: string; "x-gitbook-mcp"?: boolean } | undefined;
+        if (operation?.["x-gitbook-mcp"]) {
+          marked.push(operation.operationId ?? `${method} ${path}`);
+        }
+      }
+    }
+    // The marker is computed from each operation's `security`, with the same
+    // predicate used to derive the tools — the two can never disagree.
+    expect(marked.sort()).toEqual(mcpTools.map((tool) => tool.name).sort());
+  });
+
+  it("does not mark project-token-only or internal operations", () => {
+    const createBuild = schema.paths?.["/builds"]?.post as
+      Record<string, unknown> | undefined;
+    expect(createBuild).toBeDefined();
+    expect(createBuild!["x-gitbook-mcp"]).toBeUndefined();
+    const exchangeCliToken = schema.paths?.["/auth/cli/token"]?.post as
+      Record<string, unknown> | undefined;
+    expect(exchangeCliToken).toBeDefined();
+    expect(exchangeCliToken!["x-gitbook-mcp"]).toBeUndefined();
+  });
+});

--- a/apps/backend/src/mcp/tools.test.ts
+++ b/apps/backend/src/mcp/tools.test.ts
@@ -27,6 +27,7 @@ describe("buildMcpTools", () => {
         "listBuildDiffs",
         "listBuilds",
         "listComments",
+        "listProjects",
         "listReviews",
         "removeCommentReaction",
         "resolveCommentThread",

--- a/apps/backend/src/mcp/tools.test.ts
+++ b/apps/backend/src/mcp/tools.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { schema } from "@/api/schema";
+import { getMcpResourceUrl } from "@/oauth/metadata";
 
 import { buildMcpTools, mcpTools } from "./tools";
 
@@ -199,5 +200,11 @@ describe("x-gitbook-mcp stamping", () => {
       Record<string, unknown> | undefined;
     expect(exchangeCliToken).toBeDefined();
     expect(exchangeCliToken!["x-gitbook-mcp"]).toBeUndefined();
+  });
+
+  it("advertises the MCP server URL at the document root", () => {
+    expect((schema as unknown as Record<string, unknown>)["x-gitbook-mcp-url"]).toBe(
+      getMcpResourceUrl(),
+    );
   });
 });

--- a/apps/backend/src/mcp/tools.test.ts
+++ b/apps/backend/src/mcp/tools.test.ts
@@ -203,8 +203,8 @@ describe("x-gitbook-mcp stamping", () => {
   });
 
   it("advertises the MCP server URL at the document root", () => {
-    expect((schema as unknown as Record<string, unknown>)["x-gitbook-mcp-url"]).toBe(
-      getMcpResourceUrl(),
-    );
+    expect(
+      (schema as unknown as Record<string, unknown>)["x-gitbook-mcp-url"],
+    ).toBe(getMcpResourceUrl());
   });
 });

--- a/apps/backend/src/mcp/tools.ts
+++ b/apps/backend/src/mcp/tools.ts
@@ -17,9 +17,7 @@ import type { OAuthScope } from "@/oauth/scopes";
 
 import { isMcpEligible, type XMcpExtension } from "./eligibility";
 
-export type { XMcpExtension };
-
-export type McpHttpMethod = "get" | "post" | "put" | "patch" | "delete";
+type McpHttpMethod = "get" | "post" | "put" | "patch" | "delete";
 
 const HTTP_METHODS: McpHttpMethod[] = ["get", "post", "put", "patch", "delete"];
 

--- a/apps/backend/src/mcp/tools.ts
+++ b/apps/backend/src/mcp/tools.ts
@@ -1,0 +1,253 @@
+/**
+ * MCP tool definitions derived from the OpenAPI document.
+ *
+ * The whole tool surface is generated at module load from {@link zodSchema}:
+ * one tool per operation that a user token (personal access token or OAuth
+ * access token) can call. There is no per-endpoint MCP code — adding an
+ * operation to the OpenAPI document automatically adds the matching tool.
+ *
+ * Operations can customize their MCP projection with the `x-mcp` extension
+ * ({@link XMcpExtension}): opt out entirely, or override the tool name and
+ * agent-facing description.
+ */
+import { z } from "zod";
+
+import { zodSchema } from "@/api/schema";
+import type { OAuthScope } from "@/oauth/scopes";
+
+import { isMcpEligible, type XMcpExtension } from "./eligibility";
+
+export type { XMcpExtension };
+
+export type McpHttpMethod = "get" | "post" | "put" | "patch" | "delete";
+
+const HTTP_METHODS: McpHttpMethod[] = ["get", "post", "put", "patch", "delete"];
+
+export type McpToolDefinition = {
+  // -- Wire fields, sent to MCP clients --
+  name: string;
+  title: string | undefined;
+  description: string;
+  /**
+   * Zod schemas, passed to the MCP SDK as-is: it converts them to JSON Schema
+   * for `tools/list` (`io: "input"` for inputs, `io: "output"` for outputs)
+   * and validates `tools/call` arguments and structured results against them.
+   */
+  inputSchema: z.ZodObject;
+  outputSchema: z.ZodObject | undefined;
+  annotations: {
+    readOnlyHint: boolean;
+    destructiveHint: boolean;
+    idempotentHint: boolean;
+    openWorldHint: boolean;
+  };
+  // -- Dispatch metadata, never sent to clients --
+  method: McpHttpMethod;
+  /** OpenAPI path template, e.g. `/projects/{owner}/{project}/builds`. */
+  path: string;
+  pathKeys: string[];
+  queryKeys: string[];
+  /**
+   * Top-level keys of the JSON request body, or `null` when the body is not an
+   * object schema and is nested under a literal `body` argument instead.
+   */
+  bodyKeys: string[] | null;
+  /** `null` when the body schema is absent. */
+  hasBody: boolean;
+  requiredScopes: OAuthScope[] | null;
+};
+
+const TOOL_NAME_RE = /^[a-zA-Z0-9_-]{1,128}$/;
+
+type AnyOperation = {
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  security?: readonly Record<string, unknown>[];
+  requestParams?: {
+    path?: unknown;
+    query?: unknown;
+  };
+  requestBody?: {
+    content?: Record<string, { schema?: unknown }>;
+  };
+  responses?: Record<string, unknown>;
+  "x-internal"?: boolean;
+  "x-mcp"?: XMcpExtension;
+};
+
+function getRequiredScopes(operation: AnyOperation): OAuthScope[] | null {
+  for (const requirement of operation.security ?? []) {
+    const scopes = requirement["oauth2"];
+    if (Array.isArray(scopes)) {
+      return scopes as OAuthScope[];
+    }
+  }
+  return null;
+}
+
+function asZodObject(value: unknown): z.ZodObject | null {
+  return value instanceof z.ZodObject ? value : null;
+}
+
+function getJsonBodySchema(operation: AnyOperation): z.ZodType | null {
+  const schema = operation.requestBody?.content?.["application/json"]?.schema;
+  return schema instanceof z.ZodType ? schema : null;
+}
+
+/**
+ * The tool's output schema: the first 2xx JSON response schema, when it is an
+ * object (MCP output schemas must describe an object).
+ */
+function getOutputSchema(operation: AnyOperation): z.ZodObject | undefined {
+  for (const [status, response] of Object.entries(operation.responses ?? {})) {
+    if (!/^2\d\d$/.test(status)) {
+      continue;
+    }
+    const content = (
+      response as { content?: Record<string, { schema?: unknown }> }
+    ).content;
+    const schema = asZodObject(content?.["application/json"]?.schema);
+    if (schema) {
+      return schema;
+    }
+  }
+  return undefined;
+}
+
+function buildTool(
+  path: string,
+  method: McpHttpMethod,
+  operation: AnyOperation,
+): McpToolDefinition {
+  const operationId = operation.operationId;
+  if (!operationId) {
+    throw new Error(`MCP tool for "${method} ${path}" has no operationId`);
+  }
+
+  const xMcp = operation["x-mcp"];
+  const name = xMcp?.name ?? operationId;
+  if (!TOOL_NAME_RE.test(name)) {
+    throw new Error(`MCP tool name "${name}" is invalid`);
+  }
+
+  // Merge path params, query params and body keys into a single flat argument
+  // object. A key collision would make dispatch ambiguous, so it is a build
+  // failure — caught at boot and by unit tests.
+  const shape: Record<string, z.ZodType> = {};
+  const sources = new Map<string, string>();
+  const merge = (object: z.ZodObject | null, source: string): string[] => {
+    if (!object) {
+      return [];
+    }
+    const keys = Object.keys(object.shape);
+    for (const key of keys) {
+      const existing = sources.get(key);
+      if (existing) {
+        throw new Error(
+          `MCP tool ${name}: parameter key collision on "${key}" (${existing} and ${source})`,
+        );
+      }
+      sources.set(key, source);
+      shape[key] = object.shape[key] as z.ZodType;
+    }
+    return keys;
+  };
+
+  const pathKeys = merge(asZodObject(operation.requestParams?.path), "path");
+  const queryKeys = merge(asZodObject(operation.requestParams?.query), "query");
+
+  const bodySchema = getJsonBodySchema(operation);
+  const bodyObject = asZodObject(bodySchema);
+  let bodyKeys: string[] | null = null;
+  if (bodyObject) {
+    bodyKeys = merge(bodyObject, "body");
+  } else if (bodySchema) {
+    // Non-object body: nest it under a literal `body` argument.
+    merge(z.object({ body: bodySchema }), "body");
+  }
+
+  // The MCP SDK converts these schemas to JSON Schema on every `tools/list`.
+  // Validate the conversion once at build time so a non-representable schema
+  // (e.g. a `.transform()` in a response) fails unit tests and boot, not
+  // clients at runtime.
+  const inputSchema = z.object(shape);
+  const outputSchema = getOutputSchema(operation);
+  try {
+    z.toJSONSchema(inputSchema, { io: "input" });
+    if (outputSchema) {
+      z.toJSONSchema(outputSchema, { io: "output" });
+    }
+  } catch (error) {
+    throw new Error(
+      `MCP tool ${name}: schema cannot be represented as JSON Schema: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  const requiredScopes = getRequiredScopes(operation);
+  const description =
+    xMcp?.description ??
+    [
+      operation.summary,
+      operation.description,
+      requiredScopes
+        ? `Requires the OAuth scope(s): ${requiredScopes.join(", ")} (personal access tokens are not scope-restricted).`
+        : null,
+    ]
+      .filter(Boolean)
+      .join("\n\n");
+
+  return {
+    name,
+    title: operation.summary,
+    description,
+    inputSchema,
+    outputSchema,
+    annotations: {
+      readOnlyHint: method === "get",
+      destructiveHint: method === "delete",
+      idempotentHint:
+        method === "get" || method === "put" || method === "delete",
+      openWorldHint: false,
+    },
+    method,
+    path,
+    pathKeys,
+    queryKeys,
+    bodyKeys,
+    hasBody: bodySchema !== null,
+    requiredScopes,
+  };
+}
+
+/**
+ * Build the MCP tool definitions from the OpenAPI document. Deterministic —
+ * exported for tests; use {@link mcpTools} instead.
+ */
+export function buildMcpTools(
+  paths: Record<string, Record<string, unknown>> = zodSchema.paths,
+): McpToolDefinition[] {
+  const tools: McpToolDefinition[] = [];
+  const names = new Set<string>();
+  for (const [path, pathItem] of Object.entries(paths)) {
+    for (const method of HTTP_METHODS) {
+      const operation = pathItem[method] as AnyOperation | undefined;
+      if (!operation || !isMcpEligible(operation)) {
+        continue;
+      }
+      const tool = buildTool(path, method, operation);
+      if (names.has(tool.name)) {
+        throw new Error(`Duplicate MCP tool name "${tool.name}"`);
+      }
+      names.add(tool.name);
+      tools.push(tool);
+    }
+  }
+  return tools;
+}
+
+/** The MCP tool surface, derived once at module load. */
+export const mcpTools: readonly McpToolDefinition[] =
+  Object.freeze(buildMcpTools());

--- a/apps/backend/src/mcp/tools.ts
+++ b/apps/backend/src/mcp/tools.ts
@@ -181,6 +181,7 @@ function buildTool(
       `MCP tool ${name}: schema cannot be represented as JSON Schema: ${
         error instanceof Error ? error.message : String(error)
       }`,
+      { cause: error },
     );
   }
 

--- a/apps/backend/src/oauth/README.md
+++ b/apps/backend/src/oauth/README.md
@@ -1,9 +1,8 @@
 # OAuth 2.1 Authorization Server
 
 Argos is its own OAuth 2.1 **Authorization Server** (AS) and **Resource Server**
-(RS). This powers the CLI login and is compatible with the
-[MCP authorization spec](https://modelcontextprotocol.io/docs/tutorials/security/authorization.md)
-so the future MCP server can plug in without further AS work.
+(RS). This powers the CLI login and the MCP server (`src/mcp/`), following the
+[MCP authorization spec](https://modelcontextprotocol.io/docs/tutorials/security/authorization.md).
 
 Tokens are **opaque and hashed at rest** (like personal access tokens and
 sessions — no JWT). Every request re-validates the token's account scope against
@@ -12,13 +11,15 @@ authenticated user is already allowed to do.
 
 ## Endpoints
 
-The AS lives on the app origin (`config.server.url`). The RS is the REST API
-(`config.api.baseUrl` + `/v2`) today; a future MCP server is another RS.
+The AS lives on the app origin (`config.server.url`). There are two RSs: the
+REST API (`config.api.baseUrl` + `/v2`) and the MCP server (`config.mcp.baseUrl`,
+see `src/mcp/README.md`), each serving its own Protected Resource Metadata.
 
 | Endpoint                                          | Purpose                                                            |
 | ------------------------------------------------- | ------------------------------------------------------------------ |
 | `GET  /.well-known/oauth-authorization-server`    | AS metadata (RFC 8414)                                             |
 | `GET  {api}/.well-known/oauth-protected-resource` | Protected Resource Metadata (RFC 9728)                             |
+| `GET  {mcp}/.well-known/oauth-protected-resource` | Protected Resource Metadata of the MCP server (RFC 9728)           |
 | `GET  /oauth/authorize`                           | Consent screen (SPA; `apps/frontend/src/pages/OAuthAuthorize.tsx`) |
 | `POST /oauth/token`                               | `authorization_code` + `refresh_token`                             |
 | `POST /oauth/register`                            | Dynamic Client Registration (RFC 7591)                             |

--- a/apps/backend/src/oauth/metadata.ts
+++ b/apps/backend/src/oauth/metadata.ts
@@ -42,9 +42,21 @@ export function getMcpProtectedResourceMetadataUrl(): string {
   return `${getMcpResourceUrl()}/.well-known/oauth-protected-resource`;
 }
 
+/**
+ * Normalize an RFC 8707 resource identifier for comparison and storage.
+ * Clients canonicalize URLs (e.g. `new URL(...)` appends a trailing slash to
+ * an origin), so `https://mcp.argos-ci.com/` and `https://mcp.argos-ci.com`
+ * must identify the same resource.
+ */
+export function normalizeResource(resource: string): string {
+  return trimTrailingSlash(resource);
+}
+
 /** Resource identifiers (RFC 8707 audiences) the Authorization Server issues tokens for. */
 export function isKnownResource(resource: string): boolean {
-  return [getApiResourceUrl(), getMcpResourceUrl()].includes(resource);
+  return [getApiResourceUrl(), getMcpResourceUrl()].includes(
+    normalizeResource(resource),
+  );
 }
 
 /**

--- a/apps/backend/src/oauth/metadata.ts
+++ b/apps/backend/src/oauth/metadata.ts
@@ -30,6 +30,24 @@ export function getProtectedResourceMetadataUrl(): string {
 }
 
 /**
+ * The canonical resource identifier (audience) for the MCP server, which lives
+ * on its own subdomain (e.g. `https://mcp.argos-ci.com`).
+ */
+export function getMcpResourceUrl(): string {
+  return trimTrailingSlash(config.get("mcp.baseUrl"));
+}
+
+/** URL of the MCP server's Protected Resource Metadata document. */
+export function getMcpProtectedResourceMetadataUrl(): string {
+  return `${getMcpResourceUrl()}/.well-known/oauth-protected-resource`;
+}
+
+/** Resource identifiers (RFC 8707 audiences) the Authorization Server issues tokens for. */
+export function isKnownResource(resource: string): boolean {
+  return [getApiResourceUrl(), getMcpResourceUrl()].includes(resource);
+}
+
+/**
  * RFC 8414 Authorization Server Metadata.
  */
 export function getAuthorizationServerMetadata() {
@@ -55,8 +73,8 @@ export function getAuthorizationServerMetadata() {
 }
 
 /**
- * RFC 9728 Protected Resource Metadata. Defaults to the REST API resource; a
- * future MCP server can pass its own resource identifier.
+ * RFC 9728 Protected Resource Metadata. Defaults to the REST API resource;
+ * the MCP server passes its own resource identifier.
  */
 export function getProtectedResourceMetadata(resource?: string) {
   return {

--- a/apps/backend/src/oauth/oauth.test.ts
+++ b/apps/backend/src/oauth/oauth.test.ts
@@ -13,6 +13,7 @@ import {
   getMcpResourceUrl,
   getProtectedResourceMetadata,
   isKnownResource,
+  normalizeResource,
 } from "./metadata";
 import {
   isOAuthScope,
@@ -181,5 +182,13 @@ describe("metadata", () => {
     expect(isKnownResource(getMcpResourceUrl())).toBe(true);
     expect(isKnownResource("https://evil.example")).toBe(false);
     expect(isKnownResource("")).toBe(false);
+  });
+
+  it("normalizes canonicalized resource URLs (trailing slash)", () => {
+    // MCP clients canonicalize the server URL: `new URL(origin)` appends "/".
+    expect(isKnownResource(`${getMcpResourceUrl()}/`)).toBe(true);
+    expect(normalizeResource(`${getMcpResourceUrl()}/`)).toBe(
+      getMcpResourceUrl(),
+    );
   });
 });

--- a/apps/backend/src/oauth/oauth.test.ts
+++ b/apps/backend/src/oauth/oauth.test.ts
@@ -7,8 +7,12 @@ import {
 } from "./clients";
 import { resolveKnownApp } from "./known-apps";
 import {
+  getApiResourceUrl,
   getAuthorizationServerMetadata,
+  getMcpProtectedResourceMetadataUrl,
+  getMcpResourceUrl,
   getProtectedResourceMetadata,
+  isKnownResource,
 } from "./metadata";
 import {
   isOAuthScope,
@@ -159,5 +163,23 @@ describe("metadata", () => {
     expect(prm.resource).toMatch(/\/v2$/);
     expect(prm.authorization_servers).toEqual([as.issuer]);
     expect(prm.scopes_supported).toEqual(OAUTH_SCOPE_LIST);
+  });
+
+  it("exposes the MCP server as its own protected resource", () => {
+    const prm = getProtectedResourceMetadata(getMcpResourceUrl());
+    const as = getAuthorizationServerMetadata();
+    expect(prm.resource).toBe(getMcpResourceUrl());
+    expect(prm.resource).not.toBe(getApiResourceUrl());
+    expect(prm.authorization_servers).toEqual([as.issuer]);
+    expect(getMcpProtectedResourceMetadataUrl()).toBe(
+      `${getMcpResourceUrl()}/.well-known/oauth-protected-resource`,
+    );
+  });
+
+  it("recognizes only the resources we actually serve", () => {
+    expect(isKnownResource(getApiResourceUrl())).toBe(true);
+    expect(isKnownResource(getMcpResourceUrl())).toBe(true);
+    expect(isKnownResource("https://evil.example")).toBe(false);
+    expect(isKnownResource("")).toBe(false);
   });
 });

--- a/apps/backend/src/oauth/router.ts
+++ b/apps/backend/src/oauth/router.ts
@@ -46,6 +46,7 @@ type OAuthErrorCode =
   | "invalid_client"
   | "invalid_grant"
   | "invalid_scope"
+  | "invalid_target"
   | "unauthorized_client"
   | "unsupported_grant_type"
   | "server_error";
@@ -209,7 +210,9 @@ oauthApiRouter.post("/token", async (req: Request, res: Response) => {
         result.error,
         result.error === "invalid_scope"
           ? "Requested scope exceeds the original grant."
-          : "Invalid or expired refresh token.",
+          : result.error === "invalid_target"
+            ? "Unknown resource."
+            : "Invalid or expired refresh token.",
       );
       return;
     }

--- a/apps/backend/src/oauth/tokens.ts
+++ b/apps/backend/src/oauth/tokens.ts
@@ -9,6 +9,7 @@ import {
 import { hashToken } from "@/database/services/crypto";
 import { transaction } from "@/database/transaction";
 
+import { isKnownResource } from "./metadata";
 import { isOAuthScope, type OAuthScope } from "./scopes";
 
 const ACCESS_TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
@@ -84,7 +85,7 @@ export async function issueTokens(params: {
 
 export type RefreshResult =
   | { ok: true; tokens: IssuedTokens }
-  | { ok: false; error: "invalid_grant" | "invalid_scope" };
+  | { ok: false; error: "invalid_grant" | "invalid_scope" | "invalid_target" };
 
 /**
  * Rotate a refresh token: validate it, issue a new pair, and mark the old token
@@ -137,6 +138,10 @@ export async function rotateRefreshToken(params: {
     scopes = params.requestedScopes;
   }
 
+  // RFC 8707: only issue tokens for resources we actually serve.
+  if (params.resource && !isKnownResource(params.resource)) {
+    return { ok: false, error: "invalid_target" };
+  }
   const resource = params.resource ?? existing.resource;
 
   let result: Awaited<ReturnType<typeof insertTokenPair>>;
@@ -231,8 +236,9 @@ export type IntrospectionResult = {
 };
 
 /**
- * RFC 7662 token introspection, for resource servers (e.g. the future MCP
- * server) that validate access tokens out-of-process.
+ * RFC 7662 token introspection, for resource servers that validate access
+ * tokens out-of-process. (The MCP server validates in-process and does not
+ * need it.)
  */
 export async function introspectToken(
   token: string,

--- a/apps/backend/src/oauth/tokens.ts
+++ b/apps/backend/src/oauth/tokens.ts
@@ -9,7 +9,7 @@ import {
 import { hashToken } from "@/database/services/crypto";
 import { transaction } from "@/database/transaction";
 
-import { isKnownResource } from "./metadata";
+import { isKnownResource, normalizeResource } from "./metadata";
 import { isOAuthScope, type OAuthScope } from "./scopes";
 
 const ACCESS_TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
@@ -142,7 +142,9 @@ export async function rotateRefreshToken(params: {
   if (params.resource && !isKnownResource(params.resource)) {
     return { ok: false, error: "invalid_target" };
   }
-  const resource = params.resource ?? existing.resource;
+  const resource = params.resource
+    ? normalizeResource(params.resource)
+    : existing.resource;
 
   let result: Awaited<ReturnType<typeof insertTokenPair>>;
   try {

--- a/apps/backend/src/web/app.ts
+++ b/apps/backend/src/web/app.ts
@@ -7,10 +7,12 @@ import { pinoHttp } from "pino-http";
 
 import config from "@/config";
 import logger from "@/logger";
+import { mcpRouter } from "@/mcp/router";
 
 import { installApiRouter } from "./api";
 import { installAppRouter } from "./app-router";
 import { jsonErrorHandler } from "./middlewares/errorHandler";
+import { subdomain } from "./util";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -75,6 +77,7 @@ export const createApp = async (): Promise<express.Express> => {
 
   await installAppRouter(app);
   installApiRouter(app);
+  app.use(subdomain(mcpRouter, "mcp"));
 
   Sentry.setupExpressErrorHandler(app);
   app.use(jsonErrorHandler());

--- a/apps/frontend/src/pages/OAuthAuthorize.tsx
+++ b/apps/frontend/src/pages/OAuthAuthorize.tsx
@@ -171,8 +171,9 @@ function ConsentForm(props: {
 
   const form = useForm<Inputs>({
     defaultValues: {
-      // Default to the personal account only — teams are opt-in (least privilege).
-      accountIds: [me.id],
+      // All accessible accounts are checked by default; the user may uncheck
+      // any to narrow the grant.
+      accountIds: availableAccounts.map((account) => account.id),
       // All requested scopes are checked by default; the user may uncheck any to
       // grant a narrower set (OAuth 2.1 / RFC 6749 §3.3 downscoping).
       scopes: consent.scopes.map((scope) => scope.scope),

--- a/apps/frontend/vite.config.mts
+++ b/apps/frontend/vite.config.mts
@@ -94,6 +94,16 @@ export default defineConfig((args) => {
                   target: "https://app.argos-ci.dev:4001",
                   secure: false,
                 },
+              // OAuth Authorization Server endpoints. `/oauth/authorize` is
+              // NOT proxied: it is the consent page, an SPA route.
+              "^/oauth/(token|register|introspect|revoke)$": {
+                target: "https://app.argos-ci.dev:4001",
+                secure: false,
+              },
+              "/.well-known": {
+                target: "https://app.argos-ci.dev:4001",
+                secure: false,
+              },
             },
           }
         : undefined,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,9 +9,6 @@ catalogs:
     '@types/react':
       specifier: ^19.2.17
       version: 19.2.17
-    '@types/react-dom':
-      specifier: ^19.2.3
-      version: 19.2.3
     eslint:
       specifier: ^10.6.0
       version: 10.6.0
@@ -160,6 +157,9 @@ importers:
       '@graphql-tools/schema':
         specifier: ^10.0.35
         version: 10.0.35(graphql@16.14.2)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@octokit/auth-app':
         specifier: ^8.2.0
         version: 8.2.0
@@ -1792,6 +1792,12 @@ packages:
     peerDependencies:
       graphql: 16.14.2
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@hookform/resolvers@5.4.0':
     resolution: {integrity: sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==}
     peerDependencies:
@@ -2167,6 +2173,16 @@ packages:
 
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@mswjs/interceptors@0.41.9':
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
@@ -5452,6 +5468,10 @@ packages:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   eventsource@4.1.0:
     resolution: {integrity: sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==}
     engines: {node: '>=20.0.0'}
@@ -5854,6 +5874,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  hono@4.12.30:
+    resolution: {integrity: sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==}
+    engines: {node: '>=16.9.0'}
+
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
@@ -6124,6 +6148,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   jotai-family@1.0.2:
     resolution: {integrity: sha512-U1aTMGxmsmz2Z8gaJD1/ljmMnsmG4/dqrcsfwGbjWV7p6boB9Vy3+75YwUpwPj7GbLNJk9O8rl1VNi8d7+6Rxw==}
@@ -7053,6 +7080,10 @@ packages:
 
   piscina@4.9.3:
     resolution: {integrity: sha512-3e3ka9QCE8RJ5I9uszdAADZnkcYi21cqmF3gxox3u884N72qpFHCsIVhHt8cEQ9t3Auq/NqoiCEuhxlxxQuDWA==}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   playwright-core@1.61.0:
     resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
@@ -8491,6 +8522,11 @@ packages:
     peerDependencies:
       zod: ^4.0.0
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
@@ -9811,6 +9847,10 @@ snapshots:
     dependencies:
       graphql: 16.14.2
 
+  '@hono/node-server@1.19.14(hono@4.12.30)':
+    dependencies:
+      hono: 4.12.30
+
   '@hookform/resolvers@5.4.0(react-hook-form@7.81.0(react@19.2.7))':
     dependencies:
       '@standard-schema/utils': 0.3.0
@@ -10108,6 +10148,28 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@keyv/serialize@1.1.1': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.30)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.30
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@mswjs/interceptors@0.41.9':
     dependencies:
@@ -13219,6 +13281,10 @@ snapshots:
 
   eventsource-parser@3.1.0: {}
 
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   eventsource@4.1.0:
     dependencies:
       eventsource-parser: 3.1.0
@@ -13699,6 +13765,8 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  hono@4.12.30: {}
+
   html-to-text@9.0.5:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.11.0
@@ -13910,6 +13978,8 @@ snapshots:
   jiti@2.4.2: {}
 
   jiti@2.7.0: {}
+
+  jose@6.2.3: {}
 
   jotai-family@1.0.2(jotai@2.20.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.7)):
     dependencies:
@@ -14788,6 +14858,8 @@ snapshots:
   piscina@4.9.3:
     optionalDependencies:
       '@napi-rs/nice': 1.1.1
+
+  pkce-challenge@5.0.1: {}
 
   playwright-core@1.61.0: {}
 
@@ -16252,6 +16324,10 @@ snapshots:
   yoctocolors@2.1.2: {}
 
   zod-openapi@6.0.0(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
 


### PR DESCRIPTION
## Summary

Adds the **Argos MCP server**, exposing the public REST API to AI agents over the [Model Context Protocol](https://modelcontextprotocol.io), served on its own subdomain (`mcp.argos-ci.com`) with **PAT + OAuth 2.1** authentication.

### Architecture: derived from OpenAPI, near-zero maintenance

There is no per-endpoint MCP code (see `apps/backend/src/mcp/README.md`):

- **Derivation** (`mcp/tools.ts` + `mcp/eligibility.ts`): every operation in the OpenAPI `zodSchema` whose `security` accepts a PAT or OAuth becomes a tool (23 today). Project-token-only CI endpoints, `x-internal` and public operations are excluded automatically. An `x-mcp` extension allows opt-out/name/description overrides, but nothing needs it.
- **`x-gitbook-mcp` is computed, never hand-written**: the generated OpenAPI document stamps eligible operations using the same predicate the server derives tools from, so docs and tool surface cannot drift.
- **Dispatch** (`mcp/dispatch.ts`): tool calls become HTTP requests through the real `openAPIRouter` (private loopback server), forwarding the caller's bearer — validation, auth, **scope enforcement**, serialization and error messages are the API's own, verbatim.
- **Transport** (`mcp/router.ts`): stateless Streamable HTTP on `POST /`, own Redis rate-limit bucket. Browser `GET /` redirects to the docs.

Adding a REST endpoint automatically adds the MCP tool; the only review touchpoint is the tool-name snapshot in `mcp/tools.test.ts`.

### Auth

- 401s send `WWW-Authenticate: Bearer resource_metadata="{mcp}/.well-known/oauth-protected-resource"` — the standard MCP discovery handshake (DCR + consent already supported by the AS).
- MCP is its own RFC 8707 resource: the AS now rejects unknown `resource` values (`invalid_target`), and RS audience validation is parametric — `/mcp` accepts MCP- and API-audience tokens; public `/v2` keeps strict audience binding (covered by tests).
- Project tokens are rejected with a clear message.
- The four `anyTokenAuth` read endpoints (`getProject`, `listBuilds`, `getBuild`, `listBuildDiffs`) now also accept OAuth with `projects:read` (backward compatible).

### Also in this PR

- `BuildSchema.number` no longer reuses the string→number path-param transform in responses (not representable in an output JSON Schema, and would fail structured-output validation).
- `MCP_BASE_URL` added to config (`mcp.baseUrl`) and to the release workflow env.
- Docs live in the docs repo (companion PR).

## Test plan

- [x] `pnpm check-types` clean
- [x] 267 backend unit tests pass — incl. tool derivation/exclusions/collisions/overrides, `x-gitbook-mcp` ↔ tool-surface invariant, resource helpers
- [x] 355 e2e tests pass (api/mcp/graphql/auth) — incl. 15 MCP e2e (handshake, PRM, redirect, read+write tool calls, scope failure, audience accept/reject), OAuth scope + audience isolation on `getBuild`, consent/refresh `invalid_target` hardening
- [x] Manual: route `mcp.argos-ci.com` via Cloudflare, set `MCP_BASE_URL`, connect Claude Code (`claude mcp add --transport http argos https://mcp.argos-ci.com`) and exercise the OAuth flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)