### PR TITLE
feat(discord): notify when a project is transferred to a team

### DIFF
--- a/apps/backend/src/database/services/project.e2e.test.ts
+++ b/apps/backend/src/database/services/project.e2e.test.ts
@@ -1,12 +1,12 @@
 import { invariant } from "@argos/util/invariant";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { Project } from "@/database/models";
+import { Account, Project } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
 import { notifyDiscord } from "@/discord";
 import { HTTPError } from "@/util/error";
 
-import { createProject } from "./project";
+import { createProject, notifyProjectTransfer } from "./project";
 
 // The Discord webhook is configured in the test env; stub it so creating a
 // project here doesn't post a real notification.
@@ -169,5 +169,75 @@ describe("createProject service", () => {
     );
     expect(error.message).toBe("Name is already used by another project");
     expect(error.code).toBe("PROJECT_NAME_INVALID");
+  });
+});
+
+describe("notifyProjectTransfer service", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await setupDatabase();
+  });
+
+  /**
+   * Transfer `project` between the two given accounts, keeping the arguments
+   * the resolver would pass.
+   */
+  async function transfer(input: {
+    previousAccount: Account;
+    targetAccount: Account;
+  }) {
+    const project = await factory.Project.create({
+      accountId: input.targetAccount.id,
+      name: "shared-project",
+    });
+
+    await notifyProjectTransfer({
+      project,
+      previousAccount: input.previousAccount,
+      previousName: "side-project",
+      targetAccount: input.targetAccount,
+      email: "jane@example.com",
+    });
+  }
+
+  it("notifies when a project moves from a personal account to a team", async () => {
+    await transfer({
+      previousAccount: await factory.UserAccount.create(),
+      targetAccount: await factory.TeamAccount.create(),
+    });
+
+    expect(vi.mocked(notifyDiscord)).toHaveBeenCalledOnce();
+    // Both names are reported: a transfer can rename the project on the way.
+    const { content } = vi.mocked(notifyDiscord).mock.calls[0]![0];
+    expect(content).toContain("side-project");
+    expect(content).toContain("shared-project");
+    expect(content).toContain("jane@example.com");
+  });
+
+  it("stays silent when a project moves from a team to a personal account", async () => {
+    await transfer({
+      previousAccount: await factory.TeamAccount.create(),
+      targetAccount: await factory.UserAccount.create(),
+    });
+
+    expect(vi.mocked(notifyDiscord)).not.toHaveBeenCalled();
+  });
+
+  it("stays silent when a project moves between two teams", async () => {
+    await transfer({
+      previousAccount: await factory.TeamAccount.create(),
+      targetAccount: await factory.TeamAccount.create(),
+    });
+
+    expect(vi.mocked(notifyDiscord)).not.toHaveBeenCalled();
+  });
+
+  it("stays silent when a project moves between two personal accounts", async () => {
+    await transfer({
+      previousAccount: await factory.UserAccount.create(),
+      targetAccount: await factory.UserAccount.create(),
+    });
+
+    expect(vi.mocked(notifyDiscord)).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/database/services/project.ts
+++ b/apps/backend/src/database/services/project.ts
@@ -233,3 +233,36 @@ ${input.account.slug} / ${input.project.name}
     Sentry.captureException(error);
   });
 }
+
+/**
+ * Notify a Discord channel that a project moved from a personal account to a
+ * team, which is the moment a side project turns into something a team relies
+ * on. Only that direction is notified: team to personal, or any transfer
+ * between accounts of the same kind, carries no such signal.
+ *
+ * Notification failures are swallowed and reported to Sentry — they must never
+ * break the transfer itself.
+ */
+export async function notifyProjectTransfer(input: {
+  project: Project;
+  previousAccount: Account;
+  previousName: string;
+  targetAccount: Account;
+  email: string | null;
+}) {
+  if (
+    input.previousAccount.type !== "user" ||
+    input.targetAccount.type !== "team"
+  ) {
+    return;
+  }
+
+  await notifyDiscord({
+    content: `
+Project transferred to a team by ${input.email ?? "unknown email"}:
+${input.previousAccount.slug} / ${input.previousName} → ${input.targetAccount.slug} / ${input.project.name}
+`.trim(),
+  }).catch((error) => {
+    Sentry.captureException(error);
+  });
+}

--- a/apps/backend/src/graphql/definitions/Project.ts
+++ b/apps/backend/src/graphql/definitions/Project.ts
@@ -1114,18 +1114,20 @@ export const resolvers: IResolvers = {
         accountId: targetAccountId,
       });
 
-      // Load both accounts before patching: `patchAndFetch` mutates the
-      // instance in place, overwriting the source account id and the old name.
-      const [previousAccount, targetAccount] = await Promise.all([
-        ctx.loaders.Account.load(project.accountId),
-        ctx.loaders.Account.load(targetAccountId),
-      ]);
+      // Capture the source account id and name before patching: `patchAndFetch`
+      // mutates the instance in place, overwriting both.
+      const previousAccountId = project.accountId;
       const previousName = project.name;
 
