### PR TITLE
feat(test): surface and filter ignored changes on the test page

### DIFF
--- a/apps/backend/src/graphql/definitions/Test.ts
+++ b/apps/backend/src/graphql/definitions/Test.ts
@@ -1,7 +1,7 @@
 import { invariant } from "@argos/util/invariant";
 import gqlTag from "graphql-tag";
 
-import { ScreenshotDiff } from "@/database/models";
+import { IgnoredChange, ScreenshotDiff } from "@/database/models";
 import { getStartDateFromPeriod, getTestSeriesMetrics } from "@/metrics/test";
 import { formatTestId } from "@/util/test-id";
 
@@ -60,6 +60,11 @@ export const typeDefs = gql`
       period: MetricsPeriod!
       after: Int!
       first: Int!
+      """
+      Restrict the changes to the ones currently ignored (\`true\`) or to the ones
+      still under review (\`false\`). Null returns both.
+      """
+      ignored: Boolean
     ): TestChangesConnection!
     metrics(period: MetricsPeriod): TestMetrics!
     trails: [AuditTrail!]!
@@ -103,7 +108,7 @@ export const resolvers: IResolvers = {
       return res.last;
     },
     changes: async (test, args, ctx) => {
-      const { period, after, first } = args;
+      const { period, after, first, ignored } = args;
       const from = getStartDateFromPeriod(period);
 
       const totalOccurrencesQuery = `
