### PR TITLE
fix(frontend): stop the git settings page from suspending as a whole

### DIFF
--- a/apps/frontend/src/containers/Project/GitRepository.tsx
+++ b/apps/frontend/src/containers/Project/GitRepository.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { useApolloClient, useMutation } from "@apollo/client/react";
 import { SubmitHandler, useForm } from "react-hook-form";
 
@@ -9,6 +10,7 @@ import { Form } from "@/ui/Form";
 import { FormCardFooter } from "@/ui/FormCardFooter";
 import { FormSwitch } from "@/ui/FormSwitch";
 import { Link } from "@/ui/Link";
+import { Loader } from "@/ui/Loader";
 import { toast } from "@/ui/Toaster";
 import { getErrorMessage } from "@/util/error";
 
@@ -295,10 +297,20 @@ export const ProjectGitRepository = (props: {
           </div>
         ) : (
           <Card className="p-4">
-            <LinkRepository
-              projectId={project.id}
-              accountSlug={project.account.slug}
-            />
+            {/* `LinkRepository` fetches the Git providers with a suspense query,
+                keep it contained so it does not blow away the settings page. */}
+            <Suspense
+              fallback={
+                <div className="flex justify-center py-2">
+                  <Loader className="size-6" />
+                </div>
+              }
+            >
+              <LinkRepository
+                projectId={project.id}
+                accountSlug={project.account.slug}
+              />
+            </Suspense>
           </Card>
         )}
       </CardBody>


### PR DESCRIPTION
Fixes ARG-482.

## Problem

Accessing a project's Git settings (`/:accountSlug/:projectName/settings/git`) looked like a page reload: the settings nav and cards were wiped and replaced by the full-page loader.

## Cause

`ConnectRepository` lists the Git providers with `useSuspenseQuery`, but it was rendered without a boundary of its own. For a project with no linked repository, that suspension bubbled up to the page-level `Suspense` in `pages/Project/Settings.tsx`, unmounting the whole settings page — nav included — in favor of `PageLoader`.

## Fix

Contain it in the card that renders it, the way the members list already does, so the cards stay put and only the provider picker shows a loader.

## Verification

Drove the built app with Playwright against the test database, with a project that has no linked repository and the `ConnectRepository` response delayed by 4s to make the window observable:

- With the fix: the nav and the "Connected Git Repository" card are visible while the picker query is still in flight, with no page loader; the picker appears when it resolves. Holds both on direct URL access and when clicking the Git nav link.
- Reverting the fix makes both cases fail — the nav never appears on direct load, and clicking the Git tab wipes the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)