### PR TITLE
feat(discord): improve notifications and add trial payment-method alert

### DIFF
--- a/apps/backend/src/api/handlers/createProject.e2e.test.ts
+++ b/apps/backend/src/api/handlers/createProject.e2e.test.ts
@@ -16,7 +16,10 @@ import { createProject } from "./createProject";
 
 // The Discord webhook is configured in the test env; stub it so creating a
 // project here doesn't post a real notification.
-vi.mock("@/discord", () => ({ notifyDiscord: vi.fn(() => Promise.resolve()) }));
+vi.mock("@/discord", async (importActual) => ({
+  ...(await importActual<typeof import("@/discord")>()),
+  notifyDiscord: vi.fn(() => Promise.resolve()),
+}));
 
 const app = createTestHandlerApp(createProject);
 

--- a/apps/backend/src/api/handlers/createProject.e2e.test.ts
+++ b/apps/backend/src/api/handlers/createProject.e2e.test.ts
@@ -1,5 +1,5 @@
 import request from "supertest";
-import { test as base, beforeAll, describe, expect, vi } from "vitest";
+import { test as base, beforeAll, describe, expect } from "vitest";
 import z from "zod";
 
 import {
@@ -13,13 +13,6 @@ import { factory, setupDatabase } from "@/database/testing";
 
 import { createTestHandlerApp } from "../test-util";
 import { createProject } from "./createProject";
-
-// The Discord webhook is configured in the test env; stub it so creating a
-// project here doesn't post a real notification.
-vi.mock("@/discord", async (importActual) => ({
-  ...(await importActual<typeof import("@/discord")>()),
-  notifyDiscord: vi.fn(() => Promise.resolve()),
-}));
 
 const app = createTestHandlerApp(createProject);
 

--- a/apps/backend/src/database/services/project.e2e.test.ts
+++ b/apps/backend/src/database/services/project.e2e.test.ts
@@ -3,17 +3,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Account, Project } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
-import { notifyDiscord } from "@/discord";
+import * as discord from "@/discord";
 import { HTTPError } from "@/util/error";
 
 import { createProject, notifyProjectTransfer } from "./project";
 
