### PR TITLE
perf(tests): speed up the account and project Tests lists

### DIFF
--- a/apps/backend/db/migrations/20260730120000_tests-list-indexes.js
+++ b/apps/backend/db/migrations/20260730120000_tests-list-indexes.js
@@ -1,0 +1,73 @@
+/**
+ * Indexes backing the account-wide and per-project Tests lists.
+ *
+ * 1. `screenshot_diffs_buildid_active_idx` — the "candidate diffs" step of
+ *    `queryActiveTests` reads every diff of every latest reference build and
+ *    needs `(testId, compareScreenshotId)`. The index it replaces only carried
+ *    `testId`, so each of those rows cost a heap fetch just to read the second
+ *    column. Both columns in `INCLUDE` makes the step index-only.
+ *
+ * 2. `screenshot_diffs_testid_id_with_file_idx` — `Test.firstSeenDiff` /
+ *    `lastSeenDiff` look for the oldest and newest diff of a test that still has
+ *    an image (`fileId IS NOT NULL`, i.e. the diff recorded a change). No index
+ *    could serve both the filter and the ordering: the partial one is keyed
+ *    `(testId, fingerprint, id)`, so `fingerprint` sits between the equality and
+ *    the sort key, and the only `(testId, id)` index is not partial — Postgres
+ *    walked the test's whole history heap-fetching rows to test `fileId`. A test
+ *    that has never changed has no matching row at all, so that walk covered
+ *    every diff it ever had.
+ *
+ * 3. `test_stats_fingerprints_testid_date_idx` — the flakiness computation
+ *    filters on `(testId, date-range)`, but the primary key is
+ *    `(testId, fingerprint, date)`, so answering a 7-day window meant reading
+ *    every fingerprint row the test ever recorded. `INCLUDE` carries the two
+ *    columns the aggregation needs so it stays index-only.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async (knex) => {
+  await knex.raw(
+    `CREATE INDEX CONCURRENTLY IF NOT EXISTS screenshot_diffs_buildid_active_idx
+       ON screenshot_diffs ("buildId")
+       INCLUDE ("testId", "compareScreenshotId")
+       WHERE "testId" IS NOT NULL`,
+  );
+  await knex.raw(
+    `DROP INDEX CONCURRENTLY IF EXISTS screenshot_diffs_buildid_notnull_include_testid_idx`,
+  );
+  await knex.raw(
+    `CREATE INDEX CONCURRENTLY IF NOT EXISTS screenshot_diffs_testid_id_with_file_idx
+       ON screenshot_diffs ("testId", id)
+       WHERE "fileId" IS NOT NULL`,
+  );
+  await knex.raw(
+    `CREATE INDEX CONCURRENTLY IF NOT EXISTS test_stats_fingerprints_testid_date_idx
+       ON test_stats_fingerprints ("testId", date)
+       INCLUDE (fingerprint, value)`,
+  );
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async (knex) => {
+  await knex.raw(
+    `CREATE INDEX CONCURRENTLY IF NOT EXISTS screenshot_diffs_buildid_notnull_include_testid_idx
+       ON screenshot_diffs ("buildId")
+       INCLUDE ("testId")
+       WHERE "testId" IS NOT NULL`,
+  );
+  await knex.raw(
+    `DROP INDEX CONCURRENTLY IF EXISTS screenshot_diffs_buildid_active_idx`,
+  );
+  await knex.raw(
+    `DROP INDEX CONCURRENTLY IF EXISTS screenshot_diffs_testid_id_with_file_idx`,
+  );
+  await knex.raw(
+    `DROP INDEX CONCURRENTLY IF EXISTS test_stats_fingerprints_testid_date_idx`,
+  );
+};
+
+export const config = { transaction: false };

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -4492,17 +4492,17 @@ CREATE INDEX screenshot_diffs_basescreenshotid_index ON public.screenshot_diffs 
 
 
 --
+-- Name: screenshot_diffs_buildid_active_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX screenshot_diffs_buildid_active_idx ON public.screenshot_diffs USING btree ("buildId") INCLUDE ("testId", "compareScreenshotId") WHERE ("testId" IS NOT NULL);
+
+
+--
 -- Name: screenshot_diffs_buildid_index; Type: INDEX; Schema: public; Owner: postgres
 --
 
 CREATE INDEX screenshot_diffs_buildid_index ON public.screenshot_diffs USING btree ("buildId");
-
-
---
--- Name: screenshot_diffs_buildid_notnull_include_testid_idx; Type: INDEX; Schema: public; Owner: postgres
---
-
-CREATE INDEX screenshot_diffs_buildid_notnull_include_testid_idx ON public.screenshot_diffs USING btree ("buildId") INCLUDE ("testId") WHERE ("testId" IS NOT NULL);
 
 
 --
@@ -4545,6 +4545,13 @@ CREATE INDEX screenshot_diffs_testid_createdat_desc_cmp_notnull_idx ON public.sc
 --
 
 CREATE INDEX screenshot_diffs_testid_fingerprint_id_desc_notnull_idx ON public.screenshot_diffs USING btree ("testId", fingerprint, id DESC) WHERE ("fileId" IS NOT NULL);
+
+
+--
+-- Name: screenshot_diffs_testid_id_with_file_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX screenshot_diffs_testid_id_with_file_idx ON public.screenshot_diffs USING btree ("testId", id) WHERE ("fileId" IS NOT NULL);
 
 
 --
@@ -4657,6 +4664,13 @@ CREATE INDEX team_users_userid_index ON public.team_users USING btree ("userId")
 --
 
 CREATE INDEX teams_ssogithubaccountid_index ON public.teams USING btree ("ssoGithubAccountId");
+
+
+--
+-- Name: test_stats_fingerprints_testid_date_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX test_stats_fingerprints_testid_date_idx ON public.test_stats_fingerprints USING btree ("testId", date) INCLUDE (fingerprint, value);
 
 
 --
@@ -5847,3 +5861,4 @@ INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('2026072
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260725120000_screenshot-base-names.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260726130000_screenshot-diffs-fingerprint-index.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260726140000_signup-source.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260730120000_tests-list-indexes.js', 1, NOW());

--- a/apps/backend/src/graphql/definitions/Account.ts
+++ b/apps/backend/src/graphql/definitions/Account.ts
@@ -39,7 +39,7 @@ import type { Context } from "../context";
 import { getAdminAccount } from "../services/account";
 import { getAccountAvatar } from "../services/avatar";
 import { getVisibleProjectIds } from "../services/project";
-import { queryActiveTests } from "../services/test";
+import { primeActiveTestMetrics, queryActiveTests } from "../services/test";
 import { badUserInput, toGraphQLError, unauthenticated } from "../util";
 import { paginateResult } from "./PageInfo";
 
@@ -325,6 +325,11 @@ export const commonAccountResolvers: IResolvers["Team"] = {
       filters: filters ?? null,
       after,
       first,
+    });
+    primeActiveTestMetrics({
+      loaders: ctx.loaders,
+      results: result.results,
+      period,
     });
     return paginateResult({ result, first, after });
   },

--- a/apps/backend/src/graphql/definitions/Project.ts
+++ b/apps/backend/src/graphql/definitions/Project.ts
@@ -48,7 +48,7 @@ import {
   IResolvers,
 } from "../__generated__/resolver-types";
 import { deleteProject, getAdminProject } from "../services/project";
-import { queryActiveTests } from "../services/test";
+import { primeActiveTestMetrics, queryActiveTests } from "../services/test";
 import {
   badUserInput,
   forbidden,
@@ -679,13 +679,18 @@ export const resolvers: IResolvers = {
         after,
       });
     },
-    tests: async (project, { first, after, period, filters }) => {
+    tests: async (project, { first, after, period, filters }, ctx) => {
       const result = await queryActiveTests({
         projectIds: [project.id],
         period,
         filters: filters ?? null,
         after,
         first,
+      });
+      primeActiveTestMetrics({
+        loaders: ctx.loaders,
+        results: result.results,
+        period,
       });
       return paginateResult({ result, first, after });
     },

--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -1,5 +1,6 @@
 import type { BuildAggregatedStatus } from "@argos/schemas/build-status";
 import { invariant } from "@argos/util/invariant";
+import * as Sentry from "@sentry/node";
 import DataLoader from "dataloader";
 import { memoize } from "lodash-es";
 import type { ModelClass } from "objection";
@@ -56,6 +57,7 @@ import {
 import { getChangesTotalOccurrences, getTestAllMetrics } from "@/metrics/test";
 
 import { ISignupSource, ITestStatus } from "./__generated__/resolver-types";
+import { getLatestReferenceBuildIds } from "./services/test";
 
 function createModelLoader<TModelClass extends ModelClass<Model>>(
   Model: TModelClass,
@@ -1132,7 +1134,17 @@ function createTestAllMetricsLoader() {
       // Return results in the same order as inputs
       return inputs.map((_, idx) => groupResults.get(idx));
     },
-    { cacheKeyFn: (input) => JSON.stringify(input) },
+    {
+      // Spelled out rather than `JSON.stringify(input)` so the key does not
+      // depend on property order — `queryActiveTests` primes this loader and
+      // has to produce the exact same key as the `Test.metrics` resolver.
+      cacheKeyFn: (input) =>
+        [
+          input.testId,
+          input.from?.toISOString() ?? "",
+          input.to?.toISOString() ?? "",
+        ].join("|"),
+    },
   );
 }
 
@@ -1389,6 +1401,15 @@ function createTestAuditTrailLoader() {
   );
 }
 
+/**
+ * A test is "ongoing" when it still appears in the latest reference build of its
+ * build name, and "removed" otherwise.
+ *
+ * The latest reference builds come from the skip scan in `queryActiveTests`.
+ * Resolving them here with `DISTINCT ON (projectId, name)` instead meant reading
+ * every reference build of every project on the way — the exact scan that
+ * `getLatestReferenceBuildIds` exists to avoid.
+ */
 function createTestStatusLoader() {
   return new DataLoader<
     {
@@ -1405,35 +1426,47 @@ function createTestStatusLoader() {
       const projectIds = Array.from(new Set(pairs.map((p) => p.projectId)));
       const testIds = Array.from(new Set(pairs.map((p) => p.testId)));
 
-      const rows = (await ScreenshotDiff.query()
-        .join(
-          Build.query()
-            .select("id", "projectId", "name")
-            .distinctOn(["projectId", "name"])
-            .where("type", "reference")
-            .whereIn("projectId", projectIds)
-            .orderBy("projectId")
-            .orderBy("name")
-            .orderBy("createdAt", "desc")
-            .as("latest_reference_build"),
-          "latest_reference_build.id",
-          "screenshot_diffs.buildId",
-        )
-        .whereIn("testId", testIds)
-        .select("latest_reference_build.projectId", "screenshot_diffs.testId")
-        .distinct()) as unknown as { projectId: string; testId: string }[];
+      return Sentry.startSpan(
+        {
+          name: "TestStatusLoader",
+          attributes: {
+            "argos.project.count": projectIds.length,
+            "argos.test.count": testIds.length,
+          },
+        },
+        async () => {
+          const latestBuilds = await getLatestReferenceBuildIds(projectIds);
+          if (latestBuilds.length === 0) {
+            return pairs.map(() => ITestStatus.Removed);
+          }
+          const projectIdByBuildId = new Map(
+            latestBuilds.map((build) => [build.id, build.projectId]),
+          );
 
-      const activeKeySet = new Set(
-        rows.map((r) => `${r.projectId}:${r.testId}`),
-      );
+          const rows = (await ScreenshotDiff.query()
+            .distinct("buildId", "testId")
+            .whereRaw(`"buildId" = any(:buildIds::bigint[])`, {
+              buildIds: latestBuilds.map((build) => build.id),
+            })
+            .whereRaw(`"testId" = any(:testIds::bigint[])`, {
+              testIds,
+            })) as unknown as { buildId: string; testId: string }[];
 
-      return pairs.map(({ projectId, testId }) =>
-        activeKeySet.has(`${projectId}:${testId}`)
-          ? ITestStatus.Ongoing
-          : ITestStatus.Removed,
+          const activeKeySet = new Set(
+            rows.map(
+              (row) => `${projectIdByBuildId.get(row.buildId)}:${row.testId}`,
+            ),
+          );
+
+          return pairs.map(({ projectId, testId }) =>
+            activeKeySet.has(`${projectId}:${testId}`)
+              ? ITestStatus.Ongoing
+              : ITestStatus.Removed,
+          );
+        },
       );
     },
-    { cacheKeyFn: (input) => JSON.stringify(input) },
+    { cacheKeyFn: (input) => `${input.projectId}:${input.testId}` },
   );
 }
 
@@ -1447,61 +1480,71 @@ function createSeenDiffsLoader() {
       return [];
     }
 
-    const valuesSql = testIds.map(() => "(?::bigint)").join(", ");
+    return Sentry.startSpan(
+      {
+        name: "SeenDiffsLoader",
+        attributes: { "argos.test.count": testIds.length },
+      },
+      () => loadSeenDiffs(testIds),
+    );
+  });
+}
 
