### PR TITLE
fix(build): remove ineffective dynamic import of BrowserIcon (ARG-470)

### DIFF
--- a/apps/frontend/src/pages/Build/sidebar/metadata/BrowserRow.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/metadata/BrowserRow.tsx
@@ -1,7 +1,5 @@
-import { lazy, Suspense } from "react";
 import { checkIsNonNullable } from "@argos/util/checkIsNonNullable";
 import { invariant } from "@argos/util/invariant";
-import { GlobeIcon } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 
 import { useBuildHotkey } from "@/containers/Build/BuildHotkeys";
@@ -11,6 +9,7 @@ import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 import { Tooltip } from "@/ui/Tooltip";
 
 import type { Diff } from "../../BuildDiffState";
+import { BrowserIcon } from "../../metadata/browser/BrowserIcon";
 import { getBrowserLabel } from "../../metadata/browser/browserLabels";
 import { MetadataRow } from "./MetadataRow";
 import {
@@ -20,21 +19,6 @@ import {
   useGetDiffPath,
   type MetadataBrowser,
 } from "./utils";
-
-const LazyBrowserIcon = lazy(() =>
-  import("../../metadata/browser/BrowserIcon").then((mod) => ({
-    default: mod.BrowserIcon,
-  })),
-);
-
-function BrowserIcon(props: { browser: MetadataBrowser; className?: string }) {
-  const { browser, ...rest } = props;
-  return (
-    <Suspense fallback={<GlobeIcon aria-busy {...rest} />}>
-      <LazyBrowserIcon browser={browser} {...rest} />
-    </Suspense>
-  );
-}
 
 export function BrowserRow(props: { diff: Diff; siblingDiffs: Diff[] }) {
   const { diff, siblingDiffs } = props;


### PR DESCRIPTION
Fixes [ARG-470](https://linear.app/argos/issue/ARG-470).

Vite reported `INEFFECTIVE_DYNAMIC_IMPORT`: `BrowserIcon` was lazy-loaded in `BrowserRow.tsx` but also statically imported by `ContextSection.tsx` and `FilterIcon.tsx`, so it could never be split into its own chunk — the `lazy()` only added a useless Suspense fallback.

Replaced the dynamic import with a static one and removed the wrapper component.

Verified: `tsc --noEmit` passes and `pnpm build` no longer emits the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)