### PR TITLE
fix(oauth): replace polynomial regex in trimTrailingSlash

### DIFF
--- a/apps/backend/src/oauth/metadata.ts
+++ b/apps/backend/src/oauth/metadata.ts
@@ -1,10 +1,8 @@
+import { trimTrailingSlash } from "@argos/util/url";
+
 import config from "@/config";
 
 import { OAUTH_SCOPE_LIST } from "./scopes";
-
-function trimTrailingSlash(url: string): string {
-  return url.replace(/\/+$/, "");
-}
 
 /**
  * The OAuth issuer / Authorization Server base URL (the app origin, where login

--- a/packages/util/src/url.test.ts
+++ b/packages/util/src/url.test.ts
@@ -1,6 +1,30 @@
 import { describe, expect, it } from "vitest";
 
-import { isAllowedRedirectUri, isHttpUri, isSafeUri } from "./url";
+import {
+  isAllowedRedirectUri,
+  isHttpUri,
+  isSafeUri,
+  trimTrailingSlash,
+} from "./url";
+
+describe("#trimTrailingSlash", () => {
+  it("removes a single trailing slash", () => {
+    expect(trimTrailingSlash("https://x.com/")).toBe("https://x.com");
+  });
+
+  it("removes multiple trailing slashes", () => {
+    expect(trimTrailingSlash("https://x.com///")).toBe("https://x.com");
+  });
+
+  it("leaves URLs without trailing slashes untouched", () => {
+    expect(trimTrailingSlash("https://x.com/v2")).toBe("https://x.com/v2");
+    expect(trimTrailingSlash("")).toBe("");
+  });
+
+  it("handles slash-only strings", () => {
+    expect(trimTrailingSlash("///")).toBe("");
+  });
+});
 
 describe("#isSafeUri", () => {
   it("accepts http(s) and custom app schemes", () => {

--- a/packages/util/src/url.ts
+++ b/packages/util/src/url.ts
@@ -31,6 +31,18 @@ export function isSafeUri(uri: string): boolean {
   return url !== null && !DANGEROUS_URI_SCHEMES.has(url.protocol.toLowerCase());
 }
 
+/**
+ * Remove all trailing slashes from a URL. Implemented without a regex to keep
+ * matching linear-time on untrusted input (CWE-1333).
+ */
+export function trimTrailingSlash(url: string): string {
+  let end = url.length;
+  while (end > 0 && url[end - 1] === "/") {
+    end -= 1;
+  }
+  return url.slice(0, end);
+}
+
 /** Whether a URL is a plain web link (http/https). */
 export function isHttpUri(uri: string): boolean {
   const url = tryParseUrl(uri);


### PR DESCRIPTION
Fixes [code scanning alert #116](https://github.com/argos-ci/argos/security/code-scanning/116) (js/polynomial-redos, high severity).

## Problem

`trimTrailingSlash` in `apps/backend/src/oauth/metadata.ts` used the unanchored regex `/\/+$/`, which backtracks quadratically on strings containing long runs of `/`. It runs on the user-controlled `resource` parameter of the OAuth token endpoint (via `normalizeResource`), so a malicious client could send a slash-heavy string and burn CPU (ReDoS, CWE-1333).

## Fix

- Replace the regex with a linear-time loop that slices off trailing slashes.
- Move the helper to `@argos/util/url` alongside the other URL utilities.
- Add direct unit tests (single/multiple trailing slashes, no-op, empty and slash-only strings).

## Verification

- `packages/util` url tests and `apps/backend` oauth tests pass (37/37).
- Typecheck clean on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)