-    const rows = await ScreenshotDiff.query()
-      .from(ScreenshotDiff.raw(`(values ${valuesSql}) as t("testId")`, testIds))
-      .joinRaw(
-        `
-        join lateral (
-          (
-            select sd.id, 'first' as kind
-            from screenshot_diffs sd
-            where sd."testId" = t."testId"
-              and sd."fileId" is not null
-            order by sd.id asc
-            limit 1
-          )
-          union all
-          (
-            select sd.id, 'last' as kind
-            from screenshot_diffs sd
-            where sd."testId" = t."testId"
-              and sd."fileId" is not null
-            order by sd.id desc
-            limit 1
-          )
-        ) pick on true
-        `,
-      )
-      .join("screenshot_diffs", "screenshot_diffs.id", "pick.id")
-      .select(
-        ScreenshotDiff.raw(`t."testId"::text as "testId"`),
-        "pick.kind",
-        "screenshot_diffs.*",
-      );
+async function loadSeenDiffs(testIds: readonly string[]): Promise<SeenDiffs[]> {
+  const valuesSql = testIds.map(() => "(?::bigint)").join(", ");
 
-    const map = new Map<string, SeenDiffs>();
-    for (const testId of testIds) {
-      map.set(testId, { first: null, last: null });
-    }
+  const rows = await ScreenshotDiff.query()
+    .from(ScreenshotDiff.raw(`(values ${valuesSql}) as t("testId")`, testIds))
+    .joinRaw(
+      `
+      join lateral (
+        (
+          select sd.id, 'first' as kind
+          from screenshot_diffs sd
+          where sd."testId" = t."testId"
+            and sd."fileId" is not null
+          order by sd.id asc
+          limit 1
+        )
+        union all
+        (
+          select sd.id, 'last' as kind
+          from screenshot_diffs sd
+          where sd."testId" = t."testId"
+            and sd."fileId" is not null
+          order by sd.id desc
+          limit 1
+        )
+      ) pick on true
+      `,
+    )
+    .join("screenshot_diffs", "screenshot_diffs.id", "pick.id")
+    .select(
+      ScreenshotDiff.raw(`t."testId"::text as "testId"`),
+      "pick.kind",
+      "screenshot_diffs.*",
+    );
 
-    for (const row of rows as any[]) {
-      const entry = map.get(String(row.testId))!;
-      switch (row.kind) {
-        case "first": {
-          entry.first = row;
-          break;
-        }
-        case "last": {
-          entry.last = row;
-          break;
-        }
+  const map = new Map<string, SeenDiffs>();
+  for (const testId of testIds) {
+    map.set(testId, { first: null, last: null });
+  }
+
+  for (const row of rows as any[]) {
+    const entry = map.get(String(row.testId))!;
+    switch (row.kind) {
+      case "first": {
+        entry.first = row;
+        break;
+      }
+      case "last": {
+        entry.last = row;
+        break;
       }
     }
+  }
 
-    return testIds.map((id) => map.get(id)!);
-  });
+  return testIds.map((id) => map.get(id)!);
 }
 
 type LatestCompareScreenshot = Screenshot | null;
