### PR TITLE
feat(jobs): retry failed jobs with a backoff ladder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,8 @@ jobs:
         #   --health-retries 5
 
       rabbit:
-        image: rabbitmq:4-alpine
+        # Keep in sync with docker-compose.yml and production (Amazon MQ 4.2).
+        image: rabbitmq:4.2-alpine
         ports:
           - 5672:5672
         # Speed up initialization by disabling health checks

--- a/apps/backend/src/job-core/backoff.test.ts
+++ b/apps/backend/src/job-core/backoff.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_RETRY_LADDER,
+  getRetryQueueName,
+  getRetryQueueOptions,
+  getRetryTier,
+} from "./backoff";
+
+const LADDER = [
+  { label: "10s", delay: 10_000 },
+  { label: "1m", delay: 60_000 },
+];
+
+describe("getRetryTier", () => {
+  it("picks the tier matching the number of attempts already made", () => {
+    expect(getRetryTier(LADDER, 0)).toEqual({ label: "10s", delay: 10_000 });
+    expect(getRetryTier(LADDER, 1)).toEqual({ label: "1m", delay: 60_000 });
+  });
+
+  it("returns null once the ladder is exhausted", () => {
+    expect(getRetryTier(LADDER, 2)).toBeNull();
+    expect(getRetryTier(LADDER, 99)).toBeNull();
+  });
+
+  it("returns null for an empty ladder, disabling retries", () => {
+    expect(getRetryTier([], 0)).toBeNull();
+  });
+});
+
+describe("getRetryQueueName", () => {
+  it("derives the delay queue name from the job queue and the tier label", () => {
+    expect(
+      getRetryQueueName("test:build", { label: "10s", delay: 10_000 }),
+    ).toBe("test:build.retry.10s");
+  });
+
+  it("gives each tier its own queue so delays never share a TTL", () => {
+    const names = DEFAULT_RETRY_LADDER.map((tier) =>
+      getRetryQueueName("build", tier),
+    );
+
+    expect(names).toEqual([
+      "build.retry.10s",
+      "build.retry.1m",
+      "build.retry.5m",
+    ]);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});
+
+describe("getRetryQueueOptions", () => {
+  it("expires messages back onto the job queue after the tier delay", () => {
+    const options = getRetryQueueOptions("test:build", {
+      label: "10s",
+      delay: 10_000,
+    });
+
+    expect(options.messageTtl).toBe(10_000);
+    // The default exchange routes by queue name, so this lands the expired
+    // message back on the job queue.
+    expect(options.deadLetterExchange).toBe("");
+    expect(options.deadLetterRoutingKey).toBe("test:build");
+    expect(options.durable).toBe(true);
+  });
+
+  it("keeps the dead-letter hop lossless", () => {
+    const options = getRetryQueueOptions("build", {
+      label: "5m",
+      delay: 300_000,
+    });
+
+    expect(options.arguments).toMatchObject({
+      "x-queue-type": "quorum",
+      "x-dead-letter-strategy": "at-least-once",
+    });
+    // at-least-once dead-lettering is rejected by RabbitMQ without it.
+    expect(options.overflow).toBe("reject-publish");
+  });
+});

--- a/apps/backend/src/job-core/backoff.ts
+++ b/apps/backend/src/job-core/backoff.ts
@@ -1,0 +1,77 @@
+import type { Options } from "amqplib";
+
+/**
+ * One step of the retry backoff ladder.
+ *
+ * `label` is part of the delay queue name, so changing a delay creates a new
+ * queue instead of colliding with the existing one. Re-asserting a queue with
+ * different arguments fails with PRECONDITION_FAILED, which closes the channel
+ * — and the channel is shared by every job.
+ */
+export interface RetryTier {
+  label: string;
+  delay: number;
+}
+
+/**
+ * Delay applied before each retry. A job runs at most
+ * `DEFAULT_RETRY_LADDER.length + 1` times before failing terminally, so the
+ * worst case here is ~6m10s of waiting spread over 4 attempts.
+ */
+export const DEFAULT_RETRY_LADDER: RetryTier[] = [
+  { label: "10s", delay: 10_000 },
+  { label: "1m", delay: 60_000 },
+  { label: "5m", delay: 300_000 },
+];
+
+/**
+ * Tier to use for the next attempt, or `null` when the ladder is exhausted and
+ * the job must fail terminally. `attempts` counts executions already made, so
+ * it indexes the ladder directly.
+ */
+export function getRetryTier(
+  ladder: RetryTier[],
+  attempts: number,
+): RetryTier | null {
+  return ladder[attempts] ?? null;
+}
+
+/**
+ * Name of the delay queue holding jobs waiting out `tier` before their next
+ * attempt on `queue`.
+ */
+export function getRetryQueueName(queue: string, tier: RetryTier): string {
+  return `${queue}.retry.${tier.label}`;
+}
+
+/**
+ * Arguments for a delay queue.
+ *
+ * A delay queue has no consumer: a message published to it sits there until its
+ * TTL expires, at which point RabbitMQ dead-letters it back to the job queue on
+ * its own. Nothing in the app schedules or polls.
+ *
+ * The queue is a quorum queue purely so it can use the at-least-once
+ * dead-letter strategy, which confirms the message reached the job queue before
+ * dropping it here. With the default at-most-once strategy a broker failure
+ * during that hop loses the message, which would leave the job's row stuck in
+ * `progress` forever instead of being marked as failed.
+ */
+export function getRetryQueueOptions(
+  queue: string,
+  tier: RetryTier,
+): Options.AssertQueue {
+  return {
+    durable: true,
+    messageTtl: tier.delay,
+    // Empty exchange means the default exchange, which routes by queue name.
+    deadLetterExchange: "",
+    deadLetterRoutingKey: queue,
+    // Required by the at-least-once dead-letter strategy.
+    overflow: "reject-publish",
+    arguments: {
+      "x-queue-type": "quorum",
+      "x-dead-letter-strategy": "at-least-once",
+    },
+  };
+}

--- a/apps/backend/src/job-core/createJob.ts
+++ b/apps/backend/src/job-core/createJob.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/node";
-import type { Channel } from "amqplib";
+import type { Channel, Options } from "amqplib";
 import pRetry from "p-retry";
 
 import config from "@/config";
@@ -8,6 +8,13 @@ import { checkIsRetryable } from "@/util/error";
 import { redisLock } from "@/util/redis";
 
 import { connect } from "./amqp";
+import {
+  DEFAULT_RETRY_LADDER,
+  getRetryQueueName,
+  getRetryQueueOptions,
+  getRetryTier,
+  type RetryTier,
+} from "./backoff";
 
 interface Payload<TValue> {
   args: [TValue];
@@ -61,6 +68,13 @@ export interface JobParams {
    * @default 20000 (20 seconds)
    */
   timeout?: number;
+
+  /**
+   * Delay applied before each retry. One delay queue is declared per tier, so
+   * prefer reusing the shared tiers over inventing new delays.
+   * @default DEFAULT_RETRY_LADDER (10s, 1m, 5m)
+   */
+  retryLadder?: RetryTier[];
 }
 
 type JobContext = {
@@ -121,7 +135,11 @@ function getSharedChannel(direction: ChannelDirection): Promise<Channel> {
 // new channel naturally re-asserts.
 const assertedQueues = new WeakMap<Channel, Map<string, Promise<void>>>();
 
-function ensureQueueAsserted(channel: Channel, queue: string): Promise<void> {
+function ensureQueueAsserted(
+  channel: Channel,
+  queue: string,
+  options: Options.AssertQueue = { durable: true },
+): Promise<void> {
   let queues = assertedQueues.get(channel);
   if (!queues) {
     queues = new Map();
@@ -131,9 +149,7 @@ function ensureQueueAsserted(channel: Channel, queue: string): Promise<void> {
   if (existing) {
     return existing;
   }
-  const promise = channel
-    .assertQueue(queue, { durable: true })
-    .then(() => undefined);
+  const promise = channel.assertQueue(queue, options).then(() => undefined);
   queues.set(queue, promise);
   promise.catch(() => {
     queues!.delete(queue);
@@ -197,7 +213,11 @@ export const createJob = <TValue extends string | number>(
       ctx: JobContext,
     ) => void | Promise<void>;
   },
-  { prefetch = 1, timeout = 20_000 }: JobParams = {},
+  {
+    prefetch = 1,
+    timeout = 20_000,
+    retryLadder = DEFAULT_RETRY_LADDER,
+  }: JobParams = {},
 ): Job<TValue> => {
   queue = config.get("amqp.queuePrefix") + queue;
   const logger = parentLogger.child({ module: "job", queue });
@@ -258,6 +278,18 @@ export const createJob = <TValue extends string | number>(
 
           const channel = await getSharedChannel("consumer");
           await ensureQueueAsserted(channel, queue);
+          // Retries are published from this channel, so the delay queues have
+          // to exist here. Asserting them during setup surfaces a bad
+          // declaration at startup instead of when a job first fails.
+          await Promise.all(
+            retryLadder.map((tier) =>
+              ensureQueueAsserted(
+                channel,
+                getRetryQueueName(queue, tier),
+                getRetryQueueOptions(queue, tier),
+              ),
+            ),
+          );
 
           let consumerTag: string | null = null;
 
@@ -300,14 +332,23 @@ export const createJob = <TValue extends string | number>(
                     await this.run(id, ctx);
                     channel.ack(msg);
                   } catch (error) {
-                    if (checkIsRetryable(error) && payload.attempts < 2) {
+                    const tier = getRetryTier(retryLadder, payload.attempts);
+
+                    if (checkIsRetryable(error) && tier) {
                       consumeLogger.info(
-                        { error },
-                        "Error while processing job",
+                        {
+                          error,
+                          attempts: payload.attempts,
+                          delay: tier.delay,
+                        },
+                        "Retrying job after backoff",
                       );
 
+                      // Published to the delay queue rather than back to the
+                      // job queue: it waits there for the tier's TTL, then
+                      // RabbitMQ dead-letters it onto the job queue.
                       channel.sendToQueue(
-                        queue,
+                        getRetryQueueName(queue, tier),
                         serializeMessage({
                           args: payload.args,
                           attempts: payload.attempts + 1,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,10 @@ services:
       start_period: 10s
 
   rabbitmq:
-    # Last time I have checked, production is running 3.12.6
-    image: rabbitmq:4-alpine
+    # Pinned to match production (Amazon MQ for RabbitMQ 4.2), which is the
+    # latest version Amazon MQ offers. The floating `4-alpine` tag now resolves
+    # to 4.3, which changes redelivery accounting.
+    image: rabbitmq:4.2-alpine
     ports:
       - "15672:15672"
       - "5672:5672"


### PR DESCRIPTION
Jobs were retried 3 times, but a retry was republished straight back onto the job queue — so all 3 attempts burned in a few milliseconds, which is exactly when whatever the job depended on was still down. This spreads them out: **10s, then 1m, then 5m**.

## How it works

Each job queue gets a sibling delay queue per tier (`build.retry.10s`, `build.retry.1m`, `build.retry.5m`). On a retryable failure the message is published into the tier for its attempt number instead of back onto the job queue. The delay queue has a TTL and **no consumer**, so the message sits there untouched until RabbitMQ dead-letters it back onto the job queue on its own. Nothing in the app schedules or polls.

```
build ──► worker ──fails──► build.retry.10s ──(10s, broker)──► build ──► worker ──► ✓
```

Three decisions worth reviewing:

- **One queue per tier, not one shared delay queue.** The delay is a queue argument, not a message property. RabbitMQ does support a per-message TTL, but it only checks expiry at the *head* of a queue — so a single shared queue would let a 5m message hold back every 10s message queued behind it.
- **The delay is in the queue name.** Retuning the ladder creates new queues instead of colliding with existing ones. Re-asserting a queue with different arguments fails `PRECONDITION_FAILED`, which closes the channel — and that channel is shared by every job.
- **Delay queues are quorum queues**, purely to get `x-dead-letter-strategy: at-least-once`. Under the default at-most-once, a broker failure during the expiry hop drops the message, which would leave the job's row stuck at `jobStatus: "progress"` forever rather than being marked failed. This says nothing about the job queues themselves — they stay classic, which is fine on a single-instance broker.

`checkIsRetryable` / `UnretryableError` still short-circuit to terminal failure, and terminal failure still runs `consumer.error` → `jobStatus: "error"`. The `attempts` counter stays in the message payload, so it survives the dead-letter hop untouched.

## Also: pinned RabbitMQ to 4.2

The floating `4-alpine` tag had drifted *ahead* of production — it now resolves to 4.3, and the local container had landed on 4.0.4. Production is Amazon MQ for RabbitMQ 4.2. 4.3 also changed redelivery accounting (`acquired-count` tracked separately from `delivery-count`), so this was a real skew. Takes effect on the next `docker compose up -d`.

## Trade-off to be aware of

A job now runs at most 4 times instead of 3, so worst case is ~6m10s of waiting before terminal failure — a `build` will sit visibly in `progress` for that long. `JobParams.retryLadder` is there if any job wants a shorter one; no job overrides it yet.

## Testing

- 7 unit tests in `backoff.test.ts` covering tier selection, ladder exhaustion, queue naming, and the exact queue arguments — a wrong `deadLetterRoutingKey` or a missing `at-least-once`/`reject-publish` pair only shows up in production during a broker restart, so it's asserted explicitly.
- Verified against a real broker (4.0.4 locally): the argument combination is accepted, a message published to a 400ms tier came back to the job queue after 417ms with `x-death: reason=expired`, payload byte-identical and `deliveryMode=2` preserved.
- `pnpm run static-checks` clean (23/23, including knip).

No round-trip test of `process()` itself — `Job.process()` loops forever with no shutdown path, so a test consumer can't be stopped cleanly. Worth fixing separately if we want that coverage.

## Not in this PR

Migrating the job queues themselves to quorum queues. Discussed and skipped: it only buys replication on a cluster deployment, and we're single-instance.

## Future

RabbitMQ 4.3 makes this native via `x-delayed-retry-type` / `-min` / `-max` on quorum queues. `backoff.ts` is deliberately small and self-contained so it becomes deletable once Amazon MQ ships 4.3 — that plus the `attempts` field is the whole migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)