### PR TITLE
feat(project): add an Ignored changes page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,19 +2,20 @@
 
 ## Rules
 
-Before finishing any change:
+While iterating, use the fast local checks on what you touched:
 
-- Format: `prettier` on modified files
+- `prettier --write <target>`
+- `tsc --noEmit <target>`
+- `eslint <target>`
 
-- If **local**:
-  - `tsc --noEmit <target>`
-  - `eslint <target>`
+**Before finishing any change, run `pnpm run static-checks`.** It is the same
+turbo task CI runs (`check-types`, `check-format`, `lint`, `lint:root`, `knip`),
+so it is the only thing that tells you CI will pass. Fix everything it reports,
+including unused code found by knip.
 
-- If **global**:
-  - `pnpm run check-types`
-  - `pnpm run knip` (fix unused code)
-
-All checks must pass.
+Do not substitute an ad-hoc `prettier --check` from the repository root: each
+workspace runs prettier from its own directory with its own ignore paths, so a
+root-level invocation is not equivalent and will miss files that CI rejects.
 
 ## TypeScript
 

--- a/apps/backend/db/migrations/20260726130000_screenshot-diffs-fingerprint-index.js
+++ b/apps/backend/db/migrations/20260726130000_screenshot-diffs-fingerprint-index.js
@@ -1,0 +1,33 @@
+/**
+ * Index backing the lookup of the latest diff for a given change, used by
+ * `TestChange.lastSeenDiff` (the ignored-changes ledger reads one per row).
+ *
+ * Without it, `(testId, fingerprint)` lookups fall back to
+ * `screenshot_diffs_test_id_id_desc_idx` and read every diff of the test before
+ * filtering on the fingerprint — a long-lived test has one diff per build, so
+ * that is thousands of heap fetches per row. Partial on `fileId IS NOT NULL`
+ * because the lookup only wants diffs whose image is still available, and
+ * `id DESC` so the "most recent first" ordering is served by the index.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async (knex) => {
+  await knex.raw(
+    `CREATE INDEX CONCURRENTLY IF NOT EXISTS screenshot_diffs_testid_fingerprint_id_desc_notnull_idx
+       ON screenshot_diffs ("testId", fingerprint, id DESC)
+       WHERE "fileId" IS NOT NULL`,
+  );
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async (knex) => {
+  await knex.raw(
+    `DROP INDEX IF EXISTS screenshot_diffs_testid_fingerprint_id_desc_notnull_idx`,
+  );
+};
+
+export const config = { transaction: false };

--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -2,7 +2,9 @@ import type { ScreenshotMetadata } from "@argos/schemas/screenshot-metadata";
 import { invariant } from "@argos/util/invariant";
 
 import { concludeBuild } from "@/build/concludeBuild";
+import { decodeFingerprint } from "@/util/fingerprint";
 
+import { knex } from "./knex";
 import { UserEmail } from "./models";
 import { Account } from "./models/Account";
 import { Build } from "./models/Build";
@@ -24,6 +26,7 @@ import { Team } from "./models/Team";
 import { TeamUser } from "./models/TeamUser";
 import { Test } from "./models/Test";
 import { User } from "./models/User";
+import { ignoreChange } from "./services/ignored-change";
 
 function duplicate<T>(obj: T, count: number): T[] {
   return Array.from({ length: count }, () => obj);
@@ -673,6 +676,66 @@ export async function createTestChangeScenario(input: {
       fingerprint: "penelope-argos-change",
       createdAt: now,
       updatedAt: now,
+    },
+  ]);
+
+  return { test, build };
+}
+
+/**
+ * The Argos bot account, created on demand. The production row comes from a
+ * migration, but the e2e database is truncated between runs.
+ */
+async function getSeedArgosBotUserId(): Promise<string> {
+  const email = "argos-bot@no-reply.argos-ci.com";
+  const existing = await User.query().select("id").findOne({ email });
+  if (existing) {
+    return existing.id;
+  }
+  const { user } = await createUserAccount({
+    email,
+    name: "Argos Bot",
+    slug: "argos-bot",
+    type: "bot",
+  });
+  return user.id;
+}
+
+/**
+ * A change that has been ignored and kept reappearing afterwards, so the ignore
+ * ledger has a row with an author, a date and a non-zero occurrence count.
+ */
+export async function createIgnoredChangeScenario(input: {
+  projectId: string;
+  userId: string;
+  /**
+   * Attribute the ignore to the Argos bot, as auto-ignore does, instead of to
+   * `userId`.
+   * @default false
+   */
+  auto?: boolean;
+}): Promise<{ test: Test; build: Build }> {
+  const { projectId, auto = false } = input;
+  const { test, build } = await createTestChangeScenario({ projectId });
+
+  // Change ids embed the fingerprint and are parsed back by splitting on `-`,
+  // so the scenario needs a realistically shaped (dash-free) fingerprint rather
+  // than the readable placeholder `createTestChangeScenario` uses.
+  const fingerprint = decodeFingerprint("v14f3a9c2e1b8d7605");
+  await ScreenshotDiff.query().where("testId", test.id).patch({ fingerprint });
+
+  const userId = auto ? await getSeedArgosBotUserId() : input.userId;
+  await ignoreChange({ projectId, testId: test.id, fingerprint, userId });
+
+  // Occurrences are read from the daily fingerprint stats, which the diff
+  // pipeline fills on reference builds — seed them directly here. They must be
+  // dated after the ignore, since that is the window the ledger counts.
+  await knex("test_stats_fingerprints").insert([
+    {
+      testId: test.id,
+      fingerprint,
+      date: new Date(Date.now() + 60_000),
+      value: 4,
     },
   ]);
 

--- a/apps/backend/src/database/services/ignored-change.e2e.test.ts
+++ b/apps/backend/src/database/services/ignored-change.e2e.test.ts
@@ -11,6 +11,7 @@ import { factory, setupDatabase } from "@/database/testing";
 import {
   ignoreChange,
   isChangeIgnored,
+  queryIgnoredChanges,
   unignoreChange,
 } from "./ignored-change";
 
@@ -127,6 +128,124 @@ describe("ignored-change service", () => {
       ]);
       expect(ignoredChanges).toHaveLength(0);
       expect(auditTrails).toHaveLength(0);
+    });
+  });
+
+  describe("queryIgnoredChanges", () => {
+    const pagination = { after: 0, first: 30 };
+
+    it("returns an empty page when nothing is ignored", async () => {
+      await expect(
+        queryIgnoredChanges({ projectId: test.projectId, ...pagination }),
+      ).resolves.toEqual({ total: 0, results: [] });
+    });
+
+    it("returns the ignored change", async () => {
+      await ignoreChange(identity());
+
+      const { total, results } = await queryIgnoredChanges({
+        projectId: test.projectId,
+        ...pagination,
+      });
+
+      expect(total).toBe(1);
+      expect(results).toEqual([{ testId: test.id, fingerprint }]);
+    });
+
+    it("orders by the latest ignore date, most recent first", async () => {
+      const otherTest = await factory.Test.create({
+        projectId: test.projectId,
+      });
+      await ignoreChange(identity());
+      await ignoreChange({
+        projectId: test.projectId,
+        testId: otherTest.id,
+        fingerprint: "fingerprint-2",
+        userId: user.id,
+      });
+      // Re-ignoring moves the first change back to the top: the order comes
+      // from the latest `files.ignored` entry, not from the insert order.
+      await unignoreChange(identity());
+      await ignoreChange(identity());
+
+      const { results } = await queryIgnoredChanges({
+        projectId: test.projectId,
+        ...pagination,
+      });
+
+      expect(results.map((row) => row.fingerprint)).toEqual([
+        fingerprint,
+        "fingerprint-2",
+      ]);
+    });
+
+    it("keeps a row whose audit trail entry is missing, ordered last", async () => {
+      await ignoreChange(identity());
+      await IgnoredChange.query().insert({
+        projectId: test.projectId,
+        testId: test.id,
+        fingerprint: "orphan-fingerprint",
+      });
+
+      const { total, results } = await queryIgnoredChanges({
+        projectId: test.projectId,
+        ...pagination,
+      });
+
+      expect(total).toBe(2);
+      expect(results.map((row) => row.fingerprint)).toEqual([
+        fingerprint,
+        "orphan-fingerprint",
+      ]);
+    });
+
+    it("excludes unignored changes and other projects", async () => {
+      const otherTest = await factory.Test.create();
+      await ignoreChange(identity());
+      await ignoreChange({
+        projectId: otherTest.projectId,
+        testId: otherTest.id,
+        fingerprint,
+        userId: user.id,
+      });
+      await unignoreChange(identity());
+
+      await expect(
+        queryIgnoredChanges({ projectId: test.projectId, ...pagination }),
+      ).resolves.toEqual({ total: 0, results: [] });
+    });
+
+    it("paginates", async () => {
+      const tests = await Promise.all([
+        factory.Test.create({ projectId: test.projectId }),
+        factory.Test.create({ projectId: test.projectId }),
+      ]);
+      for (const [index, currentTest] of tests.entries()) {
+        await ignoreChange({
+          projectId: test.projectId,
+          testId: currentTest.id,
+          fingerprint: `fingerprint-${index}`,
+          userId: user.id,
+        });
+      }
+
+      const firstPage = await queryIgnoredChanges({
+        projectId: test.projectId,
+        after: 0,
+        first: 1,
+      });
+      const secondPage = await queryIgnoredChanges({
+        projectId: test.projectId,
+        after: 1,
+        first: 1,
+      });
+
+      expect(firstPage.total).toBe(2);
+      expect(firstPage.results).toHaveLength(1);
+      expect(secondPage.results).toHaveLength(1);
+      expect(secondPage.results[0]?.fingerprint).not.toBe(
+        firstPage.results[0]?.fingerprint,
+      );
     });
   });
 });

--- a/apps/backend/src/database/services/ignored-change.ts
+++ b/apps/backend/src/database/services/ignored-change.ts
@@ -1,6 +1,6 @@
 import { UniqueViolationError } from "objection";
 
-import { transaction } from "@/database";
+import { knex, transaction } from "@/database";
 import {
   AuditTrail,
   IgnoredChange,
@@ -117,4 +117,55 @@ export async function unignoreChange(input: ChangeIdentity): Promise<void> {
       }),
     ]);
   });
+}
+
+/** Identity of a change currently ignored in a project. */
+export type IgnoredChangeRow = {
+  testId: string;
+  fingerprint: string;
+};
+
+/**
+ * List the changes currently ignored in a project, most recently ignored first.
+ *
+ * The order can only come from `audit_trails`: `ignored_changes` is keyed by
+ * (projectId, testId, fingerprint) and holds no date. A change can be ignored,
+ * unignored, then ignored again, so we order on the latest `files.ignored`
+ * entry. Rows with no matching entry sort last rather than dropping out.
+ */
+export async function queryIgnoredChanges(input: {
+  projectId: string;
+  after: number;
+  first: number;
+}): Promise<{ total: number; results: IgnoredChangeRow[] }> {
+  const { projectId, after, first } = input;
+
+  const [total, result] = await Promise.all([
+    IgnoredChange.query().where("projectId", projectId).resultSize(),
+    knex.raw<{ rows: IgnoredChangeRow[] }>(
+      `
+      SELECT
+        ic."testId"::text as "testId",
+        ic.fingerprint
+      FROM ignored_changes ic
+      LEFT JOIN LATERAL (
+        SELECT atr.date
+        FROM audit_trails atr
+        WHERE atr."projectId" = ic."projectId"
+          AND atr."testId" = ic."testId"
+          AND atr.fingerprint = ic.fingerprint
+          AND atr.action = 'files.ignored'
+        ORDER BY atr.date DESC, atr.id DESC
+        LIMIT 1
+      ) trail ON true
+      WHERE ic."projectId" = :projectId
+      ORDER BY trail.date DESC NULLS LAST, ic."testId" DESC, ic.fingerprint DESC
+      OFFSET :after
+      LIMIT :first
+      `,
+      { projectId, after, first },
+    ),
+  ]);
+
+  return { total, results: result.rows };
 }

--- a/apps/backend/src/graphql/definitions/Project.ts
+++ b/apps/backend/src/graphql/definitions/Project.ts
@@ -20,6 +20,7 @@ import {
   User,
 } from "@/database/models";
 import { queryBuilds } from "@/database/services/build";
