### PR TITLE
feat(staff): estimate what each trial team will pay

### DIFF
--- a/apps/backend/src/database/services/period-usage.e2e.test.ts
+++ b/apps/backend/src/database/services/period-usage.e2e.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { Account, Plan, Project } from "@/database/models";
+import { factory, setupDatabase } from "@/database/testing";
+
+import { getAccountPeriodUsages } from "./period-usage";
+
+describe("getAccountPeriodUsages", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  const now = new Date();
+  let usageBasedPlan: Plan;
+  let account: Account;
+  let project: Project;
+
+  /**
+   * Well inside the current period: the subscription started on the 1st of a
+   * past month, so the period resets on the 1st of the current one.
+   */
+  const inPeriod = new Date(now.getFullYear(), now.getMonth(), 1);
+
+  beforeEach(async () => {
+    usageBasedPlan = await factory.Plan.create({
+      usageBased: true,
+      interval: "month",
+    });
+    account = await factory.TeamAccount.create();
+    project = await factory.Project.create({ accountId: account.id });
+  });
+
+  async function createUsageBasedSubscription() {
+    const user = await factory.User.create();
+    return factory.Subscription.create({
+      accountId: account.id,
+      planId: usageBasedPlan.id,
+      includedScreenshots: 1000,
+      currency: "usd",
+      additionalScreenshotPrice: 0.5,
+      additionalStorybookScreenshotPrice: 0.1,
+      provider: "stripe",
+      stripeSubscriptionId: "sub_period_usage",
+      subscriberId: user.id,
+      startDate: new Date("2021-01-01").toISOString(),
+      status: "active",
+    });
+  }
+
+  it("returns null for an account without a usage-based subscription", async () => {
+    const usages = await getAccountPeriodUsages([account]);
+    expect(usages.get(account.id)).toBeNull();
+  });
+
+  it("returns null for a granted plan, even with a subscription still on file", async () => {
+    // Open source and comped accounts read as `active` everywhere because a
+    // forced plan short-circuits the status, and they bill nothing.
+    await createUsageBasedSubscription();
+    await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      createdAt: new Date(inPeriod.getTime() + 1000).toISOString(),
+      screenshotCount: 5000,
+      storybookScreenshotCount: 0,
+    });
+    await account.$query().patch({ forcedPlanId: usageBasedPlan.id });
+    const grantedAccount = await account.$query();
+
+    const usages = await getAccountPeriodUsages([grantedAccount]);
+
+    expect(usages.get(grantedAccount.id)).toBeNull();
+  });
+
+  it("returns zero cost when the account stays inside its quota", async () => {
+    await createUsageBasedSubscription();
+    await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      createdAt: new Date(inPeriod.getTime() + 1000).toISOString(),
+      screenshotCount: 400,
+      storybookScreenshotCount: 0,
+    });
+
+    const usage = await getAccountPeriodUsages([account]).then((usages) =>
+      usages.get(account.id),
+    );
+
+    expect(usage).toEqual({
+      additionalScreenshotCost: 0,
+      storybookRatio: 0,
+      storybookCount: 0,
+    });
+  });
+
+  it("bills the overage at the neutral price", async () => {
+    await createUsageBasedSubscription();
+    await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      createdAt: new Date(inPeriod.getTime() + 1000).toISOString(),
+      screenshotCount: 1200,
+      storybookScreenshotCount: 0,
+    });
+
+    const usage = await getAccountPeriodUsages([account]).then((usages) =>
+      usages.get(account.id),
+    );
+
+    // 200 over the 1000 included, at $0.50.
+    expect(usage?.additionalScreenshotCost).toBe(100);
+  });
+
+  it("bills Storybook screenshots at their own price and reports the mix", async () => {
+    await createUsageBasedSubscription();
+    await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      createdAt: new Date(inPeriod.getTime() + 1000).toISOString(),
+      screenshotCount: 1500,
+      storybookScreenshotCount: 1000,
+    });
+
+    const usage = await getAccountPeriodUsages([account]).then((usages) =>
+      usages.get(account.id),
+    );
+
+    // 500 neutral fit under the 1000 included, so 500 of the Storybook
+    // screenshots absorb the rest of the quota and 500 are billed at $0.10.
+    expect(usage?.additionalScreenshotCost).toBeCloseTo(50);
+    expect(usage?.storybookRatio).toBeCloseTo(1000 / 1500);
+    expect(usage?.storybookCount).toBe(1000);
+  });
+
+  it("ignores screenshots uploaded before the period started", async () => {
+    await createUsageBasedSubscription();
+    await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      createdAt: new Date(inPeriod.getTime() - 86_400_000).toISOString(),
+      screenshotCount: 5000,
+      storybookScreenshotCount: 0,
+    });
+
+    const usage = await getAccountPeriodUsages([account]).then((usages) =>
+      usages.get(account.id),
+    );
+
+    // Out of period for the cost, still part of the lifetime mix.
+    expect(usage?.additionalScreenshotCost).toBe(0);
+    expect(usage?.storybookRatio).toBe(0);
+  });
+
+  it("keeps accounts apart within one batch", async () => {
+    await createUsageBasedSubscription();
+    await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      createdAt: new Date(inPeriod.getTime() + 1000).toISOString(),
+      screenshotCount: 1200,
+      storybookScreenshotCount: 0,
+    });
+
+    const otherAccount = await factory.TeamAccount.create();
+    const otherProject = await factory.Project.create({
+      accountId: otherAccount.id,
+    });
+    const otherUser = await factory.User.create();
+    await factory.Subscription.create({
+      accountId: otherAccount.id,
+      planId: usageBasedPlan.id,
+      includedScreenshots: 1000,
+      currency: "usd",
+      additionalScreenshotPrice: 0.5,
+      additionalStorybookScreenshotPrice: 0.1,
+      provider: "stripe",
+      stripeSubscriptionId: "sub_period_usage_other",
+      subscriberId: otherUser.id,
+      startDate: new Date("2021-01-01").toISOString(),
+      status: "active",
+    });
+    await factory.ScreenshotBucket.create({
+      projectId: otherProject.id,
+      createdAt: new Date(inPeriod.getTime() + 1000).toISOString(),
+      screenshotCount: 1100,
+      storybookScreenshotCount: 0,
+    });
+
+    const noSubscriptionAccount = await factory.TeamAccount.create();
+
+    const usages = await getAccountPeriodUsages([
+      account,
+      otherAccount,
+      noSubscriptionAccount,
+    ]);
+
+    expect(usages.get(account.id)?.additionalScreenshotCost).toBe(100);
+    expect(usages.get(otherAccount.id)?.additionalScreenshotCost).toBe(50);
+    expect(usages.get(noSubscriptionAccount.id)).toBeNull();
+  });
+});

