### PR TITLE
fix(docker): install corepack explicitly, no longer bundled with Node 26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG TURBO_TEAM
 FROM node:26-bookworm-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+RUN npm install -g corepack@latest --force && corepack enable
 
 FROM base AS build
 ARG TURBO_TEAM


### PR DESCRIPTION
## Summary

The release build broke after the Node.js 26 upgrade (#2368): the `node:26-bookworm-slim` image no longer ships corepack (removed from Node.js distributions since Node 25), so `RUN corepack enable` fails with `corepack: not found` (exit 127).

Failed run: https://github.com/argos-ci/argos/actions/runs/29703536795/job/88236574711

## Fix

Install corepack via npm before enabling it, same as [.github/actions/setup-deps/action.yml](https://github.com/argos-ci/argos/blob/main/.github/actions/setup-deps/action.yml) already does in CI.

Verified locally: `docker build --target base` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)