+import { queryIgnoredChanges } from "@/database/services/ignored-change";
 import {
   checkProjectName,
   createProject as createProjectService,
@@ -215,6 +216,8 @@ export const typeDefs = gql`
     defaultUserLevel: ProjectUserLevel
     "Ignore feature configuration"
     ignoreConfig: IgnoreConfig!
+    "Changes currently ignored in this project, most recently ignored first"
+    ignoredChanges(after: Int = 0, first: Int = 30): TestChangesConnection!
     "List all tests in a project"
     tests(
       after: Int = 0
@@ -660,6 +663,21 @@ export const resolvers: IResolvers = {
         return null;
       }
       return test;
+    },
+    ignoredChanges: async (project, { first, after }) => {
+      const result = await queryIgnoredChanges({
+        projectId: project.id,
+        after,
+        first,
+      });
+      return paginateResult({
+        result: {
+          total: result.total,
+          results: result.results.map((row) => ({ project, ...row })),
+        },
+        first,
+        after,
+      });
     },
     tests: async (project, { first, after, period, filters }) => {
       const result = await queryActiveTests({

--- a/apps/backend/src/graphql/definitions/Test.ts
+++ b/apps/backend/src/graphql/definitions/Test.ts
@@ -1,27 +1,16 @@
-import { assertNever } from "@argos/util/assertNever";
 import { invariant } from "@argos/util/invariant";
 import gqlTag from "graphql-tag";
 
-import { Project, ScreenshotDiff, type User } from "@/database/models";
-import {
-  getChangeMutationDenial,
-  ignoreChange as ignoreTestChange,
-  unignoreChange as unignoreTestChange,
-} from "@/database/services/ignored-change";
+import { ScreenshotDiff } from "@/database/models";
 import { getStartDateFromPeriod, getTestSeriesMetrics } from "@/metrics/test";
-import {
-  formatTestChangeId,
-  formatTestId,
-  safeParseTestChangeId,
-  type TestChangeIdPayload,
-} from "@/util/test-id";
+import { formatTestId } from "@/util/test-id";
 
 import {
   type IResolvers,
   type ITestMetrics,
 } from "../__generated__/resolver-types";
-import { badUserInput, forbidden, notFound } from "../util";
 import { paginateResult } from "./PageInfo";
+import type { TestChangeObject } from "./TestChange";
 
 const { gql } = gqlTag;
 
@@ -45,24 +34,6 @@ export const typeDefs = gql`
   type TestMetrics {
     series: [TestMetricDataPoint!]!
     all: TestMetricData!
-  }
-
-  type TestChange implements Node {
-    id: ID!
-    stats(period: MetricsPeriod!): TestChangeStats!
-    ignored: Boolean!
-    trails: [AuditTrail!]!
-  }
-
-  type TestChangeStats {
-    totalOccurrences: Int!
-    firstSeenDiff: ScreenshotDiff!
-    lastSeenDiff: ScreenshotDiff!
-  }
-
-  type TestChangesConnection implements Connection {
-    edges: [TestChange!]!
-    pageInfo: PageInfo!
   }
 
   type TestConnection implements Connection {
@@ -99,21 +70,6 @@ export const typeDefs = gql`
     date: DateTime!
     action: String!
     user: User!
-  }
-
-  input IgnoreChangeInput {
-    accountSlug: String!
-    changeId: ID!
-  }
-
-  input UnignoreChangeInput {
-    accountSlug: String!
-    changeId: ID!
-  }
-
-  extend type Mutation {
-    ignoreChange(input: IgnoreChangeInput!): TestChange!
-    unignoreChange(input: UnignoreChangeInput!): TestChange!
   }
 `;
 
@@ -184,7 +140,11 @@ export const resolvers: IResolvers = {
       return paginateResult({
         result: {
           total: result.total,
-          results: result.results.map((screenshotDiff) => {
+          results: result.results.map((screenshotDiff): TestChangeObject => {
+            invariant(
+              screenshotDiff.fingerprint,
+              "Diffs without a fingerprint are filtered out by the query",
+            );
             return {
               project,
               testId: test.id,
@@ -219,39 +179,6 @@ export const resolvers: IResolvers = {
       });
     },
   },
-  TestChange: {
-    id: (testChange) =>
-      formatTestChangeId({
-        projectName: testChange.project.name,
-        testId: testChange.testId,
-        fingerprint: testChange.fingerprint,
-      }),
-    stats: async (testChange, args, ctx) => {
-      const { period } = args;
-      const from = getStartDateFromPeriod(period);
-      const ChangeStatsLoader = ctx.loaders.getChangeStatsLoader(
-        from.toISOString(),
-        testChange.testId,
-      );
-      return ChangeStatsLoader.load({ fingerprint: testChange.fingerprint });
-    },
-    ignored: async (testChange, _args, ctx) => {
-      return ctx.loaders.IgnoredChangeLoader.load({
-        projectId: testChange.project.id,
-        testId: testChange.testId,
-        fingerprint: testChange.fingerprint,
-      });
-    },
-    trails: async (testChange, _args, ctx) => {
-      const trails = await ctx.loaders.TestAuditTrailLoader.load({
-        projectId: testChange.project.id,
-        testId: testChange.testId,
-      });
-      return trails.filter(
-        (trail) => trail.fingerprint === testChange.fingerprint,
-      );
-    },
-  },
   AuditTrail: {
     user: async (auditTrail, _args, ctx) => {
       const account = await ctx.loaders.AccountFromRelation.load({
@@ -261,106 +188,9 @@ export const resolvers: IResolvers = {
       return account;
     },
   },
-  Mutation: {
-    ignoreChange: async (_root, { input }, ctx) => {
-      return runChangeMutaton(
-        {
-          changeId: input.changeId,
-          accountSlug: input.accountSlug,
-          user: ctx.auth?.user ?? null,
-        },
-        async ({ changeIdPayload, project, user }) => {
-          await ignoreTestChange({
-            projectId: project.id,
-            testId: changeIdPayload.testId,
-            fingerprint: changeIdPayload.fingerprint,
-            userId: user.id,
-          });
-        },
-      );
-    },
-    unignoreChange: async (_root, { input }, ctx) => {
-      return runChangeMutaton(
-        {
-          changeId: input.changeId,
-          accountSlug: input.accountSlug,
-          user: ctx.auth?.user ?? null,
-        },
-        async ({ changeIdPayload, project, user }) => {
-          await unignoreTestChange({
-            projectId: project.id,
-            testId: changeIdPayload.testId,
-            fingerprint: changeIdPayload.fingerprint,
-            userId: user.id,
-          });
-        },
-      );
-    },
-  },
-};
-
-export type TestChangeObject = {
-  project: Project;
-  testId: string;
-  fingerprint: string;
 };
 
 export type TestMetrics = {
   series: () => Promise<ITestMetrics["series"]>;
   all: () => Promise<ITestMetrics["all"]>;
 };
-
-async function runChangeMutaton(
-  context: {
-    changeId: string;
-    accountSlug: string;
-    user: User | null;
-  },
-  run: (props: {
-    changeIdPayload: TestChangeIdPayload;
-    project: Project;
-    user: User;
-  }) => Promise<void>,
-): Promise<TestChangeObject> {
-  const { changeId, accountSlug, user } = context;
-  const changeIdPayload = safeParseTestChangeId(changeId);
-
-  if (!changeIdPayload) {
-    throw notFound("Test change not found");
-  }
-
-  const project = await Project.query()
-    .joinRelated("account")
-    .where("account.slug", accountSlug)
-    .whereILike("projects.name", changeIdPayload.projectName)
-    .first();
-
-  if (!project) {
-    throw notFound("Project not found");
-  }
-
-  const denial = await getChangeMutationDenial(project, user);
-
-  switch (denial) {
-    case "forbidden":
-      throw forbidden(
-        "You do not have permission to ignore test changes in this project",
-      );
-    case "ignore-disabled":
-      throw badUserInput("The ignore feature is disabled for this project.");
-    case null:
-      break;
-    default:
-      assertNever(denial);
-  }
-
-  invariant(user, "User should be defined because of permissions check");
-
-  await run({ changeIdPayload, project, user });
-
-  return {
-    project,
-    fingerprint: changeIdPayload.fingerprint,
-    testId: changeIdPayload.testId,
-  };
-}

--- a/apps/backend/src/graphql/definitions/TestChange.ts
+++ b/apps/backend/src/graphql/definitions/TestChange.ts
@@ -15,8 +15,8 @@ import {
   type TestChangeIdPayload,
 } from "@/util/test-id";
 
-import type { Context } from "../context";
 import { type IResolvers } from "../__generated__/resolver-types";
+import type { Context } from "../context";
 import { badUserInput, forbidden, notFound } from "../util";
 
 const { gql } = gqlTag;
@@ -102,9 +102,7 @@ async function getChangeTrails(
     projectId: testChange.project.id,
     testId: testChange.testId,
   });
-  return trails.filter(
-    (trail) => trail.fingerprint === testChange.fingerprint,
-  );
+  return trails.filter((trail) => trail.fingerprint === testChange.fingerprint);
 }
 
 /**
@@ -117,9 +115,7 @@ async function getLastIgnoredTrail(
   ctx: Context,
 ): Promise<AuditTrail | null> {
   const trails = await getChangeTrails(testChange, ctx);
-  return (
-    trails.findLast((trail) => trail.action === "files.ignored") ?? null
-  );
+  return trails.findLast((trail) => trail.action === "files.ignored") ?? null;
 }
 
 export const resolvers: IResolvers = {

--- a/apps/backend/src/graphql/definitions/TestChange.ts
+++ b/apps/backend/src/graphql/definitions/TestChange.ts
@@ -1,0 +1,281 @@
+import { assertNever } from "@argos/util/assertNever";
+import { invariant } from "@argos/util/invariant";
+import gqlTag from "graphql-tag";
+
+import { Project, type AuditTrail, type User } from "@/database/models";
+import {
+  getChangeMutationDenial,
+  ignoreChange as ignoreTestChange,
+  unignoreChange as unignoreTestChange,
+} from "@/database/services/ignored-change";
+import { getStartDateFromPeriod } from "@/metrics/test";
+import {
+  formatTestChangeId,
+  safeParseTestChangeId,
+  type TestChangeIdPayload,
+} from "@/util/test-id";
+
+import type { Context } from "../context";
+import { type IResolvers } from "../__generated__/resolver-types";
+import { badUserInput, forbidden, notFound } from "../util";
+
+const { gql } = gqlTag;
+
+export const typeDefs = gql`
+  """
+  A distinct change within a test: an exact diff fingerprint. This is the unit
+  reviewers ignore, so ignoring one leaves other changes to the same test
+  visible.
+  """
+  type TestChange implements Node {
+    id: ID!
+    "Test the change belongs to"
+    test: Test!
+    stats(period: MetricsPeriod!): TestChangeStats!
+    """
+    Most recent diff carrying this fingerprint, whatever its period or build
+    type — unlike \`stats.lastSeenDiff\`, which is scoped to a metrics period and
+    to auto-approved builds. Null when the diff's image is no longer available.
+    """
+    lastSeenDiff: ScreenshotDiff
+    ignored: Boolean!
+    """
+    When the change was last ignored, from the audit trail. Null when the change
+    has never been ignored.
+    """
+    ignoredAt: DateTime
+    """
+    Who last ignored the change — the Argos bot when auto-ignore did. Null when
+    the change has never been ignored.
+    """
+    ignoredBy: User
+    """
+    Number of auto-approved builds that have shown this exact change since it
+    was last ignored — how much review noise the ignore has absorbed. 0 when the
+    change has never been ignored.
+    """
+    occurrencesSinceIgnored: Int!
+    trails: [AuditTrail!]!
+  }
+
+  type TestChangeStats {
+    totalOccurrences: Int!
+    firstSeenDiff: ScreenshotDiff!
+    lastSeenDiff: ScreenshotDiff!
+  }
+
+  type TestChangesConnection implements Connection {
+    edges: [TestChange!]!
+    pageInfo: PageInfo!
+  }
+
+  input IgnoreChangeInput {
+    accountSlug: String!
+    changeId: ID!
+  }
+
+  input UnignoreChangeInput {
+    accountSlug: String!
+    changeId: ID!
+  }
+
+  extend type Mutation {
+    ignoreChange(input: IgnoreChangeInput!): TestChange!
+    unignoreChange(input: UnignoreChangeInput!): TestChange!
+  }
+`;
+
+export type TestChangeObject = {
+  project: Project;
+  testId: string;
+  fingerprint: string;
+};
+
+/**
+ * Audit trail entries for this change, oldest first.
+ */
+async function getChangeTrails(
+  testChange: TestChangeObject,
+  ctx: Context,
+): Promise<AuditTrail[]> {
+  const trails = await ctx.loaders.TestAuditTrailLoader.load({
+    projectId: testChange.project.id,
+    testId: testChange.testId,
+  });
+  return trails.filter(
+    (trail) => trail.fingerprint === testChange.fingerprint,
+  );
+}
+
+/**
+ * Latest `files.ignored` entry, or null when the change was never ignored. A
+ * change can be ignored, unignored, then ignored again, so only the latest entry
+ * describes the ignore currently in force.
+ */
+async function getLastIgnoredTrail(
+  testChange: TestChangeObject,
+  ctx: Context,
+): Promise<AuditTrail | null> {
+  const trails = await getChangeTrails(testChange, ctx);
+  return (
+    trails.findLast((trail) => trail.action === "files.ignored") ?? null
+  );
+}
+
+export const resolvers: IResolvers = {
+  TestChange: {
+    id: (testChange) =>
+      formatTestChangeId({
+        projectName: testChange.project.name,
+        testId: testChange.testId,
+        fingerprint: testChange.fingerprint,
+      }),
+    test: async (testChange, _args, ctx) => {
+      const test = await ctx.loaders.Test.load(testChange.testId);
+      invariant(test, "Test should exist");
+      return test;
+    },
+    stats: async (testChange, args, ctx) => {
+      const { period } = args;
+      const from = getStartDateFromPeriod(period);
+      const ChangeStatsLoader = ctx.loaders.getChangeStatsLoader(
+        from.toISOString(),
+        testChange.testId,
+      );
+      return ChangeStatsLoader.load({ fingerprint: testChange.fingerprint });
+    },
+    lastSeenDiff: async (testChange, _args, ctx) => {
+      return ctx.loaders.LatestChangeDiffLoader.load({
+        testId: testChange.testId,
+        fingerprint: testChange.fingerprint,
+      });
+    },
+    ignored: async (testChange, _args, ctx) => {
+      return ctx.loaders.IgnoredChangeLoader.load({
+        projectId: testChange.project.id,
+        testId: testChange.testId,
+        fingerprint: testChange.fingerprint,
+      });
+    },
+    ignoredAt: async (testChange, _args, ctx) => {
+      const trail = await getLastIgnoredTrail(testChange, ctx);
+      return trail ? new Date(trail.date) : null;
+    },
+    ignoredBy: async (testChange, _args, ctx) => {
+      const trail = await getLastIgnoredTrail(testChange, ctx);
+      if (!trail) {
+        return null;
+      }
+      const account = await ctx.loaders.AccountFromRelation.load({
+        userId: trail.userId,
+      });
+      invariant(account, "Account should exist");
+      return account;
+    },
+    occurrencesSinceIgnored: async (testChange, _args, ctx) => {
+      const trail = await getLastIgnoredTrail(testChange, ctx);
+      if (!trail) {
+        return 0;
+      }
+      return ctx.loaders.ChangeOccurrencesSinceLoader.load({
+        testId: testChange.testId,
+        fingerprint: testChange.fingerprint,
+        from: new Date(trail.date),
+      });
+    },
+    trails: async (testChange, _args, ctx) => {
+      return getChangeTrails(testChange, ctx);
+    },
+  },
+  Mutation: {
+    ignoreChange: async (_root, { input }, ctx) => {
+      return runChangeMutaton(
+        {
+          changeId: input.changeId,
+          accountSlug: input.accountSlug,
+          user: ctx.auth?.user ?? null,
+        },
+        async ({ changeIdPayload, project, user }) => {
+          await ignoreTestChange({
+            projectId: project.id,
+            testId: changeIdPayload.testId,
+            fingerprint: changeIdPayload.fingerprint,
+            userId: user.id,
+          });
+        },
+      );
+    },
+    unignoreChange: async (_root, { input }, ctx) => {
+      return runChangeMutaton(
+        {
+          changeId: input.changeId,
+          accountSlug: input.accountSlug,
+          user: ctx.auth?.user ?? null,
+        },
+        async ({ changeIdPayload, project, user }) => {
+          await unignoreTestChange({
+            projectId: project.id,
+            testId: changeIdPayload.testId,
+            fingerprint: changeIdPayload.fingerprint,
+            userId: user.id,
+          });
+        },
+      );
+    },
+  },
+};
+
+async function runChangeMutaton(
+  context: {
+    changeId: string;
+    accountSlug: string;
+    user: User | null;
+  },
+  run: (props: {
+    changeIdPayload: TestChangeIdPayload;
+    project: Project;
+    user: User;
+  }) => Promise<void>,
+): Promise<TestChangeObject> {
+  const { changeId, accountSlug, user } = context;
+  const changeIdPayload = safeParseTestChangeId(changeId);
+
+  if (!changeIdPayload) {
+    throw notFound("Test change not found");
+  }
+
+  const project = await Project.query()
+    .joinRelated("account")
+    .where("account.slug", accountSlug)
+    .whereILike("projects.name", changeIdPayload.projectName)
+    .first();
+
+  if (!project) {
+    throw notFound("Project not found");
+  }
+
+  const denial = await getChangeMutationDenial(project, user);
+
+  switch (denial) {
+    case "forbidden":
+      throw forbidden(
+        "You do not have permission to ignore test changes in this project",
+      );
+    case "ignore-disabled":
+      throw badUserInput("The ignore feature is disabled for this project.");
+    case null:
+      break;
+    default:
+      assertNever(denial);
+  }
+
+  invariant(user, "User should be defined because of permissions check");
+
+  await run({ changeIdPayload, project, user });
+
+  return {
+    project,
+    fingerprint: changeIdPayload.fingerprint,
+    testId: changeIdPayload.testId,
+  };
+}

--- a/apps/backend/src/graphql/definitions/index.ts
+++ b/apps/backend/src/graphql/definitions/index.ts
@@ -42,6 +42,7 @@ import * as SlackInstallation from "./SlackInstallation";
 import * as Staff from "./Staff";
 import * as Team from "./Team";
 import * as Test from "./Test";
+import * as TestChange from "./TestChange";
 import * as TimeSeries from "./TimeSeries";
 import * as User from "./User";
 import * as UserAccessToken from "./UserAccessToken";
@@ -91,6 +92,7 @@ export const definitions: { resolvers?: object; typeDefs?: DocumentNode }[] = [
   Staff,
   Team,
   Test,
+  TestChange,
   TimeSeries,
   User,
   UserAccessToken,

--- a/apps/backend/src/graphql/loaders.e2e.test.ts
+++ b/apps/backend/src/graphql/loaders.e2e.test.ts
@@ -1,6 +1,8 @@
 import { invariant } from "@argos/util/invariant";
 import { beforeEach, describe, expect, it } from "vitest";
 
+import { knex } from "@/database";
+import { ScreenshotDiff } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
 
 import { createLoaders } from "./loaders";
@@ -85,5 +87,210 @@ describe("ProjectTeamUserLevel loader", () => {
     expect(levelA).toBe("owner");
     expect(levelB).toBe("member");
     expect(crossed).toBeNull();
+  });
+});
+
+describe("LatestChangeDiff loader", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  async function createDiff(input: {
+    testId: string;
+    fingerprint: string | null;
+    fileId: string | null;
+  }) {
+    const diff = await factory.ScreenshotDiff.create();
+    await ScreenshotDiff.query().findById(diff.id).patch(input);
+    return diff;
+  }
+
+  it("returns the newest diff carrying the fingerprint", async () => {
+    const test = await factory.Test.create();
+    const file = await factory.File.create({ type: "screenshotDiff" });
+    await createDiff({
+      testId: test.id,
+      fingerprint: "fp-1",
+      fileId: file.id,
+    });
+    const newest = await createDiff({
+      testId: test.id,
+      fingerprint: "fp-1",
+      fileId: file.id,
+    });
+
+    const loaders = createLoaders();
+    const diff = await loaders.LatestChangeDiffLoader.load({
+      testId: test.id,
+      fingerprint: "fp-1",
+    });
+
+    expect(diff?.id).toBe(newest.id);
+  });
+
+  it("ignores diffs whose image is gone and returns null when none is left", async () => {
+    const test = await factory.Test.create();
+    await createDiff({ testId: test.id, fingerprint: "fp-1", fileId: null });
+
+    const loaders = createLoaders();
+    const diff = await loaders.LatestChangeDiffLoader.load({
+      testId: test.id,
+      fingerprint: "fp-1",
+    });
+
+    expect(diff).toBeNull();
+  });
+
+  it("keeps each key separate when the batch mixes tests and fingerprints", async () => {
+    const [testA, testB] = await Promise.all([
+      factory.Test.create(),
+      factory.Test.create(),
+    ]);
+    const file = await factory.File.create({ type: "screenshotDiff" });
+    const [diffA1, diffA2, diffB] = await Promise.all([
+      createDiff({ testId: testA.id, fingerprint: "fp-1", fileId: file.id }),
+      createDiff({ testId: testA.id, fingerprint: "fp-2", fileId: file.id }),
+      createDiff({ testId: testB.id, fingerprint: "fp-1", fileId: file.id }),
+    ]);
+
+    const loaders = createLoaders();
+    // Loaded in one tick so the DataLoader batches them into a single query.
+    const [a1, a2, b, missing] = await Promise.all([
+      loaders.LatestChangeDiffLoader.load({
+        testId: testA.id,
+        fingerprint: "fp-1",
+      }),
+      loaders.LatestChangeDiffLoader.load({
+        testId: testA.id,
+        fingerprint: "fp-2",
+      }),
+      loaders.LatestChangeDiffLoader.load({
+        testId: testB.id,
+        fingerprint: "fp-1",
+      }),
+      loaders.LatestChangeDiffLoader.load({
+        testId: testB.id,
+        fingerprint: "fp-3",
+      }),
+    ]);
+
+    expect(a1?.id).toBe(diffA1.id);
+    expect(a2?.id).toBe(diffA2.id);
+    expect(b?.id).toBe(diffB.id);
+    expect(missing).toBeNull();
+  });
+});
+
+describe("ChangeOccurrencesSince loader", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  async function insertStats(
+    rows: {
+      testId: string;
+      fingerprint: string;
+      date: string;
+      value: number;
+    }[],
+  ) {
+    await knex("test_stats_fingerprints").insert(rows);
+  }
+
+  it("only counts occurrences at or after `from`", async () => {
+    const test = await factory.Test.create();
+    await insertStats([
+      {
+        testId: test.id,
+        fingerprint: "fp-1",
+        date: "2026-01-01T00:00:00.000Z",
+        value: 5,
+      },
+      {
+        testId: test.id,
+        fingerprint: "fp-1",
+        date: "2026-02-01T00:00:00.000Z",
+        value: 3,
+      },
+      {
+        testId: test.id,
+        fingerprint: "fp-1",
+        date: "2026-03-01T00:00:00.000Z",
+        value: 2,
+      },
+    ]);
+
+    const loaders = createLoaders();
+    const total = await loaders.ChangeOccurrencesSinceLoader.load({
+      testId: test.id,
+      fingerprint: "fp-1",
+      from: new Date("2026-02-01T00:00:00.000Z"),
+    });
+
+    expect(total).toBe(5);
+  });
+
+  it("returns 0 when nothing occurred since `from`", async () => {
+    const test = await factory.Test.create();
+    await insertStats([
+      {
+        testId: test.id,
+        fingerprint: "fp-1",
+        date: "2026-01-01T00:00:00.000Z",
+        value: 4,
+      },
+    ]);
+
+    const loaders = createLoaders();
+    const total = await loaders.ChangeOccurrencesSinceLoader.load({
+      testId: test.id,
+      fingerprint: "fp-1",
+      from: new Date("2026-02-01T00:00:00.000Z"),
+    });
+
+    expect(total).toBe(0);
+  });
+
+  it("applies each key's own `from` within a single batch", async () => {
+    const test = await factory.Test.create();
+    await insertStats([
+      {
+        testId: test.id,
+        fingerprint: "fp-1",
+        date: "2026-01-01T00:00:00.000Z",
+        value: 7,
+      },
+      {
+        testId: test.id,
+        fingerprint: "fp-2",
+        date: "2026-01-01T00:00:00.000Z",
+        value: 9,
+      },
+    ]);
+
+    const loaders = createLoaders();
+    // Same test, same date, different `from` per key: the batched query must not
+    // collapse them onto a single window.
+    const [counted, excluded, allTime] = await Promise.all([
+      loaders.ChangeOccurrencesSinceLoader.load({
+        testId: test.id,
+        fingerprint: "fp-1",
+        from: new Date("2025-12-01T00:00:00.000Z"),
+      }),
+      loaders.ChangeOccurrencesSinceLoader.load({
+        testId: test.id,
+        fingerprint: "fp-2",
+        from: new Date("2026-06-01T00:00:00.000Z"),
+      }),
+      loaders.ChangeOccurrencesSinceLoader.load({
+        testId: test.id,
+        fingerprint: "fp-2",
+        from: new Date(0),
+      }),
+    ]);
+
+    expect(counted).toBe(7);
+    expect(excluded).toBe(0);
+    expect(allTime).toBe(9);
   });
 });

--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -1226,6 +1226,110 @@ function createIgnoredChangeLoader() {
   );
 }
 
+/**
+ * Loads the most recent diff carrying a given change fingerprint, across every
+ * period and every build type.
+ *
+ * `TestChangeStats` deliberately scopes its diffs to a metrics period and to
+ * reference builds; an ignored change that stopped occurring has no such diff,
+ * so it needs this unscoped lookup to still render a screenshot and a date.
+ */
+function createLatestChangeDiffLoader() {
+  return new DataLoader<
+    { testId: string; fingerprint: string },
+    ScreenshotDiff | null,
+    string
+  >(
+    async (changes) => {
+      const rows = await ScreenshotDiff.query()
+        .select("screenshot_diffs.*")
+        // The ordering below puts the newest diff of each pair first, so
+        // DISTINCT ON keeps exactly that one.
+        .distinctOn("screenshot_diffs.testId", "screenshot_diffs.fingerprint")
+        .whereIn(
+          ["screenshot_diffs.testId", "screenshot_diffs.fingerprint"],
+          changes.map(({ testId, fingerprint }) => [testId, fingerprint]),
+        )
+        .whereNotNull("screenshot_diffs.fileId")
+        .orderBy([
+          { column: "screenshot_diffs.testId" },
+          { column: "screenshot_diffs.fingerprint" },
+          { column: "screenshot_diffs.id", order: "desc" },
+        ]);
+
+      const diffByKey = new Map(
+        rows.map((diff) => [`${diff.testId}|${diff.fingerprint}`, diff]),
+      );
+
+      return changes.map(
+        ({ testId, fingerprint }) =>
+          diffByKey.get(`${testId}|${fingerprint}`) ?? null,
+      );
+    },
+    { cacheKeyFn: (input) => JSON.stringify(input) },
+  );
+}
+
+/**
+ * Counts how many times a change reappeared in auto-approved builds since a
+ * per-change date — for ignored changes, since they were ignored. Each key
+ * carries its own `from`, so this cannot reuse `getChangesTotalOccurrences`.
+ */
+function createChangeOccurrencesSinceLoader() {
+  return new DataLoader<
+    { testId: string; fingerprint: string; from: Date },
+    number,
+    string
+  >(
+    async (changes) => {
+      const result = await knex.raw<{
+        rows: {
+          testId: string;
+          fingerprint: string;
+          from: Date;
+          total: string;
+        }[];
+      }>(
+        // The join casts the *parameters* to bigint rather than the column to
+        // text: casting `tsf."testId"` would make the (testId, fingerprint,
+        // date) primary key unusable and turn this into a full table scan.
+        `
+        SELECT
+          c."testId"::text as "testId",
+          c."fingerprint",
+          c."from",
+          coalesce(sum(tsf.value), 0) as total
+        FROM unnest(:testIds::bigint[], :fingerprints::text[], :froms::timestamptz[])
+          AS c("testId", "fingerprint", "from")
+        LEFT JOIN test_stats_fingerprints tsf
+          ON tsf."testId" = c."testId"
+          AND tsf.fingerprint = c."fingerprint"
+          AND tsf.date >= c."from"
+        GROUP BY c."testId", c."fingerprint", c."from"
+        `,
+        {
+          testIds: changes.map((change) => change.testId),
+          fingerprints: changes.map((change) => change.fingerprint),
+          froms: changes.map((change) => change.from.toISOString()),
+        },
+      );
+
+      const totalByKey = new Map(
+        result.rows.map((row) => [
+          `${row.testId}|${row.fingerprint}|${new Date(row.from).getTime()}`,
+          Number(row.total),
+        ]),
+      );
+
+      return changes.map(
+        ({ testId, fingerprint, from }) =>
+          totalByKey.get(`${testId}|${fingerprint}|${from.getTime()}`) ?? 0,
+      );
+    },
+    { cacheKeyFn: (input) => JSON.stringify(input) },
+  );
+}
+
 function createTestAuditTrailLoader() {
   return new DataLoader<
     {
@@ -1500,6 +1604,8 @@ export const createLoaders = () => ({
   GithubRepository: createModelLoader(GithubRepository),
   GitlabProject: createModelLoader(GitlabProject),
   IgnoredChangeLoader: createIgnoredChangeLoader(),
+  LatestChangeDiffLoader: createLatestChangeDiffLoader(),
+  ChangeOccurrencesSinceLoader: createChangeOccurrencesSinceLoader(),
   LatestAutomationRun: createLatestAutomationRunLoader(),
   LatestDeploymentByProjectAndCommit:
     createLatestDeploymentByProjectAndCommitLoader(),

--- a/apps/frontend/src/containers/EmptyStateIllustrations.tsx
+++ b/apps/frontend/src/containers/EmptyStateIllustrations.tsx
@@ -1,0 +1,784 @@
+import { FlagOffIcon, GitBranchIcon, LockIcon } from "lucide-react";
+
+/**
+ * Feature illustrations for empty states.
+ *
+ * They share one visual language: neutral "surfaces" that read as product
+ * chrome, violet for whatever the feature acts on, and one supporting hue per
+ * scene. Every colour is a Radix CSS variable, which the `.dark` class
+ * re-points at the dark scale — so these follow the colour mode without a
+ * second set of assets.
+ */
+
+const SURFACE = "var(--gray-1)";
+const SURFACE_RAISED = "var(--gray-2)";
+const SURFACE_SUNKEN = "var(--gray-3)";
+const LINE = "var(--gray-6)";
+const LINE_SOFT = "var(--gray-4)";
+const CONTENT = "var(--gray-5)";
+const CONTENT_STRONG = "var(--gray-8)";
+const ACCENT = "var(--violet-9)";
+const ACCENT_DEEP = "var(--violet-10)";
+const ACCENT_SOFT = "var(--violet-3)";
+const ACCENT_MID = "var(--violet-5)";
+const ACCENT_LINE = "var(--violet-8)";
+const SUCCESS = "var(--grass-9)";
+const SUCCESS_SOFT = "var(--grass-4)";
+const WARNING = "var(--orange-9)";
+
+type IllustrationProps = { className?: string };
+
+function Frame(props: {
+  children: React.ReactNode;
+  className: string | undefined;
+}) {
+  return (
+    <svg
+      viewBox="0 0 320 208"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={props.className ?? "h-auto w-full"}
+    >
+      {props.children}
+    </svg>
+  );
+}
+
+/** Window chrome shared by the screenshot and browser scenes. */
+function TitleBar(props: {
+  x: number;
+  y: number;
+  width: number;
+  radius: number;
+  children?: React.ReactNode;
+}) {
+  const { x, y, width, radius, children } = props;
+  const height = 16;
+  return (
+    <>
+      <path
+        d={`M${x} ${y + radius}a${radius} ${radius} 0 0 1 ${radius} -${radius}h${width - radius * 2}a${radius} ${radius} 0 0 1 ${radius} ${radius}v${height - radius}H${x}Z`}
+        fill={SURFACE_SUNKEN}
+      />
+      <line
+        x1={x}
+        y1={y + height}
+        x2={x + width}
+        y2={y + height}
+        stroke={LINE}
+      />
+      {[10, 18, 26].map((offset) => (
+        <circle
+          key={offset}
+          cx={x + offset}
+          cy={y + 8}
+          r={2.5}
+          fill={CONTENT_STRONG}
+          opacity={0.5}
+        />
+      ))}
+      {children}
+    </>
+  );
+}
+
+/** Repeated text lines used as filler content inside the scenes. */
+function TextLines(props: {
+  x: number;
+  y: number;
+  widths: number[];
+  gap?: number;
+  fill?: string;
+  height?: number;
+}) {
+  const { x, y, widths, gap = 9, fill = CONTENT, height = 5 } = props;
+  return (
+    <>
+      {widths.map((width, index) => (
+        <rect
+          key={index}
+          x={x}
+          y={y + index * gap}
+          width={width}
+          height={height}
+          rx={height / 2}
+          fill={fill}
+        />
+      ))}
+    </>
+  );
+}
+
+/**
+ * A baseline and a candidate screenshot side by side, the differing region
+ * called out, over the run history that turns those diffs into a flakiness
+ * score.
+ */
+export function TestsIllustration(props: IllustrationProps) {
+  const history = [5, 8, 6, 20, 7, 6, 24, 8, 6, 9, 16, 7];
+
+  return (
+    <Frame className={props.className}>
+      <defs>
+        <linearGradient id="tests-diff" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={ACCENT_MID} />
+          <stop offset="100%" stopColor={ACCENT_SOFT} />
+        </linearGradient>
+      </defs>
+
+      {/* Baseline and candidate screenshots. */}
+      {[
+        { x: 14, isCompare: false },
+        { x: 168, isCompare: true },
+      ].map(({ x, isCompare }) => (
+        <g key={x}>
+          <rect
+            x={x}
+            y={10}
+            width={138}
+            height={116}
+            rx={9}
+            fill={SURFACE}
+            stroke={isCompare ? ACCENT_LINE : LINE}
+          />
+          <TitleBar x={x} y={10} width={138} radius={9}>
+            <rect
+              x={x + 36}
+              y={14}
+              width={54}
+              height={8}
+              rx={4}
+              fill={SURFACE}
+              stroke={LINE_SOFT}
+            />
+          </TitleBar>
+
+          {/* Hero image block. */}
+          <rect
+            x={x + 10}
+            y={36}
+            width={118}
+            height={38}
+            rx={5}
+            fill={SURFACE_RAISED}
+            stroke={LINE_SOFT}
+          />
+          <path d={`M${x + 12} 72l24-20 16 14 13-11 21 17Z`} fill={CONTENT} />
+
+          {/* The band that differs between the two shots. */}
+          <rect
+            x={x + 10}
+            y={80}
+            width={118}
+            height={20}
+            rx={4}
+            fill={isCompare ? "url(#tests-diff)" : SURFACE_RAISED}
+            stroke={isCompare ? ACCENT_LINE : LINE_SOFT}
+            strokeDasharray={isCompare ? "4 3" : undefined}
+          />
+          <TextLines
+            x={x + 17}
+            y={86}
+            widths={isCompare ? [72, 40] : [56, 30]}
+            gap={8}
+            height={4}
+            fill={isCompare ? ACCENT_LINE : CONTENT}
+          />
+          {/* Selection handles, only on the changed region. */}
+          {isCompare &&
+            [
+              [x + 10, 80],
+              [x + 128, 80],
+              [x + 10, 100],
+              [x + 128, 100],
+            ].map(([cx, cy]) => (
+              <rect
+                key={`${cx}-${cy}`}
+                x={(cx ?? 0) - 2.5}
+                y={(cy ?? 0) - 2.5}
+                width={5}
+                height={5}
+                rx={1}
+                fill={SURFACE}
+                stroke={ACCENT}
+                strokeWidth={1.5}
+              />
+            ))}
+
+          <TextLines x={x + 10} y={108} widths={[86, 58]} gap={8} height={4} />
+
+          {/* Baseline / changed badge. */}
+          <rect
+            x={x + 88}
+            y={0}
+            width={50}
+            height={16}
+            rx={8}
+            fill={isCompare ? ACCENT : SURFACE_SUNKEN}
+            stroke={isCompare ? ACCENT_DEEP : LINE}
+          />
+          <rect
+            x={x + 97}
+            y={6}
+            width={32}
+            height={4}
+            rx={2}
+            fill={isCompare ? "var(--violet-1)" : CONTENT_STRONG}
+            opacity={isCompare ? 0.9 : 0.7}
+          />
+        </g>
+      ))}
+
+      {/* Comparison arrows between the two shots. */}
+      <path
+        d="M158 60h6m0 0-4-4m4 4-4 4"
+        stroke={CONTENT_STRONG}
+        strokeWidth={1.6}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M162 78h-6m0 0 4-4m-4 4 4 4"
+        stroke={CONTENT_STRONG}
+        strokeWidth={1.6}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+
+      {/* Run history: how often this test changed, build over build. */}
+      <rect
+        x={14}
+        y={136}
+        width={292}
+        height={62}
+        rx={9}
+        fill={SURFACE_RAISED}
+        stroke={LINE}
+      />
+      <rect x={28} y={148} width={52} height={6} rx={3} fill={CONTENT_STRONG} />
+      <circle cx={276} cy={151} r={5} fill={WARNING} />
+      <rect x={288} y={148} width={18} height={6} rx={3} fill={CONTENT} />
+      {history.map((height, index) => {
+        const flagged = height > 12;
+        return (
+          <rect
+            key={index}
+            x={28 + index * 23.5}
+            y={186 - height}
+            width={13}
+            height={height}
+            rx={4}
+            fill={flagged ? WARNING : LINE}
+          />
+        );
+      })}
+      <line
+        x1={28}
+        y1={188}
+        x2={292}
+        y2={188}
+        stroke={LINE}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+      />
+    </Frame>
+  );
+}
+
+/**
+ * The deployed page itself, with its address, its branch, and the deployments
+ * that came before it.
+ */
+export function DeploymentsIllustration(props: IllustrationProps) {
+  return (
+    <Frame className={props.className}>
+      <defs>
+        <linearGradient id="deploy-hero" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor={ACCENT_MID} />
+          <stop offset="100%" stopColor={ACCENT_SOFT} />
+        </linearGradient>
+      </defs>
+
+      {/* Two earlier deployments, receding. */}
+      <rect
+        x={54}
+        y={8}
+        width={212}
+        height={120}
+        rx={10}
+        fill={SURFACE_RAISED}
+        stroke={LINE_SOFT}
+        opacity={0.55}
+      />
+      <rect
+        x={42}
+        y={18}
+        width={236}
+        height={124}
+        rx={10}
+        fill={SURFACE_RAISED}
+        stroke={LINE_SOFT}
+        opacity={0.8}
+      />
+
+      {/* The live one. */}
+      <rect
+        x={28}
+        y={28}
+        width={264}
+        height={124}
+        rx={11}
+        fill={SURFACE}
+        stroke={LINE}
+      />
+      <TitleBar x={28} y={28} width={264} radius={11}>
+        {/* Address bar with a padlock. */}
+        <rect
+          x={64}
+          y={32}
+          width={168}
+          height={9}
+          rx={4.5}
+          fill={SURFACE}
+          stroke={LINE_SOFT}
+        />
+        {/* Centred in the 9-unit address bar: 24 * 0.3 = 7.2 tall. */}
+        <g transform="translate(69, 32.9) scale(0.3)">
+          <LockIcon width={24} height={24} stroke={SUCCESS} strokeWidth={3} />
+        </g>
+        <rect
+          x={80}
+          y={35}
+          width={70}
+          height={3}
+          rx={1.5}
+          fill={CONTENT_STRONG}
+        />
+        <rect x={154} y={35} width={30} height={3} rx={1.5} fill={CONTENT} />
+      </TitleBar>
+
+      {/* Page navigation. */}
+      <rect x={40} y={54} width={22} height={6} rx={3} fill={CONTENT_STRONG} />
+      {[74, 104, 134].map((x) => (
+        <rect
+          key={x}
+          x={x}
+          y={55}
+          width={22}
+          height={4}
+          rx={2}
+          fill={CONTENT}
+        />
+      ))}
+      <rect
+        x={248}
+        y={52}
+        width={32}
+        height={10}
+        rx={5}
+        fill={ACCENT}
+        opacity={0.9}
+      />
+
+      {/* Hero + supporting copy. */}
+      <rect
+        x={40}
+        y={70}
+        width={110}
+        height={70}
+        rx={7}
+        fill="url(#deploy-hero)"
+        stroke={ACCENT_LINE}
+        strokeOpacity={0.4}
+      />
+      <circle cx={62} cy={92} r={7} fill={ACCENT} opacity={0.55} />
+      <path d="M46 134l24-22 16 15 14-11 22 18Z" fill={ACCENT} opacity={0.35} />
+      <TextLines x={162} y={74} widths={[118, 96]} gap={11} height={7} />
+      <TextLines
+        x={162}
+        y={100}
+        widths={[110, 118, 74]}
+        gap={9}
+        height={4}
+        fill={LINE_SOFT}
+      />
+      <rect x={162} y={130} width={44} height={10} rx={5} fill={CONTENT} />
+
+      {/* Branch and status chips. */}
+      <rect
+        x={28}
+        y={166}
+        width={150}
+        height={26}
+        rx={13}
+        fill={SURFACE_RAISED}
+        stroke={LINE}
+      />
+      {/* Centred in the 26-unit chip: 24 * 0.62 = 14.9 tall. */}
+      <g transform="translate(44, 173.5) scale(0.62)">
+        <GitBranchIcon
+          width={24}
+          height={24}
+          stroke={CONTENT_STRONG}
+          strokeWidth={2.2}
+        />
+      </g>
+      <rect
+        x={68}
+        y={176}
+        width={92}
+        height={5}
+        rx={2.5}
+        fill={CONTENT_STRONG}
+      />
+
+      <rect
+        x={190}
+        y={166}
+        width={102}
+        height={26}
+        rx={13}
+        fill={SUCCESS_SOFT}
+        stroke={SUCCESS}
+        strokeOpacity={0.45}
+      />
+      <circle cx={208} cy={179} r={5} fill={SUCCESS} />
+      <path
+        d="m205.6 179 1.7 1.8 3.3-3.4"
+        stroke="var(--grass-1)"
+        strokeWidth={1.4}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <rect x={220} y={176} width={56} height={5} rx={2.5} fill={SUCCESS} />
+    </Frame>
+  );
+}
+
+/**
+ * A rule on a canvas: an event comes in, a condition filters it, and a message
+ * goes out.
+ */
+export function AutomationsIllustration(props: IllustrationProps) {
+  const nodes = [
+    { x: 6, label: "when", widths: [28, 18] },
+    { x: 112, label: "if", widths: [32, 22] },
+  ];
+  return (
+    <Frame className={props.className}>
+      <defs>
+        <linearGradient id="automation-action" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor={ACCENT_MID} />
+          <stop offset="100%" stopColor={ACCENT_SOFT} />
+        </linearGradient>
+        <pattern
+          id="automation-grid"
+          width="16"
+          height="16"
+          patternUnits="userSpaceOnUse"
+        >
+          <circle cx="1" cy="1" r="1" fill={LINE_SOFT} />
+        </pattern>
+      </defs>
+
+      {/* Canvas the rule is laid out on. */}
+      <rect
+        x={4}
+        y={10}
+        width={312}
+        height={188}
+        rx={12}
+        fill="url(#automation-grid)"
+        opacity={0.7}
+      />
+
+      {/* Connectors. */}
+      {[86, 192].map((x) => (
+        <g key={x}>
+          <path
+            d={`M${x + 4} 74h14`}
+            stroke={CONTENT_STRONG}
+            strokeWidth={1.8}
+            strokeDasharray="4 4"
+            strokeLinecap="round"
+          />
+          <path
+            d={`M${x + 16} 69.5 L${x + 24} 74 L${x + 16} 78.5 Z`}
+            fill={CONTENT_STRONG}
+          />
+        </g>
+      ))}
+
+      {/* Trigger and condition nodes. */}
+      {nodes.map((node) => (
+        <g key={node.x}>
+          <rect
+            x={node.x}
+            y={44}
+            width={80}
+            height={60}
+            rx={9}
+            fill={SURFACE}
+            stroke={LINE}
+          />
+          <path
+            d={`M${node.x} 53a9 9 0 0 1 9-9h62a9 9 0 0 1 9 9v7H${node.x}Z`}
+            fill={SURFACE_SUNKEN}
+          />
+          <line x1={node.x} y1={60} x2={node.x + 80} y2={60} stroke={LINE} />
+          <rect
+            x={node.x + 10}
+            y={49}
+            width={node.label === "when" ? 26 : 14}
+            height={5}
+            rx={2.5}
+            fill={CONTENT_STRONG}
+          />
+          <circle cx={node.x + 19} cy={78} r={8} fill={SURFACE_SUNKEN} />
+          <circle cx={node.x + 19} cy={78} r={3.5} fill={CONTENT_STRONG} />
+          <TextLines
+            x={node.x + 33}
+            y={71}
+            widths={node.widths}
+            gap={9}
+            height={5}
+          />
+          <circle
+            cx={node.x + 80}
+            cy={74}
+            r={3.5}
+            fill={SURFACE}
+            stroke={CONTENT_STRONG}
+            strokeWidth={1.5}
+          />
+        </g>
+      ))}
+
+      {/* Action node, the one that fires. */}
+      <rect
+        x={218}
+        y={44}
+        width={80}
+        height={60}
+        rx={9}
+        fill="url(#automation-action)"
+        stroke={ACCENT_LINE}
+      />
+      <path
+        d="M218 53a9 9 0 0 1 9-9h62a9 9 0 0 1 9 9v7h-80Z"
+        fill={ACCENT}
+        opacity={0.22}
+      />
+      <line
+        x1={218}
+        y1={60}
+        x2={298}
+        y2={60}
+        stroke={ACCENT_LINE}
+        opacity={0.5}
+      />
+      <rect x={228} y={49} width={22} height={5} rx={2.5} fill={ACCENT_DEEP} />
+      <circle cx={237} cy={78} r={8} fill={ACCENT} />
+      <path
+        d="M233.5 78.5l2.5 2.5 4.5-5"
+        stroke="var(--violet-1)"
+        strokeWidth={1.6}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <TextLines
+        x={251}
+        y={71}
+        widths={[36, 24]}
+        gap={9}
+        height={5}
+        fill={ACCENT_LINE}
+      />
+
+      {/* The rule firing: rays fanning off the node's top-right corner, along
+          its diagonal. */}
+      {["M291 33l-3-9", "M300 36l6-8", "M306 44l10-4"].map((d) => (
+        <path
+          key={d}
+          d={d}
+          stroke={ACCENT}
+          strokeWidth={2.4}
+          strokeLinecap="round"
+        />
+      ))}
+
+      {/* The message it posts. */}
+      <rect
+        x={88}
+        y={130}
+        width={210}
+        height={56}
+        rx={9}
+        fill={SURFACE}
+        stroke={LINE}
+      />
+      <path
+        d="M240 104c0 16-90 8-108 24"
+        stroke={LINE}
+        strokeWidth={1.6}
+        strokeDasharray="4 4"
+        fill="none"
+      />
+      <rect x={100} y={142} width={22} height={22} rx={6} fill={ACCENT} />
+      <path
+        d="M106 153h10M106 149h10M106 157h6"
+        stroke="var(--violet-1)"
+        strokeWidth={1.4}
+        strokeLinecap="round"
+      />
+      <rect
+        x={132}
+        y={142}
+        width={54}
+        height={5}
+        rx={2.5}
+        fill={CONTENT_STRONG}
+      />
+      <rect x={192} y={142} width={26} height={5} rx={2.5} fill={LINE_SOFT} />
+      <TextLines
+        x={132}
+        y={154}
+        widths={[154, 112]}
+        gap={9}
+        height={4}
+        fill={CONTENT}
+      />
+    </Frame>
+  );
+}
+
+/**
+ * One change coming back build after build, and the rule that stops it from
+ * asking for review each time.
+ */
+export function IgnoredChangesIllustration(props: IllustrationProps) {
+  return (
+    <Frame className={props.className}>
+      <defs>
+        <linearGradient id="ignored-diff" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={ACCENT_MID} />
+          <stop offset="100%" stopColor={ACCENT_SOFT} />
+        </linearGradient>
+      </defs>
+
+      {/* The same change, coming back build after build. */}
+      {[
+        { x: 74, y: 34, opacity: 0.4 },
+        { x: 62, y: 24, opacity: 0.7 },
+      ].map((ghost) => (
+        <rect
+          key={ghost.x}
+          x={ghost.x}
+          y={ghost.y}
+          width={196}
+          height={112}
+          rx={10}
+          fill={SURFACE_RAISED}
+          stroke={LINE_SOFT}
+          opacity={ghost.opacity}
+        />
+      ))}
+
+      <rect
+        x={50}
+        y={14}
+        width={196}
+        height={116}
+        rx={10}
+        fill={SURFACE}
+        stroke={LINE}
+      />
+      <TitleBar x={50} y={14} width={196} radius={10}>
+        <rect
+          x={86}
+          y={18}
+          width={80}
+          height={8}
+          rx={4}
+          fill={SURFACE}
+          stroke={LINE_SOFT}
+        />
+      </TitleBar>
+
+      <TextLines x={66} y={44} widths={[104, 68]} gap={11} height={6} />
+
+      {/* The recurring diff, marked as handled rather than raised again. */}
+      <rect
+        x={66}
+        y={70}
+        width={164}
+        height={32}
+        rx={5}
+        fill="url(#ignored-diff)"
+        stroke={ACCENT_LINE}
+        strokeDasharray="5 3"
+      />
+      <TextLines
+        x={78}
+        y={79}
+        widths={[104, 66]}
+        gap={10}
+        height={5}
+        fill={ACCENT_LINE}
+      />
+      <TextLines x={66} y={110} widths={[76, 130]} gap={9} height={5} />
+
+      {/* Occurrence counter on the stack. */}
+      <rect
+        x={206}
+        y={2}
+        width={58}
+        height={22}
+        rx={11}
+        fill={SURFACE_SUNKEN}
+        stroke={LINE}
+      />
+      <circle cx={220} cy={13} r={4} fill={WARNING} />
+      <rect x={230} y={10} width={24} height={6} rx={3} fill={CONTENT_STRONG} />
+
+      {/* Muted badge, clear of the card so the glyph stays legible. */}
+      <circle
+        cx={48}
+        cy={112}
+        r={30}
+        fill={SURFACE}
+        stroke={LINE}
+        strokeWidth={2}
+      />
+      <g transform="translate(30, 94) scale(1.5)">
+        <FlagOffIcon width={24} height={24} stroke={ACCENT} strokeWidth={1.8} />
+      </g>
+
+      {/* Builds since: raised at first, then quietly skipped. */}
+      <line
+        x1={30}
+        y1={172}
+        x2={290}
+        y2={172}
+        stroke={LINE}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeDasharray="3 5"
+      />
+      {[30, 73, 116, 159, 202, 245, 290].map((cx, index) => {
+        const skipped = index >= 3;
+        return (
+          <circle
+            key={cx}
+            cx={cx}
+            cy={172}
+            r={skipped ? 5 : 6}
+            fill={skipped ? SURFACE : ACCENT}
+            stroke={skipped ? CONTENT_STRONG : ACCENT}
+            strokeWidth={1.5}
+          />
+        );
+      })}
+    </Frame>
+  );
+}

--- a/apps/frontend/src/containers/Team/Domains.tsx
+++ b/apps/frontend/src/containers/Team/Domains.tsx
@@ -173,7 +173,7 @@ function RemoveTeamDomainDialog(props: { teamDomain: TeamDomain }) {
       },
       onCompleted: () => {
         state.close();
-        toast.success("Domain removed");
+        toast.success("Domain removed", { id: "team-domain-removed" });
       },
     },
   );

--- a/apps/frontend/src/containers/Team/MsTeams.tsx
+++ b/apps/frontend/src/containers/Team/MsTeams.tsx
@@ -123,7 +123,9 @@ export function TeamMsTeams(props: { account: Account }) {
       },
     });
     form.reset({ name: "", url: "" });
-    toast.success("Microsoft Teams channel connected");
+    toast.success("Microsoft Teams channel connected", {
+      id: "ms-teams-connected",
+    });
   };
 
   return (
@@ -232,10 +234,13 @@ function WebhookActionsMenu(props: { webhook: MsTeamsWebhook }) {
   const [testWebhook, { loading }] = useMutation(TestMsTeamsWebhookMutation, {
     variables: { input: { id: webhook.id } },
     onCompleted: () => {
-      toast.success(`Test message sent to ${webhook.name}`);
+      toast.success(`Test message sent to ${webhook.name}`, {
+        id: `ms-teams-test:${webhook.id}`,
+      });
     },
     onError: (error) => {
-      toast.error(error.message);
+      // Same id as the success case, so retrying replaces the failure notice.
+      toast.error(error.message, { id: `ms-teams-test:${webhook.id}` });
     },
   });
   const label = `Actions for ${webhook.name}`;
@@ -263,7 +268,9 @@ function WebhookActionsMenu(props: { webhook: MsTeamsWebhook }) {
             <MenuItem
               onAction={() => {
                 clipboard.copy(webhook.url);
-                toast.success("Webhook URL copied to clipboard");
+                toast.success("Webhook URL copied to clipboard", {
+                  id: "ms-teams-webhook-copied",
+                });
               }}
             >
               <MenuItemIcon>
@@ -302,7 +309,9 @@ function DeleteWebhookDialog(props: { webhook: MsTeamsWebhook }) {
       variables: { input: { id: webhook.id } },
       onCompleted: () => {
         state.close();
-        toast.success("Microsoft Teams channel removed");
+        toast.success("Microsoft Teams channel removed", {
+          id: "ms-teams-removed",
+        });
       },
     },
   );

--- a/apps/frontend/src/containers/Team/members/InviteDialog.tsx
+++ b/apps/frontend/src/containers/Team/members/InviteDialog.tsx
@@ -112,7 +112,9 @@ export function InviteDialog(props: {
             },
           });
           state.close();
-          toast.success("Invitations sent successfully");
+          toast.success("Invitations sent successfully", {
+            id: "team-invites-sent",
+          });
         }}
         noValidate
       >
@@ -227,7 +229,9 @@ function ResetInviteLinkButton(props: {
           mutation: ResetInviteLinkMutation,
           variables: { teamAccountId: props.teamAccountId },
         });
-        toast.success("Invite link reset successfully");
+        toast.success("Invite link reset successfully", {
+          id: "team-invite-link-reset",
+        });
       }}
       variant="secondary"
       className="w-full justify-center"

