### PR TITLE
chore: upgrade dev/CI to PostgreSQL 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         #   --health-retries 5
 
       postgres:
-        image: postgres:17-alpine
+        image: postgres:18-alpine
         ports:
           - 5432:5432
         env:
@@ -199,7 +199,7 @@ jobs:
         #   --health-retries 5
 
       postgres:
-        image: postgres:17-alpine
+        image: postgres:18-alpine
         ports:
           - 5432:5432
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,8 +103,8 @@ Two files with the extension ".pem" should be generated at the root of the proje
 **5. Set up the database**
 
 ```sh
-brew install postgresql@17
-brew link postgresql@17 --force
+brew install postgresql@18
+brew link postgresql@18 --force
 docker-compose up -d
 pnpm run setup
 pnpm run --filter @argos/backend db:seed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,14 @@
 services:
   postgres:
-    # Last time I have checked, production is running 14.10
-    image: postgres:17-alpine
+    # Production runs AWS RDS for PostgreSQL 17.9. Dev/CI are intentionally
+    # ahead on 18, to validate the 18.4 major upgrade before it ships to RDS.
+    image: postgres:18-alpine
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     ports:
       - "5432:5432"
     volumes:
-      - pg_data:/var/lib/postgresql/data
+      - pg_data:/var/lib/postgresql/18/docker
     healthcheck:
       test: ["CMD-SHELL", "pg_isready", "-d", "db_prod"]
       interval: 10s


### PR DESCRIPTION
## Why

Production runs **AWS RDS for PostgreSQL 17.9**, and **18.4** is an available major upgrade target (`18.3` and `18.4` are the only ones offered from 17.9). This moves local dev and CI to 18 **first**, so the suite validates against the target version before the RDS instance is touched.

## What changed

- `docker-compose.yml` and both CI service containers → `postgres:18-alpine`, which resolves to **18.4**, the exact RDS target.
- The `pg_data` mount follows the new image layout — `PGDATA` moved to `/var/lib/postgresql/18/docker` in the `postgres:18` images.
- `CONTRIBUTING.md` bumps the brew client to `postgresql@18`. `pg_dump` refuses to dump a server of a newer major version, so a v17 client would break `db:dump` against an 18 server.

## Verification

Loaded the real schema into a throwaway 18.4 container:

- `structure.sql` loads with `ON_ERROR_STOP=1`, exit 0, no errors — despite being dumped by pg_dump 17.5.
- 68 tables, 211 indexes, both `pg_trgm` and `btree_gin` created.
- **229 `knex_migrations` rows matching the 229 migration files**, so `db:check-structure` passes and `structure.sql` needs no regeneration.
- All four indexes from #2410 present, including the `gin_trgm_ops` and `varchar_pattern_ops` ones.

Nothing in the schema trips PG 18's known incompatibilities: no generated columns (so the `VIRTUAL` default change is a non-issue), and no `MERGE`/`uuidv7`/`NULLS NOT DISTINCT`.

## ⚠️ For reviewers pulling this branch

Your existing `pg_data` volume holds a PG 17 data directory and Postgres will not upgrade it in place. You'll need:

```sh
docker compose down -v
docker compose up -d
pnpm run setup
pnpm run --filter @argos/backend db:seed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)