@@ -1512,13 +1555,26 @@ function createLatestCompareScreenshotLoader() {
       return [];
     }
 
-    const valuesSql = testIds.map(() => "(?::bigint)").join(", ");
+    return Sentry.startSpan(
+      {
+        name: "LatestCompareScreenshotLoader",
+        attributes: { "argos.test.count": testIds.length },
+      },
+      () => loadLatestCompareScreenshots(testIds),
+    );
+  });
+}
 
-    const rows = await Screenshot.query()
-      .select(Screenshot.raw(`t."testId" as "testId"`), "screenshots.*")
-      .from(Screenshot.raw(`(values ${valuesSql}) as t("testId")`, testIds))
-      .joinRaw(
-        `
+async function loadLatestCompareScreenshots(
+  testIds: readonly string[],
+): Promise<LatestCompareScreenshot[]> {
+  const valuesSql = testIds.map(() => "(?::bigint)").join(", ");
+
+  const rows = await Screenshot.query()
+    .select(Screenshot.raw(`t."testId" as "testId"`), "screenshots.*")
+    .from(Screenshot.raw(`(values ${valuesSql}) as t("testId")`, testIds))
+    .joinRaw(
+      `
     join lateral (
       select sd."compareScreenshotId"
       from "screenshot_diffs" sd
@@ -1528,22 +1584,21 @@ function createLatestCompareScreenshotLoader() {
       limit 1
     ) as sd on true
     `,
-      )
-      .join("screenshots", "screenshots.id", "sd.compareScreenshotId");
+    )
+    .join("screenshots", "screenshots.id", "sd.compareScreenshotId");
 
-    const index = new Map(testIds.map((testId, i) => [testId, i]));
-    const results: LatestCompareScreenshot[] = testIds.map(() => null);
+  const index = new Map(testIds.map((testId, i) => [testId, i]));
+  const results: LatestCompareScreenshot[] = testIds.map(() => null);
 
-    for (const row of rows as any[]) {
-      const i = index.get(row.testId);
-      if (i === undefined) {
-        continue;
-      }
-      results[i] = row;
+  for (const row of rows as any[]) {
+    const i = index.get(row.testId);
+    if (i === undefined) {
+      continue;
     }
+    results[i] = row;
+  }
 
-    return results;
-  });
+  return results;
 }
 
 function createPresenceLoader() {

--- a/apps/backend/src/graphql/services/test.ts
+++ b/apps/backend/src/graphql/services/test.ts
@@ -1,80 +1,103 @@
+import * as Sentry from "@sentry/node";
+import type { QueryBuilder } from "objection";
+
 import { Build, Screenshot, ScreenshotDiff, Test } from "@/database/models";
-import { getStartDateFromPeriod } from "@/metrics/test";
+import {
+  computeTestMetrics,
+  getStartDateFromPeriod,
+  type TestMetricsCounts,
+} from "@/metrics/test";
 
 import type { IMetricsPeriod } from "../__generated__/resolver-types";
+import type { createLoaders } from "../loaders";
 
 /**
- * Order tests by their flakiness score over a period, descending.
+ * Compute a test's metrics over a period, correlated on `tests.id`.
  *
  * Flakiness is not stored — it is derived at read-time from the daily-bucketed
  * `test_stats_builds` (how many builds saw the test) and
  * `test_stats_fingerprints` (how many changes, and how many were unique). The
- * formula mirrors `getTestAllMetrics` in `@/metrics/test`:
- *   stability   = changes > 0 ? 1 - changes / total : 1
- *   consistency = changes > 0 ? uniqueChanges / changes : 1
- *   flakiness   = 1 - (stability + consistency) / 2
+ * formula mirrors `computeTestMetrics` in `@/metrics/test`, down to the
+ * intermediate rounding, so a row is ordered by the same flakiness it displays.
  *
- * The subquery is correlated only on `tests.id` + the period bounds, so it does
- * not depend on how many projects the candidate set spans — that is what lets
- * one definition power both the per-project and the account-wide list.
+ * Joined as a LATERAL so the counts come back with the row: the list is both
+ * sorted by flakiness and able to prime the metrics loader from one pass,
+ * instead of computing it here and again per visible row.
+ *
+ * Correlated only on `tests.id` + the period bounds, so it does not depend on
+ * how many projects the candidate set spans — that is what lets one definition
+ * power both the per-project and the account-wide list.
  */
+const TEST_METRICS_LATERAL = `
+  left join lateral (
+    with
+      totals as (
+        select sum(tsb.value)::numeric as total
+        from test_stats_builds tsb
+        where tsb."testId" = "tests"."id"
+          and tsb."date" >= :from::timestamp
+          and tsb."date" <  :to::timestamp
+      ),
+      fp_agg as (
+        select
+          tsf."fingerprint",
+          sum(tsf.value)::numeric as changes_value,
+          count(*) as fp_count
+        from test_stats_fingerprints tsf
+        where tsf."testId" = "tests"."id"
+          and tsf."date" >= :from::timestamp
+          and tsf."date" <  :to::timestamp
+        group by tsf."fingerprint"
+      ),
+      changes as (
+        select
+          coalesce(sum(changes_value), 0)::numeric as changes,
+          coalesce(count(*) filter (where fp_count = 1), 0)::numeric as "uniqueChanges"
+        from fp_agg
+      ),
+      rates as (
+        select
+          coalesce(totals.total, 0)::numeric as total,
+          changes.changes as changes,
+          changes."uniqueChanges" as "uniqueChanges",
+          case
+            when changes.changes > 0
+              then round(1 - changes.changes / nullif(totals.total, 0), 2)
+            else 1
+          end as stability,
+          case
+            when changes.changes > 0
+              then case
+                when changes."uniqueChanges" > 0
+                  then round(changes."uniqueChanges" / changes.changes, 2)
+                else 0
+              end
+            else 1
+          end as consistency
+        from totals, changes
+      )
+    select
+      jsonb_build_object(
+        'total', rates.total::bigint,
+        'changes', rates.changes::bigint,
+        'uniqueChanges', rates."uniqueChanges"::bigint
+      ) as metrics,
+      round(1 - (rates.stability + rates.consistency) / 2, 2) as flakiness
+    from rates
+  ) test_metrics on true
+`;
+
 const FLAKINESS_ORDER_BY = `
-    (
-      with
-        totals as (
-          select sum(tsb.value)::numeric as total
-          from test_stats_builds tsb
-          where tsb."testId" = "tests"."id"
-            and tsb."date" >= :from::timestamp
-            and tsb."date" <  :to::timestamp
-        ),
-        fp_agg as (
-          select
-            tsf."fingerprint",
-            sum(tsf.value)::numeric as changes_value,
-            count(*) as fp_count
-          from test_stats_fingerprints tsf
-          where tsf."testId" = "tests"."id"
-            and tsf."date" >= :from::timestamp
-            and tsf."date" <  :to::timestamp
-          group by tsf."fingerprint"
-        ),
-        changes as (
-          select
-            sum(changes_value)::numeric as changes,
-            count(*) filter (where fp_count = 1)::numeric as "uniqueChanges"
-          from fp_agg
-        )
-      select
-        round(
-          (
-            1 - (
-              (
-                case
-                  when coalesce(changes.changes, 0) > 0
-                    then 1 - changes.changes / nullif(totals.total, 0)
-                  else 1
-                end
-              +
-                case
-                  when coalesce(changes.changes, 0) > 0
-                    then coalesce(changes."uniqueChanges", 0) / nullif(changes.changes, 0)
-                  else 1
-                end
-              ) / 2
-            )
-          ),
-          2
-        )
-      from totals, changes
-    ) desc,
+    test_metrics.flakiness desc nulls last,
     "tests"."createdAt" desc,
     "tests"."id" desc
 `;
 
+export type LatestReferenceBuild = { id: string; projectId: string };
+
 /**
- * Resolve the id of the latest reference build for each distinct build name in a
- * project.
+ * Resolve the id of the latest reference build for each distinct build name of
+ * each project.
  *
  * Teams can accumulate a massive reference-build history under only a handful of
  * build names (millions of builds, a few names). A plain `DISTINCT ON (name)`
@@ -84,46 +107,69 @@ const FLAKINESS_ORDER_BY = `
  * `(projectId, type, name, createdAt desc)` index, and grab that name's latest
  * build. That's ~2 index probes per build name instead of scanning the whole
  * history, so it no longer scales with the number of builds.
+ *
+ * The walk carries the project along so every project is covered by one
+ * statement. Fanning it out per project instead meant `projectIds.length`
+ * round-trips racing for a connection pool that is 6 wide by default — an
+ * account with dozens of projects serialized into waves and starved every other
+ * request on the process.
  */
-async function getLatestReferenceBuildIds(projectIds: string[]) {
-  const perProject = await Promise.all(
-    projectIds.map(async (projectId) => {
+export async function getLatestReferenceBuildIds(
+  projectIds: string[],
+): Promise<LatestReferenceBuild[]> {
+  if (projectIds.length === 0) {
+    return [];
+  }
+  return Sentry.startSpan(
+    {
+      name: "getLatestReferenceBuildIds",
+      attributes: { "argos.project.count": projectIds.length },
+    },
+    async () => {
       const result = (await Build.knex().raw(
         `WITH RECURSIVE build_names AS (
-           SELECT min(name) AS name
-           FROM builds
-           WHERE "projectId" = :projectId AND "type" = 'reference'
+           SELECT
+             p.id AS "projectId",
+             (
+               SELECT min(b.name)
+               FROM builds b
+               WHERE b."projectId" = p.id AND b."type" = 'reference'
+             ) AS name
+           FROM unnest(:projectIds::bigint[]) AS p(id)
            UNION ALL
-           SELECT (
-             SELECT min(b.name)
-             FROM builds b
-             WHERE b."projectId" = :projectId
-               AND b."type" = 'reference'
-               AND b.name > build_names.name
-           )
+           SELECT
+             build_names."projectId",
+             (
+               SELECT min(b.name)
+               FROM builds b
+               WHERE b."projectId" = build_names."projectId"
+                 AND b."type" = 'reference'
+                 AND b.name > build_names.name
+             )
            FROM build_names
            WHERE build_names.name IS NOT NULL
          )
-         SELECT (
-           SELECT b.id
-           FROM builds b
-           WHERE b."projectId" = :projectId
-             AND b."type" = 'reference'
-             AND b.name = build_names.name
-           ORDER BY b."createdAt" DESC
-           LIMIT 1
-         ) AS id
+         SELECT
+           build_names."projectId"::text AS "projectId",
+           (
+             SELECT b.id
+             FROM builds b
+             WHERE b."projectId" = build_names."projectId"
+               AND b."type" = 'reference'
+               AND b.name = build_names.name
+             ORDER BY b."createdAt" DESC
+             LIMIT 1
+           )::text AS id
          FROM build_names
          WHERE build_names.name IS NOT NULL`,
-        { projectId },
-      )) as { rows: { id: string | null }[] };
-      return result.rows;
-    }),
+        { projectIds },
+      )) as { rows: { id: string | null; projectId: string }[] };
+
+      return result.rows.filter(
+        (row): row is LatestReferenceBuild => row.id !== null,
+      );
+    },
   );
-  return perProject
-    .flat()
-    .map((row) => row.id)
-    .filter((id): id is string => id !== null);
 }
 
 /**
@@ -144,28 +190,65 @@ async function getLatestReferenceBuildIds(projectIds: string[]) {
  * Returns Objection's `{ total, results }` range page so the caller can hand it
  * straight to `paginateResult`.
  */
+export type ActiveTest = Test & { metrics: TestMetricsCounts };
+
 export async function queryActiveTests(input: {
   projectIds: string[];
   period: IMetricsPeriod;
   filters?: { buildName?: string | null; search?: string | null } | null;
   after: number;
   first: number;
-}) {
+}): Promise<{ total: number; results: ActiveTest[] }> {
+  return Sentry.startSpan(
+    {
+      name: "queryActiveTests",
+      attributes: {
+        "argos.project.count": input.projectIds.length,
+        "argos.tests.period": input.period,
+      },
+    },
+    (span) => queryActiveTestsInner(input, span),
+  );
+}
+
+async function queryActiveTestsInner(
+  input: {
+    projectIds: string[];
+    period: IMetricsPeriod;
+    filters?: { buildName?: string | null; search?: string | null } | null;
+    after: number;
+    first: number;
+  },
+  span: Sentry.Span,
+): Promise<{ total: number; results: ActiveTest[] }> {
   const { projectIds, period, filters, after, first } = input;
   const search = filters?.search?.trim();
 
   // Step 1 — the latest reference build per (project, name).
-  const latestBuildIds = await getLatestReferenceBuildIds(projectIds);
-  if (latestBuildIds.length === 0) {
+  const latestBuilds = await getLatestReferenceBuildIds(projectIds);
+  span.setAttribute("argos.tests.latest_build_count", latestBuilds.length);
+  if (latestBuilds.length === 0) {
     return { total: 0, results: [] };
   }
+  const latestBuildIds = latestBuilds.map((build) => build.id);
 
   // Step 2 — the candidate `(testId, compareScreenshotId)` pairs in those builds.
-  const diffs = await ScreenshotDiff.query()
-    .distinct("testId", "compareScreenshotId")
-    .whereIn("buildId", latestBuildIds)
-    .whereNotNull("testId")
-    .whereNotNull("compareScreenshotId");
+  // Passing the build ids as an array rather than an `IN (...)` list keeps this
+  // to a single bind parameter: a wide account has enough build names to make
+  // the placeholder list itself a parse cost, and Postgres caps a statement at
+  // 65535 parameters.
+  const diffs = await Sentry.startSpan(
+    { name: "queryActiveTests.candidateDiffs" },
+    () =>
+      ScreenshotDiff.query()
+        .distinct("testId", "compareScreenshotId")
+        .whereRaw(`"buildId" = any(:buildIds::bigint[])`, {
+          buildIds: latestBuildIds,
+        })
+        .whereNotNull("testId")
+        .whereNotNull("compareScreenshotId"),
+  );
+  span.setAttribute("argos.tests.candidate_diff_count", diffs.length);
   if (diffs.length === 0) {
     return { total: 0, results: [] };
   }
@@ -180,10 +263,19 @@ export async function queryActiveTests(input: {
         .filter((id): id is string => id !== null),
     ),
   ];
-  const childScreenshots = await Screenshot.query()
-    .select("id")
-    .whereIn("id", compareScreenshotIds)
-    .whereNotNull("parentName");
+  const childScreenshots = await Sentry.startSpan(
+    {
+      name: "queryActiveTests.childScreenshots",
+      attributes: {
+        "argos.tests.compare_screenshot_count": compareScreenshotIds.length,
+      },
+    },
+    () =>
+      Screenshot.query()
+        .select("id")
+        .whereRaw(`id = any(:ids::bigint[])`, { ids: compareScreenshotIds })
+        .whereNotNull("parentName"),
+  );
   const childScreenshotIds = new Set(
     childScreenshots.map((screenshot) => screenshot.id),
   );
@@ -200,6 +292,7 @@ export async function queryActiveTests(input: {
         .filter((id): id is string => id !== null),
     ),
   ];
+  span.setAttribute("argos.tests.active_count", activeTestIds.length);
   if (activeTestIds.length === 0) {
     return { total: 0, results: [] };
   }
@@ -207,24 +300,65 @@ export async function queryActiveTests(input: {
   // Step 4 — rank the active tests by flakiness and paginate. `activeTestIds`
   // already scopes the result to the requested projects, so the id filter is all
   // we need.
-  return Test.query()
-    .whereIn("tests.id", activeTestIds)
-    .where((qb) => {
-      if (filters?.buildName) {
-        qb.where("tests.buildName", filters.buildName);
-      }
-    })
-    .modify((qb) => {
-      if (search) {
-        // A test's name is its screenshot's name (see
-        // `insertFilesAndScreenshots`), so matching `tests.name` is equivalent to
-        // matching the compare screenshot name.
-        qb.whereILike("tests.name", `%${search}%`);
-      }
-    })
-    .orderByRaw(FLAKINESS_ORDER_BY, {
-      from: getStartDateFromPeriod(period).toISOString(),
-      to: new Date().toISOString(),
-    })
-    .range(after, after + first - 1);
+  const applyFilters = (qb: QueryBuilder<Test, Test[]>) => {
+    qb.whereRaw(`"tests"."id" = any(:testIds::bigint[])`, {
+      testIds: activeTestIds,
+    });
+    if (filters?.buildName) {
+      qb.where("tests.buildName", filters.buildName);
+    }
+    if (search) {
+      // A test's name is its screenshot's name (see
+      // `insertFilesAndScreenshots`), so matching `tests.name` is equivalent to
+      // matching the compare screenshot name.
+      qb.whereILike("tests.name", `%${search}%`);
+    }
+  };
+
+  const metricsBindings = {
+    from: getStartDateFromPeriod(period).toISOString(),
+    to: new Date().toISOString(),
+  };
+
+  // The page and its count run side by side, and only the page pays for the
+  // metrics lateral. `range()` would have run them back to back and dragged the
+  // lateral into the count query, where the ordering it feeds is discarded.
+  const [results, total] = await Promise.all([
+    Sentry.startSpan({ name: "queryActiveTests.page" }, () =>
+      Test.query()
+        .select("tests.*", "test_metrics.metrics")
+        .modify(applyFilters)
+        .joinRaw(TEST_METRICS_LATERAL, metricsBindings)
+        .orderByRaw(FLAKINESS_ORDER_BY)
+        .limit(first)
+        .offset(after),
+    ),
+    Sentry.startSpan({ name: "queryActiveTests.count" }, () =>
+      Test.query().modify(applyFilters).resultSize(),
+    ),
+  ]);
+
+  return { total, results: results as ActiveTest[] };
+}
+
+/**
+ * Seed the metrics loader with the counts the ranking pass already computed.
+ *
+ * Sorting by flakiness means the metrics of every returned row were computed to
+ * produce the order; without this the `Test.metrics` resolver would turn around
+ * and compute them a second time for each visible row.
+ */
+export function primeActiveTestMetrics(input: {
+  loaders: ReturnType<typeof createLoaders>;
+  results: ActiveTest[];
+  period: IMetricsPeriod;
+}) {
+  const { loaders, results, period } = input;
+  const from = getStartDateFromPeriod(period);
+  for (const test of results) {
+    loaders.TestAllMetrics.prime(
+      { testId: test.id, from },
+      computeTestMetrics(test.metrics),
+    );
+  }
 }

--- a/apps/backend/src/graphql/tests/accountTests.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/accountTests.e2e.test.ts
@@ -4,8 +4,13 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import type { Project } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
-import { upsertTestStats } from "@/metrics/test";
+import {
+  getStartDateFromPeriod,
+  getTestAllMetrics,
+  upsertTestStats,
+} from "@/metrics/test";
 
+import { IMetricsPeriod } from "../__generated__/resolver-types";
 import { apolloServer, createApolloMiddleware } from "../apollo";
 import { expectNoGraphQLError } from "../testing";
 import { createApolloServerApp } from "./util";
@@ -25,6 +30,11 @@ const ACCOUNT_TESTS_QUERY = `
           }
           metrics(period: $period) {
             all {
+              total
+              changes
+              uniqueChanges
+              stability
+              consistency
               flakiness
             }
           }
@@ -158,5 +168,78 @@ describe("GraphQL Account.tests", () => {
     expectNoGraphQLError(result);
     expect(result.body.data.account.tests.pageInfo.totalCount).toBe(0);
     expect(result.body.data.account.tests.edges).toEqual([]);
+  });
+
+  // The list orders rows by a flakiness computed in SQL, then serves each row's
+  // metrics from the counts that same pass produced. If the SQL formula and
+  // `computeTestMetrics` ever drift, a row is sorted by one number and displays
+  // another — so pin the served values against an independent computation.
+  it("serves metrics that match the flakiness it sorts by", async () => {
+    const user = await factory.User.create();
+    const account = await factory.TeamAccount.create();
+    invariant(account.teamId, "team account should have a team");
+    await factory.TeamUser.create({
+      teamId: account.teamId,
+      userId: user.id,
+      userLevel: "owner",
+    });
+    const project = await factory.Project.create({ accountId: account.id });
+    const test = await createActiveTest(project, "partly-flaky-test");
+
+    const file = await factory.File.create({
+      type: "screenshotDiff",
+      fingerprint: "recurring",
+    });
+
+    // A mix that exercises every branch of the formula: some builds with no
+    // change, one fingerprint recurring across days, one seen a single day.
+    const today = new Date();
+    for (let i = 0; i < 4; i++) {
+      const date = new Date(today);
+      date.setDate(today.getDate() - i);
+      await upsertTestStats({
+        testId: test.id,
+        date,
+        change: i < 2 ? { fileId: file.id, fingerprint: "recurring" } : null,
+      });
+    }
+    await upsertTestStats({
+      testId: test.id,
+      date: today,
+      change: { fileId: file.id, fingerprint: "one-off" },
+    });
+
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user, account },
+    );
+
+    const result = await request(app)
+      .post("/graphql")
+      .send({
+        query: ACCOUNT_TESTS_QUERY,
+        variables: { accountSlug: account.slug, period: "LAST_7_DAYS" },
+      });
+
+    expectNoGraphQLError(result);
+
+    const [edge] = result.body.data.account.tests.edges;
+    const [expected] = await getTestAllMetrics([test.id], {
+      from: getStartDateFromPeriod(IMetricsPeriod.Last_7Days),
+    });
+    invariant(expected);
+
+    expect(edge.metrics.all).toEqual({
+      total: expected.total,
+      changes: expected.changes,
+      uniqueChanges: expected.uniqueChanges,
+      stability: expected.stability,
+      consistency: expected.consistency,
+      flakiness: expected.flakiness,
+    });
+    // Guard against the assertion passing on an all-zero row.
+    expect(expected.changes).toBeGreaterThan(0);
+    expect(expected.flakiness).toBeGreaterThan(0);
   });
 });

--- a/apps/backend/src/metrics/test.e2e.test.ts
+++ b/apps/backend/src/metrics/test.e2e.test.ts
@@ -1,10 +1,15 @@
+import { invariant } from "@argos/util/invariant";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { knex } from "@/database";
 import type { File, Test } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
 
-import { getChangesTotalOccurrences, upsertTestStats } from "./test";
+import {
+  getChangesTotalOccurrences,
+  getTestAllMetrics,
+  upsertTestStats,
+} from "./test";
 
 describe("upsertTestStats", () => {
   let test: Test;
@@ -195,5 +200,101 @@ describe("getChangesTotalOccurrences", () => {
       { from: new Date("2025-06-05T00:00:00.000Z") },
     );
     expect(result).toEqual([1, 1]);
+  });
+});
+
+describe("getTestAllMetrics", () => {
+  let test: Test;
+  let otherTest: Test;
+
+  beforeEach(async () => {
+    await setupDatabase();
+    [test, otherTest] = await Promise.all([
+      factory.Test.create(),
+      factory.Test.create(),
+    ]);
+
+    // 10 builds saw the test over two days.
+    await knex("test_stats_builds").insert([
+      {
+        testId: test.id,
+        date: new Date("2025-06-01T00:00:00.000Z"),
+        value: 6,
+      },
+      {
+        testId: test.id,
+        date: new Date("2025-06-02T00:00:00.000Z"),
+        value: 4,
+      },
+    ]);
+
+    // "aa" recurs across two days (not unique), "bb" only shows up on one.
+    await knex("test_stats_fingerprints").insert([
+      {
+        testId: test.id,
+        fingerprint: "aa",
+        date: new Date("2025-06-01T00:00:00.000Z"),
+        value: 2,
+      },
+      {
+        testId: test.id,
+        fingerprint: "aa",
+        date: new Date("2025-06-02T00:00:00.000Z"),
+        value: 1,
+      },
+      {
+        testId: test.id,
+        fingerprint: "bb",
+        date: new Date("2025-06-02T00:00:00.000Z"),
+        value: 1,
+      },
+    ]);
+  });
+
+  const period = {
+    from: new Date("2025-06-01T00:00:00.000Z"),
+    to: new Date("2025-06-03T00:00:00.000Z"),
+  };
+
+  it("counts a fingerprint as a unique change only when it appears on one day", async () => {
+    const [metrics] = await getTestAllMetrics([test.id], period);
+    invariant(metrics);
+
+    expect(metrics.total).toBe(10);
+    expect(metrics.changes).toBe(4);
+    // "bb" only — "aa" spans two days.
+    expect(metrics.uniqueChanges).toBe(1);
+    expect(metrics.stability).toBe(0.6);
+    expect(metrics.consistency).toBe(0.25);
+    // 1 - (0.6 + 0.25) / 2 is exactly 0.575, which in binary floating point
+    // sits just under the midpoint and rounds down.
+    expect(metrics.flakiness).toBe(0.57);
+  });
+
+  it("returns zeroed metrics aligned to the input order", async () => {
+    const results = await getTestAllMetrics([otherTest.id, test.id], period);
+
+    expect(results[0]).toEqual({
+      total: 0,
+      changes: 0,
+      uniqueChanges: 0,
+      stability: 1,
+      consistency: 1,
+      flakiness: 0,
+    });
+    expect(results[1]?.changes).toBe(4);
+  });
+
+  it("only counts stats within the period", async () => {
+    const [metrics] = await getTestAllMetrics([test.id], {
+      from: new Date("2025-06-02T00:00:00.000Z"),
+      to: new Date("2025-06-03T00:00:00.000Z"),
+    });
+    invariant(metrics);
+
+    expect(metrics.total).toBe(4);
+    expect(metrics.changes).toBe(2);
+    // Restricted to one day, both fingerprints now appear exactly once.
+    expect(metrics.uniqueChanges).toBe(2);
   });
 });

--- a/apps/backend/src/metrics/test.ts
+++ b/apps/backend/src/metrics/test.ts
@@ -86,6 +86,50 @@ export async function upsertTestStats(input: {
   );
 }
 
+export type TestMetricsCounts = {
+  total: number;
+  changes: number;
+  uniqueChanges: number;
+};
+
+export type TestAllMetrics = TestMetricsCounts & {
+  stability: number;
+  consistency: number;
+  flakiness: number;
+};
+
+/**
+ * Derive the rates displayed on the Tests pages from the raw counts.
+ *
+ * This is the single definition of the formula: every flakiness a client sees
+ * comes from here, and `queryActiveTests` mirrors it in SQL to sort by flakiness
+ * (see `TEST_METRICS_LATERAL`). Keep the two in sync — including the
+ * intermediate rounding, otherwise a list can be ordered by a flakiness that
+ * differs from the one shown on the row.
+ *
+ * They still part ways on exact midpoints: Postgres rounds `numeric` half away
+ * from zero, while a value like 0.575 is not representable in binary floating
+ * point and lands just under. That is a one-cent difference in the sort key of
+ * tied rows, not in the value served.
+ */
+export function computeTestMetrics(counts: TestMetricsCounts): TestAllMetrics {
+  const { total, changes, uniqueChanges } = counts;
+
+  const stability =
+    changes > 0 ? Math.round((1 - changes / total) * 100) / 100 : 1;
+
+  const consistency =
+    changes > 0
+      ? uniqueChanges > 0
+        ? Math.round((uniqueChanges / changes) * 100) / 100
+        : 0
+      : 1;
+
+  const flakiness = Math.round((1 - (stability + consistency) / 2) * 100) / 100;
+
+  return { total, changes, uniqueChanges, stability, consistency, flakiness };
+}
+
 /**
  * Get the changes metrics for a test.
  */
@@ -95,16 +139,23 @@ export async function getTestAllMetrics(
     from?: Date | undefined;
     to?: Date | undefined;
   },
-): Promise<
-  {
-    total: number;
-    changes: number;
-    uniqueChanges: number;
-    stability: number;
-    consistency: number;
-    flakiness: number;
-  }[]
-> {
+): Promise<TestAllMetrics[]> {
+  return Sentry.startSpan(
+    {
+      name: "getTestAllMetrics",
+      attributes: { "argos.test.count": testIds.length },
+    },
+    () => queryTestAllMetrics(testIds, options),
+  );
+}
+
+async function queryTestAllMetrics(
+  testIds: string[],
+  options: {
+    from?: Date | undefined;
+    to?: Date | undefined;
+  },
+): Promise<TestAllMetrics[]> {
   const { from = new Date(), to = new Date() } = options;
 
   const totalQuery = `
@@ -115,25 +166,29 @@ export async function getTestAllMetrics(
     group by "testId"
   `;
 
+  // Aggregating per fingerprint first, then per test, keeps this to a single
+  // pass over the period. The previous shape ran a correlated `count(*)` for
+  // every `(testId, fingerprint, date)` row just to learn whether that
+  // fingerprint appeared on exactly one day — one extra index scan per row.
   const changesQuery = `
-   select
-      tsf."testId",
-      sum(tsf.value) as changes,
-      count(*) filter (
-        where (
-          select count(*) 
-          from test_stats_fingerprints t2
-          where t2."testId" = tsf."testId"
-            and t2."fingerprint" = tsf."fingerprint"
-            and t2."date" >= :from::timestamp
-            and t2."date" < :to::timestamp
-        ) = 1
-      ) as "uniqueChanges"
-    from test_stats_fingerprints tsf
-    where tsf."testId" = any(:testIds)
-      and tsf."date" >= :from::timestamp
-      and tsf."date" < :to::timestamp
-    group by tsf."testId"
+    with fp_agg as (
+      select
+        tsf."testId",
+        tsf."fingerprint",
+        sum(tsf.value) as changes_value,
+        count(*) as fp_count
+      from test_stats_fingerprints tsf
+      where tsf."testId" = any(:testIds)
+        and tsf."date" >= :from::timestamp
+        and tsf."date" < :to::timestamp
+      group by tsf."testId", tsf."fingerprint"
+    )
+    select
+      "testId",
+      sum(changes_value) as changes,
+      count(*) filter (where fp_count = 1) as "uniqueChanges"
+    from fp_agg
+    group by "testId"
   `;
 
   const fromISOString = from.toISOString();
@@ -180,36 +235,17 @@ export async function getTestAllMetrics(
   // Keep result order same as input
   return testIds.map((testId) => {
     const data = {
-      testId,
       changes: 0,
       total: 0,
       uniqueChanges: 0,
       ...totalRowsByTestId[testId],
       ...changesRowsByTestId[testId],
     };
-    const stability =
-      data.changes > 0
-        ? Math.round((1 - data.changes / data.total) * 100) / 100
-        : 1;
-
-    const consistency =
-      data.changes > 0
-        ? data.uniqueChanges > 0
-          ? Math.round((data.uniqueChanges / data.changes) * 100) / 100
-          : 0
-        : 1;
-
-    const flakiness =
-      Math.round((1 - (stability + consistency) / 2) * 100) / 100;
-
-    return {
+    return computeTestMetrics({
       total: Number(data.total),
       changes: Number(data.changes),
       uniqueChanges: Number(data.uniqueChanges),
-      stability,
-      consistency,
-      flakiness,
-    };
+    });
   });
 }
 

--- a/apps/frontend/src/pages/Account/Tests.tsx
+++ b/apps/frontend/src/pages/Account/Tests.tsx
@@ -73,7 +73,6 @@ const AccountTestsQuery = graphql(`
           id
           name
           buildName
-          status
           project {
             id
             name


### PR DESCRIPTION
The Tests list could take a long time to load. This instruments the path with spans so the split is visible in production, then cuts the work it does.

## Indexes

| Index | Why |
|---|---|
| `screenshot_diffs (buildId) INCLUDE (testId, compareScreenshotId)` | The candidate-diffs step needs both columns; the index it replaces carried only `testId`, so every row of every latest reference build cost a heap fetch. Now index-only. |
| `screenshot_diffs (testId, id) WHERE fileId IS NOT NULL` | `first`/`lastSeenDiff` had no index serving both the `fileId IS NOT NULL` filter and the `id` ordering. |
| `test_stats_fingerprints (testId, date) INCLUDE (fingerprint, value)` | The primary key is `(testId, fingerprint, date)`, so answering a 7-day window meant reading every fingerprint row the test ever recorded. |

Measured on synthetic data at volume:

- Candidate diffs: 855 → 300 buffers, `Heap Fetches: 0`. This is an I/O reduction — warm-cache wall time was unchanged, so expect it to show on cold data, not in a local benchmark.
- `lastSeenDiff` on a test that changed long ago and has been stable since: **10.9ms / 149,950 rows filtered → 0.05ms / 7 buffers**. Note this is the *only* shape that was slow — a test that never changed, or one that changes often, was already fast because the planner picks a different index. That shape is common among long-lived tests though, and the page does 20 of them per fetch.

## Queries

- **Latest reference builds in one statement.** The skip scan now carries the project through the recursive walk. Fanning out per project meant `projectIds.length` round-trips racing for a connection pool that is 6 wide by default.
- **`TestStatusLoader` reuses that skip scan.** It was still doing `DISTINCT ON (projectId, name)` over every reference build of every project — the exact scan `getLatestReferenceBuildIds` exists to avoid.
- **Large id lists bind as arrays.** Beyond parse cost, an `IN` list is one bind parameter per id and Postgres caps a statement at 65535 — a large enough account did not get a slow page, it got an error.
- **Flakiness computed once.** A LATERAL returns the counts with the row and primes the metrics loader, instead of computing them for the sort and again per visible row.
- **Page and count run in parallel**, with only the page paying for the lateral. `range()` ran them back to back and pulled the lateral into the count query, where the ordering it feeds is discarded.
- **De-correlated `uniqueChanges`**, which was running a `count(*)` per `(testId, fingerprint, date)` row.
- **Dropped `status` from the account query** — never rendered, and resolving it was the most expensive part of the request.

## Note on rounding

The SQL sort key and the served value can differ by 0.01 at exact midpoints: Postgres rounds `numeric` half away from zero, while a value like 0.575 is not representable in binary floating point and lands just under. This only affects the ordering of tied rows, never a value served to a client, and it is smaller than before (the previous SQL did not round intermediates at all). Documented in `computeTestMetrics`.

## What this does not fix

Ranking still evaluates flakiness once per active test — O(active tests), no `LIMIT` pushdown possible — and paging replays steps 1–4 on every `fetchMore`. Two follow-ups would address that, both trading metric freshness for speed, so they are left out of this PR:

1. Cache the ordered active-test id list per `(account, period, filters)` with a short TTL.
2. Roll flakiness into a table refreshed by a job, plus a maintained `tests.active`, which removes the O(active tests) floor entirely.

## Testing

- Migration applied locally, `structure.sql` regenerated.
- Added coverage for `getTestAllMetrics` (the de-correlated `uniqueChanges` semantics) and a guard that the served metrics equal an independent computation, since the SQL and JS formulas could otherwise drift.
- `pnpm check-types`, `pnpm lint`, and the full integration suite (807 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)