--- a/apps/frontend/src/containers/User/Auth.tsx
+++ b/apps/frontend/src/containers/User/Auth.tsx
@@ -81,6 +81,9 @@ const RevokeAllSessionsMutation = graphql(`
 
 type Session = DocumentType<typeof _SessionFragment>;
 
+const SESSION_REVOKED_TOAST_ID = "session-revoked";
+const SESSIONS_REVOKED_TOAST_ID = "sessions-revoked";
+
 function getDeviceName(session: Session) {
   return session.deviceLabel ?? "Unknown device";
 }
@@ -133,7 +136,7 @@ function RevokeSessionDialog(props: { session: Session }) {
       variables: { id: session.id },
       onCompleted: () => {
         state.close();
-        toast.success("Session revoked");
+        toast.success("Session revoked", { id: SESSION_REVOKED_TOAST_ID });
       },
     },
   );
@@ -195,7 +198,9 @@ function RevokeAllSessionsDialog(props: { count: number }) {
     {
       onCompleted: () => {
         state.close();
-        toast.success("Sessions revoked");
+        toast.success("Sessions revoked", {
+          id: SESSIONS_REVOKED_TOAST_ID,
+        });
       },
     },
   );

--- a/apps/frontend/src/containers/User/NotificationPreferences.tsx
+++ b/apps/frontend/src/containers/User/NotificationPreferences.tsx
@@ -8,6 +8,12 @@ import { Switch } from "@/ui/Switch";
 import { toast } from "@/ui/Toaster";
 import { getErrorMessage } from "@/util/error";
 
+/**
+ * Shared by every preference switch: flipping several in a row should emphasize
+ * one toast rather than stack a column of identical ones.
+ */
+const PREFERENCES_TOAST_ID = "notification-preferences-updated";
+
 const _AccountFragment = graphql(`
   fragment UserNotificationPreferences_Account on User {
     id
@@ -84,10 +90,14 @@ export function UserNotificationPreferences(props: {
                       },
                     })
                     .then(() => {
-                      toast.success("Notification preferences updated.");
+                      toast.success("Notification preferences updated.", {
+                        id: PREFERENCES_TOAST_ID,
+                      });
                     })
                     .catch((error) => {
-                      toast.error(getErrorMessage(error));
+                      toast.error(getErrorMessage(error), {
+                        id: PREFERENCES_TOAST_ID,
+                      });
                     })
                     .finally(() => {
                       setPendingIds((ids) => {

--- a/apps/frontend/src/containers/User/OAuthApps.tsx
+++ b/apps/frontend/src/containers/User/OAuthApps.tsx
@@ -30,6 +30,8 @@ import { toast } from "@/ui/Toaster";
 
 import { formatList } from "../../util/intl";
 
+const ACCESS_REVOKED_TOAST_ID = "oauth-access-revoked";
+
 const _AccountFragment = graphql(`
   fragment OAuthApps_Account on User {
     id
@@ -118,7 +120,9 @@ function RevokeAppDialog(props: {
             try {
               await revoke();
               state.close();
-              toast.success("Access revoked");
+              toast.success("Access revoked", {
+                id: ACCESS_REVOKED_TOAST_ID,
+              });
             } catch {
               // Surfaced via the mutation's `error` state above.
             }

--- a/apps/frontend/src/containers/User/emails/AddUserEmailDialog.tsx
+++ b/apps/frontend/src/containers/User/emails/AddUserEmailDialog.tsx
@@ -59,6 +59,7 @@ export function AddUserEmailDialog() {
     });
     state.close();
     toast.success("Verification email sent", {
+      id: `verification-email:${data.email}`,
       description: (
         <>
           Follow the verification link sent to <strong>{data.email}</strong> to

--- a/apps/frontend/src/containers/User/emails/DeleteUserEmailDialog.tsx
+++ b/apps/frontend/src/containers/User/emails/DeleteUserEmailDialog.tsx
@@ -38,7 +38,7 @@ export function DeleteUserEmailDialog(props: DeleteUserEmailDialogProps) {
       variables: { email: props.email },
       onCompleted: () => {
         state.close();
-        toast.success("Email deleted");
+        toast.success("Email deleted", { id: "user-email-deleted" });
       },
     },
   );

--- a/apps/frontend/src/containers/User/emails/SendUserEmailVerificationButton.tsx
+++ b/apps/frontend/src/containers/User/emails/SendUserEmailVerificationButton.tsx
@@ -30,6 +30,7 @@ export function SendUserEmailVerificationButton(
       variables: { email: props.email },
       onCompleted: () => {
         toast.success("Verification email sent", {
+          id: `verification-email:${props.email}`,
           description: (
             <>
               Follow the verification link sent to{" "}

--- a/apps/frontend/src/containers/User/tokens/DeleteTokenDialog.tsx
+++ b/apps/frontend/src/containers/User/tokens/DeleteTokenDialog.tsx
@@ -48,7 +48,7 @@ export function DeleteTokenDialog(props: DeleteTokenDialogProps) {
       variables: { input: { id: props.id } },
       onCompleted: () => {
         state.close();
-        toast.success("Token deleted");
+        toast.success("Token deleted", { id: "token-deleted" });
       },
     },
   );

--- a/apps/frontend/src/containers/User/tokens/EditTokenDialog.tsx
+++ b/apps/frontend/src/containers/User/tokens/EditTokenDialog.tsx
@@ -57,7 +57,7 @@ export function EditTokenDialog(props: EditTokenDialogProps) {
       mutation: UpdateUserAccessTokenMutation,
       variables: { input: { id, name: data.name } },
     });
-    toast.success("Token name updated");
+    toast.success("Token name updated", { id: "token-updated" });
     state.close();
   };
 

--- a/apps/frontend/src/pages/Automation/AutomationTestNotification.tsx
+++ b/apps/frontend/src/pages/Automation/AutomationTestNotification.tsx
@@ -82,7 +82,9 @@ function useTestAutomation(props: UseTestAutomationProps) {
               actions: data.actions,
             },
           });
-          toast.success("Test notification sent");
+          toast.success("Test notification sent", {
+            id: "automation-test-notification",
+          });
         } catch (error) {
           handleFormError(form, error);
         }

--- a/apps/frontend/src/pages/Automation/index.tsx
+++ b/apps/frontend/src/pages/Automation/index.tsx
@@ -1,15 +1,19 @@
 import { useSuspenseQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
-import { BoxesIcon, PlusCircleIcon } from "lucide-react";
+import { FilterIcon, PlusCircleIcon, SendIcon, ZapIcon } from "lucide-react";
 import { Heading, Text } from "react-aria-components";
 import { useParams } from "react-router-dom";
 
+import { AutomationsIllustration } from "@/containers/EmptyStateIllustrations";
 import { DocumentType, graphql } from "@/gql";
 import { ButtonIcon, LinkButton, LinkButtonProps } from "@/ui/Button";
 import {
   EmptyState,
   EmptyStateActions,
-  EmptyStateIcon,
+  EmptyStateIllustration,
+  EmptyStateLearnMore,
+  EmptyStateStep,
+  EmptyStateSteps,
   Page,
   PageContainer,
   PageHeader,
@@ -126,16 +130,44 @@ function PageContentFound(props: { project: ProjectDocument }) {
     <>
       {project.automationRules.pageInfo.totalCount === 0 ? (
         <EmptyState>
-          <EmptyStateIcon>
-            <BoxesIcon strokeWidth={1} />
-          </EmptyStateIcon>
-          <Heading>No automations</Heading>
+          <EmptyStateIllustration>
+            <AutomationsIllustration />
+          </EmptyStateIllustration>
+          <Heading>No automations yet</Heading>
           <Text slot="description">
-            There are no automations yet on this project.
+            An automation watches for something happening on this project and
+            reacts to it, so nobody has to notice and relay it by hand.
           </Text>
           <EmptyStateActions>
             <AddAutomationButton />
           </EmptyStateActions>
+          <EmptyStateLearnMore href="https://argos-ci.com/docs" />
+          <EmptyStateSteps>
+            <EmptyStateStep
+              icon={<ZapIcon />}
+              step="When"
+              title="Pick a trigger"
+            >
+              Start from a build event — a review submitted, a build failing, an
+              auto-approved build finishing.
+            </EmptyStateStep>
+            <EmptyStateStep
+              icon={<FilterIcon />}
+              step="If"
+              title="Narrow it down"
+            >
+              Add conditions so the rule only fires on the branches or build
+              names you actually care about.
+            </EmptyStateStep>
+            <EmptyStateStep
+              icon={<SendIcon />}
+              step="Then"
+              title="Send it somewhere"
+            >
+              Post to Slack or Microsoft Teams, so the right channel hears about
+              it the moment it happens.
+            </EmptyStateStep>
+          </EmptyStateSteps>
         </EmptyState>
       ) : (
         <>

--- a/apps/frontend/src/pages/Automation/index.tsx
+++ b/apps/frontend/src/pages/Automation/index.tsx
@@ -141,7 +141,7 @@ function PageContentFound(props: { project: ProjectDocument }) {
           <EmptyStateActions>
             <AddAutomationButton />
           </EmptyStateActions>
-          <EmptyStateLearnMore href="https://argos-ci.com/docs" />
+          <EmptyStateLearnMore href="https://argos-ci.com/docs/learn/review-workflow/automations" />
           <EmptyStateSteps>
             <EmptyStateStep
               icon={<ZapIcon />}

--- a/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentCard.tsx
@@ -338,13 +338,18 @@ export function CommentCard(props: {
     }
   };
 
+  const subscriptionToastId = `comment-thread-subscription:${comment.id}`;
+  const resolutionToastId = `comment-thread-resolution:${comment.id}`;
+
   const subscribeThread = () => {
     subscribeToCommentThread()
       .then(() => {
-        toast.success("You will receive notifications for this thread.");
+        toast.success("You will receive notifications for this thread.", {
+          id: subscriptionToastId,
+        });
       })
       .catch((error) => {
-        toast.error(getErrorMessage(error));
+        toast.error(getErrorMessage(error), { id: subscriptionToastId });
       });
   };
 
@@ -353,10 +358,11 @@ export function CommentCard(props: {
       .then(() => {
         toast.success(
           "You will no longer receive notifications for this thread.",
+          { id: subscriptionToastId },
         );
       })
       .catch((error) => {
-        toast.error(getErrorMessage(error));
+        toast.error(getErrorMessage(error), { id: subscriptionToastId });
       });
   };
 
@@ -364,18 +370,18 @@ export function CommentCard(props: {
     if (resolved) {
       unresolveCommentThread()
         .then(() => {
-          toast.success("Thread reopened.");
+          toast.success("Thread reopened.", { id: resolutionToastId });
         })
         .catch((error) => {
-          toast.error(getErrorMessage(error));
+          toast.error(getErrorMessage(error), { id: resolutionToastId });
         });
     } else {
       resolveCommentThread()
         .then(() => {
-          toast.success("Thread resolved.");
+          toast.success("Thread resolved.", { id: resolutionToastId });
         })
         .catch((error) => {
-          toast.error(getErrorMessage(error));
+          toast.error(getErrorMessage(error), { id: resolutionToastId });
         });
     }
   };

--- a/apps/frontend/src/pages/Build/sidebar/CommentReactions.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentReactions.tsx
@@ -77,16 +77,18 @@ function useReactionActions(commentId: string) {
       variables: { input: { commentId, emoji } },
     });
 
+  const reactionToastId = `comment-reaction:${commentId}`;
+
   const react = (emoji: string) => {
     addReaction(emoji).catch((error) => {
-      toast.error(getErrorMessage(error));
+      toast.error(getErrorMessage(error), { id: reactionToastId });
     });
   };
 
   const toggle = (group: ReactionGroup) => {
     const mutation = group.reactedByMe ? removeReaction : addReaction;
     mutation(group.emoji).catch((error) => {
-      toast.error(getErrorMessage(error));
+      toast.error(getErrorMessage(error), { id: reactionToastId });
     });
   };
 

--- a/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewActivitySection.tsx
@@ -410,24 +410,28 @@ function SubscribeToggleButton(props: { build: Build }) {
     });
   const subscribed = build.subscribed;
   const label = subscribed ? "Unsubscribe" : "Subscribe";
+  const subscriptionToastId = `build-subscription:${build.id}`;
   const handlePress = () => {
     if (subscribed) {
       unsubscribeFromBuild()
         .then(() => {
           toast.success(
             "You will no longer receive notifications for this build.",
+            { id: subscriptionToastId },
           );
         })
         .catch((error) => {
-          toast.error(getErrorMessage(error));
+          toast.error(getErrorMessage(error), { id: subscriptionToastId });
         });
     } else {
       subscribeToBuild()
         .then(() => {
-          toast.success("You will receive notifications for this build.");
+          toast.success("You will receive notifications for this build.", {
+            id: subscriptionToastId,
+          });
         })
         .catch((error) => {
-          toast.error(getErrorMessage(error));
+          toast.error(getErrorMessage(error), { id: subscriptionToastId });
         });
     }
   };

--- a/apps/frontend/src/pages/Project/Builds.tsx
+++ b/apps/frontend/src/pages/Project/Builds.tsx
@@ -234,11 +234,22 @@ function BuildsList(props: {
       lastItem &&
       lastItem.index === displayCount &&
       !isFetchingMore &&
-      hasNextPage
+      hasNextPage &&
+      // While the filters are mid-change the rendered list still belongs to the
+      // previous ones, so `edges.length` is the wrong offset: paging here would
+      // append the old query's second page to the new query's first.
+      !isUpdating
     ) {
       fetchNextPage();
     }
-  }, [lastItem, displayCount, isFetchingMore, hasNextPage, fetchNextPage]);
+  }, [
+    lastItem,
+    displayCount,
+    isFetchingMore,
+    hasNextPage,
+    isUpdating,
+    fetchNextPage,
+  ]);
 
   return (
     <List

--- a/apps/frontend/src/pages/Project/Deployments.tsx
+++ b/apps/frontend/src/pages/Project/Deployments.tsx
@@ -412,7 +412,7 @@ function PageContent() {
             Argos can track where each build was deployed, so a review links
             straight to the running site the screenshots came from.
           </Text>
-          <EmptyStateLearnMore href="https://argos-ci.com/docs" />
+          <EmptyStateLearnMore href="https://argos-ci.com/docs/learn/deployments" />
           <EmptyStateSteps>
             <EmptyStateStep
               icon={<UploadCloudIcon />}

--- a/apps/frontend/src/pages/Project/Deployments.tsx
+++ b/apps/frontend/src/pages/Project/Deployments.tsx
@@ -4,18 +4,25 @@ import { invariant } from "@argos/util/invariant";
 import { GitBranchIcon, GitCommitIcon } from "@primer/octicons-react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import clsx from "clsx";
-import { BoxesIcon, CircleArrowUpIcon, GlobeIcon } from "lucide-react";
+import {
+  CircleArrowUpIcon,
+  ExternalLinkIcon,
+  GlobeIcon,
+  UploadCloudIcon,
+} from "lucide-react";
 import { Heading, Text } from "react-aria-components";
 
+import { DeploymentsIllustration } from "@/containers/EmptyStateIllustrations";
 import { PullRequestButton } from "@/containers/PullRequestButton";
 import { DocumentType, graphql } from "@/gql";
 import type { DeploymentEnvironment, DeploymentStatus } from "@/gql/graphql";
-import { LinkButton } from "@/ui/Button";
 import { Chip } from "@/ui/Chip";
 import {
   EmptyState,
-  EmptyStateActions,
-  EmptyStateIcon,
+  EmptyStateIllustration,
+  EmptyStateLearnMore,
+  EmptyStateStep,
+  EmptyStateSteps,
   Page,
   PageContainer,
   PageHeader,
@@ -397,16 +404,41 @@ function PageContent() {
     return (
       <PageContainer>
         <EmptyState>
-          <EmptyStateIcon>
-            <BoxesIcon strokeWidth={1} />
-          </EmptyStateIcon>
-          <Heading>No deployments</Heading>
+          <EmptyStateIllustration>
+            <DeploymentsIllustration />
+          </EmptyStateIllustration>
+          <Heading>No deployments yet</Heading>
           <Text slot="description">
-            There are no deployments yet on this project.
+            Argos can track where each build was deployed, so a review links
+            straight to the running site the screenshots came from.
           </Text>
-          <EmptyStateActions>
-            <LinkButton href="/">Back to home</LinkButton>
-          </EmptyStateActions>
+          <EmptyStateLearnMore href="https://argos-ci.com/docs" />
+          <EmptyStateSteps>
+            <EmptyStateStep
+              icon={<UploadCloudIcon />}
+              step="From your CI"
+              title="Report a deployment"
+            >
+              Tell Argos the URL and environment your branch was deployed to,
+              alongside the build it belongs to.
+            </EmptyStateStep>
+            <EmptyStateStep
+              icon={<GitBranchIcon />}
+              step="Per branch"
+              title="Follow every preview"
+            >
+              Each branch keeps its own history, so you can see which commit is
+              live on a preview and which one is in production.
+            </EmptyStateStep>
+            <EmptyStateStep
+              icon={<ExternalLinkIcon />}
+              step="Back here"
+              title="Jump to the real page"
+            >
+              Open the deployed page next to its build, instead of guessing
+              which environment a screenshot came from.
+            </EmptyStateStep>
+          </EmptyStateSteps>
         </EmptyState>
       </PageContainer>
     );

--- a/apps/frontend/src/pages/Project/IgnoredChanges.tsx
+++ b/apps/frontend/src/pages/Project/IgnoredChanges.tsx
@@ -75,6 +75,10 @@ import {
 import { ProjectTitle } from "./ProjectTitle";
 
 const DOCS_URL =
+  "https://argos-ci.com/docs/learn/reliability-and-flakiness/ignored-changes";
+
+/** The page that documents the per-project ignore configuration. */
+const FLAKY_DETECTION_DOCS_URL =
   "https://argos-ci.com/docs/learn/reliability-and-flakiness/flaky-test-detection";
 
 const ProjectIgnoredChangesQuery = graphql(`
@@ -406,7 +410,7 @@ function FeatureDisabledEmptyState(props: { params: ProjectParams }) {
           </LinkButton>
         </EmptyStateActions>
       )}
-      <EmptyStateLearnMore href={DOCS_URL} />
+      <EmptyStateLearnMore href={FLAKY_DETECTION_DOCS_URL} />
     </EmptyState>
   );
 }

--- a/apps/frontend/src/pages/Project/IgnoredChanges.tsx
+++ b/apps/frontend/src/pages/Project/IgnoredChanges.tsx
@@ -1,0 +1,818 @@
+import { useEffect, useRef, useTransition } from "react";
+import {
+  useApolloClient,
+  useMutation,
+  useSuspenseQuery,
+} from "@apollo/client/react";
+import { invariant } from "@argos/util/invariant";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import clsx from "clsx";
+import {
+  BookOpenIcon,
+  FlagOffIcon,
+  SettingsIcon,
+  SlidersHorizontalIcon,
+  WavesIcon,
+  ZapIcon,
+} from "lucide-react";
+import { useNumberFormatter } from "react-aria";
+import { Heading, Text } from "react-aria-components";
+
+import { AccountAvatar } from "@/containers/AccountAvatar";
+import {
+  constraintSize,
+  DiffCard,
+  SingleImage,
+} from "@/containers/Build/BuildDiffListPrimitives";
+import { IgnoredChangesIllustration } from "@/containers/EmptyStateIllustrations";
+import { graphql, type DocumentType } from "@/gql";
+import { ProjectPermission, UserType } from "@/gql/graphql";
+import { Button, ButtonIcon, LinkButton } from "@/ui/Button";
+import { Chip } from "@/ui/Chip";
+import {
+  Dialog,
+  DialogActionButton,
+  DialogBody,
+  DialogDismiss,
+  DialogFooter,
+  DialogText,
+  DialogTitle,
+  useDialogValueState,
+  useOverlayTriggerState,
+} from "@/ui/Dialog";
+import { ErrorMessage } from "@/ui/ErrorMessage";
+import {
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateIcon,
+  EmptyStateIllustration,
+  EmptyStateLearnMore,
+  EmptyStateStep,
+  EmptyStateSteps,
+  Page,
+  PageContainer,
+  PageHeader,
+  PageHeaderContent,
+} from "@/ui/Layout";
+import { HeadlessLink, Link } from "@/ui/Link";
+import { List, ListHeaderRow, ListRow, ListRowLoader } from "@/ui/List";
+import { Modal } from "@/ui/Modal";
+import { Time } from "@/ui/Time";
+import { toast } from "@/ui/Toaster";
+import { Tooltip, TooltipContainer, TooltipHeader } from "@/ui/Tooltip";
+import { Truncable } from "@/ui/Truncable";
+import { useEventCallback } from "@/ui/useEventCallback";
+import { getUserCardData, UserHoverCard } from "@/ui/UserCard";
+
+import { NotFound } from "../NotFound";
+import { getTestURL } from "../Test/TestParams";
+import { useProjectOutletContext } from "./ProjectOutletContext";
+import {
+  getProjectURL,
+  useProjectParams,
+  type ProjectParams,
+} from "./ProjectParams";
+import { ProjectTitle } from "./ProjectTitle";
+
+const DOCS_URL =
+  "https://argos-ci.com/docs/learn/reliability-and-flakiness/flaky-test-detection";
+
+const ProjectIgnoredChangesQuery = graphql(`
+  query ProjectIgnoredChanges_project(
+    $accountSlug: String!
+    $projectName: String!
+    $after: Int!
+    $first: Int!
+  ) {
+    project(accountSlug: $accountSlug, projectName: $projectName) {
+      id
+      ignoreConfig {
+        enabled
+      }
+      ignoredChanges(after: $after, first: $first) {
+        pageInfo {
+          totalCount
+          hasNextPage
+        }
+        edges {
+          id
+          ...IgnoredChangeRow_TestChange
+        }
+      }
+    }
+  }
+`);
+
+const _IgnoredChangeFragment = graphql(`
+  fragment IgnoredChangeRow_TestChange on TestChange {
+    id
+    ignoredAt
+    occurrencesSinceIgnored
+    ignoredBy {
+      id
+      name
+      slug
+      type
+      avatar {
+        ...AccountAvatarFragment
+      }
+      ...UserCard_user
+    }
+    test {
+      id
+      name
+      buildName
+    }
+    lastSeenDiff {
+      id
+      createdAt
+      url
+      width
+      height
+      contentType
+    }
+  }
+`);
+
+type ProjectIgnoredChangesDocument = DocumentType<
+  typeof ProjectIgnoredChangesQuery
+>;
+type IgnoredChanges = NonNullable<
+  ProjectIgnoredChangesDocument["project"]
+>["ignoredChanges"];
+type IgnoredChange = DocumentType<typeof _IgnoredChangeFragment>;
+
+/**
+ * Both mutations select the fields the ledger row renders, so that undoing an
+ * unignore refreshes the restored row through normalization instead of leaving
+ * it showing the previous ignore's date and count.
+ */
+const UnignoreChangeMutation = graphql(`
+  mutation ProjectIgnoredChanges_unignoreChange(
+    $accountSlug: String!
+    $changeId: ID!
+  ) {
+    unignoreChange(input: { accountSlug: $accountSlug, changeId: $changeId }) {
+      id
+      ignored
+      ignoredAt
+      occurrencesSinceIgnored
+    }
+  }
+`);
+
+const IgnoreChangeMutation = graphql(`
+  mutation ProjectIgnoredChanges_ignoreChange(
+    $accountSlug: String!
+    $changeId: ID!
+  ) {
+    ignoreChange(input: { accountSlug: $accountSlug, changeId: $changeId }) {
+      id
+      ignored
+      ignoredAt
+      occurrencesSinceIgnored
+    }
+  }
+`);
+
+/**
+ * Add or drop a change from the project's ignore ledger in the cache, so the
+ * list reacts without refetching and losing the pages already loaded.
+ */
+function updateIgnoredChangesCache(options: {
+  cache: ReturnType<typeof useApolloClient>["cache"];
+  projectId: string;
+  changeId: string;
+  operation: "remove" | "restore";
+}) {
+  const { cache, projectId, changeId, operation } = options;
+  const cacheId = cache.identify({ __typename: "Project", id: projectId });
+  if (!cacheId) {
+    return;
+  }
+  cache.modify({
+    id: cacheId,
+    fields: {
+      ignoredChanges(existing, { readField, toReference }) {
+        if (!existing) {
+          return existing;
+        }
+        const edges = existing.edges.filter(
+          (edge: Parameters<typeof readField>[1]) =>
+            readField("id", edge) !== changeId,
+        );
+        if (operation === "restore") {
+          const ref = toReference({ __typename: "TestChange", id: changeId });
+          if (!ref) {
+            return existing;
+          }
+          // Re-ignoring makes it the most recently ignored change, which is the
+          // top of this list.
+          edges.unshift(ref);
+        }
+        const totalCount =
+          operation === "restore"
+            ? existing.pageInfo.totalCount + 1
+            : Math.max(existing.pageInfo.totalCount - 1, 0);
+        return {
+          ...existing,
+          edges,
+          pageInfo: {
+            ...existing.pageInfo,
+            totalCount,
+            isEmpty: totalCount === 0,
+          },
+        };
+      },
+    },
+  });
+}
+
+export function Component() {
+  const params = useProjectParams();
+  invariant(params, "it is a project route");
+
+  return (
+    <Page>
+      <ProjectTitle params={params}>Ignored</ProjectTitle>
+      <PageContent params={params} />
+    </Page>
+  );
+}
+
+/** The change a confirmation dialog is currently asking about. */
+type UnignoreValue = { changeId: string; testName: string };
+
+function PageContent(props: { params: ProjectParams }) {
+  const { params } = props;
+  const { fetchMore, data } = useSuspenseQuery(ProjectIgnoredChangesQuery, {
+    variables: {
+      accountSlug: params.accountSlug,
+      projectName: params.projectName,
+      after: 0,
+      first: 30,
+    },
+  });
+  const client = useApolloClient();
+  const project = data.project;
+  const ignoredChanges = project?.ignoredChanges;
+  // Held as state rather than rendered per row: removing the row on success
+  // would unmount the dialog mid-animation.
+  const unignoring = useDialogValueState<UnignoreValue | null>(null);
+  const [isFetchingMore, startFetchMoreTransition] = useTransition();
+  const fetchNextPage = useEventCallback(() => {
+    invariant(ignoredChanges);
+    startFetchMoreTransition(() => {
+      fetchMore({
+        variables: { after: ignoredChanges.edges.length },
+        updateQuery: (prev, { fetchMoreResult }) => {
+          if (
+            !prev.project?.ignoredChanges.edges ||
+            !fetchMoreResult?.project?.ignoredChanges
+          ) {
+            return fetchMoreResult;
+          }
+
+          return {
+            ...prev,
+            project: {
+              ...prev.project,
+              ignoredChanges: {
+                ...prev.project.ignoredChanges,
+                ...fetchMoreResult.project.ignoredChanges,
+                edges: [
+                  ...prev.project.ignoredChanges.edges,
+                  ...fetchMoreResult.project.ignoredChanges.edges,
+                ],
+              },
+            },
+          };
+        },
+      });
+    });
+  });
+
+  const projectId = project?.id;
+
+  // Runs from a toast, which outlives this component's dialog, so it goes
+  // through the client rather than a `useMutation` bound to a mounted tree.
+  const undoUnignore = useEventCallback((changeId: string) => {
+    invariant(projectId);
+    client
+      .mutate({
+        mutation: IgnoreChangeMutation,
+        variables: { accountSlug: params.accountSlug, changeId },
+        update: (cache) =>
+          updateIgnoredChangesCache({
+            cache,
+            projectId,
+            changeId,
+            operation: "restore",
+          }),
+      })
+      .then(
+        () =>
+          toast.success("Change ignored again", {
+            id: `ignore-change:${changeId}`,
+          }),
+        () =>
+          toast.error("Could not restore the ignored change", {
+            id: `ignore-change:${changeId}`,
+          }),
+      );
+  });
+
+  if (!project || !ignoredChanges) {
+    return <NotFound />;
+  }
+
+  if (!project.ignoreConfig.enabled) {
+    return (
+      <PageContainer>
+        <FeatureDisabledEmptyState params={params} />
+      </PageContainer>
+    );
+  }
+
+  return (
+    <PageContainer>
+      {ignoredChanges.pageInfo.totalCount === 0 ? (
+        <NothingIgnoredEmptyState params={params} />
+      ) : (
+        <>
+          <PageHeader>
+            <PageHeaderContent>
+              <Heading>Ignored changes</Heading>
+              <Text slot="headline">
+                Changes Argos no longer asks you to review, most recently
+                ignored first. Unignore one to start tracking it again.
+              </Text>
+            </PageHeaderContent>
+          </PageHeader>
+          <div className="relative flex-1">
+            <IgnoredChangesList
+              ignoredChanges={ignoredChanges}
+              params={params}
+              isFetchingMore={isFetchingMore}
+              fetchNextPage={fetchNextPage}
+              onUnignore={(value) => unignoring.open(value)}
+            />
+          </div>
+        </>
+      )}
+      {unignoring.value ? (
+        <Modal
+          isOpen={unignoring.isOpen}
+          onOpenChange={unignoring.onOpenChange}
+        >
+          <UnignoreChangeDialog
+            projectId={project.id}
+            params={params}
+            changeId={unignoring.value.changeId}
+            testName={unignoring.value.testName}
+            onUndo={undoUnignore}
+          />
+        </Modal>
+      ) : null}
+    </PageContainer>
+  );
+}
+
+/**
+ * Shown when the ignore feature is off. The tab is hidden in that case, so this
+ * is only reached through a direct link or a bookmark — it explains the state
+ * rather than pretending the list is simply empty.
+ */
+function FeatureDisabledEmptyState(props: { params: ProjectParams }) {
+  const { permissions } = useProjectOutletContext();
+  const canViewSettings = permissions.includes(ProjectPermission.ViewSettings);
+  return (
+    <EmptyState>
+      <EmptyStateIcon>
+        <SlidersHorizontalIcon strokeWidth={1} />
+      </EmptyStateIcon>
+      <Heading>Ignoring is turned off</Heading>
+      <Text slot="description">
+        New builds on this project ignore nothing — every change is treated as
+        needing review. Turn the feature on to let reviewers mute recurring
+        flaky changes.
+      </Text>
+      {canViewSettings && (
+        <EmptyStateActions>
+          <LinkButton
+            href={`${getProjectURL(props.params)}/settings/flaky-detection`}
+          >
+            Turn on ignoring
+          </LinkButton>
+        </EmptyStateActions>
+      )}
+      <EmptyStateLearnMore href={DOCS_URL} />
+    </EmptyState>
+  );
+}
+
+/**
+ * The empty state that carries the feature's explanation: most people land here
+ * before they have ever ignored anything, so it has to teach the mental model
+ * (an exact diff match, not a whole test) and point at where the action lives.
+ */
+function NothingIgnoredEmptyState(props: { params: ProjectParams }) {
+  const { permissions } = useProjectOutletContext();
+  const canViewSettings = permissions.includes(ProjectPermission.ViewSettings);
+  return (
+    <EmptyState>
+      <EmptyStateIllustration>
+        <IgnoredChangesIllustration />
+      </EmptyStateIllustration>
+      <Heading>Nothing is ignored yet</Heading>
+      <Text slot="description">
+        Ignoring a change tells Argos to stop asking you to review it. Reach for
+        it when a diff is flaky — the kind that keeps coming back build after
+        build without anything really changing.
+      </Text>
+      {canViewSettings && (
+        <EmptyStateActions>
+          <LinkButton
+            variant="secondary"
+            href={`${getProjectURL(props.params)}/settings/flaky-detection`}
+          >
+            <ButtonIcon>
+              <SettingsIcon />
+            </ButtonIcon>
+            Configure auto-ignore
+          </LinkButton>
+        </EmptyStateActions>
+      )}
+      <EmptyStateLearnMore href={DOCS_URL} />
+      <EmptyStateSteps>
+        <EmptyStateStep
+          icon={<FlagOffIcon />}
+          step="While reviewing"
+          title="Flag the change"
+        >
+          Use the flag button in the build review toolbar, on the diff you don’t
+          want to see again.
+        </EmptyStateStep>
+        <EmptyStateStep
+          icon={<WavesIcon />}
+          step="On later builds"
+          title="Argos matches it exactly"
+        >
+          Only diffs whose fingerprint is identical are skipped. A real change
+          to the same test still shows up.
+        </EmptyStateStep>
+        <EmptyStateStep
+          icon={<BookOpenIcon />}
+          step="Back here"
+          title="Keep the list honest"
+        >
+          Every ignored change lands on this page with how often it still fires,
+          so you can unignore the ones that went quiet.
+        </EmptyStateStep>
+      </EmptyStateSteps>
+    </EmptyState>
+  );
+}
+
+const DIFF_IMAGE_CONFIG = {
+  maxWidth: 112,
+  maxHeight: 56,
+  defaultHeight: 56,
+};
+
+function IgnoredChangesList(props: {
+  ignoredChanges: IgnoredChanges;
+  params: ProjectParams;
+  isFetchingMore: boolean;
+  fetchNextPage: () => void;
+  onUnignore: (value: UnignoreValue) => void;
+}) {
+  const { ignoredChanges, params, isFetchingMore, fetchNextPage, onUnignore } =
+    props;
+  const parentRef = useRef<HTMLDivElement>(null);
+  const { hasNextPage } = ignoredChanges.pageInfo;
+  const displayCount = ignoredChanges.edges.length;
+  const rowVirtualizer = useVirtualizer({
+    count: hasNextPage ? displayCount + 1 : displayCount,
+    estimateSize: () => 75,
+    getScrollElement: () => parentRef.current,
+    overscan: 20,
+    getItemKey: (index) => ignoredChanges.edges[index]?.id ?? "loader",
+  });
+
+  const virtualItems = rowVirtualizer.getVirtualItems();
+  const lastItem = virtualItems[virtualItems.length - 1];
+  useEffect(() => {
+    if (
+      lastItem &&
+      lastItem.index === displayCount &&
+      !isFetchingMore &&
+      hasNextPage
+    ) {
+      fetchNextPage();
+    }
+  }, [lastItem, displayCount, isFetchingMore, hasNextPage, fetchNextPage]);
+
+  return (
+    <List className="absolute max-h-full w-full overflow-hidden">
+      <ListHeaderRow>
+        <div className="flex-1 truncate">Change</div>
+        <div className="w-44">Ignored</div>
+        <div className="w-24 text-right">
+          <Tooltip
+            content={
+              <>
+                Number of auto-approved builds that have shown this exact change
+                since it was ignored — the review noise it has absorbed.
+              </>
+            }
+          >
+            <span className="underline-emphasis">Occurrences</span>
+          </Tooltip>
+        </div>
+        <div className="w-28 text-right">
+          <Tooltip
+            content={
+              <>
+                Last build in which this exact change appeared. A change that
+                went quiet is a good candidate to unignore.
+              </>
+            }
+          >
+            <span className="underline-emphasis">Last seen</span>
+          </Tooltip>
+        </div>
+        <div className="w-24" />
+      </ListHeaderRow>
+      <div ref={parentRef} className="overflow-auto">
+        <div
+          className="relative"
+          style={{ height: rowVirtualizer.getTotalSize() }}
+        >
+          {virtualItems.map((virtualRow) => {
+            const ignoredChange = ignoredChanges.edges[virtualRow.index];
+            const style = {
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: "100%",
+              height: virtualRow.size,
+              transform: `translateY(${virtualRow.start}px)`,
+            } as const;
+
+            if (!ignoredChange) {
+              return (
+                <ListRowLoader key={virtualRow.key} style={style}>
+                  Fetching ignored changes...
+                </ListRowLoader>
+              );
+            }
+
+            return (
+              <IgnoredChangeRow
+                key={virtualRow.key}
+                ignoredChange={ignoredChange}
+                params={params}
+                style={style}
+                onUnignore={onUnignore}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </List>
+  );
+}
+
+function IgnoredChangeRow(props: {
+  ignoredChange: IgnoredChange;
+  params: ProjectParams;
+  style: React.CSSProperties;
+  onUnignore: (value: UnignoreValue) => void;
+}) {
+  const { ignoredChange, params, style, onUnignore } = props;
+  const { permissions } = useProjectOutletContext();
+  const compactFormatter = useNumberFormatter({ notation: "compact" });
+  const { test, lastSeenDiff, ignoredBy } = ignoredChange;
+  const testURL = getTestURL(
+    { ...params, testId: test.id },
+    { change: ignoredChange.id },
+  );
+  const thumbnailURL = lastSeenDiff?.url ?? null;
+
+  return (
+    <ListRow
+      // `ListRowLink` can't be used here — the row holds a button as well as a
+      // link — so the hover and focus feedback it provides is rebuilt by hand,
+      // and the link is stretched over the row so the whole row is clickable
+      // rather than just its first cell.
+      className="group/row hover:bg-hover has-[a:focus-visible]:bg-hover relative flex items-center gap-6 p-4 text-sm"
+      style={style}
+    >
+      <HeadlessLink
+        href={testURL}
+        className="flex min-w-0 flex-1 gap-4 truncate after:absolute after:inset-0 focus:outline-hidden"
+      >
+        {lastSeenDiff && thumbnailURL ? (
+          <DiffCard
+            isActive={false}
+            variant="neutral"
+            className="w-28 shrink-0"
+          >
+            <SingleImage
+              contentType={lastSeenDiff.contentType}
+              dimensions={
+                lastSeenDiff.width != null && lastSeenDiff.height != null
+                  ? constraintSize(
+                      {
+                        width: lastSeenDiff.width,
+                        height: lastSeenDiff.height,
+                      },
+                      DIFF_IMAGE_CONFIG,
+                    )
+                  : {
+                      height: DIFF_IMAGE_CONFIG.defaultHeight,
+                      width: DIFF_IMAGE_CONFIG.maxWidth,
+                    }
+              }
+              url={thumbnailURL}
+            />
+          </DiffCard>
+        ) : null}
+        <div className="flex flex-col justify-center truncate">
+          <Truncable className="font-medium">{test.name}</Truncable>
+          {test.buildName !== "default" ? (
+            <Truncable className="text-low">{test.buildName}</Truncable>
+          ) : null}
+        </div>
+      </HeadlessLink>
+      {/* Positioned, so it stacks above the stretched link and its hover card
+          stays reachable. */}
+      <div className="text-low relative w-44 text-xs">
+        {ignoredChange.ignoredAt ? (
+          <Time date={ignoredChange.ignoredAt} />
+        ) : (
+          <span>Unknown date</span>
+        )}
+        {ignoredBy ? (
+          <div className="mt-1 flex min-w-0 items-center gap-1.5">
+            <UserHoverCard user={getUserCardData(ignoredBy)}>
+              <span
+                tabIndex={0}
+                className="flex min-w-0 items-center gap-1.5 truncate"
+              >
+                <AccountAvatar
+                  avatar={ignoredBy.avatar}
+                  className="size-3.5 shrink-0 border"
+                />
+                <span className="truncate">
+                  {ignoredBy.name || ignoredBy.slug}
+                </span>
+              </span>
+            </UserHoverCard>
+            {/* The bot as author already hints at it; the badge is what makes it
+                scannable, and carries the setting that governs it. */}
+            {ignoredBy.type === UserType.Bot && (
+              <AutoIgnoreBadge params={params} />
+            )}
+          </div>
+        ) : null}
+      </div>
+      <div
+        className={clsx(
+          "w-24 text-right tabular-nums",
+          ignoredChange.occurrencesSinceIgnored === 0 && "text-low",
+        )}
+      >
+        {compactFormatter.format(ignoredChange.occurrencesSinceIgnored)}
+      </div>
+      {/* Positioned like the cell above: `Time` carries a tooltip with the full
+          timestamp, which the stretched link would otherwise cover. */}
+      <div className="text-low relative w-28 text-right text-xs">
+        {lastSeenDiff ? (
+          <Time date={lastSeenDiff.createdAt} />
+        ) : (
+          <span>Never</span>
+        )}
+      </div>
+      {/* The cell keeps its width so revealing the action doesn't shift the
+          row. `opacity-0` rather than `invisible` so the button stays in the tab
+          order, and `focus-within` brings it back for keyboard users. */}
+      <div className="relative flex w-24 justify-end">
+        {permissions.includes(ProjectPermission.Review) && (
+          <Button
+            variant="secondary"
+            size="small"
+            className="opacity-0 transition-opacity group-focus-within/row:opacity-100 group-hover/row:opacity-100"
+            onPress={() =>
+              onUnignore({
+                changeId: ignoredChange.id,
+                testName: test.name,
+              })
+            }
+          >
+            Unignore
+          </Button>
+        )}
+      </div>
+    </ListRow>
+  );
+}
+
+/**
+ * Marks a change that auto-ignore muted on its own, and offers the setting that
+ * governs it — the only actionable thing about an ignore nobody performed.
+ */
+function AutoIgnoreBadge(props: { params: ProjectParams }) {
+  const { permissions } = useProjectOutletContext();
+  return (
+    <Tooltip
+      variant="info"
+      // The tooltip holds a link, so its content has to stay hoverable.
+      disableHoverableContent={false}
+      content={
+        <TooltipContainer>
+          <TooltipHeader icon={ZapIcon}>Ignored automatically</TooltipHeader>
+          <p>
+            Nobody flagged this one. Argos ignored it because the same change
+            came back often enough in auto-approved builds to count as flaky.
+          </p>
+          {permissions.includes(ProjectPermission.ViewSettings) && (
+            <Link
+              href={`${getProjectURL(props.params)}/settings/flaky-detection`}
+              className="underline-link"
+            >
+              Configure auto-ignore
+            </Link>
+          )}
+        </TooltipContainer>
+      }
+    >
+      <Chip color="neutral" scale="xs" icon={ZapIcon}>
+        Auto
+      </Chip>
+    </Tooltip>
+  );
+}
+
+function UnignoreChangeDialog(props: {
+  projectId: string;
+  params: ProjectParams;
+  changeId: string;
+  testName: string;
+  onUndo: (changeId: string) => void;
+}) {
+  const { projectId, params, changeId, testName, onUndo } = props;
+  const state = useOverlayTriggerState();
+  const [unignore, { error }] = useMutation(UnignoreChangeMutation, {
+    variables: { accountSlug: params.accountSlug, changeId },
+    update: (cache) =>
+      updateIgnoredChangesCache({
+        cache,
+        projectId,
+        changeId,
+        operation: "remove",
+      }),
+  });
+
+  return (
+    <Dialog size="medium" role="alertdialog">
+      <DialogBody>
+        <DialogTitle>Unignore change</DialogTitle>
+        <DialogText>
+          Argos will treat this change as a change again, so{" "}
+          <strong>{testName}</strong> will need review the next time it appears.
+          Only unignore if the flake is resolved.
+        </DialogText>
+      </DialogBody>
+      <DialogFooter>
+        {error && (
+          <ErrorMessage className="flex-1">{error.message}</ErrorMessage>
+        )}
+        <DialogDismiss>Cancel</DialogDismiss>
+        <DialogActionButton
+          variant="destructive"
+          onAction={async () => {
+            try {
+              await unignore();
+              state.close();
+              toast.success("Change unignored", {
+                // Keyed on the change so unignore → undo → unignore reuses the
+                // same toast instead of stacking duplicates.
+                id: `unignore-change:${changeId}`,
+                action: {
+                  label: "Undo",
+                  onClick: () => onUndo(changeId),
+                },
+              });
+            } catch {
+              // Surfaced via the mutation's `error` state above.
+            }
+          }}
+        >
+          Unignore change
+        </DialogActionButton>
+      </DialogFooter>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/pages/Project/Tests.tsx
+++ b/apps/frontend/src/pages/Project/Tests.tsx
@@ -219,7 +219,7 @@ function PageContent(props: {
             suite uploads its first build, every screenshot shows up here with
             the metrics that tell you which ones you can trust.
           </Text>
-          <EmptyStateLearnMore href="https://argos-ci.com/docs/quickstart" />
+          <EmptyStateLearnMore href="https://argos-ci.com/docs/learn/reliability-and-flakiness/tests-dashboard" />
           <EmptyStateSteps>
             <EmptyStateStep
               icon={<CameraIcon />}

--- a/apps/frontend/src/pages/Project/Tests.tsx
+++ b/apps/frontend/src/pages/Project/Tests.tsx
@@ -14,7 +14,13 @@ import {
 import { invariant } from "@argos/util/invariant";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import clsx from "clsx";
-import { FileImageIcon, SearchIcon } from "lucide-react";
+import {
+  ActivityIcon,
+  CameraIcon,
+  FileImageIcon,
+  GitCompareArrowsIcon,
+  SearchIcon,
+} from "lucide-react";
 import { parseAsString, useQueryStates } from "nuqs";
 import { useNumberFormatter } from "react-aria";
 import { Heading, Text } from "react-aria-components";
@@ -25,16 +31,21 @@ import {
   DiffCard,
   SingleImage,
 } from "@/containers/Build/BuildDiffListPrimitives";
+import { TestsIllustration } from "@/containers/EmptyStateIllustrations";
 import { PeriodSelect } from "@/containers/PeriodSelect";
 import { FlakinessCircleIndicator } from "@/containers/Test/FlakinessCircleIndicator";
 import { useTestPeriodState } from "@/containers/Test/Period";
 import { SeenChange } from "@/containers/Test/SeenChange";
 import { graphql, type DocumentType } from "@/gql";
-import { Button, LinkButton } from "@/ui/Button";
+import { Button } from "@/ui/Button";
 import {
   EmptyState,
   EmptyStateActions,
   EmptyStateIcon,
+  EmptyStateIllustration,
+  EmptyStateLearnMore,
+  EmptyStateStep,
+  EmptyStateSteps,
   Page,
   PageContainer,
   PageHeader,
@@ -199,16 +210,42 @@ function PageContent(props: {
     return (
       <PageContainer>
         <EmptyState>
-          <EmptyStateIcon>
-            <FileImageIcon strokeWidth={1} />
-          </EmptyStateIcon>
-          <Heading>No tests</Heading>
+          <EmptyStateIllustration>
+            <TestsIllustration />
+          </EmptyStateIllustration>
+          <Heading>No tests yet</Heading>
           <Text slot="description">
-            There are no tests yet on this project.
+            A test is one screenshot name, followed across builds. Once your
+            suite uploads its first build, every screenshot shows up here with
+            the metrics that tell you which ones you can trust.
           </Text>
-          <EmptyStateActions>
-            <LinkButton href="/">Back to home</LinkButton>
-          </EmptyStateActions>
+          <EmptyStateLearnMore href="https://argos-ci.com/docs/quickstart" />
+          <EmptyStateSteps>
+            <EmptyStateStep
+              icon={<CameraIcon />}
+              step="In your suite"
+              title="Take a screenshot"
+            >
+              Call Argos from Playwright, Cypress, Storybook or the CLI. The
+              name you give each screenshot becomes the test.
+            </EmptyStateStep>
+            <EmptyStateStep
+              icon={<GitCompareArrowsIcon />}
+              step="On every build"
+              title="Argos compares it"
+            >
+              Each run is diffed against the baseline, so a test accumulates a
+              history of when it changed and when it stayed put.
+            </EmptyStateStep>
+            <EmptyStateStep
+              icon={<ActivityIcon />}
+              step="Back here"
+              title="Spot the flaky ones"
+            >
+              Flakiness, stability and consistency are scored per test, so the
+              noisiest ones sort to the top.
+            </EmptyStateStep>
+          </EmptyStateSteps>
         </EmptyState>
       </PageContainer>
     );
@@ -308,11 +345,22 @@ function TestsList(props: {
       lastItem &&
       lastItem.index === displayCount &&
       !isFetchingMore &&
-      hasNextPage
+      hasNextPage &&
+      // While the filters are mid-change the rendered list still belongs to the
+      // previous ones, so `edges.length` is the wrong offset: paging here would
+      // append the old query's second page to the new query's first.
+      !isUpdating
     ) {
       fetchNextPage();
     }
-  }, [lastItem, displayCount, isFetchingMore, hasNextPage, fetchNextPage]);
+  }, [
+    lastItem,
+    displayCount,
+    isFetchingMore,
+    hasNextPage,
+    isUpdating,
+    fetchNextPage,
+  ]);
 
   return (
     <List

--- a/apps/frontend/src/pages/Project/index.tsx
+++ b/apps/frontend/src/pages/Project/index.tsx
@@ -22,6 +22,9 @@ const ProjectQuery = graphql(`
       permissions
       name
       deploymentEnabled
+      ignoreConfig {
+        enabled
+      }
       account {
         id
         ...PaymentBanner_Account
@@ -36,11 +39,13 @@ type Account = NonNullable<
 
 function ProjectTabs(props: {
   deploymentEnabled: boolean;
+  ignoreEnabled: boolean;
   permissions: ProjectPermission[];
   account: Account;
   children: React.ReactNode;
 }) {
-  const { account, children, permissions, deploymentEnabled } = props;
+  const { account, children, permissions, deploymentEnabled, ignoreEnabled } =
+    props;
   const isTeam = account.__typename === "Team";
   const showAutomationsTab =
     isTeam && permissions.includes(ProjectPermission.ViewSettings);
@@ -49,6 +54,9 @@ function ProjectTabs(props: {
       <TabList className="px-4" aria-label="Project navigation">
         <TabLink href="">Builds</TabLink>
         <TabLink href="tests">Tests</TabLink>
+        {/* The ignore ledger is only meaningful while the feature is on; the
+            page itself still explains itself if reached by a direct link. */}
+        {ignoreEnabled && <TabLink href="ignored">Ignored</TabLink>}
         {deploymentEnabled && <TabLink href="deployments">Deployments</TabLink>}
         {showAutomationsTab && (
           <TabLink href="automations">Automations</TabLink>
@@ -86,6 +94,7 @@ function Project(props: { params: ProjectParams }) {
       account={project.account}
       permissions={project.permissions}
       deploymentEnabled={project.deploymentEnabled}
+      ignoreEnabled={project.ignoreConfig.enabled}
     >
       <Suspense fallback={<PageLoader />}>
         <Outlet

--- a/apps/frontend/src/router.tsx
+++ b/apps/frontend/src/router.tsx
@@ -331,6 +331,11 @@ export const router: ReturnType<typeof createBrowserRouter> =
                   element: <Navigate to=".." replace={true} />,
                 },
                 {
+                  path: "ignored",
+                  HydrateFallback,
+                  lazy: () => import("./pages/Project/IgnoredChanges"),
+                },
+                {
                   path: "deployments",
                   HydrateFallback,
                   lazy: () => import("./pages/Project/Deployments"),

--- a/apps/frontend/src/ui/Layout.tsx
+++ b/apps/frontend/src/ui/Layout.tsx
@@ -3,6 +3,7 @@ import clsx from "clsx";
 import { HeadingContext, Provider, TextContext } from "react-aria-components";
 
 import { Container, type ContainerProps } from "./Container";
+import { Link } from "./Link";
 
 export function PageHeader(props: ComponentPropsWithRef<"div">) {
   return (
@@ -56,7 +57,11 @@ export function EmptyState(props: ComponentPropsWithRef<"div">) {
           TextContext,
           {
             slots: {
-              description: { className: "text-low text-sm text-center" },
+              description: {
+                // A fixed measure keeps the description readable and gives every
+                // empty state the same silhouette, whatever its copy length.
+                className: "text-low max-w-lg text-center text-sm text-balance",
+              },
             },
           },
         ],
@@ -87,9 +92,88 @@ export function EmptyStateIcon(props: ComponentPropsWithRef<"div">) {
   );
 }
 
+/**
+ * Slot for a feature illustration at the top of an empty state. Unlike
+ * {@link EmptyStateIcon} it draws no frame of its own — the illustration
+ * carries the visual weight.
+ */
+export function EmptyStateIllustration(props: ComponentPropsWithRef<"div">) {
+  return (
+    <div
+      {...props}
+      className={clsx("mb-5 w-full max-w-[200px]", props.className)}
+      aria-hidden="true"
+    />
+  );
+}
+
+/**
+ * Row of short "how it works" cards, for empty states that have to teach the
+ * feature rather than just report that there is nothing to show.
+ *
+ * Widest element of the empty state, one step down from the page container, so
+ * the block reads as illustration → prose → structure rather than three
+ * unrelated widths.
+ */
+export function EmptyStateSteps(props: ComponentPropsWithRef<"div">) {
+  return (
+    <div
+      {...props}
+      className={clsx(
+        "mt-7 grid w-full max-w-5xl gap-3 text-left sm:grid-cols-3",
+        props.className,
+      )}
+    />
+  );
+}
+
+export function EmptyStateStep(props: {
+  icon: React.ReactNode;
+  step: string;
+  title: string;
+  children: React.ReactNode;
+}) {
+  const { icon, step, title, children } = props;
+  return (
+    <div className="bg-app border-thin flex flex-col gap-2 rounded-lg p-5 shadow-xs">
+      {/* The eyebrow names *when* in the workflow this happens, so the three
+          cards read as the sequence they are. Accent stays on the icon: one
+          coloured mark per card. */}
+      <div className="text-low flex items-center gap-2 text-xs font-medium">
+        <span aria-hidden="true" className="text-primary-low [&>svg]:size-3.5">
+          {icon}
+        </span>
+        {step}
+      </div>
+      {/* A plain `h3`: the surrounding `EmptyState` provides a `HeadingContext`
+          sized for its own title. */}
+      <h3 className="text-sm font-medium">{title}</h3>
+      <div className="text-low text-sm leading-relaxed text-pretty">
+        {children}
+      </div>
+    </div>
+  );
+}
+
 export function EmptyStateActions(props: ComponentPropsWithRef<"div">) {
   return (
-    <div {...props} className={clsx("mt-2 flex gap-4 p-4", props.className)} />
+    <div {...props} className={clsx("mt-6 flex gap-3", props.className)} />
+  );
+}
+
+/**
+ * Documentation link for an empty state, sitting under the actions. Kept as a
+ * link rather than a second button so the real action stays the only thing
+ * competing for attention.
+ */
+export function EmptyStateLearnMore(props: {
+  href: string;
+  children?: string;
+}) {
+  return (
+    <Link external href={props.href} className="mt-4 text-sm" target="_blank">
+      {props.children ?? "Learn more"}
+    </Link>
   );
 }
 

--- a/apps/frontend/src/ui/Tooltip.tsx
+++ b/apps/frontend/src/ui/Tooltip.tsx
@@ -15,7 +15,9 @@ type TooltipVariant = "default" | "info";
 
 const variantClassNames: Record<TooltipVariant, string> = {
   default: clsx("text-xs py-1 px-2 max-w-sm"),
-  info: "text-sm p-2 [&_strong]:font-medium",
+  // Same measure as `default`: without it a paragraph of content stretches to
+  // whatever the viewport allows.
+  info: "text-sm p-2 max-w-sm [&_strong]:font-medium",
 };
 
 export type TooltipProps = {

--- a/codegen.ts
+++ b/codegen.ts
@@ -88,7 +88,8 @@ const config: CodegenConfig = {
             "../../database/models/index.js#GithubAccountMember",
           Test: "../../database/models/index.js#Test",
           TestMetrics: "../../graphql/definitions/Test.js#TestMetrics",
-          TestChange: "../../graphql/definitions/Test.js#TestChangeObject",
+          TestChange:
+            "../../graphql/definitions/TestChange.js#TestChangeObject",
           User: "../../database/models/index.js#Account",
           UserAccessToken: "../../database/models/index.js#UserAccessToken",
           UserSession: "../../database/models/index.js#UserSession",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint:root": "eslint . --max-warnings 0",
     "check-types": "turbo run check-types",
     "check-format": "turbo run check-format",
+    "static-checks": "turbo run static-checks",
     "format": "prettier --write .",
     "clean-deps": "rm -rf node_modules && pnpm -r exec rm -rf node_modules",
     "build-production": "BUILD_MODE=production pnpm run build && pnpm run clean-deps && pnpm install --prod",

--- a/tests/project-ignored.spec.ts
+++ b/tests/project-ignored.spec.ts
@@ -42,7 +42,7 @@ loggedTest(
       page.getByRole("link", { name: "Learn more" }),
     ).toHaveAttribute(
       "href",
-      "https://argos-ci.com/docs/learn/reliability-and-flakiness/flaky-test-detection",
+      "https://argos-ci.com/docs/learn/reliability-and-flakiness/ignored-changes",
     );
 
     await screenshot(page, "project-ignored-empty");

--- a/tests/project-ignored.spec.ts
+++ b/tests/project-ignored.spec.ts
@@ -1,0 +1,162 @@
+import { expect } from "@playwright/test";
+
+import { createIgnoredChangeScenario } from "../apps/backend/src/database/seeds";
+import { loggedTest } from "./logged-test";
+import { ensureTeamOwner, screenshot } from "./util";
+
+loggedTest.beforeEach(async ({ auth, team }) => {
+  await ensureTeamOwner({ team: team.team, user: auth.user });
+});
+
+loggedTest(
+  "ignored changes empty state",
+  async ({ page, team, project, auth }) => {
+    void auth;
+    await page.goto(`/${team.account.slug}/${project.name}`);
+
+    // The tab is reachable from the project navigation.
+    await page.getByRole("tab", { name: "Ignored" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Nothing is ignored yet" }),
+    ).toBeVisible();
+    // The empty state teaches the three parts of the flow.
+    await expect(
+      page.getByRole("heading", { name: "Flag the change" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Argos matches it exactly" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Keep the list honest" }),
+    ).toBeVisible();
+
+    // The action comes first, with the docs link quietly beneath it.
+    await expect(
+      page.getByRole("link", { name: "Configure auto-ignore" }),
+    ).toHaveAttribute(
+      "href",
+      `/${team.account.slug}/${project.name}/settings/flaky-detection`,
+    );
+    await expect(
+      page.getByRole("link", { name: "Learn more" }),
+    ).toHaveAttribute(
+      "href",
+      "https://argos-ci.com/docs/learn/reliability-and-flakiness/flaky-test-detection",
+    );
+
+    await screenshot(page, "project-ignored-empty");
+  },
+);
+
+loggedTest(
+  "auto-ignored changes are badged",
+  async ({ page, team, project, auth }) => {
+    const { test } = await createIgnoredChangeScenario({
+      projectId: project.id,
+      userId: auth.user.id,
+      auto: true,
+    });
+
+    await page.goto(`/${team.account.slug}/${project.name}/ignored`);
+
+    const row = page.getByRole("row").filter({ hasText: test.name });
+    // The bot stays named as the author, with the badge alongside it.
+    await expect(row.getByText("Argos Bot")).toBeVisible();
+    const badge = row.getByText("Auto", { exact: true });
+    await expect(badge).toBeVisible();
+
+    // The tooltip explains it and offers the setting that governs it. The
+    // first pointer event on a freshly mounted virtualized row can be swallowed
+    // by the measuring re-render, so the hover is retried rather than asserted
+    // on a single attempt.
+    await expect(async () => {
+      await page.mouse.move(0, 0);
+      await badge.hover();
+      await expect(
+        page.getByRole("heading", { name: "Ignored automatically" }),
+      ).toBeVisible({ timeout: 2_000 });
+    }).toPass();
+    await expect(
+      page.getByRole("link", { name: "Configure auto-ignore" }),
+    ).toHaveAttribute(
+      "href",
+      `/${team.account.slug}/${project.name}/settings/flaky-detection`,
+    );
+  },
+);
+
+loggedTest("ignored changes list", async ({ page, team, project, auth }) => {
+  const { test } = await createIgnoredChangeScenario({
+    projectId: project.id,
+    userId: auth.user.id,
+  });
+
+  await page.goto(`/${team.account.slug}/${project.name}/ignored`);
+
+  await expect(
+    page.getByRole("heading", { name: "Ignored changes" }),
+  ).toBeVisible();
+
+  const row = page.getByRole("row").filter({ hasText: test.name });
+  await expect(row).toBeVisible();
+  // Ignored by the seeded user, and it has fired 4 times since.
+  await expect(row.getByText("Kyle Bertolino")).toBeVisible();
+  await expect(row.getByText("4", { exact: true })).toBeVisible();
+
+  // The thumbnail is served from the CDN and actually renders.
+  await expect
+    .poll(() =>
+      row
+        .getByRole("img")
+        .first()
+        .evaluate((el: HTMLImageElement) => el.complete && el.naturalWidth > 0),
+    )
+    .toBe(true);
+
+  await screenshot(page, "project-ignored-list");
+});
+
+loggedTest(
+  "unignoring a change removes it from the list, and Undo puts it back",
+  async ({ page, team, project, auth }) => {
+    const { test } = await createIgnoredChangeScenario({
+      projectId: project.id,
+      userId: auth.user.id,
+    });
+
+    await page.goto(`/${team.account.slug}/${project.name}/ignored`);
+
+    const row = page.getByRole("row").filter({ hasText: test.name });
+    // Revealed on hover, so it stays in the tab order: asserted on opacity,
+    // which Playwright's `toBeVisible` would not catch.
+    const unignore = row.getByRole("button", { name: "Unignore" });
+    await expect(unignore).toHaveCSS("opacity", "0");
+    await expect(async () => {
+      await page.mouse.move(0, 0);
+      await row.hover();
+      await expect(unignore).toHaveCSS("opacity", "1", { timeout: 2_000 });
+    }).toPass();
+    await unignore.click();
+
+    const dialog = page.getByRole("alertdialog");
+    await expect(
+      dialog.getByRole("heading", { name: "Unignore change" }),
+    ).toBeVisible();
+    await dialog.getByRole("button", { name: "Unignore change" }).click();
+
+    // The row leaves the list and the page falls back to the empty state.
+    await expect(
+      page.getByRole("heading", { name: "Nothing is ignored yet" }),
+    ).toBeVisible();
+
+    // The confirmation toast offers a way back.
+    await page.getByRole("button", { name: "Undo" }).click();
+    await expect(
+      page.getByRole("row").filter({ hasText: test.name }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Nothing is ignored yet" }),
+    ).toBeHidden();
+  },
+);


### PR DESCRIPTION
Ignoring a change was write-only. Reviewers could mute a flaky diff from the build toolbar, but nothing listed what a project had muted — so an ignore that outlived its flake stayed a silent blind spot.

## The page

An **Ignored** tab next to Tests, listing the changes currently ignored, most recently first. Two columns carry the weight:

- **Occurrences** — auto-approved builds that have shown this exact change *since it was ignored*, i.e. how much review noise the ignore has absorbed.
- **Last seen** — a change that went quiet is a candidate to unignore, which the row offers on hover.

Auto-ignores are badged `Auto`, with a tooltip explaining that nobody flagged it and a link to the setting that governs it. Unignoring confirms first, then offers **Undo** in the toast.

The tab is hidden when the ignore feature is off; reaching the page by direct link explains that state rather than pretending the list is empty.

## `TestChange`, not a new type

First draft added an `IgnoredChange` type — but it carried the same identity and literally the same `id`, so it was a duplicate. `Project.ignoredChanges` returns `TestChangesConnection`, and `TestChange` gained the fields the ledger needs: `test`, `ignoredAt`, `ignoredBy`, `occurrencesSinceIgnored`, and a period-independent `lastSeenDiff`.

That last one is necessary rather than convenient. `stats.lastSeenDiff` is scoped to a metrics period *and* to reference builds, and asserts on the result — so an ignored change that stopped recurring has no such diff and would fail the whole query. Worth knowing if anything else starts reading `stats` off an arbitrary change.

The type and its mutations moved to their own definitions file; `Test.ts` shed ~110 lines.

## Ordering comes from the audit trail

`ignored_changes` is keyed by `(projectId, testId, fingerprint)` and holds no date, so "most recently ignored" can only come from `audit_trails`. A change can be ignored → unignored → ignored again, so the query orders on the *latest* `files.ignored` entry, via a lateral join. Rows with no matching entry sort last instead of dropping out.

## Two index findings

Measured with `EXPLAIN ANALYZE` on generated datasets — the dev database has 66 diffs, so its plans prove nothing.

| | before | after |
|---|---|---|
| `test_stats_fingerprints` occurrences | 43.8ms, seq scan of 180k rows | 0.166ms, index scan |
| `screenshot_diffs` latest-diff lookup | 400 heap rows for 5 results | 0 rows removed by filter |

The first was mine: casting the indexed column (`tsf."testId"::text`) instead of the parameter made the primary key unusable. **The same pattern exists in `getChangesTotalOccurrences`** ([metrics/test.ts](apps/backend/src/metrics/test.ts)) — untouched here, same one-line fix.

The second needed a new partial index (`CONCURRENTLY`, so it needs applying in production).

`audit_trails` needs nothing: at 400 ignored changes the lateral join runs in 1.7ms on the existing `(projectId, testId)` index, removing 0 rows per probe.

## Also in here

- **Empty states** for Tests, Deployments and Automations, which previously said only "There are no X yet" behind a generic icon. Each now has a feature illustration (React/SVG on Radix variables, so no second dark-mode asset set) and three cards naming where in the workflow each step happens.
- **Toast ids** across 13 files. `Toaster` already emphasizes a re-raised toast instead of stacking a duplicate, but almost nothing passed an id — flipping five notification switches left five identical toasts.
- **`info` tooltips had no max-width** while `default` had `max-w-sm`, so a paragraph stretched to the viewport. Fixed for all of them.
- **A page-guard on the Tests list** (bundled in the empty-state commit, same file): the virtualizer's `fetchMore` effect never checked `isUpdating`, so it could append the previous filters' second page onto the new filters' first. Found while looking into the intermittent search suspense — see below.

## Verification

67 e2e (5 new), 367 unit, 22 integration covering the ordering, re-ignore, orphan rows, pagination and both new loaders including per-key `from` windows in one batch. `check-types`, `lint`, `knip`, `prettier` clean.

The e2e run caught a real bug: the seeded fingerprint `penelope-argos-change` contains dashes, and `parseTestChangeId` recovers the fingerprint by splitting on `-`, so unignore failed server-side. Real fingerprints are dash-free — the scenario now uses a realistically shaped one. `createTestChangeScenario` still uses the readable placeholder, so ignoring from a seeded test page hits the same wall.

## On the search suspense

I could not reproduce it, including with fast typing and 700ms of induced latency on the tests query. Ruled out: nuqs returns a stable object identity (it bails out via `Object.is`), so `useDeferredValue` isn't thrashing.

The leading candidate is the unguarded `fetchMore` above: it runs inside `startTransition`, so when the virtualizer effect fires while the deferred filter render is suspending, the two updates entangle and React can be forced to commit the suspended tree — which is exactly the page-level fallback, and exactly "sometimes". The guard is correct on its own merits either way, but I'd treat the fallback as unconfirmed.

## Screenshots

<img width="3212" height="1634" alt="CleanShot 2026-07-26 at 21 03 23@2x" src="https://github.com/user-attachments/assets/87174408-416b-42ad-b0ed-91d7b2a13343" />
<img width="3212" height="1634" alt="CleanShot 2026-07-26 at 21 03 20@2x" src="https://github.com/user-attachments/assets/ec939b9f-f9a2-4ce3-a609-cd09938ca7fa" />
<img width="3212" height="1634" alt="CleanShot 2026-07-26 at 21 03 18@2x" src="https://github.com/user-attachments/assets/e38ed068-c892-429b-af1f-aa523068fefa" />
<img width="3212" height="1634" alt="CleanShot 2026-07-26 at 21 03 01@2x" src="https://github.com/user-attachments/assets/bb48c8f9-8f5e-417d-a9e9-e7c6e232d9d5" />
<img width="3302" height="1522" alt="CleanShot 2026-07-26 at 21 39 39@2x" src="https://github.com/user-attachments/assets/0ed6d303-7fa8-46f7-a3bc-604ae4ed764b" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
