### PR TITLE
ci: pin GitHub Actions to commit SHAs and add Dependabot

### DIFF
--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -10,7 +10,7 @@ runs:
         corepack enable
 
     - name: Use Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version-file: .nvmrc
         cache: pnpm

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Node.js & install dependencies
         uses: ./.github/actions/setup-deps
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Node.js & install dependencies
         uses: ./.github/actions/setup-deps
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Node.js & install dependencies
         uses: ./.github/actions/setup-deps
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Node.js & install dependencies
         uses: ./.github/actions/setup-deps
@@ -156,7 +156,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Node.js & install dependencies
         uses: ./.github/actions/setup-deps
@@ -213,7 +213,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Node.js & install dependencies
         uses: ./.github/actions/setup-deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Notify deployment start
         uses: ./.github/actions/notify-discord
@@ -41,20 +41,20 @@ jobs:
           description: "[GitHub Actions run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}
           tags: |
@@ -64,7 +64,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: true
@@ -91,10 +91,10 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -112,7 +112,7 @@ jobs:
 
       - name: Fill in task definition for migration
         id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@138c24f321fdbdf7edee4a685519d253cae2cdea # v1.9.0
         with:
           task-definition: ${{ steps.prepare-task-def.outputs.task-definition }}
           container-name: argos-migrate
@@ -194,10 +194,10 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -215,7 +215,7 @@ jobs:
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@138c24f321fdbdf7edee4a685519d253cae2cdea # v1.9.0
         with:
           task-definition: ${{ steps.prepare-task-def.outputs.task-definition }}
           container-name: ${{ matrix.container-name }}
@@ -272,7 +272,7 @@ jobs:
             STRIPE_WEBHOOK_SECRET=/production/stripe_webhook_secret
 
       - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        uses: aws-actions/amazon-ecs-deploy-task-definition@c465972ecbd160473f22e683363b422a5412a3de # v2.6.3
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: ${{ matrix.service }}
@@ -289,7 +289,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Notify migration failure
         uses: ./.github/actions/notify-discord
@@ -310,7 +310,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Notify deployment failure
         uses: ./.github/actions/notify-discord
@@ -331,7 +331,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Notify deployment success
         uses: ./.github/actions/notify-discord


### PR DESCRIPTION
## Why

Mutable action tags (`@v6`, `@v2`, …) can be retagged, which is a supply-chain risk. This PR applies [GitHub's secure-use guidance](https://docs.github.com/en/actions/reference/security/secure-use) by pinning **all** actions — official `actions/*` included — to full commit SHAs.

Supersedes #2378: its 6 SHAs were independently verified and all match, but it missed `docker/setup-buildx-action`, left `actions/checkout` / `actions/setup-node` unpinned, and only covered `release.yml`.

## What

Every SHA was resolved from the official action repository via the GitHub API and cross-checked to carry the exact release tag noted in its comment:

| Action | SHA | Version |
|---|---|---|
| actions/checkout | `d23441a48e516b6c34aea4fa41551a30e30af803` | v6.1.0 |
| actions/setup-node | `249970729cb0ef3589644e2896645e5dc5ba9c38` | v6.5.0 |
| aws-actions/configure-aws-credentials | `e6de054238d6b7531b4efff3b6587d9aade6a06c` | v6.2.3 |
| aws-actions/amazon-ecr-login | `d539f0932e70871a027e9d5a9d8fc38589180a64` | v2.1.6 |
| docker/setup-buildx-action | `bb05f3f5519dd87d3ba754cc423b652a5edd6d2c` | v4.2.0 |
| docker/metadata-action | `dc802804100637a589fabce1cb79ff13a1411302` | v6.2.0 |
| docker/build-push-action | `53b7df96c91f9c12dcc8a07bcb9ccacbed38856a` | v7.3.0 |
| aws-actions/amazon-ecs-render-task-definition | `138c24f321fdbdf7edee4a685519d253cae2cdea` | v1.9.0 |
| aws-actions/amazon-ecs-deploy-task-definition | `c465972ecbd160473f22e683363b422a5412a3de` | v2.6.3 |

- `.github/workflows/ci.yml`, `.github/workflows/release.yml`, `.github/actions/setup-deps/action.yml`: all `uses:` pinned to SHAs with exact-version comments
- `.github/dependabot.yml` (new): weekly grouped `github-actions` updates, so Dependabot keeps the SHA pins and version comments fresh

Local composite actions (`./.github/actions/…`) stay path-referenced — they live in this repo and can't be retagged by a third party.

## Audit of the rest of the secure-use checklist

Already compliant: `permissions: {}` at workflow level with per-job elevation, OIDC for AWS, no `pull_request_target`/`workflow_run`, no self-hosted runners, no untrusted `${{ github.event.* }}` interpolation in `run:` steps.

Closes #2378

🤖 Generated with [Claude Code](https://claude.com/claude-code)