### PR TITLE
ci(release): serialize release runs to avoid superseded-deploy failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,12 @@ on:
       - main
   workflow_dispatch:
 
+# Serialize releases: a concurrent deploy to the same ECS service supersedes
+# the in-flight one, which the deploy action reports as a failure.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}


### PR DESCRIPTION
## Problem

When two pushes to `main` land close together, their release runs race: the newer run's `update-service` supersedes the older in-flight ECS deployment. The deploy action then fails with:

> Error: Deployment ecs-svc/… not found after stabilization. The deployment was likely rolled back by the deployment circuit breaker.

…and we get a false "Production deployment failed" Discord notification, even though the newer deployment shipped fine. This happened today with the 14:37 / 14:39 / 14:41 UTC runs.

## Fix

Add a workflow-level `concurrency` group with `cancel-in-progress: false`:

- Release runs queue instead of racing — a deployment fully stabilizes before the next one starts, so the superseding error can't occur.
- In-flight runs are never interrupted; only queued (not-yet-started) runs get cancelled when a newer push arrives, and `cancelled` doesn't trigger `notify-deploy-failure`.
- Genuine circuit-breaker rollbacks still report `failure` and still notify Discord — we deliberately don't filter on the error message since it's identical for the benign and real cases.

Trade-off: stacked merges deploy sequentially (~18 min each), so the latest commit can take a bit longer to reach production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)