### PR TITLE
Hand review comments to a coding agent

### DIFF
--- a/apps/backend/src/api/auth/comment.ts
+++ b/apps/backend/src/api/auth/comment.ts
@@ -1,4 +1,5 @@
 import type { AuthOAuthPayload, AuthPATPayload } from "@/auth/payload";
+import { safeParseCommentId } from "@/comment/id";
 import {
   getCommentTargetProject,
   isCommentOnTarget,
@@ -58,17 +59,18 @@ export async function assertCommentTargetPermission(input: {
 }
 
 /**
- * Load a comment by id, scoped to a target: a comment whose id is unknown or
- * belongs to a different build/test surfaces as a clean 404 rather than leaking
- * across targets. Soft-deleted comments are returned as-is — callers decide
- * whether a deleted comment is meaningful for their action (mirroring the
- * GraphQL resolvers).
+ * Load a comment by its public id, scoped to a target: a comment whose id is
+ * malformed or unknown, or which belongs to a different build/test, surfaces as
+ * a clean 404 rather than leaking across targets. Soft-deleted comments are
+ * returned as-is — callers decide whether a deleted comment is meaningful for
+ * their action (mirroring the GraphQL resolvers).
  */
 export async function getTargetComment(input: {
   commentId: string;
   target: CommentTarget;
 }): Promise<Comment> {
-  const comment = await Comment.query().findById(input.commentId);
+  const commentId = safeParseCommentId(input.commentId);
+  const comment = commentId ? await Comment.query().findById(commentId) : null;
   if (!comment || !isCommentOnTarget(comment, input.target)) {
     throw boom(404, "Comment not found");
   }
@@ -84,7 +86,8 @@ export async function getTargetCommentThread(input: {
   commentId: string;
   target: CommentTarget;
 }): Promise<Comment> {
-  const thread = await getCommentThreadRoot(input.commentId);
+  const commentId = safeParseCommentId(input.commentId);
+  const thread = commentId ? await getCommentThreadRoot(commentId) : null;
   if (!thread || !isCommentOnTarget(thread, input.target)) {
     throw boom(404, "Thread not found");
   }

--- a/apps/backend/src/api/handlers/comments.e2e.test.ts
+++ b/apps/backend/src/api/handlers/comments.e2e.test.ts
@@ -3,6 +3,7 @@ import { test as base, beforeAll, describe, expect } from "vitest";
 import z from "zod";
 
 import { concludeBuild } from "@/build/concludeBuild";
+import { formatCommentId, parseCommentId } from "@/comment/id";
 import {
   Account,
   Build,
@@ -90,7 +91,7 @@ describe("createComment", () => {
     expect(res.body.text).toContain("Looks broken on mobile");
     expect(JSON.stringify(res.body.body)).toContain("bold");
 
-    const comment = await Comment.query().findById(res.body.id);
+    const comment = await Comment.query().findById(parseCommentId(res.body.id));
     expect(comment?.userId).toBe(user.id);
   });
 
@@ -117,10 +118,10 @@ describe("createComment", () => {
     const res = await request(app)
       .post(`/projects/acme/web/builds/${build.number}/comments`)
       .set(auth(scopedPatToken))
-      .send({ body: "A reply", threadId: root.id })
+      .send({ body: "A reply", threadId: formatCommentId(root.id) })
       .expect(201);
 
-    expect(res.body.threadId).toBe(root.id);
+    expect(res.body.threadId).toBe(formatCommentId(root.id));
   });
 
   test("attaches to a pending review with addToReview", async ({
@@ -136,7 +137,7 @@ describe("createComment", () => {
       .expect(201);
 
     expect(res.body.pending).toBe(true);
-    const comment = await Comment.query().findById(res.body.id);
+    const comment = await Comment.query().findById(parseCommentId(res.body.id));
     expect(comment?.buildReviewId).not.toBeNull();
   });
 
@@ -226,7 +227,7 @@ describe("createComment", () => {
       .set(auth(scopedPatToken))
       .send({
         body: "reply",
-        threadId: root.id,
+        threadId: formatCommentId(root.id),
         screenshotDiffId: screenshotDiffs[0]!.id,
       })
       .expect(400)
@@ -290,11 +291,16 @@ describe("listComments / getComment", () => {
     });
 
     const res = await request(app)
-      .get(`/projects/acme/web/builds/${build.number}/comments/${comment.id}`)
+      .get(
+        `/projects/acme/web/builds/${build.number}/comments/${formatCommentId(comment.id)}`,
+      )
       .set(auth(scopedPatToken))
       .expect(200);
 
-    expect(res.body).toMatchObject({ id: comment.id, text: "One comment" });
+    expect(res.body).toMatchObject({
+      id: formatCommentId(comment.id),
+      text: "One comment",
+    });
   });
 
   test("returns 404 for a deleted comment", async ({
@@ -310,7 +316,9 @@ describe("listComments / getComment", () => {
     });
 
     const res = await request(app)
-      .get(`/projects/acme/web/builds/${build.number}/comments/${comment.id}`)
+      .get(
+        `/projects/acme/web/builds/${build.number}/comments/${formatCommentId(comment.id)}`,
+      )
       .set(auth(scopedPatToken))
       .expect(404);
     expect(res.body.error).toEqual(expect.any(String));
@@ -334,7 +342,9 @@ describe("listComments / getComment", () => {
     });
 
     const res = await request(app)
-      .get(`/projects/acme/web/builds/${build.number}/comments/${comment.id}`)
+      .get(
+        `/projects/acme/web/builds/${build.number}/comments/${formatCommentId(comment.id)}`,
+      )
       .set(auth(scopedPatToken))
       .expect(404);
     expect(res.body.error).toEqual(expect.any(String));
@@ -358,7 +368,9 @@ describe("updateComment / deleteComment", () => {
     });
 
     const res = await request(app)
-      .patch(`/projects/acme/web/builds/${build.number}/comments/${comment.id}`)
+      .patch(
+        `/projects/acme/web/builds/${build.number}/comments/${formatCommentId(comment.id)}`,
+      )
       .set(auth(scopedPatToken))
       .send({ body: "After" })
       .expect(200);
@@ -379,7 +391,9 @@ describe("updateComment / deleteComment", () => {
     });
 
     await request(app)
-      .patch(`/projects/acme/web/builds/${build.number}/comments/${comment.id}`)
+      .patch(
+        `/projects/acme/web/builds/${build.number}/comments/${formatCommentId(comment.id)}`,
+      )
       .set(auth(scopedPatToken))
       .send({ body: "hijack" })
       .expect(403)
@@ -401,7 +415,7 @@ describe("updateComment / deleteComment", () => {
 
     await request(app)
       .delete(
-        `/projects/acme/web/builds/${build.number}/comments/${comment.id}`,
+        `/projects/acme/web/builds/${build.number}/comments/${formatCommentId(comment.id)}`,
       )
       .set(auth(scopedPatToken))
       .expect(200);
@@ -423,7 +437,7 @@ describe("updateComment / deleteComment", () => {
 
     await request(app)
       .delete(
-        `/projects/acme/web/builds/${build.number}/comments/${comment.id}`,
+        `/projects/acme/web/builds/${build.number}/comments/${formatCommentId(comment.id)}`,
       )
       .set(auth(scopedPatToken))
       .expect(403)
@@ -451,7 +465,7 @@ describe("reactions", () => {
 
     const added = await request(app)
       .post(
-        `/projects/acme/web/builds/${build.number}/comments/${comment.id}/reactions`,
+        `/projects/acme/web/builds/${build.number}/comments/${formatCommentId(comment.id)}/reactions`,
       )
       .set(auth(scopedPatToken))
       .send({ emoji: "👍" })
@@ -470,7 +484,7 @@ describe("reactions", () => {
 
     const removed = await request(app)
       .delete(
-        `/projects/acme/web/builds/${build.number}/comments/${comment.id}/reactions`,
+        `/projects/acme/web/builds/${build.number}/comments/${formatCommentId(comment.id)}/reactions`,
       )
       .query({ emoji: "👍" })
       .set(auth(scopedPatToken))
@@ -488,7 +502,7 @@ describe("reactions", () => {
 
     await request(app)
       .post(
-        `/projects/acme/web/builds/${build.number}/comments/${comment.id}/reactions`,
+        `/projects/acme/web/builds/${build.number}/comments/${formatCommentId(comment.id)}/reactions`,
       )
       .set(auth(scopedPatToken))
       .send({ emoji: "not-an-emoji" })
@@ -517,7 +531,7 @@ describe("thread resolve / subscription", () => {
 
     const resolved = await request(app)
       .post(
-        `/projects/acme/web/builds/${build.number}/comments/${comment.id}/resolve`,
+        `/projects/acme/web/builds/${build.number}/comments/${formatCommentId(comment.id)}/resolve`,
       )
       .set(auth(scopedPatToken))
       .expect(200);
@@ -525,7 +539,7 @@ describe("thread resolve / subscription", () => {
 
     const reopened = await request(app)
       .post(
-        `/projects/acme/web/builds/${build.number}/comments/${comment.id}/unresolve`,
+        `/projects/acme/web/builds/${build.number}/comments/${formatCommentId(comment.id)}/unresolve`,
       )
       .set(auth(scopedPatToken))
       .expect(200);
@@ -545,7 +559,7 @@ describe("thread resolve / subscription", () => {
 
     await request(app)
       .post(
-        `/projects/acme/web/builds/${build.number}/comments/${comment.id}/subscription`,
+        `/projects/acme/web/builds/${build.number}/comments/${formatCommentId(comment.id)}/subscription`,
       )
       .set(auth(scopedPatToken))
       .expect(200);
@@ -558,7 +572,7 @@ describe("thread resolve / subscription", () => {
 
     await request(app)
       .delete(
-        `/projects/acme/web/builds/${build.number}/comments/${comment.id}/subscription`,
+        `/projects/acme/web/builds/${build.number}/comments/${formatCommentId(comment.id)}/subscription`,
       )
       .set(auth(scopedPatToken))
       .expect(200);

--- a/apps/backend/src/api/handlers/createComment.ts
+++ b/apps/backend/src/api/handlers/createComment.ts
@@ -33,10 +33,10 @@ import { TestId } from "../schema/primitives/test";
 import { patOrOAuthAuth } from "../security";
 import { CreateAPIHandler } from "../util";
 
-const ThreadIdSchema = z
-  .string()
-  .optional()
-  .meta({ description: "Root comment ID to reply to." });
+const ThreadIdSchema = z.string().optional().meta({
+  description:
+    "Public ID of the root comment to reply to (e.g. `comment-xf23d`).",
+});
 
 const CreateCommentBodySchema = z.object({
   body: CommentBodyInputSchema,

--- a/apps/backend/src/api/handlers/testComments.e2e.test.ts
+++ b/apps/backend/src/api/handlers/testComments.e2e.test.ts
@@ -3,6 +3,7 @@ import { test as base, beforeAll, describe, expect } from "vitest";
 import z from "zod";
 
 import { TEST_COMMENTS_LIMIT } from "@/comment/getVisibleComments";
+import { parseCommentId } from "@/comment/id";
 import { knex } from "@/database";
 import {
   Comment,
@@ -70,7 +71,7 @@ describe("test comments API", () => {
     });
     expect(res.body.text).toContain("This one is flaky");
 
-    const comment = await Comment.query().findById(res.body.id);
+    const comment = await Comment.query().findById(parseCommentId(res.body.id));
     expect(comment?.userId).toBe(user.id);
     expect(comment?.buildId).toBeNull();
     expect(comment?.testId).toBe(testModel.id);
@@ -115,7 +116,7 @@ describe("test comments API", () => {
     expect(res.body.screenshotDiffId).toBeNull();
     expect(res.body.pending).toBe(false);
 
-    const comment = await Comment.query().findById(res.body.id);
+    const comment = await Comment.query().findById(parseCommentId(res.body.id));
     expect(comment?.screenshotDiffId).toBeNull();
     expect(comment?.buildReviewId).toBeNull();
   });
@@ -209,7 +210,9 @@ describe("test comments API", () => {
       .set(auth(scopedPatToken))
       .expect(200);
 
-    const comment = await Comment.query().findById(created.body.id);
+    const comment = await Comment.query().findById(
+      parseCommentId(created.body.id),
+    );
     expect(comment?.deletedAt).not.toBeNull();
 
     await request(app)
@@ -286,7 +289,7 @@ describe("test comments API", () => {
       .expect(200);
 
     let subscription = await CommentNotificationSubscription.query().findOne({
-      commentId: created.body.id,
+      commentId: parseCommentId(created.body.id),
       userId: user.id,
     });
     expect(subscription?.isSubscribed()).toBe(false);
@@ -299,7 +302,7 @@ describe("test comments API", () => {
       .expect(200);
 
     subscription = await CommentNotificationSubscription.query().findOne({
-      commentId: created.body.id,
+      commentId: parseCommentId(created.body.id),
       userId: user.id,
     });
     expect(subscription?.isSubscribed()).toBe(true);

--- a/apps/backend/src/api/schema/primitives/comment.ts
+++ b/apps/backend/src/api/schema/primitives/comment.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { formatCommentId } from "@/comment/id";
 import { schema as proseMirrorSchema } from "@/comment/schema";
 import { BuildReview, Comment, CommentReaction } from "@/database/models";
 
@@ -61,7 +62,10 @@ export const CommentAnchorSchema = z
 
 export const CommentSchema = z
   .object({
-    id: z.string(),
+    id: z.string().meta({
+      description:
+        "Public ID of the comment (e.g. `comment-xf23d`) — the one the app links to, and the one every endpoint taking a comment ID expects.",
+    }),
     buildId: z.string().nullable().meta({
       description:
         "Build this comment is posted on, null when it is posted on a test.",
@@ -112,7 +116,7 @@ export type CommentPayload = z.infer<typeof CommentSchema>;
 
 /** Path parameter addressing one comment. */
 export const CommentId = z.string().meta({
-  description: "The ID of the comment",
+  description: "The public ID of the comment (e.g. `comment-xf23d`)",
   id: "CommentId",
 });
 
@@ -121,7 +125,7 @@ export const CommentId = z.string().meta({
  * root, so any comment in the thread identifies it.
  */
 export const ThreadCommentId = z.string().meta({
-  description: "ID of any comment in the thread",
+  description: "Public ID of any comment in the thread (e.g. `comment-xf23d`)",
   id: "ThreadCommentId",
 });
 
@@ -224,10 +228,10 @@ export async function serializeComments(
       : false;
 
     return {
-      id: comment.id,
+      id: formatCommentId(comment.id),
       buildId: comment.buildId,
       testId: comment.testId,
-      threadId: comment.threadId,
+      threadId: comment.threadId ? formatCommentId(comment.threadId) : null,
       body: comment.content,
       text: commentText(comment.content),
       author: account ? serializeUser(account) : null,

--- a/apps/backend/src/comment/id.ts
+++ b/apps/backend/src/comment/id.ts
@@ -15,19 +15,32 @@ export function formatCommentId(commentId: string | number): string {
 }
 
 /**
- * Decodes a public comment identifier back to the underlying model ID.
+ * Decodes a public comment identifier back to the underlying model ID, or
+ * `null` when the input is not one. Callers that address a comment by id use
+ * this, so a malformed id reads as "no such comment" rather than an error.
  */
-export function parseCommentId(input: string): string {
+export function safeParseCommentId(input: string): string | null {
   if (!input.startsWith(COMMENT_ID_PREFIX)) {
-    throw new Error("Invalid comment ID format");
+    return null;
   }
 
   const decoded = sqids.decode(input.slice(COMMENT_ID_PREFIX.length))[0];
   if (decoded === undefined) {
-    throw new Error("Invalid comment ID format");
+    return null;
   }
 
   return String(decoded);
+}
+
+/**
+ * Decodes a public comment identifier back to the underlying model ID.
+ */
+export function parseCommentId(input: string): string {
+  const parsed = safeParseCommentId(input);
+  if (parsed === null) {
+    throw new Error("Invalid comment ID format");
+  }
+  return parsed;
 }
 
 /**

--- a/apps/frontend/src/containers/AiPromptButton.tsx
+++ b/apps/frontend/src/containers/AiPromptButton.tsx
@@ -11,6 +11,7 @@ import {
   MenuItemIcon,
   MenuSeparator,
   MenuTrigger,
+  SubmenuTrigger,
 } from "@/ui/Menu";
 import { Popover } from "@/ui/Popover";
 import { Tooltip } from "@/ui/Tooltip";
@@ -20,16 +21,43 @@ import { AI_AGENTS, type AiAgentId } from "@/util/ai-agents";
  * Copying is a target like the agents are, so it can be the one remembered: it
  * is what someone whose agent Argos cannot open reaches for every time.
  */
-const COPY = "copy";
+const COPY_TARGET = "copy";
 
-type Target = AiAgentId | typeof COPY;
+export type AiPromptTarget = AiAgentId | typeof COPY_TARGET;
 
 /**
  * Where prompts went last, so the button offers that again instead of asking on
  * every build and every flaky test. Shared by every prompt Argos hands out: the
  * choice is about the user's tools, not about the prompt.
  */
-const targetAtom = atomWithStorage<Target>("aiPromptTarget", AI_AGENTS[0].id);
+const targetAtom = atomWithStorage<AiPromptTarget>(
+  "aiPromptTarget",
+  AI_AGENTS[0].id,
+);
+
+/**
+ * The agent prompts go to, and how to change it. Exported so the surfaces that
+ * hand out a prompt without this button — a comment thread's actions menu —
+ * still feed the one choice.
+ */
+export function useAiPromptTarget() {
+  return useAtom(targetAtom);
+}
+
+/** One thing Argos can ask a coding agent to do. */
+export interface AiPrompt {
+  /**
+   * What the prompt asks for, as the menu says it ("Review build"). Only shown
+   * when the button carries more than one.
+   */
+  label: string;
+  /**
+   * Names the prompt where it needs naming ("Copy review prompt"). Keep it
+   * short: it reads mid-label.
+   */
+  name: string;
+  prompt: string;
+}
 
 /**
  * Content of the button that performs the remembered action. An `iconOnly`
@@ -52,19 +80,70 @@ function PrimaryContent(props: {
 }
 
 /**
+ * The rows that send one prompt somewhere: every agent Argos can open, then the
+ * clipboard. Picking one is also meant to make it the remembered target, which
+ * is what `onPick` is for.
+ *
+ * Copying is left to the caller rather than done here, so the surface that owns
+ * the rows can confirm it in its own way — the button relabels itself, a menu
+ * that closes on the click has to say it another way.
+ */
+export function AiPromptTargetItems(props: {
+  entry: AiPrompt;
+  onPick: (target: AiPromptTarget) => void;
+  onCopy: (entry: AiPrompt) => void;
+}) {
+  const { entry, onPick, onCopy } = props;
+  return (
+    <>
+      {AI_AGENTS.map(({ id, name, Icon, getURL }) => (
+        <MenuItem
+          key={id}
+          href={getURL(entry.prompt)}
+          textValue={name}
+          onAction={() => onPick(id)}
+        >
+          <MenuItemIcon>
+            <Icon />
+          </MenuItemIcon>
+          Open in {name}
+        </MenuItem>
+      ))}
+      <MenuSeparator />
+      <MenuItem
+        textValue={`Copy ${entry.name}`}
+        onAction={() => {
+          onPick(COPY_TARGET);
+          onCopy(entry);
+        }}
+      >
+        <MenuItemIcon>
+          <CopyIcon />
+        </MenuItemIcon>
+        Copy {entry.name}
+      </MenuItem>
+    </>
+  );
+}
+
+/**
  * Hands a prompt to the coding agent the user works with: a split button that
  * opens the one picked last, and a menu for the others and for the clipboard.
  *
  * The agents are opened through their own deep links, so the prompt is typed in
  * but not sent, and never leaves the machine.
+ *
+ * A button can carry several prompts — reviewing a build and acting on what its
+ * reviewers wrote are two things to ask of the same agent about the same build.
+ * The button itself performs the first one; the menu then folds each prompt's
+ * targets into a submenu of its own, rather than listing every pairing flat.
  */
 export function AiPromptButton(props: {
-  prompt: string;
   /**
-   * Names the prompt where it needs naming ("Copy review prompt"). Keep it
-   * short: it reads mid-label.
+   * What this button can hand out, most-used first: the button performs that
+   * one, and the menu reaches the rest.
    */
-  promptName?: string;
+  prompts: readonly [AiPrompt, ...AiPrompt[]];
   size?: ButtonSize;
   /**
    * Drop the label and keep the target's icon, for rows with no room for a
@@ -72,25 +151,31 @@ export function AiPromptButton(props: {
    */
   iconOnly?: boolean;
 }) {
-  const { prompt, promptName = "prompt", size, iconOnly = false } = props;
-  const [target, setTarget] = useAtom(targetAtom);
+  const { prompts, size, iconOnly = false } = props;
+  const [target, setTarget] = useAiPromptTarget();
   const clipboard = useClipboard({ copiedTimeout: 2000 });
-  const copy = () => clipboard.copy(prompt);
-  const copyLabel = `Copy ${promptName}`;
+  const [primary] = prompts;
+  const copy = (entry: AiPrompt) => clipboard.copy(entry.prompt);
+  const copyLabel = `Copy ${primary.name}`;
   // A target this build no longer offers falls back to copying, which always
   // works.
   const agent = AI_AGENTS.find(({ id }) => id === target) ?? null;
+  const targetItems = (entry: AiPrompt) => (
+    <AiPromptTargetItems entry={entry} onPick={setTarget} onCopy={copy} />
+  );
 
   return (
     <ButtonGroup>
       {agent ? (
-        <Tooltip content={`Open the ${promptName} in ${agent.name}`}>
+        <Tooltip content={`Open the ${primary.name} in ${agent.name}`}>
           <LinkButton
             variant="secondary"
             size={size}
             iconOnly={iconOnly}
-            aria-label={iconOnly ? `Open in ${agent.name}` : undefined}
-            href={agent.getURL(prompt)}
+            aria-label={
+              iconOnly ? `Open the ${primary.name} in ${agent.name}` : undefined
+            }
+            href={agent.getURL(primary.prompt)}
           >
             <PrimaryContent iconOnly={iconOnly} icon={<agent.Icon />}>
               Open in {agent.name}
@@ -106,7 +191,7 @@ export function AiPromptButton(props: {
             aria-label={
               iconOnly ? (clipboard.copied ? "Copied" : copyLabel) : undefined
             }
-            onPress={copy}
+            onPress={() => copy(primary)}
           >
             <PrimaryContent
               iconOnly={iconOnly}
@@ -122,7 +207,11 @@ export function AiPromptButton(props: {
           variant="secondary"
           size={size}
           iconOnly
-          aria-label={`Choose what to do with the ${promptName}`}
+          aria-label={
+            prompts.length > 1
+              ? "Choose what to hand to an agent"
+              : `Choose what to do with the ${primary.name}`
+          }
         >
           <ChevronDownIcon />
         </Button>
@@ -130,34 +219,20 @@ export function AiPromptButton(props: {
             and the button sits at the right of a header, so aligning it the
             other way only to be pushed back in reads as a stutter. */}
         <Popover placement="bottom end">
-          <Menu aria-label={promptName}>
-            {AI_AGENTS.map(({ id, name, Icon, getURL }) => (
-              <MenuItem
-                key={id}
-                href={getURL(prompt)}
-                textValue={name}
-                onAction={() => setTarget(id)}
-              >
-                <MenuItemIcon>
-                  <Icon />
-                </MenuItemIcon>
-                Open in {name}
-              </MenuItem>
-            ))}
-            <MenuSeparator />
-            <MenuItem
-              textValue={copyLabel}
-              onAction={() => {
-                setTarget(COPY);
-                copy();
-              }}
-            >
-              <MenuItemIcon>
-                <CopyIcon />
-              </MenuItemIcon>
-              {copyLabel}
-            </MenuItem>
-          </Menu>
+          {prompts.length > 1 ? (
+            <Menu aria-label="Agent prompts">
+              {prompts.map((entry) => (
+                <SubmenuTrigger key={entry.label}>
+                  <MenuItem textValue={entry.label}>{entry.label}</MenuItem>
+                  <Popover>
+                    <Menu aria-label={entry.label}>{targetItems(entry)}</Menu>
+                  </Popover>
+                </SubmenuTrigger>
+              ))}
+            </Menu>
+          ) : (
+            <Menu aria-label={primary.name}>{targetItems(primary)}</Menu>
+          )}
         </Popover>
       </MenuTrigger>
     </ButtonGroup>

--- a/apps/frontend/src/containers/Comment/CommentActionsMenu.tsx
+++ b/apps/frontend/src/containers/Comment/CommentActionsMenu.tsx
@@ -5,9 +5,15 @@ import {
   LinkIcon,
   MoreHorizontalIcon,
   PencilIcon,
+  SparklesIcon,
   Trash2Icon,
 } from "lucide-react";
+import { useClipboard } from "use-clipboard-copy";
 
+import {
+  AiPromptTargetItems,
+  useAiPromptTarget,
+} from "@/containers/AiPromptButton";
 import { Button } from "@/ui/Button";
 import {
   Menu,
@@ -15,8 +21,13 @@ import {
   MenuItemIcon,
   MenuSeparator,
   MenuTrigger,
+  SubmenuTrigger,
 } from "@/ui/Menu";
 import { Popover } from "@/ui/Popover";
+import { toast } from "@/ui/Toaster";
+
+// Shared id so copying from several threads reuses one toast instead of stacking.
+const COPY_PROMPT_TOAST_ID = "thread-prompt-copied";
 
 export function CommentActionsMenu(props: {
   onCopyLink: () => void;
@@ -31,6 +42,13 @@ export function CommentActionsMenu(props: {
   onEdit?: () => void;
   /** When provided, a "Delete comment" action is shown. */
   onDelete?: () => void;
+  /**
+   * When provided, a "Handle with AI" submenu hands this prompt to a coding
+   * agent. It lives in the menu rather than next to the reactions: it acts on
+   * the whole thread, like resolving does, and a comment row has no room left
+   * for a control that only some threads would use.
+   */
+  threadPrompt?: string;
 }) {
   const {
     onCopyLink,
@@ -41,7 +59,10 @@ export function CommentActionsMenu(props: {
     onToggleResolved,
     onEdit,
     onDelete,
+    threadPrompt,
   } = props;
+  const [, setTarget] = useAiPromptTarget();
+  const clipboard = useClipboard();
   return (
     <MenuTrigger>
       <Button
@@ -74,6 +95,41 @@ export function CommentActionsMenu(props: {
               ? "Unsubscribe from thread"
               : "Subscribe to thread"}
           </MenuItem>
+          {threadPrompt ? (
+            <>
+              <MenuSeparator />
+              <SubmenuTrigger>
+                <MenuItem textValue="Handle with AI">
+                  <MenuItemIcon>
+                    <SparklesIcon />
+                  </MenuItemIcon>
+                  Handle with AI
+                </MenuItem>
+                <Popover>
+                  <Menu aria-label="Handle with AI">
+                    <AiPromptTargetItems
+                      entry={{
+                        label: "Handle this thread",
+                        name: "thread prompt",
+                        prompt: threadPrompt,
+                      }}
+                      onPick={setTarget}
+                      onCopy={(entry) => {
+                        clipboard.copy(entry.prompt);
+                        // The menu closes on the click, so the toast is the
+                        // only place left to confirm the copy.
+                        toast.success("Prompt copied", {
+                          id: COPY_PROMPT_TOAST_ID,
+                          description:
+                            "Paste it into a coding agent working in your repository.",
+                        });
+                      }}
+                    />
+                  </Menu>
+                </Popover>
+              </SubmenuTrigger>
+            </>
+          ) : null}
           {onToggleResolved ? (
             <>
               <MenuSeparator />

--- a/apps/frontend/src/containers/Comment/CommentCard.tsx
+++ b/apps/frontend/src/containers/Comment/CommentCard.tsx
@@ -189,6 +189,12 @@ export function CommentCard(props: {
    * popover, where replying is the primary action.
    */
   autoFocusReply?: boolean;
+  /**
+   * Prompt handing this thread to a coding agent, so it carries out what the
+   * thread asks for in the repository. Only threads whose owner an agent can
+   * reach through the Argos API get one.
+   */
+  threadPrompt?: string;
 }) {
   const {
     comment,
@@ -200,6 +206,7 @@ export function CommentCard(props: {
     screenshotReference = null,
     embedded = false,
     autoFocusReply = false,
+    threadPrompt,
   } = props;
   const client = useApolloClient();
   const subscribeToCommentThread = () =>
@@ -404,6 +411,7 @@ export function CommentCard(props: {
               onSubscribeThread={subscribeThread}
               onUnsubscribeThread={unsubscribeThread}
               onToggleResolved={onToggleResolved}
+              threadPrompt={threadPrompt}
             />
             <AnimatePresence initial={false}>
               {replies.map((reply) => (
@@ -483,6 +491,12 @@ function CommentMessage(props: {
   onToggleResolved?: () => void;
   separated?: boolean;
   isReply?: boolean;
+  /**
+   * Prompt handing the whole thread to a coding agent. Thread-level like
+   * resolving is, so only the root comment carries it — a reply repeating it
+   * would offer the same work several times over.
+   */
+  threadPrompt?: string;
 }) {
   const {
     comment,
@@ -494,6 +508,7 @@ function CommentMessage(props: {
     onToggleResolved,
     separated = false,
     isReply = false,
+    threadPrompt,
   } = props;
   const ref = useRef<HTMLDivElement>(null);
   const clipboard = useClipboard();
@@ -634,6 +649,7 @@ function CommentMessage(props: {
               onDelete={
                 canDelete ? () => setIsDeleteDialogOpen(true) : undefined
               }
+              threadPrompt={threadPrompt}
             />
           </div>
         </div>

--- a/apps/frontend/src/pages/Build/BuildCommentsPrompt.ts
+++ b/apps/frontend/src/pages/Build/BuildCommentsPrompt.ts
@@ -1,0 +1,57 @@
+import { config } from "@/config";
+
+import { getBuildURL } from "./BuildParams";
+
+/**
+ * A prompt to hand to a coding agent so it carries out what reviewers asked for
+ * on a build — one thread, or every thread still open.
+ *
+ * The comments themselves are deliberately left out: the agent fetches them, and
+ * in doing so also gets the snapshot each one hangs off and the anchor saying
+ * where on it they point. Quoting the text here would flatten all of that, and a
+ * comment on a visual review is rarely about its words alone — "this button"
+ * only means something next to the capture.
+ *
+ * How to drive the CLI is left out too. The `argos-cli` skill ships with the CLI
+ * and already carries the token model, the `--json` contract and every command's
+ * flags, and `argos <command> --help` covers an agent that lacks it. Spelling out
+ * REST routes here would only add a copy to keep in sync with the API.
+ */
+export function createHandleCommentsPrompt(input: {
+  accountSlug: string;
+  projectName: string;
+  buildNumber: number;
+  /**
+   * Narrows the work to a single thread, by its root comment's public id — the
+   * same id the API answers with. Every unresolved thread of the build when
+   * left out.
+   */
+  threadId?: string | null;
+}): string {
+  const { accountSlug, projectName, buildNumber, threadId = null } = input;
+  const buildUrl = new URL(
+    getBuildURL({ accountSlug, projectName, buildNumber }),
+    config.server.url,
+  ).href;
+
+  const lines = [
+    "# Handle Argos review comments",
+    "Reviewers left comments on an Argos visual review of this repository. Carry out what they ask for, here, in the code.",
+    "",
+    `- Argos build: ${buildUrl}`,
+    ...(threadId ? [`- Thread to handle: \`${threadId}\``] : []),
+    "",
+    "Drive Argos through its CLI — load the `argos-cli` skill for the token model and the flags, or run `npx @argos-ci/cli comment --help`.",
+    "",
+    threadId
+      ? `1. Read the thread: \`argos comment get ${buildUrl} ${threadId} --json\`, and its replies — the comments whose \`threadId\` is \`${threadId}\` in \`argos comment list ${buildUrl} --json\`. Leave the rest of the build alone.`
+      : `1. Read the comments: \`argos comment list ${buildUrl} --json\`. Take every thread whose root has no \`resolvedAt\` — the others are done. Skip the \`pending\` ones: they are drafts of a review nobody has submitted.`,
+    `2. See what each one points at. A comment carries \`screenshotDiffId\` and an \`anchor\` (a point in normalized 0-1 coordinates, or a line range) but no image, so match it against \`argos build snapshots ${buildUrl} --json\` and open that diff's \`url\`, \`base.url\` and \`head.url\`. A comment names its target loosely — "this button" — and the capture says which one it is.`,
+    "3. Do what it asks, in this repository. When it asks a question rather than for a change, answer it instead of touching the code. Keep to what was asked, and leave the rest of the visual diff alone. Run the repository's checks, then commit following its conventions.",
+    `4. Reply in the thread — \`argos comment create ${buildUrl} --reply-to ${threadId ?? "<rootCommentId>"} --body "..."\` — and resolve it only once its change is committed. Leave open what you could not handle, and say why in the reply.`,
+    "",
+    "The captures only change on the next build, so this build's diffs will not move.",
+  ];
+
+  return lines.join("\n");
+}

--- a/apps/frontend/src/pages/Build/header/BuildHeader.tsx
+++ b/apps/frontend/src/pages/Build/header/BuildHeader.tsx
@@ -19,6 +19,7 @@ import { HeadlessLink } from "@/ui/Link";
 import { Progress } from "@/ui/Progress";
 import { Tooltip } from "@/ui/Tooltip";
 
+import { createHandleCommentsPrompt } from "../BuildCommentsPrompt";
 import { useBuildDiffState } from "../BuildDiffState";
 import { getBuildOverviewURL } from "../BuildParams";
 import { useBuildReviewability } from "../BuildReviewability";
@@ -124,7 +125,7 @@ function LoggedReviewButton(props: {
       </div>
       <div className="flex items-center gap-2">
         <BuildReviewButton project={props.project} />
-        <BuildReviewPromptButton
+        <BuildPromptButton
           build={props.build}
           buildNumber={props.build.number}
           accountSlug={props.project.account.slug}
@@ -154,27 +155,45 @@ const _ProjectFragment = graphql(`
 `);
 
 /**
- * Hands the review prompt to the user's coding agent, so it reviews the build
- * from the CLI and reports back — or to the clipboard, for the agents Argos
- * cannot open.
+ * Hands one of the build's prompts to the user's coding agent — or to the
+ * clipboard, for the agents Argos cannot open.
+ *
+ * Two things can be asked of an agent about a build: to review it, and to carry
+ * out what its reviewers already wrote. Reviewing is the one the button itself
+ * performs — it applies to every build, where comments to handle are something
+ * a build only sometimes has.
  */
-function BuildReviewPromptButton(props: {
+function BuildPromptButton(props: {
   buildNumber: number;
   accountSlug: string;
   projectName: string;
   build: DocumentType<typeof _BuildFragment>;
 }) {
+  const { accountSlug, projectName, buildNumber } = props;
   const buildPath = `${getProjectURL({
-    accountSlug: props.accountSlug,
-    projectName: props.projectName,
-  })}/builds/${props.buildNumber}`;
+    accountSlug,
+    projectName,
+  })}/builds/${buildNumber}`;
   const buildUrl = new URL(buildPath, window.location.origin).toString();
-  const prompt = createBuildReviewPrompt({
-    buildUrl,
-    pullRequest: props.build.pullRequest,
-  });
+  const reviewPrompt = {
+    label: "Review build",
+    name: "review prompt",
+    prompt: createBuildReviewPrompt({
+      buildUrl,
+      pullRequest: props.build.pullRequest,
+    }),
+  };
+  const commentsPrompt = {
+    label: "Handle comments",
+    name: "comment prompt",
+    prompt: createHandleCommentsPrompt({
+      accountSlug,
+      projectName,
+      buildNumber,
+    }),
+  };
 
-  return <AiPromptButton prompt={prompt} promptName="review prompt" iconOnly />;
+  return <AiPromptButton prompts={[reviewPrompt, commentsPrompt]} iconOnly />;
 }
 
 export const BuildHeader = memo(

--- a/apps/frontend/src/pages/Build/sidebar/BuildCommentCard.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/BuildCommentCard.tsx
@@ -1,8 +1,11 @@
+import { useMemo } from "react";
 import { useApolloClient } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 
 import { CommentCard } from "@/containers/Comment/CommentCard";
 import { DocumentType, graphql } from "@/gql";
+import { createHandleCommentsPrompt } from "@/pages/Build/BuildCommentsPrompt";
+import { useBuildParams } from "@/pages/Build/BuildParams";
 import { useProjectParams } from "@/pages/Project/ProjectParams";
 import type { EditorValue } from "@/ui/Editor/Editor";
 
@@ -84,7 +87,24 @@ export function BuildCommentCard(props: {
   } = props;
   const projectParams = useProjectParams();
   invariant(projectParams);
+  const buildParams = useBuildParams();
   const client = useApolloClient();
+
+  // Threads live on the build page, but also in a popover on the screenshot,
+  // where the route still names the build — the prompt needs its number to tell
+  // the agent which build to read.
+  const threadPrompt = useMemo(
+    () =>
+      buildParams
+        ? createHandleCommentsPrompt({
+            accountSlug: buildParams.accountSlug,
+            projectName: buildParams.projectName,
+            buildNumber: buildParams.buildNumber,
+            threadId: comment.id,
+          })
+        : undefined,
+    [buildParams, comment.id],
+  );
 
   const anchor = (comment.anchor as CommentAnchor | null) ?? null;
   const screenshotDiff = comment.screenshotDiff ?? null;
@@ -110,6 +130,7 @@ export function BuildCommentCard(props: {
       {...cardProps}
       comment={comment}
       onReply={handleReply}
+      threadPrompt={threadPrompt}
       draftKeyPrefix={`build.${buildId}`}
       screenshotReference={
         !hideScreenshotReference && screenshotDiff && goToDiff

--- a/apps/frontend/src/pages/Test/FixFlakinessSection.tsx
+++ b/apps/frontend/src/pages/Test/FixFlakinessSection.tsx
@@ -133,7 +133,9 @@ export function FixFlakinessSection(props: {
             reads this test's stats and its recurring changes from the Argos
             API, then fixes what makes the screenshot unstable.
           </p>
-          <AiPromptButton prompt={prompt} />
+          <AiPromptButton
+            prompts={[{ label: "Fix flakiness", name: "prompt", prompt }]}
+          />
         </div>
       </Details>
     </Panel>


### PR DESCRIPTION

A review comment asks for a change someone then has to make. The build header's prompt button carries a second prompt handing the build's open threads to the agent, and a thread gets its own under "Handle with AI" in its actions menu.

The prompt sends the agent to read the comments itself rather than quoting them, so it also gets the snapshot each one points at. Driving the CLI is left to the `argos-cli` skill.

Building it surfaced an API inconsistency, fixed in the first commit: the REST API spoke the comment's model ID where GraphQL and the rest of the API speak public IDs. **Breaking** for anyone storing a numeric comment ID.


<img width="966" height="596" alt="CleanShot 2026-08-03 at 15 03 20@2x" src="https://github.com/user-attachments/assets/322547d9-03c9-4532-8480-bad09e4a98b6" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)