### PR TITLE
fix(billing): say why an add-on cannot be enabled

### DIFF
--- a/apps/backend/src/graphql/definitions/Plan.ts
+++ b/apps/backend/src/graphql/definitions/Plan.ts
@@ -3,9 +3,15 @@ import gqlTag from "graphql-tag";
 const { gql } = gqlTag;
 
 export const typeDefs = gql`
+  enum PlanInterval {
+    month
+    year
+  }
+
   type Plan implements Node {
     id: ID!
     displayName: String!
+    interval: PlanInterval!
     usageBased: Boolean!
     githubSsoIncluded: Boolean!
     fineGrainedAccessControlIncluded: Boolean!

--- a/apps/backend/src/graphql/definitions/Team.ts
+++ b/apps/backend/src/graphql/definitions/Team.ts
@@ -18,6 +18,7 @@ import {
   checkIsActiveSubscriptionStatus,
   GithubAccountMember,
   GithubInstallation,
+  Subscription,
   Team,
   TeamDomain,
   TeamInvite,
@@ -400,6 +401,25 @@ export const typeDefs = gql`
     ): ImportTeamSamlMetadataResult!
   }
 `;
+
+/**
+ * Whether add-ons can be billed onto this subscription.
+ *
+ * They ride as extra products on a Stripe subscription, so a forced plan (which
+ * has no subscription at all) and a GitHub Marketplace one have nothing to
+ * carry them — however healthy their plan is otherwise.
+ *
+ * Narrows `stripeSubscriptionId` so callers can bill without asserting.
+ */
+function checkCanBillAddOns(
+  subscription: Subscription | null,
+): subscription is Subscription & { stripeSubscriptionId: string } {
+  return (
+    subscription !== null &&
+    subscription.provider === "stripe" &&
+    subscription.stripeSubscriptionId !== null
+  );
+}
 
 /**
  * Add a Stripe product to a subscription if it's not already part of it.
@@ -1456,12 +1476,10 @@ export const resolvers: IResolvers = {
       const priced = !plan?.githubSsoIncluded;
 
       if (priced) {
-        if (!subscription) {
-          throw forbidden("A valid subscription is required to enable SSO");
-        }
-
-        if (!subscription.stripeSubscriptionId) {
-          throw forbidden("GitHub SSO is not available on your current plan");
+        if (!checkCanBillAddOns(subscription)) {
+          throw forbidden(
+            "Your plan does not allow enabling GitHub SSO, please contact us.",
+          );
         }
 
         await addStripeProductToSubscription({
@@ -1539,14 +1557,10 @@ export const resolvers: IResolvers = {
       const priced = !plan?.samlIncluded;
 
       if (priced) {
-        if (!subscription) {
+        if (!checkCanBillAddOns(subscription)) {
           throw forbidden(
-            "A valid subscription is required to enable SAML SSO",
+            "Your plan does not allow enabling SAML SSO, please contact us.",
           );
-        }
-
-        if (!subscription.stripeSubscriptionId) {
-          throw forbidden("SAML SSO is not available on your current plan");
         }
 
         await addStripeProductToSubscription({

--- a/apps/backend/src/graphql/definitions/Team.ts
+++ b/apps/backend/src/graphql/definitions/Team.ts
@@ -18,6 +18,7 @@ import {
   checkIsActiveSubscriptionStatus,
   GithubAccountMember,
   GithubInstallation,
+  Plan,
   Subscription,
   Team,
   TeamDomain,
@@ -419,6 +420,16 @@ function checkCanBillAddOns(
     subscription.provider === "stripe" &&
     subscription.stripeSubscriptionId !== null
   );
+}
+
+/**
+ * Whether the plan is billed yearly.
+ *
+ * Add-on products are priced monthly and Stripe refuses items whose interval
+ * differs from the rest of the subscription, so a yearly plan cannot take one.
+ */
+function checkIsYearlyPlan(plan: Plan | null): boolean {
+  return plan?.interval === "year";
 }
 
 /**
@@ -1482,6 +1493,12 @@ export const resolvers: IResolvers = {
           );
         }
 
+        if (checkIsYearlyPlan(plan)) {
+          throw forbidden(
+            "GitHub SSO cannot be added to a yearly plan, please contact us.",
+          );
+        }
+
         await addStripeProductToSubscription({
           stripeSubscriptionId: subscription.stripeSubscriptionId,
           productId: config.get("stripe.githubSSOProductId"),
@@ -1560,6 +1577,12 @@ export const resolvers: IResolvers = {
         if (!checkCanBillAddOns(subscription)) {
           throw forbidden(
             "Your plan does not allow enabling SAML SSO, please contact us.",
+          );
+        }
+
+        if (checkIsYearlyPlan(plan)) {
+          throw forbidden(
+            "SAML SSO cannot be added to a yearly plan, please contact us.",
           );
         }
 

--- a/apps/frontend/src/containers/Team/AddOns.tsx
+++ b/apps/frontend/src/containers/Team/AddOns.tsx
@@ -1,4 +1,3 @@
-import { checkIsActiveSubscriptionStatus } from "@argos/schemas/subscription-status";
 import { MarkGithubIcon } from "@primer/octicons-react";
 import { LockIcon } from "lucide-react";
 
@@ -14,6 +13,7 @@ import {
 } from "@/ui/Card";
 import { Chip } from "@/ui/Chip";
 import { Link } from "@/ui/Link";
+import { getAddOnBlockedReason } from "@/util/subscription";
 
 import { DisableGitHubSSOButton } from "./GitHubSSO";
 import {
@@ -27,6 +27,10 @@ const _TeamFragment = graphql(`
     slug
     subscriptionStatus
     samlPurchased
