### PR TITLE
fix(staff): stabilize the trial pipeline screenshots

### DIFF
--- a/apps/frontend/src/pages/StaffTrials.tsx
+++ b/apps/frontend/src/pages/StaffTrials.tsx
@@ -351,8 +351,10 @@ function LastActivityCell(props: { date: string | null | undefined }) {
 
   return (
     <>
-      <Time date={props.date} format="ll" tooltip="title" />
-      <div className="text-low text-xs">
+      <div className="truncate">
+        <Time date={props.date} format="ll" tooltip="title" />
+      </div>
+      <div className="text-low truncate text-xs">
         <Time date={props.date} tooltip="none" />
       </div>
     </>
@@ -450,13 +452,15 @@ function PipelineRow(props: { team: PipelineTeam; index: number }) {
           </div>
         </div>
       </td>
-      <td className="p-4 text-sm whitespace-nowrap">
-        <Time date={team.createdAt} format="ll" tooltip="title" />
-        <div className="text-low text-xs">
+      <td className="p-4 text-sm">
+        <div className="truncate">
+          <Time date={team.createdAt} format="ll" tooltip="title" />
+        </div>
+        <div className="text-low truncate text-xs">
           <Time date={team.createdAt} tooltip="none" />
         </div>
       </td>
-      <td className="p-4 text-sm whitespace-nowrap">
+      <td className="p-4 text-sm">
         <LastActivityCell date={team.lastBuildDate} />
       </td>
       <td className="p-4 text-sm">
@@ -489,20 +493,41 @@ const ALIGN_CLASS_NAMES = {
   right: "text-right",
 } as const;
 
+/**
+ * Widths are fixed rather than left to the content: the two date columns render
+ * a formatted date, so their natural width follows the calendar — every column
+ * after them would shift on the day a month name gets longer.
+ */
 const COLUMNS: {
   key: SortKey;
   label: string;
   align: keyof typeof ALIGN_CLASS_NAMES;
+  width: string;
 }[] = [
-  { key: "team", label: "Team", align: "left" },
-  { key: "createdAt", label: "Created", align: "left" },
-  { key: "lastActivity", label: "Last activity", align: "left" },
-  { key: "status", label: "Status", align: "left" },
-  { key: "bankInfo", label: "Bank info", align: "center" },
-  { key: "builds", label: "Builds", align: "right" },
-  { key: "checkBuild", label: "Check build", align: "center" },
-  { key: "screenshots", label: "Screenshots", align: "right" },
-  { key: "contacted", label: "Contacted", align: "center" },
+  { key: "team", label: "Team", align: "left", width: "w-[17%]" },
+  { key: "createdAt", label: "Created", align: "left", width: "w-[11%]" },
+  {
+    key: "lastActivity",
+    label: "Last activity",
+    align: "left",
+    width: "w-[12%]",
+  },
+  { key: "status", label: "Status", align: "left", width: "w-[12%]" },
+  { key: "bankInfo", label: "Bank info", align: "center", width: "w-[9%]" },
+  { key: "builds", label: "Builds", align: "right", width: "w-[9%]" },
+  {
+    key: "checkBuild",
+    label: "Check build",
+    align: "center",
+    width: "w-[10%]",
+  },
+  {
+    key: "screenshots",
+    label: "Screenshots",
+    align: "right",
+    width: "w-[11%]",
+  },
+  { key: "contacted", label: "Contacted", align: "center", width: "w-[9%]" },
 ];
 
 function PipelineTable(props: {
@@ -521,7 +546,7 @@ function PipelineTable(props: {
 
   return (
     <div className="overflow-x-auto rounded-sm border">
-      <table className="w-full min-w-250 border-collapse">
+      <table className="w-full min-w-300 table-fixed border-collapse">
         <thead>
           <tr className="text-low border-b text-xs font-semibold">
             {COLUMNS.map((column) => (
@@ -532,7 +557,7 @@ function PipelineTable(props: {
                 activeSortKey={props.sortKey}
                 direction={props.sortDirection}
                 onSort={props.onSort}
-                className={ALIGN_CLASS_NAMES[column.align]}
+                className={clsx(column.width, ALIGN_CLASS_NAMES[column.align])}
               />
             ))}
           </tr>
@@ -580,6 +605,7 @@ function PipelineSummary(props: { teams: PipelineTeam[] }) {
   return (
     <div className="mb-6 grid grid-cols-2 gap-4 lg:grid-cols-4">
       <StatTile
+        data-visual-test="transparent"
         icon={UsersIcon}
         color="primary"
         label="New teams"
@@ -587,6 +613,7 @@ function PipelineSummary(props: { teams: PipelineTeam[] }) {
         hint={`${teams.length - decided} still trialing`}
       />
       <StatTile
+        data-visual-test="transparent"
         icon={ImagesIcon}
         color="storybook"
         label="Reached check build"
@@ -594,6 +621,7 @@ function PipelineSummary(props: { teams: PipelineTeam[] }) {
         hint={formatShare(activated, teams.length)}
       />
       <StatTile
+        data-visual-test="transparent"
         icon={CircleCheckIcon}
         color="success"
         label="Converted"
@@ -601,6 +629,7 @@ function PipelineSummary(props: { teams: PipelineTeam[] }) {
         hint={`${formatShare(converted, decided)} decided trials`}
       />
       <StatTile
+        data-visual-test="transparent"
         icon={CircleXIcon}
         color="warning"
         label="Canceled or expired"
@@ -715,7 +744,10 @@ function StaffTrialsList() {
             onSort={onSort}
           />
           {normalizedSearch ? (
-            <div className="text-low mt-3 text-sm">
+            <div
+              className="text-low mt-3 text-sm"
+              data-visual-test="transparent"
+            >
               Showing {visibleTeams.length} of {allTeams.length} teams
             </div>
           ) : null}

--- a/apps/frontend/src/ui/StatTile.tsx
+++ b/apps/frontend/src/ui/StatTile.tsx
@@ -1,15 +1,26 @@
+import { ComponentPropsWithRef } from "react";
 import NumberFlow from "@number-flow/react";
 import { clsx } from "clsx";
 
 import { Card } from "./Card";
 
-export type StatTileColor = "primary" | "storybook" | "warning" | "success";
+type StatTileColor = "primary" | "storybook" | "warning" | "success";
 
 const StatTileChipStyles: Record<StatTileColor, string> = {
   primary: "bg-primary-ui text-primary-low",
   storybook: "bg-storybook-ui text-storybook-low",
   warning: "bg-warning-ui text-warning-low",
   success: "bg-success-ui text-success-low",
+};
+
+type StatTileProps = ComponentPropsWithRef<"div"> & {
+  icon: React.ComponentType<{ className?: string }>;
+  color: StatTileColor;
+  label: string;
+  value: number | null | undefined;
+  format?: "number" | "percent";
+  hint?: React.ReactNode;
+  visual?: React.ReactNode;
 };
 
 /**
@@ -19,29 +30,29 @@ const StatTileChipStyles: Record<StatTileColor, string> = {
  * `value` is `undefined` while loading (skeleton), `null` when there is no
  * meaningful figure to show (rendered as an em dash), otherwise the number.
  */
-export function StatTile(props: {
-  icon: React.ComponentType<{ className?: string }>;
-  color: StatTileColor;
-  label: string;
-  value: number | null | undefined;
-  format?: "number" | "percent";
-  hint?: React.ReactNode;
-  visual?: React.ReactNode;
-}) {
-  const { icon: Icon, value, format = "number" } = props;
+export function StatTile({
+  icon: Icon,
+  color,
+  label,
+  value,
+  format = "number",
+  hint,
+  visual,
+  ...rest
+}: StatTileProps) {
   const isLoading = value === undefined;
   return (
-    <Card className="flex flex-col gap-4 p-5">
+    <Card {...rest} className={clsx("flex flex-col gap-4 p-5", rest.className)}>
       <div className="flex items-center gap-2.5">
         <div
           className={clsx(
             "flex size-7 shrink-0 items-center justify-center rounded-md",
-            StatTileChipStyles[props.color],
+            StatTileChipStyles[color],
           )}
         >
           <Icon className="size-4" />
         </div>
-        <span className="text-low text-sm font-medium">{props.label}</span>
+        <span className="text-low text-sm font-medium">{label}</span>
       </div>
       <div>
         <div className="relative text-3xl leading-none font-black tabular-nums">
@@ -58,13 +69,13 @@ export function StatTile(props: {
             <NumberFlow value={value} />
           )}
         </div>
-        {props.hint ? (
+        {hint ? (
           <p className="text-low mt-0.5 h-4 text-sm">
-            {isLoading ? null : props.hint}
+            {isLoading ? null : hint}
           </p>
         ) : null}
       </div>
-      {props.visual ? <div className="mt-auto">{props.visual}</div> : null}
+      {visual ? <div className="mt-auto">{visual}</div> : null}
     </Card>
   );
 }


### PR DESCRIPTION
Les chiffres des cards comptent toute la fenêtre : sur un environnement partagé ils bougent d'un run à l'autre, ils sont donc sortis des captures (idem pour le total sous le tableau).

Le tableau dimensionnait ses colonnes de dates sur la date formatée, ce qui décalait toutes les colonnes suivantes selon le calendrier — il passe en largeurs fixes, comme celui de `/staff/teams`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)