### PR TITLE
fix(build): use gallery icon for the single view toggle

### DIFF
--- a/apps/frontend/src/containers/Build/toolbar/ViewToggle.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/ViewToggle.tsx
@@ -1,6 +1,6 @@
 import { memo, startTransition } from "react";
 import { useAtom } from "jotai/react";
-import { ColumnsIcon, SquareIcon } from "lucide-react";
+import { ColumnsIcon, GalleryHorizontalIcon } from "lucide-react";
 
 import { Button } from "@/ui/Button";
 import { ButtonGroup } from "@/ui/ButtonGroup";
@@ -97,7 +97,7 @@ export const SplitViewToggle = memo(() => {
       {/* Two panes or one: the icon is the state, so there is no pressed
           state on top of it. */}
       <Button variant="secondary" iconOnly onPress={toggleSplitView}>
-        {viewMode === "split" ? <SquareIcon /> : <ColumnsIcon />}
+        {viewMode === "split" ? <GalleryHorizontalIcon /> : <ColumnsIcon />}
       </Button>
     </HotkeyTooltip>
   );


### PR DESCRIPTION
Replaces the plain square icon on the split view toggle with the gallery icon: a square alone reads like a checkbox, while the gallery frame conveys "show only one image at a time". Columns2 stays for the side-by-side direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)