### PR TITLE
fix(editor): don't read a destroyed editor in the toolbar selector

### DIFF
--- a/apps/frontend/src/ui/Editor/EditorToolbar.tsx
+++ b/apps/frontend/src/ui/Editor/EditorToolbar.tsx
@@ -44,8 +44,15 @@ export function EditorToolbar(props: EditorToolbarProps) {
   const { editor } = props;
   const state = useEditorState({
     editor,
-    selector: ({ editor }): ToolbarState | null => {
-      if (!editor) {
+    selector: ({ editor: snapshotEditor }): ToolbarState | null => {
+      // `useEditorState` keeps its own reference to the editor and only
+      // re-points it in a layout effect, so a render that happens right after
+      // the editor was torn down (`useEditor` destroys the instance a tick
+      // after the effects are cleaned up, then hands back `null`) still passes
+      // the previous instance to the selector. A destroyed editor keeps
+      // answering `state` and `isActive()` from its cached state, but its
+      // command manager is gone, so `can()` throws.
+      if (snapshotEditor !== editor || !editor || editor.isDestroyed) {
         return null;
       }
       const { selection } = editor.state;
@@ -90,7 +97,8 @@ export function EditorToolbar(props: EditorToolbarProps) {
     : null;
 
   useEffect(() => {
-    if (!editor) {
+    // A destroyed editor has no view — reading `view.dom` off it throws.
+    if (!editor || editor.isDestroyed) {
       return;
     }
     const dom = editor.view.dom;


### PR DESCRIPTION
Fixes the Sentry issue [ARGOS-BROWSER-HX](https://argos-ci.sentry.io/issues/7588004877/) — `TypeError: can't access property "can", this.commandManager is null`, thrown from the `EditorToolbar` selector and caught by the build page's error boundary.

## Root cause

`useEditorState` doesn't read the editor from the prop we pass it. It reads it from a snapshot held by tiptap's internal `EditorStateManager`, and that reference is only re-pointed in a **layout effect** (`watch(options.editor)`). The selector runs during render, so it can be handed the *previous* editor instance.

Meanwhile `useEditor` tears an instance down asynchronously: on effect cleanup it calls `scheduleDestroy()`, which a tick later runs `editor.destroy()` and then `setEditor(null)`. That notification re-renders `Editor` with `editor === null` → `mountedEditor` becomes `null` → `EditorToolbar` re-renders with `editor={null}`. Because the toolbar's selector is an inline arrow function, its identity changes every render, so `useSyncExternalStoreWithSelector` re-runs it — against a snapshot still pointing at the just-destroyed instance.

`destroy()` nulls `commandManager` but leaves `editorState` cached. That's why `editor.state` and `editor.isActive(...)` kept working and only `editor.can()` blew up, exactly as the stack trace shows. Same failure class as the one the existing comment in `Editor.tsx` already guards against for `editor.commands`.

## The fix

The selector now bails out unless the snapshot's editor is the very instance the toolbar was handed *and* it is still alive:

```ts
if (snapshotEditor !== editor || !editor || editor.isDestroyed) {
  return null;
}
```

The identity check also fixes a quieter bug: after an instance swap the snapshot lags a transaction behind, so the toolbar was rendering the *old* editor's formatting state for one render.

The link-edit effect is guarded too — on a destroyed editor `view` returns a proxy that throws on any property it doesn't stub, `dom` included.

## Notes for the reviewer

- No test. The frontend suite is Storybook browser tests, and deterministically reproducing "editor destroyed while the toolbar stays mounted" would mean reaching into tiptap's instance manager from a play function.
- Typecheck and lint pass.
- Behavior is unchanged on the happy path: once the editor is live and a transaction has bumped the snapshot, `snapshotEditor === editor` holds and the selector runs as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)