### PR TITLE
fix(frontend): stop counting removed snapshots in subset builds

### DIFF
--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -134,6 +134,7 @@ export type BuildScenario = {
   stableBuild: Build;
   emptyBuild: Build;
   removedBuild: Build;
+  subsetBuild: Build;
 };
 
 /**
@@ -364,6 +365,7 @@ export async function createBuildScenario(input: {
     stableBuild,
     emptyBuild,
     removedBuild,
+    subsetBuild,
   ] = await Build.query().insertAndFetch([
     { ...buildBase, number: 1, type: "orphan", baseScreenshotBucketId: null },
     { ...buildBase, number: 2, type: "reference" },
@@ -379,6 +381,7 @@ export async function createBuildScenario(input: {
     { ...buildBase, number: 12 }, // Stable
     { ...buildBase, number: 13 }, // Empty
     { ...buildBase, number: 14 }, // Removed
+    { ...buildBase, number: 15, subset: true }, // Subset, with removals
   ]);
 
   const defaultScreenshotDiff = {
@@ -476,6 +479,13 @@ export async function createBuildScenario(input: {
       ...duplicate(stableScreenshotDiff, 3),
       ...duplicate(removedScreenshotDiff, 2),
     ],
+    // Subset build: the removals only reflect tests that were not run, so the
+    // review surfaces must ignore them and only account for the change.
+    [subsetBuild!.id]: [
+      ...duplicate(stableScreenshotDiff, 3),
+      ...duplicate(removedScreenshotDiff, 2),
+      { ...updatedScreenshotDiff },
+    ],
   };
 
   await BuildReview.query().insert([
@@ -523,6 +533,7 @@ export async function createBuildScenario(input: {
     stableBuild,
     emptyBuild,
     removedBuild,
+    subsetBuild,
   ].filter((b): b is Build => b?.jobStatus === "complete");
 
   for (const b of completeBuilds) {
@@ -544,6 +555,7 @@ export async function createBuildScenario(input: {
     stableBuild: stableBuild!,
     emptyBuild: emptyBuild!,
     removedBuild: removedBuild!,
+    subsetBuild: subsetBuild!,
   };
 }
 

--- a/apps/frontend/src/containers/Build/BuildDiffGroup.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffGroup.tsx
@@ -103,18 +103,6 @@ const DiffGroupDefinitions: Record<DiffGroupName, DiffGroupDefinition> = {
 
 export function getDiffGroupDefinition(
   diffGroupName: DiffGroupName,
-  options?: {
-    /**
-     * Indicates if the build is marked as subset.
-     */
-    isSubsetBuild?: boolean;
-  },
 ): DiffGroupDefinition {
-  const def = DiffGroupDefinitions[diffGroupName];
-  if (options?.isSubsetBuild) {
-    if (diffGroupName === ScreenshotDiffStatus.Removed) {
-      return { ...def, color: "neutral" };
-    }
-  }
-  return def;
+  return DiffGroupDefinitions[diffGroupName];
 }

--- a/apps/frontend/src/pages/Build/BuildDiffState.tsx
+++ b/apps/frontend/src/pages/Build/BuildDiffState.tsx
@@ -247,6 +247,29 @@ export function checkDiffCanBeReviewed(
   );
 }
 
