### PR TITLE
feat(skills): serve agent-skills discovery + MCP resources

### DIFF
--- a/apps/backend/src/mcp/router.ts
+++ b/apps/backend/src/mcp/router.ts
@@ -138,7 +138,7 @@ router.post(
     // Stateless mode (no `sessionIdGenerator`): a fresh server + transport
     // pair per request, so concurrent requests never collide and no session
     // state has to be replicated across instances.
-    const server = await createMcpServer({ authorization });
+    const server = createMcpServer({ authorization });
     const transport = new StreamableHTTPServerTransport({
       enableJsonResponse: true,
     });

--- a/apps/backend/src/mcp/router.ts
+++ b/apps/backend/src/mcp/router.ts
@@ -138,7 +138,7 @@ router.post(
     // Stateless mode (no `sessionIdGenerator`): a fresh server + transport
     // pair per request, so concurrent requests never collide and no session
     // state has to be replicated across instances.
-    const server = createMcpServer({ authorization });
+    const server = await createMcpServer({ authorization });
     const transport = new StreamableHTTPServerTransport({
       enableJsonResponse: true,
     });

--- a/apps/backend/src/mcp/server.ts
+++ b/apps/backend/src/mcp/server.ts
@@ -6,7 +6,11 @@
  * Schema for `tools/list` and validates arguments and structured results, so
  * MCP clients get the exact same validation the REST API applies.
  */
+import { trimTrailingSlash } from "@argos/util/url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import config from "@/config";
+import { getSkillFileUrl, getSkills } from "@/skills/registry";
 
 import { callTool } from "./dispatch";
 import { mcpTools } from "./tools";
@@ -21,7 +25,9 @@ Projects are identified by an "owner" (account slug) and a "project" (project na
  * Create an MCP server bound to the caller's authorization. One instance per
  * request (the transport is stateless).
  */
-export function createMcpServer(context: { authorization: string }): McpServer {
+export async function createMcpServer(context: {
+  authorization: string;
+}): Promise<McpServer> {
   const server = new McpServer(
     { name: "argos", title: "Argos", version: "2.0.0" },
     { instructions: MCP_INSTRUCTIONS },
@@ -42,5 +48,44 @@ export function createMcpServer(context: { authorization: string }): McpServer {
     );
   }
 
+  await registerSkillResources(server);
+
   return server;
+}
+
+/**
+ * Expose the published Argos skills (from `argos-javascript`, the same source
+ * `npx skills add` installs) as MCP resources, so an MCP client on
+ * `mcp.argos-ci.com` discovers them via `resources/list` and reads the
+ * `SKILL.md` on demand. Never fail server creation if the skills can't load.
+ */
+async function registerSkillResources(server: McpServer): Promise<void> {
+  const skills = await getSkills().catch(() => []);
+  const appOrigin = trimTrailingSlash(config.get("server.url"));
+  for (const skill of skills) {
+    // The canonical, dereferenceable location — the same URL `npx skills add`
+    // resolves — even though the content is fetched from the repo below.
+    const uri = `${appOrigin}/.well-known/agent-skills/${skill.name}/SKILL.md`;
+    server.registerResource(
+      skill.name,
+      uri,
+      {
+        title: skill.name,
+        description: skill.description,
+        mimeType: "text/markdown",
+      },
+      async (resourceUri) => {
+        const response = await fetch(getSkillFileUrl(skill.name, "SKILL.md"));
+        return {
+          contents: [
+            {
+              uri: resourceUri.href,
+              mimeType: "text/markdown",
+              text: response.ok ? await response.text() : "",
+            },
+          ],
+        };
+      },
+    );
+  }
 }

--- a/apps/backend/src/mcp/server.ts
+++ b/apps/backend/src/mcp/server.ts
@@ -7,7 +7,10 @@
  * MCP clients get the exact same validation the REST API applies.
  */
 import { trimTrailingSlash } from "@argos/util/url";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  McpServer,
+  ResourceTemplate,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import config from "@/config";
 import { getSkillFileUrl, getSkills } from "@/skills/registry";
@@ -25,9 +28,7 @@ Projects are identified by an "owner" (account slug) and a "project" (project na
  * Create an MCP server bound to the caller's authorization. One instance per
  * request (the transport is stateless).
  */
-export async function createMcpServer(context: {
-  authorization: string;
-}): Promise<McpServer> {
+export function createMcpServer(context: { authorization: string }): McpServer {
   const server = new McpServer(
     { name: "argos", title: "Argos", version: "2.0.0" },
     { instructions: MCP_INSTRUCTIONS },
@@ -48,7 +49,7 @@ export async function createMcpServer(context: {
     );
   }
 
-  await registerSkillResources(server);
+  registerSkillResources(server);
 
   return server;
 }
@@ -56,36 +57,64 @@ export async function createMcpServer(context: {
 /**
  * Expose the published Argos skills (from `argos-javascript`, the same source
  * `npx skills add` installs) as MCP resources, so an MCP client on
- * `mcp.argos-ci.com` discovers them via `resources/list` and reads the
- * `SKILL.md` on demand. Never fail server creation if the skills can't load.
+ * `mcp.argos-ci.com` discovers them via `resources/list` and reads a
+ * `SKILL.md` on demand.
+ *
+ * Registration is a single lazy resource template: servers are created per
+ * request, so the skills must never be fetched at creation time — the registry
+ * (cached, stale-on-error) is only hit when a client actually calls
+ * `resources/list` or `resources/read`.
  */
-async function registerSkillResources(server: McpServer): Promise<void> {
-  const skills = await getSkills().catch(() => []);
+function registerSkillResources(server: McpServer): void {
   const appOrigin = trimTrailingSlash(config.get("server.url"));
-  for (const skill of skills) {
-    // The canonical, dereferenceable location — the same URL `npx skills add`
-    // resolves — even though the content is fetched from the repo below.
-    const uri = `${appOrigin}/.well-known/agent-skills/${skill.name}/SKILL.md`;
-    server.registerResource(
-      skill.name,
-      uri,
-      {
-        title: skill.name,
-        description: skill.description,
-        mimeType: "text/markdown",
-      },
-      async (resourceUri) => {
-        const response = await fetch(getSkillFileUrl(skill.name, "SKILL.md"));
+  // The canonical, dereferenceable location — the same URL `npx skills add`
+  // resolves — even though the content is fetched from the repo on read.
+  const skillUri = (name: string) =>
+    `${appOrigin}/.well-known/agent-skills/${name}/SKILL.md`;
+
+  server.registerResource(
+    "skill",
+    new ResourceTemplate(skillUri("{skill}"), {
+      // A listing failure degrades to "no skills" instead of erroring the
+      // whole resources/list call.
+      list: async () => {
+        const skills = await getSkills().catch(() => []);
         return {
-          contents: [
-            {
-              uri: resourceUri.href,
-              mimeType: "text/markdown",
-              text: response.ok ? await response.text() : "",
-            },
-          ],
+          resources: skills.map((skill) => ({
+            uri: skillUri(skill.name),
+            name: skill.name,
+            description: skill.description,
+            mimeType: "text/markdown",
+          })),
         };
       },
-    );
-  }
+    }),
+    {
+      title: "Argos agent skills",
+      description:
+        "Installable agent skills published by Argos (also served at /.well-known/agent-skills).",
+      mimeType: "text/markdown",
+    },
+    async (uri, variables) => {
+      const name = String(variables["skill"]);
+      const skills = await getSkills();
+      const skill = skills.find((s) => s.name === name);
+      if (!skill) {
+        throw new Error(`Unknown Argos skill: ${name}`);
+      }
+      const response = await fetch(getSkillFileUrl(skill.name, "SKILL.md"));
+      if (!response.ok) {
+        throw new Error(`Failed to load the "${name}" skill`);
+      }
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "text/markdown",
+            text: await response.text(),
+          },
+        ],
+      };
+    },
+  );
 }

--- a/apps/backend/src/skills/registry.ts
+++ b/apps/backend/src/skills/registry.ts
@@ -7,12 +7,12 @@
  */
 import { parse as parseYaml } from "yaml";
 
-export const SKILLS_REPO = "argos-ci/argos-javascript";
-export const SKILLS_REF = "main";
+const SKILLS_REPO = "argos-ci/argos-javascript";
+const SKILLS_REF = "main";
 const SKILLS_ROOT = "skills";
 
 /** Canonical raw content base: `${RAW_BASE}/<name>/<file>`. */
-export const RAW_BASE = `https://raw.githubusercontent.com/${SKILLS_REPO}/${SKILLS_REF}/${SKILLS_ROOT}`;
+const RAW_BASE = `https://raw.githubusercontent.com/${SKILLS_REPO}/${SKILLS_REF}/${SKILLS_ROOT}`;
 
 /** GitHub tree API — called at most once per cache window to enumerate files. */
 const TREE_URL = `https://api.github.com/repos/${SKILLS_REPO}/git/trees/${SKILLS_REF}?recursive=1`;

--- a/apps/backend/src/skills/registry.ts
+++ b/apps/backend/src/skills/registry.ts
@@ -1,0 +1,180 @@
+/**
+ * Argos publishes its agent skills from the public `argos-ci/argos-javascript`
+ * repo. Both the well-known discovery index (for `npx skills add`) and the MCP
+ * resources point at the repo's raw files — the skill content is never copied
+ * into the backend, so there is a single source of truth. We track `main`, so
+ * an edit to a skill goes live as soon as it merges.
+ */
+import { parse as parseYaml } from "yaml";
+
+export const SKILLS_REPO = "argos-ci/argos-javascript";
+export const SKILLS_REF = "main";
+const SKILLS_ROOT = "skills";
+
+/** Canonical raw content base: `${RAW_BASE}/<name>/<file>`. */
+export const RAW_BASE = `https://raw.githubusercontent.com/${SKILLS_REPO}/${SKILLS_REF}/${SKILLS_ROOT}`;
+
+/** GitHub tree API — called at most once per cache window to enumerate files. */
+const TREE_URL = `https://api.github.com/repos/${SKILLS_REPO}/git/trees/${SKILLS_REF}?recursive=1`;
+
+const CACHE_TTL = 30 * 60 * 1000; // 30 minutes
+
+export interface Skill {
+  /** Directory name and skill identifier, e.g. `argos-pr-review`. */
+  name: string;
+  /** One-line summary, from the SKILL.md frontmatter. */
+  description: string;
+  /**
+   * Every installable file, relative to the skill directory, `SKILL.md` first,
+   * e.g. `["SKILL.md", "references/baseline.md"]`.
+   */
+  files: string[];
+}
+
+/** Legacy (v0.1.0) discovery index, the digest-free format `npx skills` reads. */
+export interface DiscoveryIndex {
+  skills: { name: string; description: string; files: string[] }[];
+}
+
+interface GitHubTreeResponse {
+  tree?: { path: string; type: string }[];
+}
+
+let cache: { skills: Skill[]; expiresAt: number } | null = null;
+let inflight: Promise<Skill[]> | null = null;
+
+/** Extract `name`/`description` from a SKILL.md YAML frontmatter block. */
+function parseFrontmatter(content: string): {
+  name?: string;
+  description?: string;
+} | null {
+  const block = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content)?.[1];
+  if (!block) {
+    return null;
+  }
+  try {
+    const data = parseYaml(block) as Record<string, unknown>;
+    const name = data["name"];
+    const description = data["description"];
+    const result: { name?: string; description?: string } = {};
+    if (typeof name === "string") {
+      result.name = name;
+    }
+    if (typeof description === "string") {
+      result.description = description.trim();
+    }
+    return result;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchText(url: string): Promise<string | null> {
+  const response = await fetch(url);
+  return response.ok ? response.text() : null;
+}
+
+/** Enumerate the skills in the repo and resolve each one's metadata. */
+async function loadSkills(): Promise<Skill[]> {
+  const response = await fetch(TREE_URL, {
+    headers: { Accept: "application/vnd.github+json" },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to list Argos skills: GitHub returned ${response.status}`,
+    );
+  }
+  const body = (await response.json()) as GitHubTreeResponse;
+
+  // Group blob paths under `skills/<name>/…` by skill directory.
+  const filesByName = new Map<string, string[]>();
+  const prefix = `${SKILLS_ROOT}/`;
+  for (const entry of body.tree ?? []) {
+    if (entry.type !== "blob" || !entry.path.startsWith(prefix)) {
+      continue;
+    }
+    const rest = entry.path.slice(prefix.length);
+    const slash = rest.indexOf("/");
+    if (slash <= 0) {
+      continue; // a file directly in skills/, not inside a skill directory
+    }
+    const name = rest.slice(0, slash);
+    const files = filesByName.get(name) ?? [];
+    files.push(rest.slice(slash + 1));
+    filesByName.set(name, files);
+  }
+
+  const resolved = await Promise.all(
+    [...filesByName].map(async ([name, files]) => {
+      if (!files.some((file) => file.toLowerCase() === "skill.md")) {
+        return null;
+      }
+      const content = await fetchText(`${RAW_BASE}/${name}/SKILL.md`);
+      const frontmatter = content ? parseFrontmatter(content) : null;
+      if (!frontmatter?.description) {
+        return null;
+      }
+      // SKILL.md first, then the remaining files in a stable order.
+      const rest = files
+        .filter((file) => file.toLowerCase() !== "skill.md")
+        .sort();
+      return {
+        name,
+        description: frontmatter.description,
+        files: ["SKILL.md", ...rest],
+      } satisfies Skill;
+    }),
+  );
+
+  return resolved
+    .filter((skill): skill is Skill => skill !== null)
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Return the published skills, cached in-memory with a TTL. On a refresh
+ * failure the last good value is served (stale-while-error) so the public
+ * well-known endpoint never breaks because of a transient GitHub hiccup.
+ */
+export async function getSkills(): Promise<Skill[]> {
+  if (cache && cache.expiresAt > Date.now()) {
+    return cache.skills;
+  }
+  inflight ??= loadSkills()
+    .then((skills) => {
+      cache = { skills, expiresAt: Date.now() + CACHE_TTL };
+      return skills;
+    })
+    .catch((error: unknown) => {
+      if (cache) {
+        return cache.skills; // serve stale on error
+      }
+      throw error;
+    })
+    .finally(() => {
+      inflight = null;
+    });
+  return inflight;
+}
+
+/** Build the legacy (v0.1.0) discovery index served at `.../index.json`. */
+export function buildDiscoveryIndex(skills: Skill[]): DiscoveryIndex {
+  return {
+    skills: skills.map(({ name, description, files }) => ({
+      name,
+      description,
+      files,
+    })),
+  };
+}
+
+/** The canonical raw content URL for a skill file. */
+export function getSkillFileUrl(name: string, file: string): string {
+  return `${RAW_BASE}/${name}/${file}`;
+}
+
+/** Reset the in-memory cache. Test-only. */
+export function resetSkillsCache(): void {
+  cache = null;
+  inflight = null;
+}

--- a/apps/backend/src/skills/router.ts
+++ b/apps/backend/src/skills/router.ts
@@ -1,0 +1,53 @@
+/**
+ * Serves the agent-skills discovery index and redirects individual skill files
+ * to their canonical location in the `argos-javascript` repo.
+ *
+ * Mounted on the app subdomain BEFORE the SPA static handler and catch-all, so
+ * these paths return JSON / redirects instead of the SPA shell.
+ *
+ * The `skills` CLI (`npx skills add https://argos-ci.com`) probes
+ * `/.well-known/agent-skills/index.json` first, then `/.well-known/skills/…`,
+ * and for the legacy index format fetches each file from
+ * `<well-known>/<name>/<file>`. We answer both prefixes and redirect the files
+ * to `raw.githubusercontent.com`, so the skill content is never copied here.
+ * (`argos-ci.com` reaches this via its `/.well-known/*` → app redirect.)
+ */
+import cors from "cors";
+import { Router } from "express";
+
+import { asyncHandler } from "../web/util";
+import { buildDiscoveryIndex, getSkillFileUrl, getSkills } from "./registry";
+
+export function installSkillsRoutes(router: Router): void {
+  const skills = Router();
+
+  skills.use(cors({ origin: "*" }));
+
+  skills.get(
+    "/index.json",
+    asyncHandler(async (_req, res) => {
+      res.setHeader("Cache-Control", "public, max-age=300");
+      res.json(buildDiscoveryIndex(await getSkills()));
+    }),
+  );
+
+  skills.get(
+    "/:name/{*file}",
+    asyncHandler(async (req, res) => {
+      const raw = (req.params as { file?: string | string[] }).file;
+      const file = Array.isArray(raw) ? raw.join("/") : (raw ?? "");
+      const name = req.params["name"];
+      const skill = (await getSkills()).find((s) => s.name === name);
+      // Only redirect files the skill actually declares, so this can't be used
+      // as an open redirect or to path-traverse into the repo.
+      if (!skill || !skill.files.includes(file)) {
+        res.sendStatus(404);
+        return;
+      }
+      res.redirect(302, getSkillFileUrl(skill.name, file));
+    }),
+  );
+
+  router.use("/.well-known/agent-skills", skills);
+  router.use("/.well-known/skills", skills);
+}

--- a/apps/backend/src/skills/skills.test.ts
+++ b/apps/backend/src/skills/skills.test.ts
@@ -1,0 +1,213 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import express from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createMcpServer } from "../mcp/server";
+import { buildDiscoveryIndex, getSkills, resetSkillsCache } from "./registry";
+import { installSkillsRoutes } from "./router";
+
+const TREE = {
+  tree: [
+    { path: "README.md", type: "blob" }, // outside skills/ — ignored
+    { path: "skills/argos-cli/SKILL.md", type: "blob" },
+    { path: "skills/argos-cli/agents/openai.yaml", type: "blob" },
+    { path: "skills/argos-pr-review", type: "tree" }, // dir entry — ignored
+    { path: "skills/argos-pr-review/SKILL.md", type: "blob" },
+    { path: "skills/argos-pr-review/references/flaky-fixes.md", type: "blob" },
+    { path: "skills/argos-pr-review/references/baseline.md", type: "blob" },
+    { path: "skills/no-skill-md/notes.txt", type: "blob" }, // no SKILL.md — dropped
+  ],
+};
+
+const SKILL_MD: Record<string, string> = {
+  "argos-cli":
+    "---\nname: argos-cli\ndescription: Operate Argos from the CLI.\n---\n# Argos CLI",
+  "argos-pr-review":
+    "---\nname: argos-pr-review\ndescription: >\n  Review Argos visual\n  regression builds.\n---\n# Argos PR Review",
+};
+
+function mockResponse(
+  body: unknown,
+  { ok = true, status = 200 } = {},
+): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+  } as Response;
+}
+
+function stubFetch(impl: (url: string) => Response) {
+  const fn = vi.fn(async (url: unknown) => impl(String(url)));
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+const happyFetch = (url: string): Response => {
+  if (url.startsWith("https://api.github.com/")) {
+    return mockResponse(TREE);
+  }
+  const match = /\/skills\/([^/]+)\/SKILL\.md$/.exec(url);
+  if (match && SKILL_MD[match[1]!]) {
+    return mockResponse(SKILL_MD[match[1]!]);
+  }
+  return mockResponse("", { ok: false, status: 404 });
+};
+
+beforeEach(() => {
+  resetSkillsCache();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("getSkills", () => {
+  it("enumerates the repo, parses frontmatter, and orders files", async () => {
+    stubFetch(happyFetch);
+    const skills = await getSkills();
+    expect(skills).toEqual([
+      {
+        name: "argos-cli",
+        description: "Operate Argos from the CLI.",
+        files: ["SKILL.md", "agents/openai.yaml"],
+      },
+      {
+        name: "argos-pr-review",
+        // A folded (`>`) YAML scalar is joined and trimmed.
+        description: "Review Argos visual regression builds.",
+        files: [
+          "SKILL.md",
+          "references/baseline.md",
+          "references/flaky-fixes.md",
+        ],
+      },
+    ]);
+  });
+
+  it("caches so the tree is fetched once", async () => {
+    const fetchMock = stubFetch(happyFetch);
+    await getSkills();
+    await getSkills();
+    const treeCalls = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).startsWith("https://api.github.com/"),
+    );
+    expect(treeCalls).toHaveLength(1);
+  });
+
+  it("serves the last good value when a refresh fails (stale-while-error)", async () => {
+    vi.useFakeTimers();
+    try {
+      stubFetch(happyFetch);
+      const first = await getSkills();
+      expect(first).toHaveLength(2);
+
+      // Past the TTL, GitHub is down — the cached value is still returned.
+      vi.advanceTimersByTime(31 * 60 * 1000);
+      stubFetch(() => mockResponse("", { ok: false, status: 503 }));
+      expect(await getSkills()).toEqual(first);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("buildDiscoveryIndex", () => {
+  it("produces the legacy digest-free index shape", () => {
+    const index = buildDiscoveryIndex([
+      { name: "argos-cli", description: "d", files: ["SKILL.md"] },
+    ]);
+    expect(index).toEqual({
+      skills: [{ name: "argos-cli", description: "d", files: ["SKILL.md"] }],
+    });
+  });
+});
+
+describe("well-known routes", () => {
+  const app = express();
+  const router = express.Router();
+  installSkillsRoutes(router);
+  app.use(router);
+
+  beforeEach(() => {
+    stubFetch(happyFetch);
+  });
+
+  it("serves the discovery index at both prefixes", async () => {
+    for (const prefix of ["/.well-known/agent-skills", "/.well-known/skills"]) {
+      const res = await request(app).get(`${prefix}/index.json`);
+      expect(res.status).toBe(200);
+      expect(res.body.skills.map((s: { name: string }) => s.name)).toEqual([
+        "argos-cli",
+        "argos-pr-review",
+      ]);
+    }
+  });
+
+  it("redirects a declared skill file to the repo raw URL", async () => {
+    const res = await request(app).get(
+      "/.well-known/agent-skills/argos-pr-review/references/baseline.md",
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers["location"]).toBe(
+      "https://raw.githubusercontent.com/argos-ci/argos-javascript/main/skills/argos-pr-review/references/baseline.md",
+    );
+  });
+
+  it("404s a file the skill does not declare (allowlist, no open redirect)", async () => {
+    const res = await request(app).get(
+      "/.well-known/agent-skills/argos-cli/references/secret.md",
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("404s an unknown skill", async () => {
+    const res = await request(app).get(
+      "/.well-known/agent-skills/nope/SKILL.md",
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("MCP resources", () => {
+  beforeEach(() => {
+    stubFetch(happyFetch);
+  });
+
+  it("lists the skills as resources and reads their SKILL.md", async () => {
+    const server = await createMcpServer({ authorization: "Bearer test" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test", version: "0" });
+    await Promise.all([
+      server.connect(serverTransport as unknown as Transport),
+      client.connect(clientTransport as unknown as Transport),
+    ]);
+
+    try {
+      const { resources } = await client.listResources();
+      const byName = new Map(resources.map((r) => [r.name, r]));
+      expect([...byName.keys()]).toEqual(
+        expect.arrayContaining(["argos-cli", "argos-pr-review"]),
+      );
+
+      const prReview = byName.get("argos-pr-review");
+      // URI is the canonical app well-known location (origin varies by env).
+      expect(prReview?.uri).toMatch(
+        /\/\.well-known\/agent-skills\/argos-pr-review\/SKILL\.md$/,
+      );
+
+      const read = await client.readResource({ uri: prReview!.uri });
+      const content = read.contents[0];
+      const text = content && "text" in content ? content.text : "";
+      expect(String(text)).toContain("# Argos PR Review");
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/apps/backend/src/skills/skills.test.ts
+++ b/apps/backend/src/skills/skills.test.ts
@@ -174,12 +174,9 @@ describe("well-known routes", () => {
 });
 
 describe("MCP resources", () => {
-  beforeEach(() => {
-    stubFetch(happyFetch);
-  });
-
   it("lists the skills as resources and reads their SKILL.md", async () => {
-    const server = await createMcpServer({ authorization: "Bearer test" });
+    const fetchMock = stubFetch(happyFetch);
+    const server = createMcpServer({ authorization: "Bearer test" });
     const [clientTransport, serverTransport] =
       InMemoryTransport.createLinkedPair();
     const client = new Client({ name: "test", version: "0" });
@@ -189,6 +186,10 @@ describe("MCP resources", () => {
     ]);
 
     try {
+      // Server creation is lazy: the skills repo is only contacted once a
+      // client actually asks for resources.
+      expect(fetchMock).not.toHaveBeenCalled();
+
       const { resources } = await client.listResources();
       const byName = new Map(resources.map((r) => [r.name, r]));
       expect([...byName.keys()]).toEqual(

--- a/apps/backend/src/web/app-router.ts
+++ b/apps/backend/src/web/app-router.ts
@@ -11,6 +11,7 @@ import config from "@/config";
 import { getGoogleAuthUrl } from "@/google";
 import { apolloServer, createApolloMiddleware } from "@/graphql";
 import { mountOAuthServer } from "@/oauth/router";
+import { installSkillsRoutes } from "@/skills/router";
 import { getSlackMiddleware } from "@/slack";
 import { boom } from "@/util/error";
 import { createRedisStore } from "@/util/rate-limit";
@@ -196,6 +197,11 @@ export const installAppRouter = async (app: express.Application) => {
   // static handler and SPA catch-all so `GET /oauth/authorize` still falls
   // through to the SPA consent page.
   mountOAuthServer(router);
+
+  // Agent-skills discovery (`npx skills add https://argos-ci.com`). Mounted
+  // before the static handler and SPA catch-all so `/.well-known/agent-skills/*`
+  // returns the index / repo redirects instead of the SPA shell.
+  installSkillsRoutes(router);
 
   router.use(getSlackMiddleware());
 


### PR DESCRIPTION
## What

Makes the Argos skills (`argos-cli`, `argos-pr-review`, from [`argos-ci/argos-javascript`](https://github.com/argos-ci/argos-javascript/tree/main/skills)) installable via `npx skills add https://argos-ci.com` / `https://app.argos-ci.com`, and discoverable from the MCP server — without copying skill content into this repo.

## How

**Discovery (`npx skills add`)** — new `apps/backend/src/skills/`, wired into the `app` router **before** the SPA catch-all:
- `GET /.well-known/agent-skills/index.json` (+ legacy `/.well-known/skills/…`) → a generated **v0.1.0 (digest-free)** index. v0.1.0 on purpose: the preferred v0.2.0 requires a `sha256` digest verified against the bytes, which would break the moment a skill on `main` is edited.
- `GET /.well-known/agent-skills/:name/*file` → **302 to `raw.githubusercontent.com/argos-ci/argos-javascript/main/skills/…`**, allowlisted to files each skill declares (no open redirect).
- Skill list/descriptions/files are read from the repo (GitHub tree API + SKILL.md frontmatter), cached in-memory 30 min with **stale-on-error**.

`argos-ci.com` needs no change — its existing `/.well-known/*` → `app.argos-ci.com` redirect covers it.

**MCP** — `createMcpServer` now registers each skill as an **MCP resource** (`resources/list` + `read`), reading `SKILL.md` from the same repo source.

## Tests

`apps/backend/src/skills/skills.test.ts` (9 tests): index generation, repo enumeration + frontmatter parsing, caching, stale-on-error, file redirect + allowlist 404s, and an in-memory MCP client asserting the skills list and read back. Existing MCP e2e (17) still pass.

## Note

Inert until deployed — these routes live on the backend `app` subdomain, so a true end-to-end `npx skills add https://argos-ci.com` only passes after this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)