### PR TITLE
fix(staff): align the Stripe link across trial pipeline rows

### DIFF
--- a/apps/frontend/src/pages/Staff/Trials.tsx
+++ b/apps/frontend/src/pages/Staff/Trials.tsx
@@ -629,15 +629,22 @@ function PipelineRow(props: { team: PipelineTeam; index: number }) {
       <td className="p-2 text-sm">
         <div className="flex min-w-0 items-center gap-3">
           <AccountAvatar avatar={team.avatar} className="size-8 shrink-0" />
-          <div className="min-w-0">
+          {/* `flex-1` is what pushes the Stripe link to the cell edge: this
+              wrapper takes the width the link does not, so the link lands at
+              the same offset on every row whatever the name is. */}
+          <div className="min-w-0 flex-1">
             <div className="flex min-w-0 items-center gap-3">
               <Link href={teamURL} className="truncate font-medium">
                 {team.name || team.slug}
               </Link>
-              <StripeCustomerLink stripeCustomerId={team.stripeCustomerId} />
             </div>
             <FoundViaLine owners={team.staff.owners} />
           </div>
+          {/* A sibling of the name block rather than part of it, so the row's
+              `items-center` centers it against the whole cell. Nested next to
+              the name it sat on the first line, riding up whenever the team
+              had a "Found via" line under it. */}
+          <StripeCustomerLink stripeCustomerId={team.stripeCustomerId} />
         </div>
       </td>
       <td className="truncate p-2 text-sm">


### PR DESCRIPTION
The Stripe link's `ml-auto` never had free space to absorb — the wrapper holding the team name sized to its content rather than to the cell — so the logo trailed each name at a different offset. `flex-1` on that wrapper leaves the link the width it needs and no more.

It also moves up a level, out of the name line, so the row's `items-center` centers it against the whole cell rather than parking it on the first line, where it rode up whenever a team had a "Found via" line under it.

Latent since the column was introduced; widening Team to 25% made it visible by leaving short names a lot of slack.

Not verified in a running app — CSS reasoning, types and lint only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)