### PR TITLE
fix(frontend): render a loader while the build page query loads

### DIFF
--- a/apps/frontend/src/pages/Build/BuildPage.tsx
+++ b/apps/frontend/src/pages/Build/BuildPage.tsx
@@ -6,6 +6,7 @@ import { ProjectIgnoreEnabledProvider } from "@/containers/Project/IgnoreContext
 import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
 import { graphql } from "@/gql";
 import { BuildStatus } from "@/gql/graphql";
+import { Loader } from "@/ui/Loader";
 
 import { BuildDiffProvider } from "./BuildDiffState";
 import { BuildNotFound } from "./BuildNotFound";
@@ -120,7 +121,15 @@ export const BuildPage = ({ params }: { params: BuildParams }) => {
                       build={build}
                       project={project}
                     />
-                  ) : null}
+                  ) : (
+                    // Initial load: the query is still in flight (a missing
+                    // build is caught by BuildNotFound above). Render a loader
+                    // with `aria-busy` so Argos waits for the build to render
+                    // before screenshotting, instead of catching a blank body.
+                    <div className="flex min-h-0 flex-1 items-center justify-center">
+                      <Loader className="size-16" />
+                    </div>
+                  )}
                 </div>
               </RejectCommentDialogProvider>
             </BuildReviewDialogProvider>


### PR DESCRIPTION
## Problem

The `firefox/build-error` Argos snapshot is flaky ([build 5250](https://app.argos-ci.com/argos-ci/argos/builds/5250/373385660) — a `retryFailure` with a tiny 0.88% diff). Comparing base vs. head, the head captured a **near-blank body**: only the header rendered, with no status badge, sidebar, or "Build failed" card.

## Root cause

`BuildPage` renders `BuildHeader` immediately from the route params, but `BuildWorkspace` (the sidebar + status content) only renders once the `BuildPage_Project` query resolves. In between, the body was `null` — **nothing signaled the in-flight load**.

Argos stabilization waits for `[aria-busy="true"]` elements to disappear before capturing. With no loader in that gap, the screenshot could fire before the build data rendered. The e2e test only waits on `getByText("Build N")` (the header, rendered from params) before screenshotting, so every compare-less build state (error, expired, aborted, scheduled, in progress, empty) shared this race — `build-error` is just the one that tripped.

## Fix

Render the shared `Loader` (which sets `aria-busy`) in the loading gap instead of `null`, matching the app's existing `HydrateFallback` / `PageLoader` convention. Argos now waits for the build to render before capturing, on every build state. A missing build is still handled by `BuildNotFound` above, so this branch is only ever the initial-load state — no visual change to any approved screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)