-// The Discord webhook is configured in the test env; stub it so creating a
-// project here doesn't post a real notification.
-vi.mock("@/discord", async (importActual) => ({
-  ...(await importActual<typeof import("@/discord")>()),
-  notifyDiscord: vi.fn(() => Promise.resolve()),
-}));
+// Real notifications are already disabled in tests (the webhook client is off);
+// spy on the sender only to assert what would have been posted.
+const notifyDiscord = vi
+  .spyOn(discord, "notifyDiscord")
+  .mockResolvedValue(undefined);
 
 /**
  * Create a team account with an owner (admin) user and its personal account.

--- a/apps/backend/src/database/services/project.e2e.test.ts
+++ b/apps/backend/src/database/services/project.e2e.test.ts
@@ -10,7 +10,10 @@ import { createProject, notifyProjectTransfer } from "./project";
 
 // The Discord webhook is configured in the test env; stub it so creating a
 // project here doesn't post a real notification.
-vi.mock("@/discord", () => ({ notifyDiscord: vi.fn(() => Promise.resolve()) }));
+vi.mock("@/discord", async (importActual) => ({
+  ...(await importActual<typeof import("@/discord")>()),
+  notifyDiscord: vi.fn(() => Promise.resolve()),
+}));
 
 /**
  * Create a team account with an owner (admin) user and its personal account.

--- a/apps/backend/src/database/services/project.ts
+++ b/apps/backend/src/database/services/project.ts
@@ -3,7 +3,7 @@ import { assertNever } from "@argos/util/assertNever";
 import * as Sentry from "@sentry/node";
 import type { QueryBuilder } from "objection";
 
-import { notifyDiscord } from "@/discord";
+import { formatDiscordLink, getProjectUrl, notifyDiscord } from "@/discord";
 import { boom } from "@/util/error";
 
 import type { Account } from "../models/Account";
@@ -220,14 +220,21 @@ export async function notifyProjectCreation(input: {
     return;
   }
 
+  const projectLink = formatDiscordLink(
+    `${input.account.slug} / ${input.project.name}`,
+    getProjectUrl(input.account.slug, input.project.name),
+  );
+
   await notifyDiscord({
     content: `
-New project from ${input.account.name} (${input.email ?? "unknown email"}) ${
+New project from ${input.account.displayName} (${
+      input.email ?? "unknown email"
+    }) ${
       input.source
         ? `imported from ${input.source}`
         : "created without a Git provider"
     }:
-${input.account.slug} / ${input.project.name}
+${projectLink}
 `.trim(),
   }).catch((error) => {
     Sentry.captureException(error);
@@ -257,10 +264,15 @@ export async function notifyProjectTransfer(input: {
     return;
   }
 
+  const targetLink = formatDiscordLink(
+    `${input.targetAccount.slug} / ${input.project.name}`,
+    getProjectUrl(input.targetAccount.slug, input.project.name),
+  );
+
   await notifyDiscord({
     content: `
 Project transferred to a team by ${input.email ?? "unknown email"}:
-${input.previousAccount.slug} / ${input.previousName} → ${input.targetAccount.slug} / ${input.project.name}
+${input.previousAccount.slug} / ${input.previousName} → ${targetLink}
 `.trim(),
   }).catch((error) => {
     Sentry.captureException(error);

--- a/apps/backend/src/database/services/subscription.ts
+++ b/apps/backend/src/database/services/subscription.ts
@@ -1,7 +1,7 @@
 import { assertNever } from "@argos/util/assertNever";
 import { captureException } from "@sentry/node";
 
-import { notifyDiscord } from "@/discord";
+import { formatDiscordLink, getAccountUrl, notifyDiscord } from "@/discord";
 
 import { Account, type Subscription } from "../models";
 
@@ -73,23 +73,12 @@ export async function notifySubscriptionStatusUpdate(args: {
   const providerName = getProviderName(provider);
   const statusMessage = getStatusMessage({ status, previousStatus });
 
-  const teamLink = `[View Team](<https://app.argos-ci.com/${account.slug}>)`;
-
-  const links = [teamLink];
-
-  if (provider === "stripe" && account.stripeCustomerId) {
-    links.push(
-      `[View in Stripe](<https://dashboard.stripe.com/customers/${account.stripeCustomerId}>)`,
-    );
-  }
-
   try {
     await notifyDiscord({
       content: [
         `${providerName} • ${statusMessage}`,
         reason ? `📝 Reason: ${reason}` : "",
-        `👤 *${account.displayName}* (ID: ${account.id})`,
-        `🔗 ${links.join(" • ")}`,
+        ...formatAccountLines(account, provider),
       ]
         .filter(Boolean)
         .join("\n"),
@@ -97,4 +86,53 @@ export async function notifySubscriptionStatusUpdate(args: {
   } catch (error) {
     captureException(error);
   }
+}
+
+/**
+ * Notify that a trialing team has added its payment method, so it will convert
+ * to a paid subscription instead of being canceled when the trial ends.
+ */
+export async function notifyPaymentMethodAdded(args: {
+  provider: Subscription["provider"];
+  account: Account;
+}) {
+  const { provider, account } = args;
+  const providerName = getProviderName(provider);
+
+  try {
+    await notifyDiscord({
+      content: [
+        `${providerName} • 💳 Payment method added during trial`,
+        ...formatAccountLines(account, provider),
+      ].join("\n"),
+    });
+  } catch (error) {
+    captureException(error);
+  }
+}
+
+/**
+ * Build the shared account identity used by every subscription notification:
+ * the team name linked to the team in the app (the name falls back to the slug
+ * so it is never "null"), and, for Stripe, a link to the customer in the Stripe
+ * dashboard.
+ */
+function formatAccountLines(
+  account: Account,
+  provider: Subscription["provider"],
+): string[] {
+  const lines = [
+    `👤 ${formatDiscordLink(account.displayName, getAccountUrl(account.slug))} (ID: ${account.id})`,
+  ];
+
+  if (provider === "stripe" && account.stripeCustomerId) {
+    lines.push(
+      `🔗 ${formatDiscordLink(
+        "View in Stripe",
+        `https://dashboard.stripe.com/customers/${account.stripeCustomerId}`,
+      )}`,
+    );
+  }
+
+  return lines;
 }

--- a/apps/backend/src/discord/index.ts
+++ b/apps/backend/src/discord/index.ts
@@ -21,3 +21,29 @@ export async function notifyDiscord(input: { content: string }) {
     });
   }
 }
+
+/**
+ * Build a Discord markdown link with its embed preview suppressed (the `<...>`
+ * wrapper), so notification lines stay compact.
+ */
+export function formatDiscordLink(label: string, url: string): string {
+  return `[${label}](<${url}>)`;
+}
+
+/**
+ * URL of an account (team or user) in the app.
+ */
+export function getAccountUrl(slug: string): string {
+  return new URL(`/${slug}`, config.get("server.url")).href;
+}
+
+/**
+ * URL of a project in the app.
+ */
+export function getProjectUrl(
+  accountSlug: string,
+  projectName: string,
+): string {
+  return new URL(`/${accountSlug}/${projectName}`, config.get("server.url"))
+    .href;
+}

--- a/apps/backend/src/graphql/definitions/Team.ts
+++ b/apps/backend/src/graphql/definitions/Team.ts
@@ -36,7 +36,7 @@ import {
   normalizeTeamDomain,
   type AutoInvite,
 } from "@/database/services/team-domain";
-import { notifyDiscord } from "@/discord";
+import { formatDiscordLink, notifyDiscord } from "@/discord";
 import { sendEmailTemplate } from "@/email/send-email-template";
 import { getAppOctokit, getInstallationOctokit } from "@/github/client";
 import {
@@ -1078,7 +1078,7 @@ export const resolvers: IResolvers = {
 
       await notifyDiscord({
         content:
-          `Trial extended for ${teamAccount.name} (${teamUrl}) (by ${auth.user.email})`.trim(),
+          `Trial extended for ${formatDiscordLink(teamAccount.displayName, teamUrl)} (by ${auth.user.email ?? "unknown email"})`.trim(),
       }).catch((error) => {
         captureException(error);
       });

--- a/apps/backend/src/graphql/tests/createProject.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/createProject.e2e.test.ts
@@ -11,7 +11,10 @@ import { createApolloServerApp } from "./util";
 
 // The Discord webhook is configured in the test env; stub it so creating a
 // project here doesn't post a real notification.
-vi.mock("@/discord", () => ({ notifyDiscord: vi.fn(() => Promise.resolve()) }));
+vi.mock("@/discord", async (importActual) => ({
+  ...(await importActual<typeof import("@/discord")>()),
+  notifyDiscord: vi.fn(() => Promise.resolve()),
+}));
 
 const CreateProjectMutation = `
   mutation CreateProject($input: CreateProjectInput!) {

--- a/apps/backend/src/graphql/tests/createProject.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/createProject.e2e.test.ts
@@ -1,6 +1,6 @@
 import { invariant } from "@argos/util/invariant";
 import request from "supertest";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { Project } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
@@ -8,13 +8,6 @@ import { factory, setupDatabase } from "@/database/testing";
 import { apolloServer, createApolloMiddleware } from "../apollo";
 import { expectNoGraphQLError } from "../testing";
 import { createApolloServerApp } from "./util";
-
-// The Discord webhook is configured in the test env; stub it so creating a
-// project here doesn't post a real notification.
-vi.mock("@/discord", async (importActual) => ({
-  ...(await importActual<typeof import("@/discord")>()),
-  notifyDiscord: vi.fn(() => Promise.resolve()),
-}));
 
 const CreateProjectMutation = `
   mutation CreateProject($input: CreateProjectInput!) {

--- a/apps/backend/src/graphql/tests/transferProject.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/transferProject.e2e.test.ts
@@ -11,7 +11,10 @@ import { createApolloServerApp } from "./util";
 
 // The Discord webhook is configured in the test env; stub it so transferring a
 // project here doesn't post a real notification.
-vi.mock("@/discord", () => ({ notifyDiscord: vi.fn(() => Promise.resolve()) }));
+vi.mock("@/discord", async (importActual) => ({
+  ...(await importActual<typeof import("@/discord")>()),
+  notifyDiscord: vi.fn(() => Promise.resolve()),
+}));
 
 const TransferProjectMutation = `
   mutation TransferProject($input: TransferProjectInput!) {

--- a/apps/backend/src/graphql/tests/transferProject.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/transferProject.e2e.test.ts
@@ -3,18 +3,17 @@ import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { factory, setupDatabase } from "@/database/testing";
-import { notifyDiscord } from "@/discord";
+import * as discord from "@/discord";
 
 import { apolloServer, createApolloMiddleware } from "../apollo";
 import { expectNoGraphQLError } from "../testing";
 import { createApolloServerApp } from "./util";
 
-// The Discord webhook is configured in the test env; stub it so transferring a
-// project here doesn't post a real notification.
-vi.mock("@/discord", async (importActual) => ({
-  ...(await importActual<typeof import("@/discord")>()),
-  notifyDiscord: vi.fn(() => Promise.resolve()),
-}));
+// Real notifications are already disabled in tests (the webhook client is off);
+// spy on the sender only to assert what would have been posted.
+const notifyDiscord = vi
+  .spyOn(discord, "notifyDiscord")
+  .mockResolvedValue(undefined);
 
 const TransferProjectMutation = `
   mutation TransferProject($input: TransferProjectInput!) {

--- a/apps/backend/src/mcp/mcp.e2e.test.ts
+++ b/apps/backend/src/mcp/mcp.e2e.test.ts
@@ -20,7 +20,10 @@ import { issueTokens } from "@/oauth/tokens";
 
 import { mcpRouter } from "./router";
 
-vi.mock("@/discord", () => ({ notifyDiscord: vi.fn(() => Promise.resolve()) }));
+vi.mock("@/discord", async (importActual) => ({
+  ...(await importActual<typeof import("@/discord")>()),
+  notifyDiscord: vi.fn(() => Promise.resolve()),
+}));
 
 const app = express();
 app.use(mcpRouter);

--- a/apps/backend/src/mcp/mcp.e2e.test.ts
+++ b/apps/backend/src/mcp/mcp.e2e.test.ts
@@ -13,17 +13,18 @@ import {
 } from "@/database/models";
 import { hashToken } from "@/database/services/crypto";
 import { factory, setupDatabase } from "@/database/testing";
-import { notifyDiscord } from "@/discord";
+import * as discord from "@/discord";
 import { getApiResourceUrl, getMcpResourceUrl } from "@/oauth/metadata";
 import type { OAuthScope } from "@/oauth/scopes";
 import { issueTokens } from "@/oauth/tokens";
 
 import { mcpRouter } from "./router";
 
-vi.mock("@/discord", async (importActual) => ({
-  ...(await importActual<typeof import("@/discord")>()),
-  notifyDiscord: vi.fn(() => Promise.resolve()),
-}));
+// Real notifications are already disabled in tests (the webhook client is off);
+// spy on the sender only to assert it is not called.
+const notifyDiscord = vi
+  .spyOn(discord, "notifyDiscord")
+  .mockResolvedValue(undefined);
 
 const app = express();
 app.use(mcpRouter);

--- a/apps/backend/src/stripe/events.e2e.test.ts
+++ b/apps/backend/src/stripe/events.e2e.test.ts
@@ -1,6 +1,7 @@
 import type Stripe from "stripe";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { Plan } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
 import * as discord from "@/discord";
 
@@ -8,6 +9,9 @@ import {
   CANCEL_SUBSCRIPTION_EVENT_PAYLOAD,
   CANCELLATION_FEEDBACK_UPDATED_SUBSCRIPTION_EVENT_PAYLOAD,
   STRIPE_PRODUCT_ID,
+  TRIALING_CUSTOMER_ID,
+  TRIALING_SUBSCRIPTION_ID,
+  TRIALING_SUBSCRIPTION_WITH_PAYMENT_METHOD,
 } from "./fixtures/cancel-subscription-event-payload";
 import { handleStripeEvent, stripe } from "./index";
 
@@ -74,6 +78,54 @@ describe("handleStripeEvent", () => {
       const content = send.mock.calls[0][0].content;
       expect(content).toContain("Subscription canceled");
       expect(content).toContain("Reason: The price jump was too sporadic.");
+    });
+  });
+
+  describe("payment_method.attached", () => {
+    it("notifies when a trialing team adds its payment method", async () => {
+      const send = vi
+        .spyOn(discord, "notifyDiscord")
+        .mockResolvedValue(undefined);
+      vi.spyOn(stripe.subscriptions, "list").mockResolvedValue({
+        data: [TRIALING_SUBSCRIPTION_WITH_PAYMENT_METHOD],
+      } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Subscription>>);
+
+      const plan = await Plan.query()
+        .findOne({ stripeProductId: STRIPE_PRODUCT_ID })
+        .throwIfNotFound();
+      const [user, account] = await Promise.all([
+        factory.User.create(),
+        // No name: the notification must fall back to the slug, never "null".
+        factory.TeamAccount.create({
+          name: null,
+          stripeCustomerId: TRIALING_CUSTOMER_ID,
+        }),
+      ]);
+      await factory.Subscription.create({
+        accountId: account.id,
+        subscriberId: user.id,
+        planId: plan.id,
+        provider: "stripe",
+        stripeSubscriptionId: TRIALING_SUBSCRIPTION_ID,
+        status: "trialing",
+        paymentMethodFilled: false,
+      });
+
+      await handleStripeEvent({
+        type: "payment_method.attached",
+        data: {
+          object: { customer: TRIALING_CUSTOMER_ID },
+        } as unknown as Stripe.PaymentMethodAttachedEvent.Data,
+      });
+
+      expect(send).toHaveBeenCalledOnce();
+      if (send.mock.calls[0] === undefined) {
+        throw new Error("Expected notifyDiscord to be called with arguments");
+      }
+      const content = send.mock.calls[0][0].content;
+      expect(content).toContain("Payment method added during trial");
+      expect(content).not.toContain("null");
+      expect(content).toContain(account.slug);
     });
   });
 });

--- a/apps/backend/src/stripe/fixtures/cancel-subscription-event-payload.ts
+++ b/apps/backend/src/stripe/fixtures/cancel-subscription-event-payload.ts
@@ -53,6 +53,24 @@ const cancellationFeedbackUpdatedSubscription = {
   },
 } as unknown as Stripe.Subscription;
 
+export const TRIALING_CUSTOMER_ID = "cus_trialing_test";
+export const TRIALING_SUBSCRIPTION_ID = "sub_trialing_test";
+
+/**
+ * A trialing subscription that now has a payment method attached: the trial is
+ * still running, but it will convert to paid instead of being canceled.
+ */
+export const TRIALING_SUBSCRIPTION_WITH_PAYMENT_METHOD = {
+  ...subscription,
+  id: TRIALING_SUBSCRIPTION_ID,
+  status: "trialing",
+  customer: TRIALING_CUSTOMER_ID,
+  default_payment_method: "pm_trialing_test",
+  cancel_at: null,
+  ended_at: null,
+  trial_end: 1900000000,
+} as unknown as Stripe.Subscription;
+
 export const CANCEL_SUBSCRIPTION_EVENT_PAYLOAD = {
   id: "evt_test",
   object: "event",

--- a/apps/backend/src/stripe/index.ts
+++ b/apps/backend/src/stripe/index.ts
@@ -8,7 +8,10 @@ import { z } from "zod";
 import config from "@/config";
 import { Account, Plan, Subscription } from "@/database/models";
 import { computeAdditionalScreenshots } from "@/database/services/additional-screenshots";
-import { notifySubscriptionStatusUpdate } from "@/database/services/subscription";
+import {
+  notifyPaymentMethodAdded,
+  notifySubscriptionStatusUpdate,
+} from "@/database/services/subscription";
 import { sendNotification } from "@/notification";
 import { redisLock } from "@/util/redis";
 
@@ -766,6 +769,14 @@ async function updateArgosSubscriptionFromStripe(
 ): Promise<Subscription> {
   const notifyStatusUpdate = options?.notifyStatusUpdate ?? true;
   const data = await getArgosSubscriptionDataFromStripe(stripeSubscription);
+  // A trial that gains a payment method without changing status: the team is
+  // still trialing, but it will now convert to paid instead of being canceled
+  // at the end of the trial.
+  const paymentMethodAddedDuringTrial =
+    data.status === "trialing" &&
+    argosSubscription.status === "trialing" &&
+    data.paymentMethodFilled &&
+    !argosSubscription.paymentMethodFilled;
   const [updatedSubscription] = await Promise.all([
     argosSubscription.$query().patchAndFetch(data),
     (async () => {
@@ -779,6 +790,11 @@ async function updateArgosSubscriptionFromStripe(
           previousStatus: argosSubscription.status,
           account,
         });
+      } else if (notifyStatusUpdate && paymentMethodAddedDuringTrial) {
+        const account = await Account.query()
+          .findById(argosSubscription.accountId)
+          .throwIfNotFound();
+        await notifyPaymentMethodAdded({ provider: "stripe", account });
       }
     })(),
   ]);

--- a/vitest/vitest.global-setup.mts
+++ b/vitest/vitest.global-setup.mts
@@ -1,3 +1,7 @@
 export const setup = () => {
   process.env.TZ = "UTC";
+  // Never send real Discord notifications from tests. Set before the config
+  // module loads .env: dotenv does not override an already-defined key, so an
+  // empty value here keeps the webhook client disabled in every worker.
+  process.env.DISCORD_WEBHOOK_URL = "";
 };


### PR DESCRIPTION
## What

Improves the Discord notifications we receive and adds a new one.

### Clearer, actionable notifications
- **Never render `null`.** Account name falls back to `displayName` (name → slug), and missing user emails show `unknown email`.
- **Teams and projects are clickable.** The team/project name is itself the link to the app — the separate "View Team" label is gone.
- App URLs are built from `config.server.url` (works in staging/dev too) instead of a hardcoded `app.argos-ci.com`, via shared helpers `formatDiscordLink` / `getAccountUrl` / `getProjectUrl`.

### New notification
When a **trialing team attaches a payment method** without ending the trial, we now get:

```
Stripe • 💳 Payment method added during trial
👤 [Acme Inc](<https://app.argos-ci.com/acme>) (ID: 123)
🔗 [View in Stripe](<https://dashboard.stripe.com/customers/cus_x>)
```

It fires from the `payment_method.attached` / `customer.updated` webhook paths — the team is still trialing but will now convert to paid instead of being canceled at trial end.

## Tests
- Mocks that stub `notifyDiscord` now keep the real `@/discord` helpers so the new exports aren't dropped.
- Added an e2e test for the payment-method-added path (also asserts the message never contains `null` for a nameless team).
- **No real notifications during tests:** `.env` carries a real `DISCORD_WEBHOOK_URL` and is always loaded, so the webhook client is now disabled globally in the vitest setup.

All affected suites pass; `turbo static-checks` clean for the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)