### PR TITLE
Drop the Claude Code terminal deep link

### DIFF
--- a/apps/frontend/src/containers/agent-icons.tsx
+++ b/apps/frontend/src/containers/agent-icons.tsx
@@ -27,24 +27,6 @@ export function ClaudeIcon({ className }: IconProps) {
   );
 }
 
-export function ClaudeCodeIcon({ className }: IconProps) {
-  return (
-    <svg
-      className={className}
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-      fill="currentColor"
-      fillRule="evenodd"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        clipRule="evenodd"
-        d="M20.998 10.949H24v3.102h-3v3.028h-1.487V20H18v-2.921h-1.487V20H15v-2.921H9V20H7.488v-2.921H6V20H4.487v-2.921H3V14.05H0V10.95h3V5h17.998v5.949zM6 10.949h1.488V8.102H6v2.847zm10.51 0H18V8.102h-1.49v2.847z"
-      />
-    </svg>
-  );
-}
-
 export function CodexIcon({ className }: IconProps) {
   return (
     <svg

--- a/apps/frontend/src/util/ai-agents.ts
+++ b/apps/frontend/src/util/ai-agents.ts
@@ -1,35 +1,25 @@
-import {
-  ClaudeCodeIcon,
-  ClaudeIcon,
-  CodexIcon,
-  CursorIcon,
-} from "@/containers/agent-icons";
+import { ClaudeIcon, CodexIcon, CursorIcon } from "@/containers/agent-icons";
 
 /**
  * Coding agents Argos can hand a prompt to, in the order menus offer them.
  *
  * Each `getURL` is that agent's own deep link: opening it starts the agent
  * installed on the machine with the prompt typed in but not sent, so the prompt
- * never leaves the user's computer. They all cap the URL length (5,000
- * characters for the Claude Code CLI, 8,000 for Cursor), which is well above the
- * prompts Argos builds.
+ * never leaves the user's computer. Each caps how much it carries — around
+ * 14,000 characters for Claude, 8,000 for Cursor — well above the prompts Argos
+ * builds.
  *
- * Claude appears twice because the CLI and the desktop app register different
- * schemes, and only the one that is installed answers: `claude-cli://` opens a
- * terminal session, `claude://` opens the same session inside Claude Desktop.
+ * Claude Code's own `claude-cli://` scheme is deliberately absent. It opens a
+ * terminal, and on macOS it does so by having AppleScript *type* its launch
+ * command into iTerm2 or Terminal.app — a line the tty cuts at 1,024 bytes,
+ * which left roughly 650 characters of prompt and truncated the rest silently.
+ * `claude://code/new` opens the same Claude Code session inside the desktop app,
+ * where the prompt never goes near a terminal.
  */
 export const AI_AGENTS = [
   {
-    id: "claude-code",
-    name: "Claude Code",
-    Icon: ClaudeCodeIcon,
-    // https://code.claude.com/docs/en/deep-links
-    getURL: (prompt: string) =>
-      `claude-cli://open?q=${encodeURIComponent(prompt)}`,
-  },
-  {
     id: "claude-desktop",
-    name: "Claude Desktop",
+    name: "Claude",
     Icon: ClaudeIcon,
     // https://support.claude.com/en/articles/14729294-open-claude-desktop-with-a-link
     getURL: (prompt: string) =>

--- a/tests/project-tests.spec.ts
+++ b/tests/project-tests.spec.ts
@@ -168,19 +168,19 @@ loggedTest(
     }
 
     // The test is flaky, so the section opens itself: the actions are reachable
-    // without expanding anything. Claude Code is the agent offered by default.
+    // without expanding anything. Claude is the agent offered by default.
     await expect(
       page.getByRole("heading", { name: "Fix with AI" }),
     ).toBeVisible();
-    const openInClaudeCode = page.getByRole("link", {
-      name: "Open in Claude Code",
+    const openInClaude = page.getByRole("link", {
+      name: "Open in Claude",
     });
-    await expect(openInClaudeCode).toBeVisible();
+    await expect(openInClaude).toBeVisible();
 
     // The agent is opened through its own deep link, which carries the prompt:
     // it names the test and the API endpoints the agent has to call.
-    const href = (await openInClaudeCode.getAttribute("href")) ?? "";
-    expect(href).toMatch(/^claude-cli:\/\/open\?q=/);
+    const href = (await openInClaude.getAttribute("href")) ?? "";
+    expect(href).toMatch(/^claude:\/\/code\/new\?q=/);
     const prompt = new URLSearchParams(href.split("?")[1]).get("q") ?? "";
     expect(prompt).toContain("Fix the flaky Argos visual test");
     expect(prompt).toContain("penelope-argos.jpg");
@@ -251,14 +251,14 @@ loggedTest(
     // there, but not competing with the metrics saying the test is fine.
     const heading = page.getByRole("heading", { name: "Fix with AI" });
     await expect(heading).toBeVisible();
-    const openInClaudeCode = page.getByRole("link", {
-      name: "Open in Claude Code",
+    const openInClaude = page.getByRole("link", {
+      name: "Open in Claude",
     });
-    await expect(openInClaudeCode).toBeHidden();
+    await expect(openInClaude).toBeHidden();
 
     // And opening it hands out the same prompt.
     await heading.click();
-    await expect(openInClaudeCode).toBeVisible();
+    await expect(openInClaude).toBeVisible();
   },
 );
 


### PR DESCRIPTION
`claude-cli://` opens a terminal, and on macOS it does so by having AppleScript type its launch command into iTerm2 or Terminal.app. A typed line is cut at 1,024 bytes by the tty, and the prompt rides there base64-encoded, so anything past roughly 650 characters reached the agent truncated mid-sentence — silently, since a cut base64 tail still decodes.

`claude://code/new` opens the same Claude Code session inside the desktop app, carries around 14,000 characters and never goes near a terminal. It becomes the Claude entry, and the menu now reads "Open in Claude".

Prompts are untouched. Anyone who had picked Claude Code falls back to copying, which `AiPromptButton` already handles for a target that no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)