### PR TITLE
fix(builds): allocate build numbers from an atomic per-project counter

### DIFF
--- a/apps/backend/db/migrations/20260801130000_builds-number-counter.js
+++ b/apps/backend/db/migrations/20260801130000_builds-number-counter.js
@@ -1,0 +1,41 @@
+/**
+ * Move build-number allocation to a per-project counter.
+ *
+ * A build number is user-facing — it is the build's URL — and must be unique
+ * within a project. It used to be allocated inline with
+ * `select coalesce(max(number),0) + 1 from builds where "projectId" = ?`, a
+ * read-modify-write with no unique constraint behind it: two concurrent inserts
+ * read the same max and produced the same number. It also reused the number of
+ * the most recent build whenever that build was deleted.
+ *
+ * `projects."buildNumber"` replaces it. Allocation becomes
+ * `UPDATE projects SET "buildNumber" = "buildNumber" + 1 ... RETURNING`, which
+ * is atomic: the row lock serializes concurrent allocations, and the counter
+ * never goes backwards when a build is deleted.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async (knex) => {
+  await knex.schema.alterTable("projects", (table) => {
+    table.integer("buildNumber").notNullable().defaultTo(0);
+  });
+
+  await knex.raw(`
+    UPDATE projects p
+    SET "buildNumber" = COALESCE(
+      (SELECT max(number) FROM builds WHERE "projectId" = p.id),
+      0
+    )
+  `);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async (knex) => {
+  await knex.schema.alterTable("projects", (table) => {
+    table.dropColumn("buildNumber");
+  });
+};

--- a/apps/backend/db/migrations/20260801130001_builds-number-unique.js
+++ b/apps/backend/db/migrations/20260801130001_builds-number-unique.js
@@ -1,0 +1,40 @@
+const INDEX_NAME = "builds_projectid_number_unique";
+
+/**
+ * Make a duplicate build number impossible.
+ *
+ * The counter added by the previous migration removes the race that produced
+ * duplicates, but nothing in the schema forbade them — a future regression
+ * would corrupt data silently again. `GET /projects/{owner}/{project}/builds/
+ * {buildNumber}` resolves a build by number with `.first()`, so a duplicate
+ * made the lookup pick non-deterministically between two builds.
+ *
+ * Created concurrently: `builds` is large in production and a plain
+ * `CREATE UNIQUE INDEX` would lock out writes for the duration.
+ *
+ * The drop before the create is deliberate. A failed `CREATE INDEX
+ * CONCURRENTLY` leaves an INVALID index behind; dropping first means a retry
+ * rebuilds it instead of finding the broken one and skipping. If the create
+ * fails because duplicates exist in the target database, resolve them (renumber
+ * or delete) and run the migration again.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async (knex) => {
+  await knex.raw(`DROP INDEX IF EXISTS ${INDEX_NAME}`);
+  await knex.raw(
+    `CREATE UNIQUE INDEX CONCURRENTLY ${INDEX_NAME}
+       ON builds ("projectId", number)`,
+  );
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async (knex) => {
+  await knex.raw(`DROP INDEX IF EXISTS ${INDEX_NAME}`);
+};
+
+export const config = { transaction: false };

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict Ivk5kSu7HHeKeaIzkDrOSxkNc9H2c9lQGXyfvpcQgxDjJtd0nLlOZNdHcaRseoE
+\restrict NCWaxg9ST6yzu49EdXJQgn0VVLYuBuCa1kVx30782FUnwQbDu43cyD2URwP6Qg7
 
 -- Dumped from database version 18.4
 -- Dumped by pg_dump version 18.4 (Homebrew)
@@ -1943,6 +1943,7 @@ CREATE TABLE public.projects (
     "tokenlessAuthEnabled" boolean DEFAULT false NOT NULL,
     "autoIgnore" jsonb,
     "ignoreConfig" jsonb,
+    "buildNumber" integer DEFAULT 0 NOT NULL,
     CONSTRAINT "projects_defaultUserLevel_check" CHECK (("defaultUserLevel" = ANY (ARRAY['admin'::text, 'reviewer'::text, 'viewer'::text]))),
     CONSTRAINT "projects_deploymentAuth_check" CHECK (("deploymentAuth" = ANY (ARRAY['public'::text, 'domain-private'::text, 'private'::text]))),
     CONSTRAINT "projects_summaryCheck_check" CHECK (("summaryCheck" = ANY (ARRAY['always'::text, 'auto'::text, 'never'::text])))
@@ -4326,6 +4327,13 @@ CREATE INDEX builds_projectid_name_createdat_idx ON public.builds USING btree ("
 
 
 --
+-- Name: builds_projectid_number_unique; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX builds_projectid_number_unique ON public.builds USING btree ("projectId", number);
+
+
+--
 -- Name: builds_projectid_prheadcommit_name_createdat_idx; Type: INDEX; Schema: public; Owner: postgres
 --
 
@@ -5848,7 +5856,7 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-\unrestrict Ivk5kSu7HHeKeaIzkDrOSxkNc9H2c9lQGXyfvpcQgxDjJtd0nLlOZNdHcaRseoE
+\unrestrict NCWaxg9ST6yzu49EdXJQgn0VVLYuBuCa1kVx30782FUnwQbDu43cyD2URwP6Qg7
 
 -- Knex migrations
 
@@ -6085,3 +6093,5 @@ INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('2026073
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260730140000_test-notification-subscriptions.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260731120000_user-passkeys.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260801120000_discord-webhooks.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260801130000_builds-number-counter.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260801130001_builds-number-unique.js', 1, NOW());

--- a/apps/backend/src/database/models/Build.e2e.test.ts
+++ b/apps/backend/src/database/models/Build.e2e.test.ts
@@ -33,6 +33,38 @@ describe("models/Build", () => {
       });
       expect(build.number).toBe(0);
     });
+
+    it("should reject a duplicated number", async () => {
+      const build = await factory.Build.create();
+      const bucket = await factory.ScreenshotBucket.create({
+        projectId: build.projectId,
+      });
+      // The atomic counter is what prevents two builds from racing onto the
+      // same number; `builds_projectid_number_unique` is the backstop that
+      // keeps a regression from silently corrupting data again.
+      await expect(
+        Build.query().insert({
+          jobStatus: "pending",
+          projectId: build.projectId,
+          compareScreenshotBucketId: bucket.id,
+          number: build.number,
+        }),
+      ).rejects.toThrow("builds_projectid_number_unique");
+    });
+
+    it("should not reuse the number of a deleted build", async () => {
+      const build = await factory.Build.create();
+      expect(build.number).toBe(1);
+      await build.$query().delete();
+      const next = await factory.Build.create({ projectId: build.projectId });
+      expect(next.number).toBe(2);
+    });
+
+    it("should push the counter past an explicitly numbered build", async () => {
+      const build = await factory.Build.create({ number: 42 });
+      const next = await factory.Build.create({ projectId: build.projectId });
+      expect(next.number).toBe(43);
+    });
   });
 
   describe("patch build", () => {

--- a/apps/backend/src/database/models/Build.ts
+++ b/apps/backend/src/database/models/Build.ts
@@ -260,22 +260,42 @@ export class Build extends Model {
     }
   }
 
-  override $beforeInsert(queryContext: QueryContext) {
+  override async $beforeInsert(queryContext: QueryContext) {
     super.$beforeInsert(queryContext);
-    if (this.number === undefined) {
-      this.number = -1;
-    }
+    await this.$allocateNumber(queryContext);
   }
 
-  override $formatDatabaseJson(json: Pojo): Pojo {
-    json = super.$formatDatabaseJson(json);
-    if (json["number"] === -1) {
-      json["number"] = this.$knex().raw(
-        '(select coalesce(max(number),0) + 1 as number from builds where "projectId" = ?)',
-        this.projectId,
+  /**
+   * Allocate the build number from the project's counter.
+   *
+   * The number is user-facing — it is the build's URL — and unique per project
+   * (`builds_projectid_number_unique`). It used to be allocated inline with
+   * `max(number) + 1`, which two concurrent inserts could resolve to the same
+   * value. `UPDATE ... RETURNING` is atomic: the row lock on the project
+   * serializes concurrent allocations, and the counter never goes backwards
+   * when the most recent build is deleted.
+   *
+   * A caller that sets `number` itself (seeds, fixtures) pushes the counter
+   * forward instead, so a later allocation cannot collide with it.
+   */
+  private async $allocateNumber(queryContext: QueryContext) {
+    const knex = queryContext.transaction;
+
+    if (this.number !== undefined) {
+      await knex.raw(
+        'UPDATE projects SET "buildNumber" = GREATEST("buildNumber", ?) WHERE id = ?',
+        [this.number, this.projectId],
       );
+      return;
     }
-    return json;
+
+    const result = await knex.raw<{ rows: { buildNumber: number }[] }>(
+      'UPDATE projects SET "buildNumber" = "buildNumber" + 1 WHERE id = ? RETURNING "buildNumber"',
+      [this.projectId],
+    );
+    const row = result.rows[0];
+    invariant(row, `Project ${this.projectId} not found, cannot number build`);
+    this.number = row.buildNumber;
   }
 
   override $afterInsert(queryContext: QueryContext) {

--- a/apps/backend/src/database/models/Project.ts
+++ b/apps/backend/src/database/models/Project.ts
@@ -141,6 +141,7 @@ export class Project extends Model {
             enum: ["public", "domain-private", "private"],
           },
           summaryCheck: { type: "string", enum: ["always", "never", "auto"] },
+          buildNumber: { type: "integer", minimum: 0 },
           defaultUserLevel: {
             anyOf: [{ type: "null" }, UserLevelJsonSchema as JSONSchema],
           },
@@ -189,6 +190,12 @@ export class Project extends Model {
   defaultUserLevel!: UserLevel | null;
   ignoreConfig!: ProjectIgnoreConfig | null;
   deploymentProdBranchGlob!: string | null;
+  /**
+   * Last build number allocated for this project. Incremented atomically by
+   * `Build.$allocateNumber`; never decremented, so a deleted build's number is
+   * not handed out again.
+   */
+  buildNumber!: number;
 
   /**
    * Resolve the effective ignore configuration of the project.

--- a/apps/backend/src/metrics/account.e2e.test.ts
+++ b/apps/backend/src/metrics/account.e2e.test.ts
@@ -241,10 +241,13 @@ describe("getAccountMetrics", () => {
       total: 2,
       projects: { [project.id]: 2 },
     });
-    expect(metrics.screenshots.projects).toEqual([project]);
+    // Creating the builds above bumped `projects."buildNumber"`, so the factory
+    // instance is stale — compare against the current row.
+    const currentProject = await project.$query();
+    expect(metrics.screenshots.projects).toEqual([currentProject]);
     expect(metrics.builds.all.total).toBe(1);
     expect(metrics.builds.all.projects).toEqual({ [project.id]: 1 });
-    expect(metrics.builds.projects).toEqual([project]);
+    expect(metrics.builds.projects).toEqual([currentProject]);
   });
 
   it("returns no metrics when no project names match", async () => {


### PR DESCRIPTION
## Problem

A build number is user-facing — it is the build's URL — and must be unique within a project. It was allocated inline in `Build.$formatDatabaseJson`:

```sql
select coalesce(max(number),0) + 1 from builds where "projectId" = ?
```

A read-modify-write with no unique constraint behind it. Two concurrent inserts read the same max and produce two builds with the same number. The Redis lock around `createBuild` covers the common case, but not a lock expiry (40s TTL) or a Redis blip — and we have duplicates in production to show for it.

Two consequences:

- `GET /projects/{owner}/{project}/builds/{buildNumber}` resolves by number with `.first()` and no `orderBy`, so a duplicate makes the lookup pick non-deterministically between two builds.
- Deleting the most recent build handed its number straight back to the next one.

## Fix

`projects."buildNumber"` becomes the source of truth. Allocation is a single statement:

```sql
UPDATE projects SET "buildNumber" = "buildNumber" + 1 WHERE id = ? RETURNING "buildNumber"
```

Atomic — the project row lock serializes concurrent allocations, with or without an enclosing transaction — and the counter never goes backwards, so a deleted build's number is not reused. A caller that sets `number` itself (seeds, fixtures) pushes the counter forward with `GREATEST` instead, so a later allocation can't collide with it.

`builds_projectid_number_unique` is the backstop that keeps a future regression from silently corrupting data again. Created concurrently — `builds` is large in production and a plain `CREATE UNIQUE INDEX` would lock out writes for the duration.

## Migrations

1. `20260801130000_builds-number-counter` — adds `projects."buildNumber"`, backfilled from `max(builds.number)` per project.
2. `20260801130001_builds-number-unique` — the concurrent unique index.

The index migration drops before creating: a failed `CREATE INDEX CONCURRENTLY` leaves an INVALID index behind, and dropping first means a retry rebuilds it rather than finding the broken one and skipping. **If the create fails because a database still holds duplicates, renumber or remove them and run the migration again.** Production is already clean.

## Notes for review

- Gaps are expected and fine: a rolled-back build burns its number, same as GitHub Actions run numbers.
- `Build.$beforeInsert` is now async. Objection supports it, and it runs per model, so a batch insert allocates one number per row.
- `account.e2e.test.ts` compared a stale factory `Project` instance against the DB row; it now reloads, since creating a build mutates `buildNumber`.

## Testing

- `pnpm run static-checks` clean.
- Full integration suite: 879 passed / 135 files.
- Guard test `should not reuse the number of a deleted build` verified to fail with the fix reverted.
- Both migrations verified to roll back and re-apply cleanly on `development` and `test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)