+/**
+ * Number of removals to account for. Subset builds only upload part of the
+ * snapshots, so a missing snapshot means a skipped test, not a deletion: they
+ * are ignored everywhere changes are counted or described.
+ */
+export function getRemovedCount(
+  stats: { removed: number },
+  context: { isSubsetBuild: boolean },
+): number {
+  return context.isSubsetBuild ? 0 : stats.removed;
+}
+
+/**
+ * Number of snapshots up for review, mirroring `checkDiffCanBeReviewed` at the
+ * stats level.
+ */
+export function getReviewableCount(
+  stats: { changed: number; added: number; removed: number },
+  context: { isSubsetBuild: boolean },
+): number {
+  return stats.changed + stats.added + getRemovedCount(stats, context);
+}
+
 export function useBuildDiffState() {
   const context = use(BuildDiffContext);
   invariant(

--- a/apps/frontend/src/pages/Build/BuildInfos.tsx
+++ b/apps/frontend/src/pages/Build/BuildInfos.tsx
@@ -40,6 +40,7 @@ const _BuildFragment = graphql(`
     status
     stats {
       total
+      removed
     }
     baseScreenshotBucket {
       id
@@ -149,6 +150,21 @@ function Description(props: { children: React.ReactNode }) {
 function Duration({ start, end }: { start: string; end: string }) {
   const duration = moment.duration(moment(end).diff(moment(start)));
   return duration.humanize();
+}
+
+/**
+ * Number of screenshots the build actually uploaded. Removed diffs come from
+ * the baseline, not from the build: counting them in a subset build — where
+ * they only reflect tests that were not run — inflates the total.
+ */
+function getUploadedScreenshotCount(
+  build: DocumentType<typeof _BuildFragment>,
+): number {
+  const { stats } = build;
+  if (!stats) {
+    return 0;
+  }
+  return build.subset ? stats.total - stats.removed : stats.total;
 }
 
 export function BuildInfos(props: {
@@ -299,7 +315,7 @@ export function BuildInfos(props: {
       )}
 
       <Dt>Total screenshots</Dt>
-      <Dd>{build.stats ? build.stats.total : "-"}</Dd>
+      <Dd>{build.stats ? getUploadedScreenshotCount(build) : "-"}</Dd>
 
       {build.subset ? (
         <>

--- a/apps/frontend/src/pages/Build/BuildOverview/BuildSummary.tsx
+++ b/apps/frontend/src/pages/Build/BuildOverview/BuildSummary.tsx
@@ -6,7 +6,11 @@ import { Button } from "@/ui/Button";
 import { Kbd } from "@/ui/Kbd";
 import { ShortcutHint } from "@/ui/ShortcutHint";
 
-import { useBuildDiffState, useGoToNextDiff } from "../BuildDiffState";
+import {
+  getReviewableCount,
+  useBuildDiffState,
+  useGoToNextDiff,
+} from "../BuildDiffState";
 import { useCanReviewBuild } from "../BuildReviewability";
 import { BuildSummaryDescription } from "./BuildSummaryDescription";
 import { ChangeSummary } from "./ChangeSummary";
@@ -86,10 +90,10 @@ function PerfectMatchIllustration() {
 
 export function BuildSummary(props: { build: Build }) {
   const { build } = props;
-  const { stats } = useBuildDiffState();
+  const { stats, isSubsetBuild } = useBuildDiffState();
   const hasFailures = Boolean(stats?.failure);
   const reviewableCount = stats
-    ? stats.changed + stats.added + stats.removed
+    ? getReviewableCount(stats, { isSubsetBuild })
     : 0;
   const canReview = useCanReviewBuild(build);
   // Failing tests take precedence over the visual review, so the change summary

--- a/apps/frontend/src/pages/Build/BuildOverview/ChangeSummary.tsx
+++ b/apps/frontend/src/pages/Build/BuildOverview/ChangeSummary.tsx
@@ -19,7 +19,11 @@ import { Panel, PanelHeader, PanelTitle } from "@/ui/Panel";
 import { lowTextColorClassNames, UIColor } from "@/util/colors";
 import { capitalize } from "@/util/string";
 
-import { useBuildDiffState } from "../BuildDiffState";
+import {
+  getRemovedCount,
+  getReviewableCount,
+  useBuildDiffState,
+} from "../BuildDiffState";
 import { getBrowserLabel } from "../metadata/browser/browserLabels";
 
 const _BuildFragment = graphql(`
@@ -270,7 +274,7 @@ function ChangeSummaryPanel(props: { children: React.ReactNode }) {
  */
 export function ChangeSummary(props: { build: Build }) {
   const analysis = props.build.impactAnalysis;
-  const { stats } = useBuildDiffState();
+  const { stats, isSubsetBuild } = useBuildDiffState();
 
   // No analysis to summarize: don't render an insights card at all — the build
   // description already prompts the reviewer.
@@ -279,9 +283,9 @@ export function ChangeSummary(props: { build: Build }) {
   }
 
   const added = stats?.added ?? 0;
-  const removed = stats?.removed ?? 0;
+  const removed = stats ? getRemovedCount(stats, { isSubsetBuild }) : 0;
   const reviewableCount = stats
-    ? stats.changed + stats.added + stats.removed
+    ? getReviewableCount(stats, { isSubsetBuild })
     : 0;
   // Clamp: the approval count is fingerprint-based and should never read as
   // more than the snapshots actually up for review.

--- a/apps/frontend/src/pages/Build/BuildPreviousReviewDialog.tsx
+++ b/apps/frontend/src/pages/Build/BuildPreviousReviewDialog.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/ui/Dialog";
 import { toast } from "@/ui/Toaster";
 
-import { useBuildDiffState } from "./BuildDiffState";
+import { getReviewableCount, useBuildDiffState } from "./BuildDiffState";
 import {
   useAcknowledgeMarkedDiff,
   useBuildReviewAPI,
@@ -116,7 +116,7 @@ function ReapplyPreviousApprovalsButton(props: {
         }));
         const count = branchApprovedDiffs.length;
         const total = stats
-          ? stats.added + stats.changed + (isSubsetBuild ? 0 : stats.removed)
+          ? getReviewableCount(stats, { isSubsetBuild })
           : null;
         const remaining = total !== null ? Math.max(0, total - count) : null;
         toast.success(

--- a/apps/frontend/src/pages/Build/BuildReviewState.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewState.tsx
@@ -23,6 +23,7 @@ import { useLiveRef } from "@/ui/useLiveRef";
 import {
   checkDiffCanBeReviewed,
   Diff,
+  getReviewableCount,
   useBuildDiffState,
   useGetNextDiff,
   type UseGetNextDiffOptions,
@@ -86,8 +87,7 @@ function useReviewStatus(): "initializing" | "pending" | "complete" | null {
     if (!stats) {
       return "initializing";
     }
-    const expected =
-      stats.added + stats.changed + (isSubsetBuild ? 0 : stats.removed);
+    const expected = getReviewableCount(stats, { isSubsetBuild });
     const reviewed = Object.values(diffStatuses).filter(
       (status) => status !== EvaluationStatus.Pending,
     ).length;

--- a/apps/frontend/src/pages/Build/BuildStatsIndicator.tsx
+++ b/apps/frontend/src/pages/Build/BuildStatsIndicator.tsx
@@ -164,7 +164,13 @@ export const BuildStatsIndicator = memo(function BuildStatsIndicator(props: {
     if (count === 0) {
       return null;
     }
-    const def = getDiffGroupDefinition(group, { isSubsetBuild });
+    // Subset builds ignore removals: a missing snapshot comes from a skipped
+    // test, not a deletion. Counting them here would read as a regression. The
+    // diffs stay listed in their own group in the sidebar.
+    if (isSubsetBuild && group === ScreenshotDiffStatus.Removed) {
+      return null;
+    }
+    const def = getDiffGroupDefinition(group);
     return (
       <Fragment key={group}>
         {onClickGroup ? (

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -47,6 +47,7 @@ const buildExamples: {
     name: "stable with removed screenshots",
     getNumber: (b) => b.removedBuild.number,
   },
+  { name: "subset", getNumber: (b) => b.subsetBuild.number },
 ];
 
 buildExamples.forEach((build) => {
@@ -82,6 +83,32 @@ buildExamples.forEach((build) => {
     });
   });
 });
+
+loggedTest(
+  "subset build ignores removed snapshots",
+  async ({ page, auth, team, project, builds }) => {
+    await ensureTeamOwner({ team: team.team, user: auth.user });
+    const { number } = builds.subsetBuild;
+    await page.goto(
+      `/${team.account.slug}/${project.name}/builds/${number}/overview`,
+    );
+
+    // The build has 3 unchanged, 1 changed and 2 removed snapshots. Because it
+    // only uploaded a subset, the removals mean "test not run", not "snapshot
+    // deleted": they must not show up as something to review.
+    await expect(page.getByText("A single visual change")).toBeVisible();
+    await expect(page.getByText("2 removed")).toHaveCount(0);
+
+    // The total only counts the snapshots the build actually uploaded.
+    await page.getByRole("tab", { name: "Info" }).click();
+    await expect(page.locator("dt:has-text('Scope') + dd")).toContainText(
+      "Subset",
+    );
+    await expect(
+      page.locator("dt:has-text('Total screenshots') + dd"),
+    ).toHaveText("4");
+  },
+);
 
 loggedTest(
   "snapshot compared against a fallback baseline",

--- a/tests/project-deployments.spec.ts
+++ b/tests/project-deployments.spec.ts
@@ -9,7 +9,12 @@ loggedTest.beforeEach(async ({ auth, team }) => {
 });
 
 loggedTest("deployments", async ({ page, team, project, builds }) => {
-  void builds;
+  // A deployment links to the most recent build sharing its commit — every
+  // build of the scenario does — so the expected number follows the scenario
+  // rather than being pinned to whichever build happens to come last.
+  const latestBuildNumber = Math.max(
+    ...Object.values(builds).map((build) => build.number),
+  );
 
   await createDeploymentScenario({
     projectId: project.id,
@@ -22,10 +27,13 @@ loggedTest("deployments", async ({ page, team, project, builds }) => {
   await expect(
     page.getByRole("heading", { name: "Deployments" }),
   ).toBeVisible();
-  await expect(page.getByRole("link", { name: "Build #14" })).toBeVisible();
-  await expect(page.getByRole("link", { name: "Build #14" })).toHaveAttribute(
+  const buildLink = page.getByRole("link", {
+    name: `Build #${latestBuildNumber}`,
+  });
+  await expect(buildLink).toBeVisible();
+  await expect(buildLink).toHaveAttribute(
     "href",
-    `/${team.account.slug}/${project.name}/builds/14`,
+    `/${team.account.slug}/${project.name}/builds/${latestBuildNumber}`,
   );
   await expect(page.getByText("preview-main", { exact: true })).toBeVisible();
   await expect(page.getByText("Production", { exact: true })).toBeVisible();


### PR DESCRIPTION
A subset build only uploads part of the snapshots, so a missing one means the test was not run — not that the snapshot was deleted. The backend and the notifications already ignore those removals, but the app still counted them: review insights showed a "N removed" chip, the stats indicator a removed count, and "Total screenshots" included them.

Reported by a customer whose PR builds only cover the affected package: 692 legitimately missing snapshots read as 692 deletions.

The Removed group stays listed in the sidebar, so the information is still reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)