@@ -129,6 +134,22 @@ export const resolvers: IResolvers = {
         .whereIn("id", diffQuery.clone())
         .orderByRaw(`(${totalOccurrencesQuery}) DESC`, { from })
         .range(after, after + first - 1);
+
+      if (ignored != null) {
+        // A change is ignored per project + test + fingerprint, and both the
+        // test and the project are fixed here, so matching on the fingerprint
+        // alone is enough.
+        const ignoredFingerprints = IgnoredChange.query()
+          .select("fingerprint")
+          .where("projectId", test.projectId)
+          .where("testId", test.id);
+
+        if (ignored) {
+          query.whereIn("screenshot_diffs.fingerprint", ignoredFingerprints);
+        } else {
+          query.whereNotIn("screenshot_diffs.fingerprint", ignoredFingerprints);
+        }
+      }
 
       const [project, result] = await Promise.all([
         ctx.loaders.Project.load(test.projectId),

--- a/apps/backend/src/graphql/tests/testChanges.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/testChanges.e2e.test.ts
@@ -1,0 +1,146 @@
+import { invariant } from "@argos/util/invariant";
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { Account, Project, Test } from "@/database/models";
+import { IgnoredChange } from "@/database/models";
+import { factory, setupDatabase } from "@/database/testing";
+import { formatTestId } from "@/util/test-id";
+
+import { apolloServer, createApolloMiddleware } from "../apollo";
+import { expectNoGraphQLError } from "../testing";
+import { createApolloServerApp } from "./util";
+
+const TEST_CHANGES_QUERY = `
+  query TestChanges(
+    $accountSlug: String!
+    $projectName: String!
+    $testId: ID!
+    $ignored: Boolean
+  ) {
+    project(accountSlug: $accountSlug, projectName: $projectName) {
+      id
+      test(id: $testId) {
+        id
+        changes(period: LAST_7_DAYS, after: 0, first: 30, ignored: $ignored) {
+          pageInfo {
+            totalCount
+          }
+          edges {
+            ignored
+          }
+        }
+      }
+    }
+  }
+`;
+
+const IGNORED_FINGERPRINT = "ignored-fp";
+
+describe("GraphQL Test.changes", () => {
+  let userAccount: Account;
+  let project: Project;
+  let visualTest: Test;
+
+  /**
+   * A change is a distinct fingerprint seen in an auto-approved build of the
+   * test, so each one needs its own reference build carrying a diff.
+   */
+  async function createChange(input: { test: Test; fingerprint: string }) {
+    const build = await factory.Build.create({
+      projectId: project.id,
+      type: "reference",
+    });
+    await factory.ScreenshotDiff.create({
+      buildId: build.id,
+      testId: input.test.id,
+      fingerprint: input.fingerprint,
+      score: 0.5,
+    });
+  }
+
+  async function queryChanges(
+    input: { test?: Test; ignored?: boolean } = {},
+  ): Promise<{
+    pageInfo: { totalCount: number };
+    edges: { ignored: boolean }[];
+  }> {
+    const { test = visualTest, ignored } = input;
+    const user = userAccount.user;
+    invariant(user, "the user account should have a user");
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user, account: userAccount },
+    );
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: TEST_CHANGES_QUERY,
+        variables: {
+          accountSlug: userAccount.slug,
+          projectName: project.name,
+          testId: formatTestId({ projectName: project.name, testId: test.id }),
+          ignored,
+        },
+      });
+    expectNoGraphQLError(res);
+    expect(res.status).toBe(200);
+    return res.body.data.project.test.changes;
+  }
+
+  beforeEach(async () => {
+    await setupDatabase();
+    userAccount = await factory.UserAccount.create();
+    await userAccount.$fetchGraph("user");
+    project = await factory.Project.create({ accountId: userAccount.id });
+    visualTest = await factory.Test.create({ projectId: project.id });
+    await createChange({ test: visualTest, fingerprint: IGNORED_FINGERPRINT });
+    await createChange({ test: visualTest, fingerprint: "live-fp" });
+    await IgnoredChange.query().insert({
+      projectId: project.id,
+      testId: visualTest.id,
+      fingerprint: IGNORED_FINGERPRINT,
+    });
+  });
+
+  it("returns ignored and non-ignored changes alike by default", async () => {
+    const changes = await queryChanges();
+    expect(changes.pageInfo.totalCount).toBe(2);
+    expect(changes.edges.filter((edge) => edge.ignored)).toHaveLength(1);
+    expect(changes.edges.filter((edge) => !edge.ignored)).toHaveLength(1);
+  });
+
+  it("returns only the ignored changes when `ignored` is true", async () => {
+    const changes = await queryChanges({ ignored: true });
+    expect(changes.pageInfo.totalCount).toBe(1);
+    expect(changes.edges).toEqual([{ ignored: true }]);
+  });
+
+  it("returns only the changes still under review when `ignored` is false", async () => {
+    const changes = await queryChanges({ ignored: false });
+    expect(changes.pageInfo.totalCount).toBe(1);
+    expect(changes.edges).toEqual([{ ignored: false }]);
+  });
+
+  it("scopes the filter to the test it is asked about", async () => {
+    // Same fingerprint on another test of the same project: ignoring it on
+    // `visualTest` says nothing about this one.
+    const otherTest = await factory.Test.create({
+      projectId: project.id,
+      name: "other-test",
+    });
+    await createChange({ test: otherTest, fingerprint: IGNORED_FINGERPRINT });
+
+    const ignoredChanges = await queryChanges({
+      test: otherTest,
+      ignored: true,
+    });
+    expect(ignoredChanges.pageInfo.totalCount).toBe(0);
+    expect(ignoredChanges.edges).toEqual([]);
+
+    const liveChanges = await queryChanges({ test: otherTest, ignored: false });
+    expect(liveChanges.pageInfo.totalCount).toBe(1);
+    expect(liveChanges.edges).toEqual([{ ignored: false }]);
+  });
+});

