### PR TITLE
fix(frontend): make the diff indicator report its loading state

### DIFF
--- a/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
@@ -1153,7 +1153,7 @@ function RectHighlights(props: {
   const color = useAtomValue(overlayColorAtom);
   const containerRef = useRef<HTMLDivElement>(null);
   const transform = useZoomTransform();
-  const rects = useColoredRects({ url, blockSize: 24 });
+  const { rects } = useColoredRects({ url, blockSize: 24 });
   const [imgScale] = useScaleContext();
   const realScale = imgScale ? imgScale * transform.scale : null;
   // Convert image coordinates to pane coordinates.
@@ -1288,7 +1288,7 @@ const DiffIndicator = memo(function DiffIndicator(props: {
 }) {
   const { imgSize, url } = props;
   const [imgScale] = useScaleContext();
-  const rects = useColoredRects({ url, blockSize: 5 });
+  const { rects, loading } = useColoredRects({ url, blockSize: 5 });
   const color = useAtomValue(overlayColorAtom);
   const transform = useZoomTransform();
   const [containerSize, setContainerSize] = useState<{
@@ -1324,7 +1324,13 @@ const DiffIndicator = memo(function DiffIndicator(props: {
       )}
       <div
         ref={containerRef}
-        className="bg-ui absolute inset-y-0 -left-3 m-px w-1.5 overflow-hidden rounded-sm"
+        // Detecting the changed areas is asynchronous, `aria-busy` tells Argos
+        // to wait for it before screenshotting, else the indicator is empty.
+        aria-busy={loading}
+        className={clsx(
+          "bg-ui absolute inset-y-0 -left-3 m-px w-1.5 overflow-hidden rounded-sm",
+          loading && "animate-pulse",
+        )}
       >
         {(() => {
           if (!rects || !imgScale || !containerSize) {

--- a/apps/frontend/src/util/color-detection/hook.ts
+++ b/apps/frontend/src/util/color-detection/hook.ts
@@ -3,30 +3,44 @@ import { useEffect, useState } from "react";
 import type { MessageData, Rect } from "./types";
 
 /**
+ * State of the colored rects detection.
+ * `rects` is `null` when the detection is not possible (unsupported browser
+ * or unsupported image format).
+ */
+export type ColoredRectsState =
+  { loading: true; rects: null } | { loading: false; rects: Rect[] | null };
+
+const LOADING_STATE = {
+  loading: true,
+  rects: null,
+} satisfies ColoredRectsState;
+
+/**
  * Detects colored areas in the image provided by the URL.
  */
 export function useColoredRects(input: {
   url: string;
   blockSize: number;
-}): null | Rect[] {
+}): ColoredRectsState {
   const { url, blockSize } = input;
-  const [rects, setRects] = useState<null | Rect[]>(null);
+  const [state, setState] = useState<ColoredRectsState>(LOADING_STATE);
   useEffect(() => {
-    setRects(null);
+    setState(LOADING_STATE);
 
     const worker = new Worker(new URL("./worker.ts", import.meta.url), {
       type: "module",
     });
     worker.addEventListener("message", (event: MessageEvent<MessageData>) => {
-      setRects(event.data);
+      setState({ loading: false, rects: event.data });
     });
     worker.addEventListener("error", (event) => {
       console.error(event.message);
+      setState({ loading: false, rects: null });
     });
     worker.postMessage({ url, blockSize });
     return () => {
       worker.terminate();
     };
   }, [url, blockSize]);
-  return rects;
+  return state;
 }

--- a/apps/frontend/src/util/color-detection/worker.ts
+++ b/apps/frontend/src/util/color-detection/worker.ts
@@ -18,7 +18,11 @@ self.onmessage = (event) => {
       self.postMessage(rects satisfies MessageData);
     },
     { retries: 3 },
-  );
+  ).catch((error) => {
+    console.error(error);
+    // Always answer, else the consumer stays in a loading state forever.
+    self.postMessage(null satisfies MessageData);
+  });
 };
 
 /**


### PR DESCRIPTION
Fixes the flaky build detail screenshot: https://app.argos-ci.com/argos-ci/argos/builds/5304/382039669

The changed areas are detected in a web worker, so the vertical diff indicator on the left of the screenshot was captured empty, partially filled, or complete depending on timing.

- `useColoredRects` now returns a `{ loading, rects }` state instead of `Rect[] | null`.
- While loading, the vertical indicator pulses and carries `aria-busy`, so Argos waits for the detection to finish before screenshotting.
- The worker now answers with `null` when detection fails after its retries, so the loading state always ends (this also fixes an unhandled rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)