--- a/apps/backend/src/database/services/period-usage.e2e.test.ts
+++ b/apps/backend/src/database/services/period-usage.e2e.test.ts
@@ -70,6 +70,40 @@ describe("getAccountPeriodUsages", () => {
     expect(usages.get(grantedAccount.id)).toBeNull();
   });
 
+  it("resolves the same subscription as the account manager does", async () => {
+    // Two active subscriptions at once: the manager picks on
+    // `includedScreenshots` alone, so the flat one wins and the account is not
+    // billed by usage. Picking the usage-based one here would price the row
+    // against a plan it is not billed on.
+    await createUsageBasedSubscription();
+    const flatPlan = await factory.Plan.create({
+      usageBased: false,
+      interval: "month",
+      includedScreenshots: 1_000_000,
+    });
+    const flatUser = await factory.User.create();
+    await factory.Subscription.create({
+      accountId: account.id,
+      planId: flatPlan.id,
+      includedScreenshots: 1_000_000,
+      currency: "usd",
+      provider: "github",
+      subscriberId: flatUser.id,
+      startDate: new Date("2021-01-01").toISOString(),
+      status: "active",
+    });
+    await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      createdAt: new Date(inPeriod.getTime() + 1000).toISOString(),
+      screenshotCount: 5000,
+      storybookScreenshotCount: 0,
+    });
+
+    const usages = await getAccountPeriodUsages([account]);
+
+    expect(usages.get(account.id)).toBeNull();
+  });
+
   it("returns zero cost when the account stays inside its quota", async () => {
     await createUsageBasedSubscription();
     await factory.ScreenshotBucket.create({

--- a/apps/backend/src/database/services/period-usage.ts
+++ b/apps/backend/src/database/services/period-usage.ts
@@ -143,6 +143,13 @@ export async function getAccountPeriodUsages(
     return result;
   }
 
+  // Deliberately not filtered on `plan.usageBased`: this has to pick the same
+  // subscription as `Account.getActiveSubscription()`, which selects on
+  // `includedScreenshots` alone. Narrowing to usage-based plans before the
+  // `DISTINCT ON` would let an account holding both a flat and a usage-based
+  // active subscription resolve one subscription here and the other there —
+  // pricing the row against a plan it is not billed on. The plan is checked
+  // below instead, once the same winner has been picked.
   const subscriptions = await Subscription.query()
     .select("subscriptions.*")
     .withGraphFetched("plan")
@@ -151,7 +158,6 @@ export async function getAccountPeriodUsages(
       "subscriptions.accountId",
       subscribedAccounts.map((account) => account.id),
     )
-    .where("plan.usageBased", true)
     .whereRaw("?? < now()", "subscriptions.startDate")
     .whereIn("subscriptions.status", ["active", "trialing", "past_due"])
     .where((query) =>
@@ -172,7 +178,7 @@ export async function getAccountPeriodUsages(
 
   for (const account of subscribedAccounts) {
     const subscription = subscriptionByAccountId.get(account.id);
-    if (!subscription?.plan) {
+    if (!subscription?.plan?.usageBased) {
       result.set(account.id, null);
       continue;
     }

--- a/apps/backend/src/database/services/period-usage.ts
+++ b/apps/backend/src/database/services/period-usage.ts
@@ -1,0 +1,233 @@
+import { knex } from "@/database";
+
+import { Account, Subscription } from "../models";
+import { computeAdditionalScreenshots } from "./additional-screenshots";
+
+/**
+ * Billing usage for one account, as needed to explain what it is about to pay.
+ */
+export type AccountPeriodUsage = {
+  /**
+   * Cost of the screenshots consumed beyond the included quota since the
+   * current period started, in the subscription's currency.
+   */
+  additionalScreenshotCost: number;
+  /**
+   * Share of Storybook screenshots in everything the account ever uploaded,
+   * between 0 and 1. Null when it never uploaded a screenshot at all — an
+   * undefined mix, which is not the same as an all-neutral one.
+   */
+  storybookRatio: number | null;
+  /** Storybook screenshots uploaded since the account was created. */
+  storybookCount: number;
+};
+
+/** Usage of an account on a usage-based plan that has yet to upload anything. */
+const EMPTY_PERIOD_USAGE: AccountPeriodUsage = {
+  additionalScreenshotCost: 0,
+  storybookRatio: null,
+  storybookCount: 0,
+};
+
+/**
+ * Screenshot totals for one account: over the current billing period, which is
+ * what gets invoiced, and over its whole life, which is what describes its mix.
+ */
+type ScreenshotTotals = {
+  periodAll: number;
+  periodStorybook: number;
+  allTimeAll: number;
+  allTimeStorybook: number;
+};
+
+/**
+ * Sum screenshots per account in a single pass.
+ *
+ * Every account has its own period start — it follows the subscription's
+ * anniversary, not the calendar — so the boundaries travel with the rows as a
+ * `VALUES` list and the period totals come out of a filtered aggregate. The
+ * alternative is one query per account, which is what this exists to avoid.
+ *
+ * The joins are left joins throughout: an account whose projects never produced
+ * a bucket still has to come back with zeros rather than vanish from the batch.
+ */
+async function getScreenshotTotals(
+  periodStartByAccountId: Map<string, Date>,
+): Promise<Map<string, ScreenshotTotals>> {
+  const entries = [...periodStartByAccountId];
+
+  // `accounts.id` is a bigint and the bindings arrive as strings, so the values
+  // are cast explicitly — Postgres cannot infer the type of a bare parameter in
+  // a `VALUES` list, and would refuse to join it against `projects."accountId"`.
+  const values = entries.map(() => `(?::bigint, ?::timestamptz)`).join(", ");
+  const bindings = entries.flatMap(([accountId, periodStart]) => [
+    accountId,
+    periodStart.toISOString(),
+  ]);
+
+  const rows = (await knex
+    .select("v.accountId")
+    .select(
+      // `screenshotCount` is null until a bucket completes, and the billing
+      // aggregate it mirrors sums it as-is rather than filtering incomplete
+      // buckets out. Coalescing here keeps both sides on the same number.
+      knex.raw(
+        `coalesce(sum(sb."screenshotCount") filter (where sb."createdAt" >= v."periodStart"), 0) as "periodAll"`,
+      ),
+      knex.raw(
+        `coalesce(sum(sb."storybookScreenshotCount") filter (where sb."createdAt" >= v."periodStart"), 0) as "periodStorybook"`,
+      ),
+      knex.raw(`coalesce(sum(sb."screenshotCount"), 0) as "allTimeAll"`),
+      knex.raw(
+        `coalesce(sum(sb."storybookScreenshotCount"), 0) as "allTimeStorybook"`,
+      ),
+    )
+    .from(
+      knex.raw(`(values ${values}) as v("accountId", "periodStart")`, bindings),
+    )
+    .leftJoin("projects as p", "p.accountId", "v.accountId")
+    .leftJoin("screenshot_buckets as sb", "sb.projectId", "p.id")
+    .groupBy("v.accountId")) as unknown as {
+    accountId: string | number;
+    periodAll: string | number;
+    periodStorybook: string | number;
+    allTimeAll: string | number;
+    allTimeStorybook: string | number;
+  }[];
+
+  return new Map(
+    rows.map((row) => [
+      String(row.accountId),
+      {
+        periodAll: Number(row.periodAll) || 0,
+        periodStorybook: Number(row.periodStorybook) || 0,
+        allTimeAll: Number(row.allTimeAll) || 0,
+        allTimeStorybook: Number(row.allTimeStorybook) || 0,
+      },
+    ]),
+  );
+}
+
+/**
+ * Billing usage for a batch of accounts, in two queries whatever the batch size.
+ *
+ * An account maps to `null` when it is not on a usage-based plan: it has no
+ * overage to compute and no period to compute it over, which is a different
+ * answer from one that consumed nothing. Callers that render money need to tell
+ * the two apart, so the distinction is kept here rather than flattened to zero.
+ */
+export async function getAccountPeriodUsages(
+  accounts: Account[],
+): Promise<Map<string, AccountPeriodUsage | null>> {
+  const result = new Map<string, AccountPeriodUsage | null>();
+
+  if (accounts.length === 0) {
+    return result;
+  }
+
+  // A forced plan overrides whatever subscription rows the account may still
+  // carry — the subscription manager reports no active subscription at all for
+  // it. These are the granted plans, open source above all: they read as
+  // `active` everywhere while billing nothing, so a leftover subscription must
+  // not earn them a price here.
+  const subscribedAccounts: Account[] = [];
+  for (const account of accounts) {
+    if (account.forcedPlanId === null) {
+      subscribedAccounts.push(account);
+    } else {
+      result.set(account.id, null);
+    }
+  }
+
+  if (subscribedAccounts.length === 0) {
+    return result;
+  }
+
+  const subscriptions = await Subscription.query()
+    .select("subscriptions.*")
+    .withGraphFetched("plan")
+    .joinRelated("plan")
+    .whereIn(
+      "subscriptions.accountId",
+      subscribedAccounts.map((account) => account.id),
+    )
+    .where("plan.usageBased", true)
+    .whereRaw("?? < now()", "subscriptions.startDate")
+    .whereIn("subscriptions.status", ["active", "trialing", "past_due"])
+    .where((query) =>
+      query
+        .whereNull("subscriptions.endDate")
+        .orWhereRaw("?? >= now()", "subscriptions.endDate"),
+    )
+    .distinctOn("subscriptions.accountId")
+    .orderBy("subscriptions.accountId")
+    .orderBy("plan.includedScreenshots", "DESC");
+
+  const subscriptionByAccountId = new Map(
+    subscriptions.map((subscription) => [subscription.accountId, subscription]),
+  );
+
+  const now = new Date();
+  const periodStartByAccountId = new Map<string, Date>();
+
+  for (const account of subscribedAccounts) {
+    const subscription = subscriptionByAccountId.get(account.id);
+    if (!subscription?.plan) {
+      result.set(account.id, null);
+      continue;
+    }
+    periodStartByAccountId.set(
+      account.id,
+      subscription.getLastResetDate(now, subscription.plan.interval),
+    );
+  }
+
+  if (periodStartByAccountId.size === 0) {
+    return result;
+  }
+
+  const totalsByAccountId = await getScreenshotTotals(periodStartByAccountId);
+
+  for (const accountId of periodStartByAccountId.keys()) {
+    const subscription = subscriptionByAccountId.get(accountId);
+    const totals = totalsByAccountId.get(accountId);
+
+    if (!subscription || !totals) {
+      result.set(accountId, EMPTY_PERIOD_USAGE);
+      continue;
+    }
+
+    const additional =
+      subscription.includedScreenshots === null
+        ? null
+        : computeAdditionalScreenshots({
+            neutral: totals.periodAll - totals.periodStorybook,
+            storybook: totals.periodStorybook,
+            included: subscription.includedScreenshots,
+          });
+
+    // Storybook screenshots fall back to the neutral price when they have none
+    // of their own, exactly as the per-account cost does.
+    const price = {
+      neutral: subscription.additionalScreenshotPrice ?? 0,
+      storybook:
+        subscription.additionalStorybookScreenshotPrice ??
+        subscription.additionalScreenshotPrice ??
+        0,
+    };
+
+    result.set(accountId, {
+      additionalScreenshotCost: additional
+        ? additional.neutral * price.neutral +
+          additional.storybook * price.storybook
+        : 0,
+      storybookRatio:
+        totals.allTimeAll > 0
+          ? totals.allTimeStorybook / totals.allTimeAll
+          : null,
+      storybookCount: totals.allTimeStorybook,
+    });
+  }
+
+  return result;
+}

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -65,6 +65,19 @@ export const typeDefs = gql`
     user: User!
   }
 
+  "What a team is consuming, as needed to explain what it is about to pay."
+  type TeamStaffPeriodUsage {
+    "Cost of the screenshots consumed beyond the included quota, this period."
+    additionalScreenshotsCost: Float!
+    """
+    Share of Storybook screenshots in everything the team ever uploaded, between
+    0 and 1. Null when it never uploaded a screenshot at all.
+    """
+    storybookRatio: Float
+    "Storybook screenshots uploaded since the team was created."
+    storybookScreenshotsCount: Int!
+  }
+
   """
   Team data reserved to Argos staff.
 
@@ -82,6 +95,8 @@ export const typeDefs = gql`
     owners: [TeamStaffOwner!]!
     "When a staff member reached out to the team, null if never"
     contact: TeamStaffContact
+    "Billing usage. Null when the team is not on a usage-based plan."
+    periodUsage: TeamStaffPeriodUsage
   }
 
   extend type Team {
@@ -131,6 +146,19 @@ export const resolvers: IResolvers = {
     contact: async (account, _args, ctx) => {
       invariant(account.teamId, "not a team account");
       return ctx.loaders.StaffTeamContactByTeamId.load(account.teamId);
+    },
+    periodUsage: async (account, _args, ctx) => {
+      const usage = await ctx.loaders.AccountPeriodUsageByAccountId.load(
+        account.id,
+      );
+      if (!usage) {
+        return null;
+      }
+      return {
+        additionalScreenshotsCost: usage.additionalScreenshotCost,
+        storybookRatio: usage.storybookRatio,
+        storybookScreenshotsCount: usage.storybookCount,
+      };
     },
   },
   TeamStaffContact: {

--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -45,6 +45,10 @@ import {
   User,
 } from "@/database/models";
 import {
+  getAccountPeriodUsages,
+  type AccountPeriodUsage,
+} from "@/database/services/period-usage";
+import {
   checkOctokitErrorStatus,
   getAppOctokit,
   GhApiInstallation,
@@ -715,6 +719,26 @@ function createAccountActivationByAccountIdLoader() {
         EMPTY_ACCOUNT_ACTIVATION,
     );
   });
+}
+
+/**
+ * Batches the billing usage that the staff trial pipeline reads per team.
+ *
+ * Without it, every row would resolve its own subscription and run its own
+ * aggregate over `screenshot_buckets` — the exact N+1 the loaders around it
+ * exist to prevent, on a list that has no upper bound on its row count.
+ */
+function createAccountPeriodUsageByAccountIdLoader() {
+  return new DataLoader<string, AccountPeriodUsage | null>(
+    async (accountIds) => {
+      const uniqueAccountIds = [...new Set(accountIds as string[])];
+      const accounts = await Account.query().findByIds(uniqueAccountIds);
+      const usageByAccountId = await getAccountPeriodUsages(accounts);
+      return accountIds.map(
+        (accountId) => usageByAccountId.get(accountId) ?? null,
+      );
+    },
+  );
 }
 
 /** An owner of a team, as needed to write to them. */
@@ -1589,6 +1613,7 @@ export const createLoaders = () => ({
   AccountLastBuildDateByAccountId:
     createAccountLastBuildDateByAccountIdLoader(),
   AccountActivationByAccountId: createAccountActivationByAccountIdLoader(),
+  AccountPeriodUsageByAccountId: createAccountPeriodUsageByAccountIdLoader(),
   TeamOwnersByTeamId: createTeamOwnersByTeamIdLoader(),
   StaffTeamContactByTeamId: createStaffTeamContactByTeamIdLoader(),
   AccountSubscriptionStatusByAccountId:

--- a/apps/frontend/src/pages/Staff/Trials.tsx
+++ b/apps/frontend/src/pages/Staff/Trials.tsx
@@ -6,6 +6,7 @@ import clsx from "clsx";
 import {
   CheckIcon,
   CircleCheckIcon,
+  CircleDollarSignIcon,
   CircleXIcon,
   CreditCardIcon,
   ImagesIcon,
@@ -65,6 +66,11 @@ const TrialPipelineQuery = graphql(`
         buildsCount
         screenshotsCount
         firstComparisonAt
+        periodUsage {
+          additionalScreenshotsCost
+          storybookRatio
+          storybookScreenshotsCount
+        }
         owners {
           id
           name
@@ -165,7 +171,65 @@ type SortKey =
   | "checkBuild"
   | "builds"
   | "screenshots"
+  | "estimatedPrice"
   | "contacted";
+
+/**
+ * Flat monthly price of the Pro plan, in dollars.
+ *
+ * Hardcoded because the flat price is the one part of the pricing that is not
+ * persisted: the Stripe sync keeps `includedScreenshots` and the per-screenshot
+ * prices on the subscription, but not the plan's own amount. Pro is the only
+ * usage-based plan a self-serve trial can land on, so the constant holds for
+ * this page — it does not for a negotiated enterprise subscription, nor for a
+ * customer billed in euros. Hence "estimated".
+ */
+const PRO_FLAT_PRICE = 100;
+
+const PRICE_FORMAT = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+
+/**
+ * What the team would be invoiced if its period closed right now, or null when
+ * it would be invoiced nothing at all.
+ *
+ * What is owed depends on where the team sits in its lifecycle, not only on
+ * what it consumed:
+ *
+ * - Active: billing has started, so the flat price plus the overage accrued
+ *   since the period opened. The period opened when the subscription did, which
+ *   for a converted trial is the conversion itself, so that overage is real.
+ * - Trialing with a card: Stripe never bills usage consumed during a trial, and
+ *   a trial that goes over quota with a card on file is converted to active on
+ *   the next build. Whatever it consumed, it owes the flat price and no more.
+ * - Trialing with no card: committed to nothing, and a build would be rejected
+ *   before it could owe anything.
+ * - Anything else: canceled, expired, or never subscribed.
+ *
+ * A team off a usage-based plan is null throughout — there is no flat price of
+ * ours to quote for it.
+ */
+function getEstimatedPrice(team: PipelineTeam): number | null {
+  const { periodUsage } = team.staff;
+
+  if (!periodUsage) {
+    return null;
+  }
+
+  switch (team.subscriptionStatus) {
+    case AccountSubscriptionStatus.Active:
+      return PRO_FLAT_PRICE + periodUsage.additionalScreenshotsCost;
+
+    case AccountSubscriptionStatus.TrialingWithPaymentMethod:
+      return PRO_FLAT_PRICE;
+
+    default:
+      return null;
+  }
+}
 
 /**
  * Sortable value per column. Booleans and dates collapse to numbers so a single
@@ -193,6 +257,10 @@ function getSortValue(team: PipelineTeam, key: SortKey): string | number {
       return team.staff.buildsCount;
     case "screenshots":
       return team.staff.screenshotsCount;
+    // Teams with nothing to bill sort below every paying one rather than tying
+    // with a $0 estimate, which no billed team can have.
+    case "estimatedPrice":
+      return getEstimatedPrice(team) ?? -1;
     case "contacted":
       return team.staff.contact ? 1 : 0;
   }
@@ -261,15 +329,14 @@ function StatusCell(props: { team: PipelineTeam }) {
         )}
 
         {daysRemaining != null && (
-          <span
+          <div
             className={clsx(
               "text-xs",
               isEndingUnpaid ? "text-warning-low" : "text-low",
             )}
           >
-            {" "}
-            • {daysRemaining}d left
-          </span>
+            {daysRemaining}d left
+          </div>
         )}
       </div>
     );
@@ -330,6 +397,56 @@ function CheckBuildCell(props: { team: PipelineTeam }) {
     <div className="flex justify-center">
       {hint ? <Tooltip content={hint}>{icon}</Tooltip> : icon}
     </div>
+  );
+}
+
+/**
+ * Screenshots uploaded, with the Storybook share of them underneath.
+ *
+ * The share is what explains an overage that looks too cheap for its volume:
+ * Storybook screenshots bill at their own, lower rate. It is a property of the
+ * mix rather than a slice of the number above it — the total counts build
+ * stats, the share is measured on the buckets that billing actually reads — so
+ * it is shown as a percentage, which invites no subtraction.
+ *
+ * Silent below one percent: a team with a handful of Storybook screenshots is
+ * not a Storybook team, and rounding it to `0%` would say the opposite of what
+ * a blank line says.
+ */
+function ScreenshotsCell(props: { team: PipelineTeam }) {
+  const { team } = props;
+  const { periodUsage } = team.staff;
+  const ratio = periodUsage?.storybookRatio ?? null;
+
+  return (
+    <div className="inline-block text-right">
+      <div className="text-low">
+        {team.staff.screenshotsCount.toLocaleString()}
+      </div>
+      {ratio !== null && ratio >= 0.01 ? (
+        <Tooltip
+          content={`${periodUsage?.storybookScreenshotsCount.toLocaleString()} Storybook screenshots, billed at the Storybook rate`}
+        >
+          <div className="text-low text-xs">
+            {Math.round(ratio * 100)}% Storybook
+          </div>
+        </Tooltip>
+      ) : null}
+    </div>
+  );
+}
+
+function EstimatedPriceCell(props: { team: PipelineTeam }) {
+  const price = getEstimatedPrice(props.team);
+
+  if (price === null) {
+    return <span className="text-low">—</span>;
+  }
+
+  return (
+    <Tooltip content="Flat Pro plan, plus the overage accrued this period once billing has started. A running trial owes the flat price only: trial usage is never billed.">
+      <span className="font-medium">{PRICE_FORMAT.format(price)}</span>
+    </Tooltip>
   );
 }
 
@@ -493,7 +610,7 @@ function PipelineRow(props: { team: PipelineTeam; index: number }) {
 
   return (
     <tr className={clsx("border-b", index % 2 === 0 ? "bg-app" : "bg-subtle")}>
-      <td className="p-4 text-sm">
+      <td className="p-2 text-sm">
         <div className="flex min-w-0 items-center gap-3">
           <AccountAvatar avatar={team.avatar} className="size-8 shrink-0" />
           <div className="min-w-0">
@@ -507,25 +624,28 @@ function PipelineRow(props: { team: PipelineTeam; index: number }) {
           </div>
         </div>
       </td>
-      <td className="truncate p-4 text-sm">
+      <td className="truncate p-2 text-sm">
         <Time date={team.createdAt} />
       </td>
-      <td className="truncate p-4 text-sm">
+      <td className="truncate p-2 text-sm">
         {team.lastBuildDate && <Time date={team.lastBuildDate} />}
       </td>
-      <td className="p-4 text-sm">
+      <td className="p-2 text-sm">
         <StatusCell team={team} />
       </td>
-      <td className="text-low p-4 text-right text-sm tabular-nums">
+      <td className="text-low p-2 text-right text-sm tabular-nums">
         {team.staff.buildsCount.toLocaleString()}
       </td>
-      <td className="p-4 text-right">
+      <td className="p-2 text-right">
         <CheckBuildCell team={team} />
       </td>
-      <td className="text-low p-4 text-right text-sm tabular-nums">
-        {team.staff.screenshotsCount.toLocaleString()}
+      <td className="p-2 text-right text-sm tabular-nums">
+        <ScreenshotsCell team={team} />
       </td>
-      <td className="p-4">
+      <td className="p-2 text-right text-sm tabular-nums">
+        <EstimatedPriceCell team={team} />
+      </td>
+      <td className="p-2">
         <ContactCell team={team} />
       </td>
     </tr>
@@ -542,8 +662,16 @@ const ALIGN_CLASS_NAMES = {
 
 /**
  * Widths are fixed rather than left to the content: the two date columns render
- * a formatted date, so their natural width follows the calendar — every column
- * after them would shift on the day a month name gets longer.
+ * a relative time, so their natural width follows how long ago it was — every
+ * column after them would shift as rows age.
+ *
+ * They add up to 100 on purpose. `table-fixed` splits whatever the table is
+ * wide between them, so a total under 100 does not shrink the table, it only
+ * hands the remainder back out — which makes the numbers read as if they were
+ * doing something they are not. The table's real width is its `min-w`.
+ *
+ * `status` gets the widest slice of the narrow ones: it is the only cell with
+ * `whitespace-nowrap` text, so it overflows rather than wraps when squeezed.
  */
 const COLUMNS: {
   key: SortKey;
@@ -551,29 +679,35 @@ const COLUMNS: {
   align: keyof typeof ALIGN_CLASS_NAMES;
   width: string;
 }[] = [
-  { key: "team", label: "Team", align: "left", width: "w-[20%]" },
-  { key: "createdAt", label: "Created", align: "left", width: "w-[12%]" },
+  { key: "team", label: "Team", align: "left", width: "w-[25%]" },
+  { key: "createdAt", label: "Created", align: "left", width: "w-[9%]" },
   {
     key: "lastActivity",
     label: "Last activity",
     align: "left",
-    width: "w-[12%]",
+    width: "w-[9%]",
   },
-  { key: "status", label: "Status", align: "left", width: "w-[9%]" },
-  { key: "builds", label: "Builds", align: "right", width: "w-[9%]" },
+  { key: "status", label: "Status", align: "left", width: "w-[12%]" },
+  { key: "builds", label: "Builds", align: "right", width: "w-[7%]" },
   {
     key: "checkBuild",
     label: "Check build",
     align: "center",
-    width: "w-[8%]",
+    width: "w-[6%]",
   },
   {
     key: "screenshots",
     label: "Screenshots",
     align: "right",
-    width: "w-[9%]",
+    width: "w-[11%]",
   },
-  { key: "contacted", label: "Contacted", align: "center", width: "w-[9%]" },
+  {
+    key: "estimatedPrice",
+    label: "Est. price",
+    align: "right",
+    width: "w-[10%]",
+  },
+  { key: "contacted", label: "Contacted", align: "center", width: "w-[11%]" },
 ];
 
 function PipelineTable(props: {
@@ -662,11 +796,39 @@ function DecidedTrialsHint() {
   );
 }
 
+/**
+ * What the window is worth per month: the Est. price column, added up.
+ *
+ * Deliberately nothing more than that sum — no separate notion of who counts.
+ * The rule for who owes what lives in `getEstimatedPrice` alone, so the tile
+ * and the column cannot drift into disagreeing, and the tile stays a figure a
+ * reader can check by adding up what is on screen.
+ *
+ * The overage half is usage to date rather than a settled month, so the total
+ * is a floor: it can only be revised upwards as the periods close.
+ */
+function getEstimatedMrr(teams: PipelineTeam[]): {
+  total: number;
+  billedTeams: number;
+} {
+  return teams.reduce(
+    (acc, team) => {
+      const price = getEstimatedPrice(team);
+      if (price === null) {
+        return acc;
+      }
+      return { total: acc.total + price, billedTeams: acc.billedTeams + 1 };
+    },
+    { total: 0, billedTeams: 0 },
+  );
+}
+
 function PipelineSummary(props: { teams: PipelineTeam[] }) {
   const { teams } = props;
   const activated = teams.filter((team) => team.staff.firstComparisonAt).length;
   const lost = teams.filter(checkIsLost).length;
   const converted = teams.filter(checkIsConverted).length;
+  const estimatedMrr = getEstimatedMrr(teams);
 
   // Teams whose outcome is still open would drag both rates down for no reason
   // other than being recent — the rates only mean something over decided
@@ -674,7 +836,7 @@ function PipelineSummary(props: { teams: PipelineTeam[] }) {
   const decided = converted + lost;
 
   return (
-    <div className="mb-6 grid grid-cols-2 gap-4 lg:grid-cols-4">
+    <div className="mb-6 grid grid-cols-2 gap-4 lg:grid-cols-5">
       <StatTile
         data-visual-test="transparent"
         icon={UsersIcon}
@@ -716,6 +878,21 @@ function PipelineSummary(props: { teams: PipelineTeam[] }) {
           <>
             {formatShare(lost, decided)} <DecidedTrialsHint />
           </>
+        }
+      />
+      <StatTile
+        data-visual-test="transparent"
+        icon={CircleDollarSignIcon}
+        color="success"
+        label="Est. MRR"
+        value={estimatedMrr.total}
+        format="currency"
+        hint={
+          <Tooltip content="The Est. price column added up. Active teams count their overage, running trials count the flat price only, and everything else counts nothing. Periods are still open, so this is a floor.">
+            <span className="underline decoration-dotted underline-offset-2">
+              from {estimatedMrr.billedTeams} billed
+            </span>
+          </Tooltip>
         }
       />
     </div>

--- a/apps/frontend/src/pages/Staff/Trials.tsx
+++ b/apps/frontend/src/pages/Staff/Trials.tsx
@@ -13,6 +13,7 @@ import {
   MailIcon,
   MinusIcon,
   SearchIcon,
+  TriangleAlertIcon,
   UsersIcon,
   XIcon,
   type LucideIcon,
@@ -342,6 +343,21 @@ function StatusCell(props: { team: PipelineTeam }) {
     );
   }
 
+  // A failed payment is the one state that has to be caught at a glance. The
+  // team is still on a paid plan and still building, so nothing else on the row
+  // looks wrong — only the money stopped arriving. Printed in the default color
+  // like every other status, it disappears into the list.
+  if (subscriptionStatus === AccountSubscriptionStatus.PastDue) {
+    return (
+      <Tooltip content="Payment failed. The subscription is still running while Stripe retries the charge.">
+        <span className="text-danger-low inline-flex items-center gap-1 font-medium whitespace-nowrap">
+          <TriangleAlertIcon className="size-4 shrink-0" />
+          past due
+        </span>
+      </Tooltip>
+    );
+  }
+
   return (
     <span
       className={clsx(
@@ -425,7 +441,7 @@ function ScreenshotsCell(props: { team: PipelineTeam }) {
       </div>
       {ratio !== null && ratio >= 0.01 ? (
         <Tooltip
-          content={`${periodUsage?.storybookScreenshotsCount.toLocaleString()} Storybook screenshots, billed at the Storybook rate`}
+          content={`${periodUsage?.storybookScreenshotsCount.toLocaleString()} Storybook screenshots since signup. Storybook bills at its own, lower rate, which is why a large volume can still cost little.`}
         >
           <div className="text-low text-xs">
             {Math.round(ratio * 100)}% Storybook
@@ -817,7 +833,14 @@ function getEstimatedMrr(teams: PipelineTeam[]): {
       if (price === null) {
         return acc;
       }
-      return { total: acc.total + price, billedTeams: acc.billedTeams + 1 };
+      // Rounded per team, exactly as each cell rounds itself. Summing the exact
+      // amounts and rounding once at the end would be marginally more accurate
+      // and would break the promise above: three teams at $100.50 would print
+      // $101 three times over a total of $302.
+      return {
+        total: acc.total + Math.round(price),
+        billedTeams: acc.billedTeams + 1,
+      };
     },
     { total: 0, billedTeams: 0 },
   );

--- a/apps/frontend/src/ui/StatTile.tsx
+++ b/apps/frontend/src/ui/StatTile.tsx
@@ -18,7 +18,8 @@ type StatTileProps = ComponentPropsWithRef<"div"> & {
   color: StatTileColor;
   label: string;
   value: number | null | undefined;
-  format?: "number" | "percent";
+  /** `currency` renders US dollars — the currency Argos reports revenue in. */
+  format?: "number" | "percent" | "currency";
   hint?: React.ReactNode;
   visual?: React.ReactNode;
 };
@@ -64,6 +65,15 @@ export function StatTile({
             <NumberFlow
               value={value}
               format={{ style: "percent", maximumFractionDigits: 0 }}
+            />
+          ) : format === "currency" ? (
+            <NumberFlow
+              value={value}
+              format={{
+                style: "currency",
+                currency: "USD",
+                maximumFractionDigits: 0,
+              }}
             />
           ) : (
             <NumberFlow value={value} />


### PR DESCRIPTION
Adds an Est. price column and an Est. MRR tile to the trial pipeline, plus the Storybook share of each team's screenshots to explain an overage that looks cheap for its volume.

What a team owes follows its lifecycle, not only its usage: active teams pay the flat plan plus the period's overage, running trials pay the flat plan alone since Stripe never bills trial usage, and everything else pays nothing. That rule lives in one place, so the tile is literally the column added up.

Figures come from a batched loader — two queries per page rather than three per row — resolving the same subscription as `getActiveSubscription`, and treating a forced plan as overriding any subscription still on file so granted open source accounts stay unpriced.

The $100 flat price is hardcoded: it is the one part of the pricing Stripe syncs but we never persist. Holds for Pro, not for a negotiated enterprise plan or a customer billed in euros.

Not verified in a running app — the layout is checked by types and tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)