--- a/apps/frontend/src/pages/Test/ChangesFilter.tsx
+++ b/apps/frontend/src/pages/Test/ChangesFilter.tsx
@@ -1,0 +1,63 @@
+import { parseAsStringLiteral, useQueryState } from "nuqs";
+
+import { ButtonGroup } from "@/ui/ButtonGroup";
+import { IconButton } from "@/ui/IconButton";
+import { Tooltip } from "@/ui/Tooltip";
+
+import type { TestSearchParams } from "./TestParams";
+
+const CHANGES_FILTERS = ["all", "ignored"] as const;
+
+/**
+ * Which changes the list shows. `all` includes ignored changes: the filter is
+ * there to audit what a test has ignored, not to reveal changes hidden from the
+ * default view.
+ */
+export type ChangesFilter = (typeof CHANGES_FILTERS)[number];
+
+const CHANGES_FILTER_PARAM = "changes" satisfies keyof TestSearchParams;
+
+export interface ChangesFilterState {
+  value: ChangesFilter;
+  setValue: (value: ChangesFilter) => void;
+}
+
+export function useChangesFilterState(): ChangesFilterState {
+  const [value, setValue] = useQueryState(
+    CHANGES_FILTER_PARAM,
+    parseAsStringLiteral(CHANGES_FILTERS).withDefault("all"),
+  );
+  return { value, setValue };
+}
+
+/**
+ * Value of the `ignored` argument of `Test.changes` for a filter. `null` returns
+ * ignored and non-ignored changes alike.
+ */
+export function getChangesFilterIgnored(filter: ChangesFilter): boolean | null {
+  return filter === "ignored" ? true : null;
+}
+
+export function ChangesFilterToggle(props: { state: ChangesFilterState }) {
+  const { state } = props;
+  return (
+    <ButtonGroup>
+      <IconButton
+        variant="contained"
+        aria-pressed={state.value === "all"}
+        onPress={() => state.setValue("all")}
+      >
+        All
+      </IconButton>
+      <Tooltip content="Only the changes this test no longer asks you to review.">
+        <IconButton
+          variant="contained"
+          aria-pressed={state.value === "ignored"}
+          onPress={() => state.setValue("ignored")}
+        >
+          Ignored
+        </IconButton>
+      </Tooltip>
+    </ButtonGroup>
+  );
+}

