### PR TITLE
feat(auth): propose installing the Argos skill after CLI login

### DIFF
--- a/apps/frontend/src/pages/AuthCLISuccess.tsx
+++ b/apps/frontend/src/pages/AuthCLISuccess.tsx
@@ -1,11 +1,14 @@
-import { CheckCircleIcon } from "lucide-react";
+import { CheckCircleIcon, SparklesIcon } from "lucide-react";
 import { Helmet } from "react-helmet";
 
 import { BrandShield } from "@/ui/BrandShield";
-import { Card, CardBody } from "@/ui/Card";
+import { Card, CardBody, CardSeparator } from "@/ui/Card";
+import { Code } from "@/ui/Code";
 import { Container } from "@/ui/Container";
+import { CopyButton } from "@/ui/CopyButton";
+import { Link } from "@/ui/Link";
 
-import { Code } from "../ui/Code";
+const SKILL_INSTALL_COMMAND = "npx skills add https://argos-ci.com";
 
 export function Component() {
   return (
@@ -13,31 +16,74 @@ export function Component() {
       <Helmet>
         <title>Authorization successful — Argos</title>
       </Helmet>
-      <Container className="mt-12 max-w-sm px-4">
+      <Container className="mt-12 max-w-md px-4">
         <div className="flex flex-col items-center gap-6">
           <BrandShield className="mt-3 w-28" />
 
           <div className="text-center">
             <h1 className="text-2xl font-semibold">Authorization successful</h1>
-            <p className="text-primary-low mt-1 text-base font-semibold">
-              You can close this tab.
+            <p className="text-low mt-1 text-base">
+              You can close this tab and return to your terminal.
             </p>
           </div>
 
           <Card className="w-full">
-            <CardBody className="flex flex-col gap-3">
+            <CardBody>
               <div className="flex items-center gap-2">
                 <CheckCircleIcon className="text-success size-4 shrink-0" />
                 <span className="text-sm font-medium">
                   Logged in to Argos CLI
                 </span>
               </div>
+              <p className="text-low mt-1.5 pl-6 text-xs">
+                Token saved to <Code>~/.config/argos-ci/config.json</Code>
+              </p>
+            </CardBody>
+
+            <CardSeparator />
+
+            <CardBody className="flex flex-col gap-4">
+              <div className="flex gap-3">
+                <div className="bg-primary-ui text-primary-low flex size-8 shrink-0 items-center justify-center rounded-lg">
+                  <SparklesIcon className="size-4" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium">
+                    Using an AI coding agent?
+                  </p>
+                  <p className="text-low mt-0.5 text-sm">
+                    Add the Argos skill so it can set up and review visual tests
+                    for you.
+                  </p>
+                </div>
+              </div>
+
+              <div className="bg-subtle flex items-center gap-3 rounded-lg border px-3.5 py-3">
+                <span
+                  aria-hidden="true"
+                  className="text-primary-low shrink-0 font-mono text-sm select-none"
+                >
+                  $
+                </span>
+                <code className="text-default no-scrollbar min-w-0 flex-1 overflow-x-auto font-mono text-sm whitespace-nowrap">
+                  {SKILL_INSTALL_COMMAND}
+                </code>
+                <CopyButton
+                  text={SKILL_INSTALL_COMMAND}
+                  className="shrink-0 text-base"
+                />
+              </div>
+
+              <Link
+                href="https://argos-ci.com/docs"
+                target="_blank"
+                className="text-sm"
+              >
+                Learn more about Argos skills
+              </Link>
             </CardBody>
           </Card>
         </div>
-        <p className="text-low mt-3 text-center text-xs">
-          Token saved to <Code>~/.config/argos-ci/config.json</Code>
-        </p>
       </Container>
     </>
   );

--- a/tests/auth-cli.spec.ts
+++ b/tests/auth-cli.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "@playwright/test";
+
+import { screenshot } from "./util";
+
+test("auth cli success", async ({ page }) => {
+  await page.goto("/auth/cli/success");
+  await expect(
+    page.getByRole("heading", { name: "Authorization successful" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("npx skills add https://argos-ci.com"),
+  ).toBeVisible();
+  await screenshot(page, "auth-cli-success");
+});


### PR DESCRIPTION
## What

Redesign the CLI authorization success page (`/auth/cli/success`). On top of confirming the login, it now invites the user to install the Argos agent skill with a copyable `npx skills add https://argos-ci.com` command — so people using an AI coding agent can wire up Argos in one step.

Closes ARG-475.

## How

- Kept the login confirmation (green check + token path) and added a second section, separated by a divider, that proposes the skill.
- The command lives in a terminal-style block with a `$` prompt and a `CopyButton`; the copy payload is just the command (the `$` is decorative / `aria-hidden`).
- Built entirely from existing UI primitives (`Card`, `CardSeparator`, `CopyButton`, `Code`, `Link`, `BrandShield`) and design tokens — the violet "skill" badge reuses the brand color so it reads as the "next step" next to the green "done" check.
- Verified locally in light, dark, and mobile (375px) — no horizontal overflow; the command scrolls inside its box with the copy button pinned.

## Tests

- New `tests/auth-cli.spec.ts` visits `/auth/cli/success`, asserts the heading and the command are visible, and captures an Argos screenshot (`auth-cli-success`) — same pattern as `login.spec.ts`.

## Note

The `npx skills add https://argos-ci.com` command depends on the skills discovery endpoint from #2386, so it only works end-to-end once that ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