+    subscription {
+      id
+      provider
+    }
     plan {
       id
       githubSsoIncluded
@@ -45,14 +49,18 @@ export function TeamAddOns(props: {
   team: DocumentType<typeof _TeamFragment>;
 }) {
   const { team } = props;
-  const hasActiveSubscription = checkIsActiveSubscriptionStatus(
-    team.subscriptionStatus,
-  );
   const usageBased = Boolean(team.plan?.usageBased);
   const githubSsoIncluded = Boolean(team.plan?.githubSsoIncluded);
   const samlIncluded = Boolean(team.plan?.samlIncluded);
   const githubSsoEnabled = Boolean(team.ssoGithubAccount);
   const samlEnabled = team.samlPurchased;
+  const githubSsoBlockedReason = getAddOnBlockedReason({
+    status: team.subscriptionStatus,
+    provider: team.subscription?.provider,
+    includedInPlan: githubSsoIncluded,
+    usageBased,
+    featureName: "GitHub SSO",
+  });
   return (
     <Card>
       <CardBody>
@@ -80,13 +88,7 @@ export function TeamAddOns(props: {
                 <ConfigureGitHubSSO
                   team={team}
                   priced={!githubSsoIncluded}
-                  disabledReason={
-                    !hasActiveSubscription
-                      ? "You must have an active subscription to enable GitHub SSO."
-                      : !githubSsoIncluded && !usageBased
-                        ? "This feature is not available on your current plan, please contact us."
-                        : undefined
-                  }
+                  disabledReason={githubSsoBlockedReason ?? undefined}
                 />
               )
             }

--- a/apps/frontend/src/containers/Team/AddOns.tsx
+++ b/apps/frontend/src/containers/Team/AddOns.tsx
@@ -36,6 +36,7 @@ const _TeamFragment = graphql(`
       githubSsoIncluded
       samlIncluded
       usageBased
+      interval
     }
     ssoGithubAccount {
       id
@@ -57,6 +58,7 @@ export function TeamAddOns(props: {
   const githubSsoBlockedReason = getAddOnBlockedReason({
     status: team.subscriptionStatus,
     provider: team.subscription?.provider,
+    interval: team.plan?.interval,
     includedInPlan: githubSsoIncluded,
     usageBased,
     featureName: "GitHub SSO",

--- a/apps/frontend/src/containers/Team/GitHubSSO/index.tsx
+++ b/apps/frontend/src/containers/Team/GitHubSSO/index.tsx
@@ -1,6 +1,5 @@
 import { memo } from "react";
 import { useMutation } from "@apollo/client/react";
-import { checkIsActiveSubscriptionStatus } from "@argos/schemas/subscription-status";
 import { MarkGithubIcon } from "@primer/octicons-react";
 
 import { GITHUB_SSO_PRICING } from "@/constants";
@@ -28,6 +27,7 @@ import {
 import { ErrorMessage } from "@/ui/ErrorMessage";
 import { Modal } from "@/ui/Modal";
 import { getErrorMessage } from "@/util/error";
+import { getAddOnBlockedReason } from "@/util/subscription";
 
 import { ConfigureGitHubSSO } from "./Configure";
 
@@ -41,6 +41,10 @@ const _TeamFragment = graphql(`
       githubSsoIncluded
     }
     subscriptionStatus
+    subscription {
+      id
+      provider
+    }
     ssoGithubAccount {
       id
       ...GithubAccountLink_GithubAccount
@@ -105,11 +109,14 @@ export function TeamGitHubSSO(props: {
   team: DocumentType<typeof _TeamFragment>;
 }) {
   const { team } = props;
-  const hasActiveSubscription = checkIsActiveSubscriptionStatus(
-    team.subscriptionStatus,
-  );
   const priced = !team.plan?.githubSsoIncluded;
-  const usageBased = team.plan?.usageBased;
+  const disabledReason = getAddOnBlockedReason({
+    status: team.subscriptionStatus,
+    provider: team.subscription?.provider,
+    includedInPlan: !priced,
+    usageBased: Boolean(team.plan?.usageBased),
+    featureName: "GitHub SSO",
+  });
   return (
     <Card>
       <CardBody>
@@ -146,13 +153,7 @@ export function TeamGitHubSSO(props: {
           <ConfigureGitHubSSO
             team={team}
             priced={priced}
-            disabledReason={
-              !hasActiveSubscription
-                ? "You must have an active subscription to enable GitHub SSO."
-                : priced && !usageBased
-                  ? "This feature is not available on your current plan, please contact us."
-                  : undefined
-            }
+            disabledReason={disabledReason ?? undefined}
           />
         )}
       </CardFooter>

--- a/apps/frontend/src/containers/Team/GitHubSSO/index.tsx
+++ b/apps/frontend/src/containers/Team/GitHubSSO/index.tsx
@@ -39,6 +39,7 @@ const _TeamFragment = graphql(`
       displayName
       usageBased
       githubSsoIncluded
+      interval
     }
     subscriptionStatus
     subscription {
@@ -113,6 +114,7 @@ export function TeamGitHubSSO(props: {
   const disabledReason = getAddOnBlockedReason({
     status: team.subscriptionStatus,
     provider: team.subscription?.provider,
+    interval: team.plan?.interval,
     includedInPlan: !priced,
     usageBased: Boolean(team.plan?.usageBased),
     featureName: "GitHub SSO",

--- a/apps/frontend/src/containers/Team/SAMLSSOAddOn.tsx
+++ b/apps/frontend/src/containers/Team/SAMLSSOAddOn.tsx
@@ -33,6 +33,7 @@ const _TeamFragment = graphql(`
       id
       samlIncluded
       usageBased
+      interval
     }
     ...AddOnsPricingTable_Team
   }
@@ -64,6 +65,7 @@ export function EnableSAMLSSOAddOnButton(props: {
     getAddOnBlockedReason({
       status: team.subscriptionStatus,
       provider: team.subscription?.provider,
+      interval: team.plan?.interval,
       includedInPlan: Boolean(team.plan?.samlIncluded),
       usageBased: Boolean(team.plan?.usageBased),
       featureName: "SAML SSO",

--- a/apps/frontend/src/containers/Team/SAMLSSOAddOn.tsx
+++ b/apps/frontend/src/containers/Team/SAMLSSOAddOn.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from "@apollo/client/react";
-import { checkIsActiveSubscriptionStatus } from "@argos/schemas/subscription-status";
 
 import { SAML_SSO_PRICING } from "@/constants";
 import { AddOnsPricingTable } from "@/containers/Team/AddOnsPricingTable";
@@ -19,12 +18,17 @@ import { ErrorMessage } from "@/ui/ErrorMessage";
 import { Modal } from "@/ui/Modal";
 import { Tooltip } from "@/ui/Tooltip";
 import { getErrorMessage } from "@/util/error";
+import { getAddOnBlockedReason } from "@/util/subscription";
 
 const _TeamFragment = graphql(`
   fragment SAMLSSOAddOn_Team on Team {
     id
     samlPurchased
     subscriptionStatus
+    subscription {
+      id
+      provider
+    }
     plan {
       id
       samlIncluded
@@ -56,14 +60,14 @@ export function EnableSAMLSSOAddOnButton(props: {
   team: DocumentType<typeof _TeamFragment>;
 }) {
   const { team } = props;
-  const hasActiveSubscription = checkIsActiveSubscriptionStatus(
-    team.subscriptionStatus,
-  );
-  const disabledReason = !hasActiveSubscription
-    ? "You must have an active subscription to enable SAML SSO."
-    : !team.plan?.usageBased
-      ? "This feature is not available on your current plan, please contact us."
-      : undefined;
+  const disabledReason =
+    getAddOnBlockedReason({
+      status: team.subscriptionStatus,
+      provider: team.subscription?.provider,
+      includedInPlan: Boolean(team.plan?.samlIncluded),
+      usageBased: Boolean(team.plan?.usageBased),
+      featureName: "SAML SSO",
+    }) ?? undefined;
   if (disabledReason) {
     return (
       <Tooltip content={disabledReason}>

--- a/apps/frontend/src/util/subscription.ts
+++ b/apps/frontend/src/util/subscription.ts
@@ -1,0 +1,48 @@
+import { checkIsActiveSubscriptionStatus } from "@argos/schemas/subscription-status";
+
+import {
+  AccountSubscriptionProvider,
+  AccountSubscriptionStatus,
+} from "@/gql/graphql";
+
+/**
+ * Why a paid add-on cannot be turned on, or null when it can.
+ *
+ * The order of these checks is the point. A plan that already carries the
+ * feature answers before anything about billing is asked — otherwise accounts
+ * that legitimately have it, but no Stripe subscription to bill an add-on to,
+ * would be refused the feature they already own.
+ *
+ * Lives here rather than in `@argos/schemas` because it produces user-facing
+ * copy: the backend enforces the same rule, it does not phrase it.
+ */
+export function getAddOnBlockedReason(args: {
+  status: AccountSubscriptionStatus | null | undefined;
+  provider: AccountSubscriptionProvider | null | undefined;
+  includedInPlan: boolean;
+  usageBased: boolean;
+  featureName: string;
+}): string | null {
+  const { status, provider, includedInPlan, usageBased, featureName } = args;
+
+  if (!checkIsActiveSubscriptionStatus(status)) {
+    return `You must have an active subscription to enable ${featureName}.`;
+  }
+
+  if (includedInPlan) {
+    return null;
+  }
+
+  // Add-ons are billed as extra products on top of a Stripe subscription. A
+  // forced plan has none, and a GitHub Marketplace subscription cannot carry
+  // them — both are healthy plans that simply have nothing to bill against.
+  if (provider !== AccountSubscriptionProvider.Stripe) {
+    return `Your plan does not allow enabling ${featureName}, please contact us.`;
+  }
+
+  if (!usageBased) {
+    return "This feature is not available on your current plan, please contact us.";
+  }
+
+  return null;
+}

--- a/apps/frontend/src/util/subscription.ts
+++ b/apps/frontend/src/util/subscription.ts
@@ -3,6 +3,7 @@ import { checkIsActiveSubscriptionStatus } from "@argos/schemas/subscription-sta
 import {
   AccountSubscriptionProvider,
   AccountSubscriptionStatus,
+  PlanInterval,
 } from "@/gql/graphql";
 
 /**
@@ -19,11 +20,19 @@ import {
 export function getAddOnBlockedReason(args: {
   status: AccountSubscriptionStatus | null | undefined;
   provider: AccountSubscriptionProvider | null | undefined;
+  interval: PlanInterval | null | undefined;
   includedInPlan: boolean;
   usageBased: boolean;
   featureName: string;
 }): string | null {
-  const { status, provider, includedInPlan, usageBased, featureName } = args;
+  const {
+    status,
+    provider,
+    interval,
+    includedInPlan,
+    usageBased,
+    featureName,
+  } = args;
 
   if (!checkIsActiveSubscriptionStatus(status)) {
     return `You must have an active subscription to enable ${featureName}.`;
@@ -38,6 +47,12 @@ export function getAddOnBlockedReason(args: {
   // them — both are healthy plans that simply have nothing to bill against.
   if (provider !== AccountSubscriptionProvider.Stripe) {
     return `Your plan does not allow enabling ${featureName}, please contact us.`;
+  }
+
+  // Add-on products are priced monthly, and Stripe refuses items whose interval
+  // differs from the rest of the subscription.
+  if (interval === PlanInterval.Year) {
+    return `${featureName} cannot be added to a yearly plan, please contact us.`;
   }
 
   if (!usageBased) {


### PR DESCRIPTION
Stacked on #2379.

Add-ons are billed as extra products on a Stripe subscription. A forced plan has none, and a GitHub Marketplace one cannot carry them — both were offered an Enable button that the API then refused, or a message naming the wrong reason. Neither was an access hole: the API already refused both.

The rule moves into `getAddOnBlockedReason`, shared by the three add-on screens, with the mutations returning the same wording. Its order matters: a plan that already includes the feature answers before billing is asked about, so an account that owns it without a Stripe subscription keeps it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)