### PR TITLE
feat(slack): unfurl test URLs

### DIFF
--- a/apps/backend/src/slack/events.ts
+++ b/apps/backend/src/slack/events.ts
@@ -7,7 +7,12 @@ import { SlackChannel } from "@/database/models";
 
 import { deleteInstallation, slackInstallationQuery } from "./helpers";
 import { notifySlackChannelAction } from "./notify";
-import { matchBuildPath, unfurlBuild } from "./unfurl";
+import {
+  matchBuildPath,
+  matchTestPath,
+  unfurlBuild,
+  unfurlTest,
+} from "./unfurl";
 
 export function registerEvents(boltApp: Bolt.App) {
   boltApp.event("app_uninstalled", async ({ context }) => {
@@ -110,13 +115,15 @@ export function registerEvents(boltApp: Bolt.App) {
           if (urlObj.origin !== config.get("server.url")) {
             return null;
           }
-          const match = matchBuildPath(urlObj.pathname);
-          if (match) {
-            const buildInfo = await unfurlBuild(match.params, auth);
-            if (!buildInfo) {
-              return null;
-            }
-            return [link.url, buildInfo];
+          const buildMatch = matchBuildPath(urlObj.pathname);
+          if (buildMatch) {
+            const attachment = await unfurlBuild(buildMatch.params, auth);
+            return attachment ? [link.url, attachment] : null;
+          }
+          const testMatch = matchTestPath(urlObj.pathname);
+          if (testMatch) {
+            const attachment = await unfurlTest(testMatch.params, auth);
+            return attachment ? [link.url, attachment] : null;
           }
           return null;
         },

--- a/apps/backend/src/slack/unfurl.e2e.test.ts
+++ b/apps/backend/src/slack/unfurl.e2e.test.ts
@@ -1,0 +1,135 @@
+import { invariant } from "@argos/util/invariant";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { factory, setupDatabase } from "@/database/testing";
+import { formatTestId } from "@/util/test-id";
+
+import { matchBuildPath, matchTestPath, unfurlTest } from "./unfurl";
+
+describe("matchTestPath", () => {
+  it("matches a test URL and extracts its params", () => {
+    expect(
+      matchTestPath("/acme/my-project/tests/MY-PROJECT-RJFGK"),
+    ).toMatchObject({
+      params: {
+        accountSlug: "acme",
+        projectName: "my-project",
+        testId: "MY-PROJECT-RJFGK",
+      },
+    });
+  });
+
+  it("does not match a build URL", () => {
+    expect(matchTestPath("/acme/my-project/builds/42")).toBe(false);
+  });
+
+  it("does not collide with the build matcher", () => {
+    expect(matchBuildPath("/acme/my-project/tests/MY-PROJECT-RJFGK")).toBe(
+      false,
+    );
+  });
+});
+
+describe("unfurlTest", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  it("unfurls a test owned by the account", async () => {
+    const account = await factory.TeamAccount.create({
+      slug: "acme",
+      name: "Acme Inc",
+    });
+    const project = await factory.Project.create({
+      name: "my-project",
+      accountId: account.id,
+    });
+    const test = await factory.Test.create({
+      projectId: project.id,
+      name: "Home page",
+    });
+    // A screenshot diff gives the unfurl its preview image.
+    await factory.ScreenshotDiff.create({ testId: test.id });
+
+    const attachment = await unfurlTest(
+      {
+        accountSlug: "acme",
+        projectName: "my-project",
+        testId: formatTestId({ projectName: project.name, testId: test.id }),
+      },
+      { accountId: account.id },
+    );
+
+    invariant(attachment);
+    expect(attachment.title).toBe("Home page — Acme Inc/my-project");
+    expect(attachment.fields).toContainEqual({
+      title: "Flakiness",
+      value: "0%",
+    });
+    expect(attachment.fields).toContainEqual({
+      title: "Stability",
+      value: "100%",
+    });
+    expect(attachment.image_url).toBe(
+      "https://files.argos-ci.com/test/test-s3-id",
+    );
+  });
+
+  it("does not unfurl a test that belongs to another account", async () => {
+    const account = await factory.TeamAccount.create({ slug: "acme" });
+    const otherAccount = await factory.TeamAccount.create({ slug: "other" });
+    const project = await factory.Project.create({
+      name: "my-project",
+      accountId: account.id,
+    });
+    const test = await factory.Test.create({ projectId: project.id });
+
+    const attachment = await unfurlTest(
+      {
+        accountSlug: "acme",
+        projectName: "my-project",
+        testId: formatTestId({ projectName: project.name, testId: test.id }),
+      },
+      // The link was shared in another account's Slack workspace.
+      { accountId: otherAccount.id },
+    );
+
+    expect(attachment).toBeNull();
+  });
+
+  it("does not unfurl when the project name does not match the URL", async () => {
+    const account = await factory.TeamAccount.create({ slug: "acme" });
+    const project = await factory.Project.create({
+      name: "my-project",
+      accountId: account.id,
+    });
+    const test = await factory.Test.create({ projectId: project.id });
+
+    const attachment = await unfurlTest(
+      {
+        accountSlug: "acme",
+        projectName: "another-project",
+        testId: formatTestId({ projectName: project.name, testId: test.id }),
+      },
+      { accountId: account.id },
+    );
+
+    expect(attachment).toBeNull();
+  });
+
+  it("returns null for an unparseable test id", async () => {
+    const account = await factory.TeamAccount.create({ slug: "acme" });
+    await factory.Project.create({ name: "my-project", accountId: account.id });
+
+    const attachment = await unfurlTest(
+      {
+        accountSlug: "acme",
+        projectName: "my-project",
+        testId: "not a valid test id",
+      },
+      { accountId: account.id },
+    );
+
+    expect(attachment).toBeNull();
+  });
+});

--- a/apps/backend/src/slack/unfurl.ts
+++ b/apps/backend/src/slack/unfurl.ts
@@ -5,8 +5,10 @@ import { match } from "path-to-regexp";
 
 import { getBuildLabel } from "@/build/label";
 import { getStatsMessage } from "@/build/stats";
-import { Build, ScreenshotDiff } from "@/database/models";
+import { Build, ScreenshotDiff, Test } from "@/database/models";
+import { getTestAllMetrics } from "@/metrics/test";
 import { getPublicFileUrl, getTwicPicsUrl } from "@/storage";
+import { safeParseTestId } from "@/util/test-id";
 
 type BuildMatchParams = {
   accountSlug: string;
@@ -70,6 +72,84 @@ export async function unfurlBuild(
       { title: "Status", value: getBuildLabel(build.type, status) },
       statsMessage ? { title: "Screenshots", value: statsMessage } : null,
     ].filter(checkIsNonNullable),
+  };
+
+  if (imageUrl) {
+    attachment.image_url = imageUrl;
+  }
+
+  return attachment;
+}
+
+type TestMatchParams = {
+  accountSlug: string;
+  projectName: string;
+  testId: string;
+};
+
+export const matchTestPath = match<TestMatchParams>(
+  "/:accountSlug/:projectName/tests/:testId",
+);
+
+/**
+ * Format a `0..1` metric ratio as a rounded percentage (e.g. `0.42` → `42%`).
+ */
+function formatPercent(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+export async function unfurlTest(
+  params: TestMatchParams,
+  auth: { accountId: string },
+): Promise<Bolt.types.MessageAttachment | null> {
+  const parsed = safeParseTestId(params.testId);
+  if (!parsed) {
+    return null;
+  }
+
+  const test = await Test.query()
+    .withGraphJoined("project.account")
+    .where("tests.id", parsed.testId)
+    .where("project.name", params.projectName)
+    .where("project:account.id", auth.accountId)
+    .where("project:account.slug", params.accountSlug)
+    .first();
+
+  if (!test) {
+    return null;
+  }
+
+  invariant(test.project, "Project should be loaded");
+  invariant(test.project.account, "Account should be loaded");
+
+  const [metrics, latestDiff] = await Promise.all([
+    getTestAllMetrics([test.id], { from: new Date(0) }).then(([m]) => m),
+    ScreenshotDiff.query()
+      .where("testId", test.id)
+      .whereNotNull("compareScreenshotId")
+      .orderBy("createdAt", "desc")
+      .withGraphFetched("compareScreenshot.file")
+      .first(),
+  ]);
+  invariant(metrics, "Metrics should be computed");
+
+  const screenshot = latestDiff?.compareScreenshot;
+  const imageUrl = await (() => {
+    if (!screenshot) {
+      return null;
+    }
+    if (!screenshot.file) {
+      return getTwicPicsUrl(screenshot.s3Id);
+    }
+    return getPublicFileUrl(screenshot.file);
+  })();
+
+  const attachment: Bolt.types.MessageAttachment = {
+    title: `${test.name} — ${test.project.account.displayName}/${test.project.name}`,
+    fields: [
+      { title: "Flakiness", value: formatPercent(metrics.flakiness) },
+      { title: "Stability", value: formatPercent(metrics.stability) },
+    ],
   };
 
   if (imageUrl) {


### PR DESCRIPTION
## What

Test URLs like `app.argos-ci.com/GitbookIO/gitbook-x/tests/GITBOOK-X-RJFGK` now unfurl in Slack, extending the existing build-URL unfurling.

Before, a shared test link rendered as a plain link with no preview:

<img width="852" alt="Test URL with no unfurl in Slack" src="https://uploads.linear.app/acf5a5ba-11b6-4409-8c98-76f8aff6d3fd/9eee11ac-532e-4546-b8a2-86c2b51d9693/07ab5a7e-cd58-4132-9168-eedaa5920d21" />

## How

- **`slack/unfurl.ts`** — new `matchTestPath` (`/:accountSlug/:projectName/tests/:testId`) and `unfurlTest()`, mirroring `unfurlBuild`. It decodes the `GITBOOK-X-RJFGK` slug via the existing `safeParseTestId`, loads the test **scoped to the Slack installation's account** (same invariant as build unfurling — a workspace can only preview its own tests), and builds an attachment with the test name, project, **Flakiness**/**Stability** (from `getTestAllMetrics`, all-time), and the latest compare screenshot.
- **`slack/events.ts`** — the `link_shared` handler now tries the build matcher, then the test matcher.

I picked Flakiness + Stability as the two fields since the driving use case is triaging flaky tests — easy to adjust if you'd rather show status or other metrics.

## Notes

- **No Slack app dashboard change needed** — test URLs share the `app.argos-ci.com` domain already allowlisted for build unfurling.
- End-to-end Slack rendering needs a real workspace + public URL, so it isn't covered by automated tests.

## Testing

New `slack/unfurl.e2e.test.ts` (the module had no unfurl tests): path matching, plus DB-backed `unfurlTest` covering the happy path, **cross-account rejection**, project-name mismatch, and an unparseable id. Backend type-check and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)