### PR TITLE
fix(sentry): ignore suspended GitHub installation errors

### DIFF
--- a/apps/backend/src/sentry/index.ts
+++ b/apps/backend/src/sentry/index.ts
@@ -29,6 +29,18 @@ export function setup() {
     },
     beforeSend(event, hint) {
       const error = hint.originalException;
+
+      // Ignore suspended GitHub installations, this is expected and actionable
+      // by the user, not by us.
+      if (
+        error &&
+        typeof error === "object" &&
+        "code" in error &&
+        error.code === "GITHUB_INSTALLATION_SUSPENDED"
+      ) {
+        return null;
+      }
+
       // Detect HTTP-like errors
       if (
         error instanceof Error &&


### PR DESCRIPTION
## Summary

The error "Installation suspended. Please unsuspend it in GitHub settings." is expected and actionable by the user (via their GitHub settings), not by us. It was still being reported to Sentry as noise.

This drops the event in `beforeSend` when the error carries `code === "GITHUB_INSTALLATION_SUSPENDED"`, matching on the stable error code rather than the message string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)