-      const transferredProject = await project.$query().patchAndFetch({
-        accountId: targetAccountId,
-        name: args.input.name,
-      });
+      const [previousAccount, targetAccount, transferredProject] =
+        await Promise.all([
+          ctx.loaders.Account.load(previousAccountId),
+          ctx.loaders.Account.load(targetAccountId),
+          project.$query().patchAndFetch({
+            accountId: targetAccountId,
+            name: args.input.name,
+          }),
+        ]);
 
       if (previousAccount && targetAccount) {
         await notifyProjectTransfer({

--- a/apps/backend/src/graphql/definitions/Project.ts
+++ b/apps/backend/src/graphql/definitions/Project.ts
@@ -24,6 +24,7 @@ import {
   checkProjectName,
   createProject as createProjectService,
   notifyProjectCreation,
+  notifyProjectTransfer,
   resolveProjectName,
 } from "@/database/services/project";
 import { upsertProductionInternalProjectDomain } from "@/database/services/project-domain";
@@ -1112,10 +1113,31 @@ export const resolvers: IResolvers = {
         name: args.input.name,
         accountId: targetAccountId,
       });
-      return project.$query().patchAndFetch({
+
+      // Load both accounts before patching: `patchAndFetch` mutates the
+      // instance in place, overwriting the source account id and the old name.
+      const [previousAccount, targetAccount] = await Promise.all([
+        ctx.loaders.Account.load(project.accountId),
+        ctx.loaders.Account.load(targetAccountId),
+      ]);
+      const previousName = project.name;
+
+      const transferredProject = await project.$query().patchAndFetch({
         accountId: targetAccountId,
         name: args.input.name,
       });
+
+      if (previousAccount && targetAccount) {
+        await notifyProjectTransfer({
+          project: transferredProject,
+          previousAccount,
+          previousName,
+          targetAccount,
+          email: ctx.auth?.user.email ?? null,
+        });
+      }
+
+      return transferredProject;
     },
     deleteProject: async (_root, args, ctx) => {
       const project = await Project.query().findById(args.id).select("id");

--- a/apps/backend/src/graphql/tests/transferProject.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/transferProject.e2e.test.ts
@@ -1,0 +1,128 @@
+import { invariant } from "@argos/util/invariant";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { factory, setupDatabase } from "@/database/testing";
+import { notifyDiscord } from "@/discord";
+
+import { apolloServer, createApolloMiddleware } from "../apollo";
+import { expectNoGraphQLError } from "../testing";
+import { createApolloServerApp } from "./util";
+
+// The Discord webhook is configured in the test env; stub it so transferring a
+// project here doesn't post a real notification.
+vi.mock("@/discord", () => ({ notifyDiscord: vi.fn(() => Promise.resolve()) }));
+
+const TransferProjectMutation = `
+  mutation TransferProject($input: TransferProjectInput!) {
+    transferProject(input: $input) {
+      id
+      name
+      slug
+    }
+  }
+`;
+
+/**
+ * Create a user owning both a personal account and a team account, plus a
+ * project sitting on the personal account, ready to be transferred.
+ */
+async function createTransferableProject() {
+  const userAccount = await factory.UserAccount.create();
+  await userAccount.$fetchGraph("user");
+  invariant(userAccount.user, "user not fetched");
+  invariant(userAccount.userId, "user account has no user");
+
+  const teamAccount = await factory.TeamAccount.create();
+  invariant(teamAccount.teamId, "team account has no team");
+  await factory.TeamUser.create({
+    teamId: teamAccount.teamId,
+    userId: userAccount.userId,
+    userLevel: "owner",
+  });
+
+  const project = await factory.Project.create({
+    accountId: userAccount.id,
+    name: "side-project",
+  });
+
+  return { userAccount, teamAccount, user: userAccount.user, project };
+}
+
+describe("GraphQL transferProject", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await setupDatabase();
+  });
+
+  it("moves the project and notifies Discord when the target is a team", async () => {
+    const { userAccount, teamAccount, user, project } =
+      await createTransferableProject();
+
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user, account: userAccount },
+    );
+
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: TransferProjectMutation,
+        variables: {
+          input: {
+            id: project.id,
+            name: "shared-project",
+            targetAccountId: teamAccount.id,
+          },
+        },
+      });
+
+    expectNoGraphQLError(res);
+    expect(res.body.data.transferProject).toMatchObject({
+      name: "shared-project",
+      slug: `${teamAccount.slug}/shared-project`,
+    });
+
+    expect(vi.mocked(notifyDiscord)).toHaveBeenCalledOnce();
+    // The source account and the pre-transfer name are both read before the
+    // patch overwrites them, so they must survive into the notification.
+    const { content } = vi.mocked(notifyDiscord).mock.calls[0]![0];
+    expect(content).toContain(userAccount.slug);
+    expect(content).toContain("side-project");
+    expect(content).toContain(teamAccount.slug);
+    expect(content).toContain("shared-project");
+  });
+
+  it("stays silent when the project moves back to a personal account", async () => {
+    const { userAccount, teamAccount, user } =
+      await createTransferableProject();
+
+    const teamProject = await factory.Project.create({
+      accountId: teamAccount.id,
+      name: "team-project",
+    });
+
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user, account: userAccount },
+    );
+
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: TransferProjectMutation,
+        variables: {
+          input: {
+            id: teamProject.id,
+            name: "team-project",
+            targetAccountId: userAccount.id,
+          },
+        },
+      });
+
+    expectNoGraphQLError(res);
+    expect(vi.mocked(notifyDiscord)).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Notifies when a project moves from a personal account to a team — the moment a side project becomes something a team relies on. Every other direction stays silent.

Both accounts are read before the patch: `patchAndFetch` mutates the instance in place, overwriting the source account id and the previous name. A test covers that ordering.