--- a/apps/frontend/src/pages/Test/TestParams.ts
+++ b/apps/frontend/src/pages/Test/TestParams.ts
@@ -30,6 +30,7 @@ export function useTestParams(): TestParams | null {
 export interface TestSearchParams {
   period?: string | null;
   change?: string | null;
+  changes?: string | null;
 }
 
 export function getTestURL(

--- a/apps/frontend/src/pages/Test/index.tsx
+++ b/apps/frontend/src/pages/Test/index.tsx
@@ -4,6 +4,7 @@ import { invariant } from "@argos/util/invariant";
 import clsx from "clsx";
 import {
   CircleCheckIcon,
+  FlagOffIcon,
   PartyPopperIcon,
   TriangleAlertIcon,
 } from "lucide-react";
@@ -39,8 +40,11 @@ import {
 import { SeenChange } from "@/containers/Test/SeenChange";
 import { TestStatusIndicator } from "@/containers/TestStatusIndicator";
 import { graphql, type DocumentType } from "@/gql";
+import { Button } from "@/ui/Button";
+import { Chip } from "@/ui/Chip";
 import {
   EmptyState,
+  EmptyStateActions,
   EmptyStateIcon,
   Page,
   PageContainer,
@@ -53,6 +57,12 @@ import useViewportSize from "@/ui/useViewportSize";
 
 import { NotFound } from "../NotFound";
 import { ChangesChart } from "./ChangesChart";
+import {
+  ChangesFilterToggle,
+  getChangesFilterIgnored,
+  useChangesFilterState,
+  type ChangesFilterState,
+} from "./ChangesFilter";
 import { Counter, CounterLabel, CounterValue } from "./Counter";
 import { useTestParams, type TestSearchParams } from "./TestParams";
 import {
@@ -69,6 +79,7 @@ const TestQuery = graphql(`
     $projectName: String!
     $testId: ID!
     $period: MetricsPeriod!
+    $ignored: Boolean
   ) {
     project(accountSlug: $accountSlug, projectName: $projectName) {
       id
@@ -86,7 +97,7 @@ const TestQuery = graphql(`
         lastSeenDiff {
           ...ScreenChange_ScreenshotDiff
         }
-        changes(period: $period, after: 0, first: 30) {
+        changes(period: $period, after: 0, first: 30, ignored: $ignored) {
           edges {
             ...TestChangeFragment
           }
@@ -122,8 +133,13 @@ export function Component() {
   const params = useTestParams();
   invariant(params, "Can't be used outside of a test route");
   const periodState = useTestPeriodState();
+  const filterState = useChangesFilterState();
   const deferredPeriodValue = useDeferredValue(periodState.value);
-  const isPending = periodState.value !== deferredPeriodValue;
+  const deferredFilterValue = useDeferredValue(filterState.value);
+  const isPeriodPending = periodState.value !== deferredPeriodValue;
+  // The filter only narrows the changes list, so it leaves the metrics alone.
+  const areChangesPending =
+    isPeriodPending || filterState.value !== deferredFilterValue;
   const period = periodState.definition[deferredPeriodValue];
   const { data } = useSuspenseQuery(TestQuery, {
     variables: {
@@ -131,6 +147,7 @@ export function Component() {
       projectName: params.projectName,
       testId: params.testId,
       period: deferredPeriodValue,
+      ignored: getChangesFilterIgnored(deferredFilterValue),
     },
   });
 
@@ -166,7 +183,7 @@ export function Component() {
             <div
               className={clsx(
                 "bg-app border-thin @container flex flex-col gap-2 self-stretch rounded-md p-2 pr-6 shadow-xs",
-                isPending && "animate-pulse",
+                isPeriodPending && "animate-pulse",
               )}
             >
               <div className="flex items-center gap-6">
@@ -211,21 +228,27 @@ export function Component() {
           <div
             className={clsx(
               "flex flex-col gap-2",
-              isPending && "animate-pulse",
+              areChangesPending && "animate-pulse",
             )}
           >
-            <Heading level={2} className="pl-4 font-medium">
-              Changes{" "}
-              <span className="text-low">
-                over the{" "}
-                {periodState.definition[periodState.value].label.toLowerCase()}
-              </span>
-            </Heading>
+            <div className="flex flex-wrap items-center justify-between gap-2 pl-4">
+              <Heading level={2} className="font-medium">
+                {filterState.value === "ignored"
+                  ? "Ignored changes"
+                  : "Changes"}{" "}
+                <span className="text-low">over the {periodLabel}</span>
+              </Heading>
+              <ChangesFilterToggle state={filterState} />
+            </div>
             <ProjectPermissionsContext value={project.permissions}>
               <ProjectIgnoreEnabledProvider
                 enabled={project.ignoreConfig.enabled}
               >
-                <ChangesExplorer test={test} periodState={periodState} />
+                <ChangesExplorer
+                  test={test}
+                  periodState={periodState}
+                  filterState={filterState}
+                />
               </ProjectIgnoreEnabledProvider>
             </ProjectPermissionsContext>
           </div>
@@ -242,6 +265,7 @@ type TestDocument = NonNullable<
 const _ChangesFragment = graphql(`
   fragment TestChangeFragment on TestChange {
     id
+    ignored
     stats(period: $period) {
       totalOccurrences
       lastSeenDiff {
@@ -296,24 +320,49 @@ function useActiveChange(props: { test: TestDocument }) {
 function ChangesExplorer(props: {
   test: TestDocument;
   periodState: TestMetricPeriodState;
+  filterState: ChangesFilterState;
 }) {
-  const { test, periodState } = props;
+  const { test, periodState, filterState } = props;
   const [activeChange, setActiveChangeId] = useActiveChange({ test });
   const viewportSize = useViewportSize();
   const height = viewportSize.height - 160;
+  const periodLabel =
+    periodState.definition[periodState.value].label.toLowerCase();
   if (test.changes.edges.length === 0) {
     return (
       <div className="bg-app rounded-lg border">
-        <EmptyState>
-          <EmptyStateIcon>
-            <PartyPopperIcon />
-          </EmptyStateIcon>
-          <Heading>No changes</Heading>
-          <Text slot="description">
-            This test remained unchanged over the{" "}
-            {periodState.definition[periodState.value].label.toLowerCase()}.
-          </Text>
-        </EmptyState>
+        {filterState.value === "ignored" ? (
+          <EmptyState>
+            <EmptyStateIcon>
+              <FlagOffIcon strokeWidth={1} />
+            </EmptyStateIcon>
+            <Heading>No ignored changes</Heading>
+            <Text slot="description">
+              No ignored change showed up in this test over the {periodLabel}.
+              Widen the period to look further back, or ignore a change from its
+              toolbar when it keeps coming back without anything really
+              changing.
+            </Text>
+            <EmptyStateActions>
+              <Button
+                variant="secondary"
+                onPress={() => filterState.setValue("all")}
+              >
+                See all changes
+              </Button>
+            </EmptyStateActions>
+          </EmptyState>
+        ) : (
+          <EmptyState>
+            <EmptyStateIcon>
+              <PartyPopperIcon />
+            </EmptyStateIcon>
+            <Heading>No changes</Heading>
+            <Text slot="description">
+              This test remained unchanged over the {periodLabel}.
+            </Text>
+          </EmptyState>
+        )}
       </div>
     );
   }
@@ -455,7 +504,11 @@ function ChangesList(props: {
     notation: "compact",
   });
   return (
-    <div className="group/sidebar flex min-h-0 flex-1 flex-col gap-4 overflow-auto p-4">
+    <div
+      role="region"
+      aria-label="Changes"
+      className="group/sidebar flex min-h-0 flex-1 flex-col gap-4 overflow-auto p-4"
+    >
       {test.changes.edges.map((change) => {
         const isActive = activeChange?.id === change.id;
         return (
@@ -465,6 +518,20 @@ function ChangesList(props: {
                 diff={change.stats.lastSeenDiff}
                 config={DIFF_IMAGE_CONFIG}
               />
+              {/* Always visible, unlike the footer: whether a change is ignored
+                  has to be readable while scanning the list, not on hover. */}
+              {change.ignored ? (
+                <Tooltip content="Ignored change: Argos skips it when it reappears in a build.">
+                  <Chip
+                    color="neutral"
+                    scale="xs"
+                    icon={FlagOffIcon}
+                    className="absolute top-1.5 left-1.5 z-10"
+                  >
+                    Ignored
+                  </Chip>
+                </Tooltip>
+              ) : null}
               <DiffCardFooter>
                 <DiffCardFooterText>
                   {change.stats.totalOccurrences > 1 ? (

--- a/tests/project-tests.spec.ts
+++ b/tests/project-tests.spec.ts
@@ -1,6 +1,9 @@
 import { expect } from "@playwright/test";
 
-import { createTestChangeScenario } from "../apps/backend/src/database/seeds";
+import {
+  createIgnoredChangeScenario,
+  createTestChangeScenario,
+} from "../apps/backend/src/database/seeds";
 import { formatTestId } from "../apps/backend/src/util/test-id";
 import { loggedTest } from "./logged-test";
 import { ensureTeamOwner, screenshot } from "./util";
@@ -72,3 +75,57 @@ loggedTest("test view with a change", async ({ page, team, project }) => {
 
   await screenshot(page, "test-view-change");
 });
+
+loggedTest(
+  "test view flags ignored changes and filters on them",
+  async ({ page, team, project, auth }) => {
+    const { test } = await createIgnoredChangeScenario({
+      projectId: project.id,
+      userId: auth.user.id,
+    });
+    const testId = formatTestId({ projectName: project.name, testId: test.id });
+
+    await page.goto(`/${team.account.slug}/${project.name}/tests/${testId}`);
+
+    // The badge is on the card in the list, without hovering it.
+    const badge = page
+      .getByRole("region", { name: "Changes" })
+      .getByText("Ignored", { exact: true });
+    await expect(badge).toBeVisible();
+
+    // Ignored changes are part of the default view, and the filter narrows it
+    // down to them.
+    await expect(page.getByRole("heading", { name: /^Changes/ })).toBeVisible();
+    await page.getByRole("button", { name: "Ignored", exact: true }).click();
+    await expect(
+      page.getByRole("heading", { name: /^Ignored changes/ }),
+    ).toBeVisible();
+    await expect(badge).toBeVisible();
+    // The filter is in the URL, so the view survives a reload and can be shared.
+    await expect(page).toHaveURL(/changes=ignored/);
+
+    await screenshot(page, "test-view-ignored-changes");
+  },
+);
+
+loggedTest(
+  "test view explains an empty ignored list",
+  async ({ page, team, project }) => {
+    const { test } = await createTestChangeScenario({ projectId: project.id });
+    const testId = formatTestId({ projectName: project.name, testId: test.id });
+
+    await page.goto(
+      `/${team.account.slug}/${project.name}/tests/${testId}?changes=ignored`,
+    );
+
+    // The test has a change, but none of them is ignored.
+    await expect(
+      page.getByRole("heading", { name: "No ignored changes" }),
+    ).toBeVisible();
+
+    // The empty state hands back the unfiltered list.
+    await page.getByRole("button", { name: "See all changes" }).click();
+    await expect(page.getByRole("heading", { name: /^Changes/ })).toBeVisible();
+    await expect(page.getByText("Occurrences")).toBeVisible();
+  },
+);


### PR DESCRIPTION
Closes ARG-214.

The test page listed every change alike, so there was no way to tell which ones Argos had stopped asking for review on — and no way to audit them periodically, which is what the customer asked for ("est-ce qu'il existe une vue dans argos qui liste les diffs qu'on a ignoré ?").

## Backend

`Test.changes` gained an optional `ignored: Boolean` argument. `null` returns both kinds (unchanged default), `true`/`false` filter against the project's ignore ledger by fingerprint — inside the same query, so `pageInfo.totalCount` stays correct.

## Frontend

- Change cards carry an always-visible **Ignored** chip (flag-off icon + tooltip). It sits outside `DiffCardFooter` on purpose: the footer only shows on hover, and ignore status has to be readable while scanning the list.
- An **All / Ignored** segmented toggle next to the section heading (the `ButtonGroup` + `IconButton aria-pressed` pattern the build toolbar uses), kept in the `changes` search param so a filtered view can be reloaded and shared. The heading becomes "Ignored changes over the last 7 days".
- A dedicated empty state when nothing is ignored in the period, with a "See all changes" way back. It says the period is what scopes the list, since a change ignored long ago that stopped firing won't appear here — the project-level **Ignored** page remains the full ledger.
- The pulse-while-pending now only covers the changes list; the metrics panel isn't affected by the filter.

One judgment call worth flagging: the filter shows regardless of `ignoreConfig.enabled`. A project that turned ignoring off can still have historical ignored changes, and gating the control on a flag the query resolves at the same time would leave a URL-filtered view with no way out.

## Verification

- New `testChanges.e2e.test.ts` (4 tests): default returns both, `true`/`false` each return one, and the filter is scoped to the test asked about (the same fingerprint on a sibling test is unaffected). Confirmed as a guard — 3 of the 4 fail with the resolver filter disabled.
- `apps/backend/src/graphql/` integration suite: 175 passed.
- Two new specs in `tests/project-tests.spec.ts` plus a `test-view-ignored-changes` baseline. Playwright can't run locally (known Node/resolve failure outside the CI image), so the built app was driven with an equivalent harness using the same locators and seeds: badge visible unhovered, toggle switches heading and URL, empty state and its button both work.
- `pnpm run static-checks`: 23/23 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)