### PR TITLE
refactor: replace moment with native Intl date helpers

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -85,7 +85,6 @@
     "marked": "^18.0.7",
     "mime": "^4.1.0",
     "minimatch": "catalog:",
-    "moment": "^2.30.1",
     "node-cron": "^4.6.0",
     "objection": "^3.1.5",
     "odiff-bin": "^4.5.0",
@@ -136,7 +135,6 @@
     "concurrently": "^10.0.4",
     "eslint": "catalog:",
     "factory-girl-ts": "^2.3.1",
-    "moment": "^2.30.1",
     "msw": "^2.15.0",
     "pino-pretty": "^13.1.3",
     "supertest": "^7.2.2"

--- a/apps/backend/src/database/testing/factory.ts
+++ b/apps/backend/src/database/testing/factory.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
+import { addMonths, startOfDay } from "@argos/util/date";
 import type * as Bolt from "@slack/bolt";
 import { FactoryGirl, ModelAdapter } from "factory-girl-ts";
-import moment from "moment";
 import type { Model, ModelClass, PartialModelObject } from "objection";
 
 import * as models from "../models";
@@ -133,7 +133,7 @@ export const UserAccount = defineFactory(models.Account, () => ({
 export const Subscription = defineFactory(models.Subscription, () => ({
   planId: Plan.associate("id") as unknown as string,
   accountId: UserAccount.associate("id") as unknown as string,
-  startDate: moment().startOf("day").subtract(2, "months").toISOString(),
+  startDate: addMonths(startOfDay(new Date()), -2).toISOString(),
   endDate: null,
   provider: "github" as const,
   paymentMethodFilled: false,

--- a/apps/backend/src/graphql/tests/staffTrialPipeline.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/staffTrialPipeline.e2e.test.ts
@@ -1,5 +1,5 @@
+import { addDays, isSameDay } from "@argos/util/date";
 import { invariant } from "@argos/util/invariant";
-import moment from "moment";
 import request from "supertest";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -88,15 +88,15 @@ describe("GraphQL staffTrialPipeline", () => {
 
     const old = await factory.TeamAccount.create({
       slug: "too-old",
-      createdAt: moment().subtract(45, "days").toISOString(),
+      createdAt: addDays(new Date(), -45).toISOString(),
     });
     const recent = await factory.TeamAccount.create({
       slug: "recent",
-      createdAt: moment().subtract(20, "days").toISOString(),
+      createdAt: addDays(new Date(), -20).toISOString(),
     });
     const newest = await factory.TeamAccount.create({
       slug: "newest",
-      createdAt: moment().subtract(1, "days").toISOString(),
+      createdAt: addDays(new Date(), -1).toISOString(),
     });
 
     const res = await queryPipeline(viewer, 30);
@@ -150,17 +150,17 @@ describe("GraphQL staffTrialPipeline", () => {
     await factory.Build.create({
       projectId: project.id,
       type: "orphan",
-      createdAt: moment().subtract(5, "days").toISOString(),
+      createdAt: addDays(new Date(), -5).toISOString(),
     });
     await factory.Build.create({
       projectId: project.id,
       type: "check",
-      createdAt: moment().subtract(3, "days").toISOString(),
+      createdAt: addDays(new Date(), -3).toISOString(),
     });
     await factory.Build.create({
       projectId: project.id,
       type: "check",
-      createdAt: moment().subtract(1, "days").toISOString(),
+      createdAt: addDays(new Date(), -1).toISOString(),
     });
 
     const res = await queryPipeline(viewer, 30);
@@ -171,9 +171,9 @@ describe("GraphQL staffTrialPipeline", () => {
     // The earliest *check* build wins — not the earlier orphan one, nor the
     // later check.
     expect(
-      moment(entry.staff.firstComparisonAt).isSame(
-        moment().subtract(3, "days"),
-        "day",
+      isSameDay(
+        new Date(entry.staff.firstComparisonAt),
+        addDays(new Date(), -3),
       ),
     ).toBe(true);
   });

--- a/apps/backend/src/metrics/test.ts
+++ b/apps/backend/src/metrics/test.ts
@@ -1,6 +1,6 @@
 import { assertNever } from "@argos/util/assertNever";
+import { addDays, addHours, startOfDay } from "@argos/util/date";
 import * as Sentry from "@sentry/node";
-import moment from "moment";
 
 import { knex } from "@/database";
 import { IMetricsPeriod } from "@/graphql/__generated__/resolver-types";
@@ -44,7 +44,7 @@ export async function upsertTestStats(input: {
     async () => {
       const { date, change, testId } = input;
       const promises: Promise<void>[] = [];
-      const dayISODate = moment(date).startOf("day").toDate().toISOString();
+      const dayISODate = startOfDay(date).toISOString();
 
       if (change) {
         promises.push(
@@ -424,15 +424,15 @@ export function getStartDateFromPeriod(period: IMetricsPeriod | null): Date {
   const now = new Date();
   switch (period) {
     case IMetricsPeriod.Last_24Hours:
-      return moment(now).subtract(24, "hours").toDate();
+      return addHours(now, -24);
     case IMetricsPeriod.Last_3Days:
-      return moment(now).subtract(3, "days").startOf("day").toDate();
+      return startOfDay(addDays(now, -3));
     case IMetricsPeriod.Last_7Days:
-      return moment(now).subtract(7, "days").startOf("day").toDate();
+      return startOfDay(addDays(now, -7));
     case IMetricsPeriod.Last_30Days:
-      return moment(now).subtract(30, "days").startOf("day").toDate();
+      return startOfDay(addDays(now, -30));
     case IMetricsPeriod.Last_90Days:
-      return moment(now).subtract(90, "days").startOf("day").toDate();
+      return startOfDay(addDays(now, -90));
     case null:
       return new Date(0); // Default to epoch if no period is specified
     default:

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -77,7 +77,6 @@
     "linkifyjs": "^4.3.3",
     "lucide-react": "^1.27.0",
     "memoize": "^11.0.0",
-    "moment": "^2.30.1",
     "motion": "^12.42.2",
     "nuqs": "^2.9.2",
     "p-retry": "^8.0.0",

--- a/apps/frontend/src/containers/BuildReviewersStatusList.tsx
+++ b/apps/frontend/src/containers/BuildReviewersStatusList.tsx
@@ -1,7 +1,7 @@
 import type { ComponentProps, ReactNode } from "react";
+import { formatRelativeDate } from "@argos/util/date-format";
 import clsx from "clsx";
 import { BanIcon } from "lucide-react";
-import moment from "moment";
 
 import { ReviewState } from "@/gql/graphql";
 import { Tooltip } from "@/ui/Tooltip";
@@ -128,7 +128,7 @@ export function BuildReviewersStatusList<
               <span className="flex-1 truncate font-medium">Unknown user</span>
             )}
             <Tooltip
-              content={`${descriptor.label} · ${moment(review.dismissedAt ?? review.date).fromNow()}`}
+              content={`${descriptor.label} · ${formatRelativeDate(new Date(review.dismissedAt ?? review.date))}`}
             >
               <Icon
                 className={clsx("size-3.5 shrink-0", descriptor.textColor)}

--- a/apps/frontend/src/containers/Comment/CommentCard.tsx
+++ b/apps/frontend/src/containers/Comment/CommentCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useRef, useState } from "react";
 import { useApolloClient } from "@apollo/client/react";
+import { formatDate } from "@argos/util/date-format";
 import { invariant } from "@argos/util/invariant";
 import { clsx } from "clsx";
 import {
@@ -8,7 +9,6 @@ import {
   ChevronsUpDownIcon,
   MessageSquareCheckIcon,
 } from "lucide-react";
-import moment from "moment";
 import { AnimatePresence, motion } from "motion/react";
 import { Button as RACButton } from "react-aria-components";
 import { useClipboard } from "use-clipboard-copy";
@@ -58,8 +58,8 @@ function isSelectionCollapsed() {
   return !selection || selection.isCollapsed;
 }
 
-// Detailed date format used in the date tooltip, e.g. "Thu May 21, 2026, 15:47:43".
-const DETAILED_DATE_FORMAT = "ddd MMM D, YYYY, HH:mm:ss";
+// Detailed date format used in the date tooltip, e.g. "Thu, May 21, 2026, 15:47:43".
+const DETAILED_DATE_FORMAT = "preciseWeekday";
 
 // Shared height/opacity transition for content that animates in and out: the
 // reply list, and the thread body collapsing when a thread is resolved. Kept in
@@ -613,12 +613,15 @@ function CommentMessage(props: {
                   <div className="flex flex-col">
                     <span>
                       Created:{" "}
-                      {moment(comment.date).format(DETAILED_DATE_FORMAT)}
+                      {formatDate(new Date(comment.date), DETAILED_DATE_FORMAT)}
                     </span>
                     {comment.editedAt ? (
                       <span>
                         Edited:{" "}
-                        {moment(comment.editedAt).format(DETAILED_DATE_FORMAT)}
+                        {formatDate(
+                          new Date(comment.editedAt),
+                          DETAILED_DATE_FORMAT,
+                        )}
                       </span>
                     ) : null}
                   </div>

--- a/apps/frontend/src/containers/PaymentBanner.tsx
+++ b/apps/frontend/src/containers/PaymentBanner.tsx
@@ -126,7 +126,8 @@ export const PaymentBanner = memo(
         <BannerTemplate color="warning">
           <p>
             Your {subscriptionTypeLabel} has been canceled. You can still use
-            team features until the <Time date={pendingCancelAt} format="LL" />.
+            team features until the{" "}
+            <Time date={pendingCancelAt} format="longDate" />.
           </p>
           {userIsAdmin && (
             <ManageStripeButton

--- a/apps/frontend/src/containers/PlanCard.tsx
+++ b/apps/frontend/src/containers/PlanCard.tsx
@@ -1,8 +1,9 @@
 import { ReactNode } from "react";
 import { assertNever } from "@argos/util/assertNever";
+import { isSameYear } from "@argos/util/date";
+import { formatDate } from "@argos/util/date-format";
 import { invariant } from "@argos/util/invariant";
 import { PlusCircleIcon } from "lucide-react";
-import moment from "moment";
 
 import { config } from "@/config";
 import { CONTACT_HREF } from "@/constants";
@@ -107,7 +108,7 @@ function PlanStatus(props: {
           <CardParagraph>
             Your trial has been canceled. You can still use team features until{" "}
             <strong>
-              <Time date={account.subscription.endDate} format="LL" />
+              <Time date={account.subscription.endDate} format="longDate" />
             </strong>
             .
           </CardParagraph>
@@ -188,10 +189,13 @@ function PlanStatus(props: {
                 </CardParagraph>
               );
             }
+            if (!account.periodEndDate) {
+              return null;
+            }
             return (
               <CardParagraph className="text-low">
                 The next payment will occur on{" "}
-                {moment(account.periodEndDate).format("LL")}.
+                {formatDate(new Date(account.periodEndDate), "longDate")}.
               </CardParagraph>
             );
           })()}
@@ -353,8 +357,8 @@ function ManageSubscriptionButton({
 }
 
 function Period({ start, end }: { start: string; end: string }) {
-  const sameYear = moment(start).isSame(end, "year");
-  const format = sameYear ? "MMM DD" : "MMM D, YYYY";
+  const sameYear = isSameYear(new Date(start), new Date(end));
+  const format = sameYear ? "monthDay" : "date";
   return (
     <div className="font-medium">
       Current period ({<Time date={start} format={format} />} -{" "}

--- a/apps/frontend/src/containers/Test/Period.tsx
+++ b/apps/frontend/src/containers/Test/Period.tsx
@@ -1,4 +1,4 @@
-import moment from "moment";
+import { addDays, addHours, startOfDay } from "@argos/util/date";
 
 import { MetricsPeriod } from "@/gql/graphql";
 
@@ -12,23 +12,23 @@ const now = new Date();
 
 const TEST_METRICS_PERIOD = {
   [MetricsPeriod.Last_24Hours]: {
-    from: moment(now).subtract(24, "hours").toDate(),
+    from: addHours(now, -24),
     label: "Last 24 hours",
   },
   [MetricsPeriod.Last_3Days]: {
-    from: moment(now).subtract(3, "days").startOf("day").toDate(),
+    from: startOfDay(addDays(now, -3)),
     label: "Last 3 days",
   },
   [MetricsPeriod.Last_7Days]: {
-    from: moment(now).subtract(7, "days").startOf("day").toDate(),
+    from: startOfDay(addDays(now, -7)),
     label: "Last 7 days",
   },
   [MetricsPeriod.Last_30Days]: {
-    from: moment(now).subtract(30, "days").startOf("day").toDate(),
+    from: startOfDay(addDays(now, -30)),
     label: "Last 30 days",
   },
   [MetricsPeriod.Last_90Days]: {
-    from: moment(now).subtract(90, "days").startOf("day").toDate(),
+    from: startOfDay(addDays(now, -90)),
     label: "Last 90 days",
   },
 } satisfies PeriodsDefinition;

--- a/apps/frontend/src/containers/User/Auth.tsx
+++ b/apps/frontend/src/containers/User/Auth.tsx
@@ -1,7 +1,7 @@
 import { useMutation } from "@apollo/client/react";
+import { formatRelativeDate } from "@argos/util/date-format";
 import { invariant } from "@argos/util/invariant";
 import { MonitorIcon, SmartphoneIcon } from "lucide-react";
-import moment from "moment";
 import { Button as RACButton } from "react-aria-components";
 
 import { logout } from "@/containers/Auth";
@@ -149,7 +149,7 @@ function RevokeSessionDialog(props: { session: Session }) {
     { label: "Last location", value: session.location ?? "—" },
     {
       label: "Original sign in",
-      value: <Time date={session.createdAt} format="ll" tooltip="none" />,
+      value: <Time date={session.createdAt} format="date" tooltip="none" />,
     },
   ];
 
@@ -305,7 +305,8 @@ function UserSessions(props: { sessions: readonly Session[] }) {
                   subtitle={
                     <>
                       {session.location ? `${session.location} · ` : null}
-                      Last seen {moment(session.lastSeenAt).fromNow()}
+                      Last seen{" "}
+                      {formatRelativeDate(new Date(session.lastSeenAt))}
                     </>
                   }
                   trailing={

--- a/apps/frontend/src/containers/User/providers/PasskeyAuth.tsx
+++ b/apps/frontend/src/containers/User/providers/PasskeyAuth.tsx
@@ -231,13 +231,13 @@ function PasskeyRow(props: {
           {passkey.lastUsedAt ? (
             <>
               Last used{" "}
-              <Time date={passkey.lastUsedAt} format="ll" tooltip="none" />
+              <Time date={passkey.lastUsedAt} format="date" tooltip="none" />
               {" • "}
             </>
           ) : (
             "Never used • "
           )}
-          Created <Time date={passkey.createdAt} format="ll" tooltip="none" />
+          Created <Time date={passkey.createdAt} format="date" tooltip="none" />
           {passkey.synced ? " • Synced" : null}
         </div>
       </div>

--- a/apps/frontend/src/pages/Account/Analytics.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.tsx
@@ -1,5 +1,16 @@
 import { Suspense, useCallback, useEffect, useId, useMemo } from "react";
 import { useSuspenseQuery } from "@apollo/client/react";
+import {
+  addDays,
+  diffInCalendarDays,
+  endOfDay,
+  endOfWeek,
+  formatISODay,
+  parseISODay,
+  startOfDay,
+  startOfWeek,
+} from "@argos/util/date";
+import { formatDate } from "@argos/util/date-format";
 import { invariant } from "@argos/util/invariant";
 import { getLocalTimeZone, today } from "@internationalized/date";
 import clsx from "clsx";
@@ -11,7 +22,6 @@ import {
   SearchIcon,
   ThumbsUpIcon,
 } from "lucide-react";
-import moment from "moment";
 import { useFilter } from "react-aria";
 import {
   Autocomplete,
@@ -1233,21 +1243,17 @@ const GroupByLabels: Record<TimeSeriesGroupBy, string> = {
 
 function formatSeriesDateLabel(ts: number, groupBy: TimeSeriesGroupBy) {
   const date = new Date(ts);
+  const locale = navigator.language;
   switch (groupBy) {
     case TimeSeriesGroupBy.Day:
-      return date.toLocaleDateString(navigator.language, {
-        month: "short",
-        day: "numeric",
-      });
+      return formatDate(date, "monthDay", { locale });
     case TimeSeriesGroupBy.Week: {
-      const startOfWeek = moment(date).startOf("week").format("MMM D");
-      const endOfWeek = moment(date).endOf("week").format("MMM D");
-      return `${startOfWeek} - ${endOfWeek}`;
+      const start = formatDate(startOfWeek(date), "monthDay", { locale });
+      const end = formatDate(endOfWeek(date), "monthDay", { locale });
+      return `${start} - ${end}`;
     }
     case TimeSeriesGroupBy.Month:
-      return date.toLocaleDateString(navigator.language, {
-        month: "short",
-      });
+      return formatDate(date, "month", { locale });
   }
 }
 
@@ -1414,22 +1420,18 @@ function PeriodSelect(props: {
 }
 
 function getDateQueryValue(date: Date): string {
-  return moment(date).format("YYYY-MM-DD");
+  return formatISODay(date);
 }
 
 function parseDateQueryValue(value: string | null): Date | null {
   if (!value) {
     return null;
   }
-  const parsed = moment(value, "YYYY-MM-DD", true);
-  if (!parsed.isValid()) {
-    return null;
-  }
-  return parsed.startOf("day").toDate();
+  return parseISODay(value);
 }
 
 function getDurationInDays(range: { from: Date; to: Date }) {
-  return moment(range.to).diff(moment(range.from), "days") + 1;
+  return diffInCalendarDays(range.to, range.from) + 1;
 }
 
 function checkIsDurationValid(range: { from: Date; to: Date }) {
@@ -1440,10 +1442,10 @@ function checkIsDurationValid(range: { from: Date; to: Date }) {
 }
 
 function getDefaultCustomPeriod() {
-  const now = moment();
+  const today = startOfDay(new Date());
   return {
-    from: now.clone().startOf("day").subtract(30, "days").toDate(),
-    to: now.clone().startOf("day").toDate(),
+    from: addDays(today, -30),
+    to: today,
   };
 }
 
@@ -1467,8 +1469,8 @@ function getPeriodSettings(
   if (period === "custom") {
     const range = customPeriod ?? getDefaultCustomPeriod();
     return {
-      from: moment(range.from).startOf("day").toDate(),
-      to: moment(range.to).endOf("day").toDate(),
+      from: startOfDay(range.from),
+      to: endOfDay(range.to),
       groupBy:
         getDurationInDays(range) <= 30
           ? TimeSeriesGroupBy.Day
@@ -1478,10 +1480,10 @@ function getPeriodSettings(
     };
   }
 
-  const today = moment().startOf("day");
+  const today = startOfDay(new Date());
   return {
-    from: today.clone().subtract(Periods[period].days, "days").toDate(),
-    to: today.clone().endOf("day").toDate(),
+    from: addDays(today, -Periods[period].days),
+    to: endOfDay(today),
     groupBy: Periods[period].groupBy,
   };
 }

--- a/apps/frontend/src/pages/Build/BuildInfos.tsx
+++ b/apps/frontend/src/pages/Build/BuildInfos.tsx
@@ -1,6 +1,6 @@
 import { assertNever } from "@argos/util/assertNever";
+import { formatDuration } from "@argos/util/date-format";
 import clsx from "clsx";
-import moment from "moment";
 
 import {
   BuildModeDescription,
@@ -148,8 +148,7 @@ function Description(props: { children: React.ReactNode }) {
 }
 
 function Duration({ start, end }: { start: string; end: string }) {
-  const duration = moment.duration(moment(end).diff(moment(start)));
-  return duration.humanize();
+  return formatDuration(new Date(end).getTime() - new Date(start).getTime());
 }
 
 /**
@@ -177,14 +176,14 @@ export function BuildInfos(props: {
     <dl>
       <Dt>Created</Dt>
       <Dd>
-        <Time date={build.createdAt} format="LLL" />
+        <Time date={build.createdAt} format="dateTime" />
       </Dd>
 
       {build.finalizedAt ? (
         <>
           <Dt>Completed</Dt>
           <Dd>
-            <Time date={build.finalizedAt} format="LLL" />
+            <Time date={build.finalizedAt} format="dateTime" />
             <Description>
               <Duration start={build.createdAt} end={build.finalizedAt} />
             </Description>
@@ -196,7 +195,7 @@ export function BuildInfos(props: {
         <>
           <Dt>Processed</Dt>
           <Dd>
-            <Time date={build.concludedAt} format="LLL" />
+            <Time date={build.concludedAt} format="dateTime" />
             <Description>
               <Duration start={build.finalizedAt} end={build.concludedAt} />
             </Description>

--- a/apps/frontend/src/pages/Project/Deployments.tsx
+++ b/apps/frontend/src/pages/Project/Deployments.tsx
@@ -143,11 +143,7 @@ function CurrentDeploymentBadge(props: { createdAt: string }) {
             production traffic
           </div>
           <div className="text-low">
-            <Time
-              date={props.createdAt}
-              format="D MMM YYYY [at] HH:mm:ss"
-              tooltip="none"
-            />
+            <Time date={props.createdAt} format="precise" tooltip="none" />
           </div>
         </div>
       }

--- a/apps/frontend/src/pages/Staff/Teams.tsx
+++ b/apps/frontend/src/pages/Staff/Teams.tsx
@@ -270,7 +270,7 @@ function StaffTeamRow(props: {
           </div>
         </td>
         <td className="p-4 text-sm">
-          <Time date={team.createdAt} format="ll" tooltip="title" />
+          <Time date={team.createdAt} format="date" tooltip="title" />
         </td>
         <td className="p-4 text-sm">
           <SubscriptionLabel status={team.subscriptionStatus} />

--- a/apps/frontend/src/pages/Staff/Trials.tsx
+++ b/apps/frontend/src/pages/Staff/Trials.tsx
@@ -2,6 +2,7 @@ import { useDeferredValue, useMemo, useState } from "react";
 import { CombinedGraphQLErrors } from "@apollo/client";
 import { useMutation, useQuery } from "@apollo/client/react";
 import { checkIsTrialingSubscriptionStatus } from "@argos/schemas/subscription-status";
+import { addDays, startOfDay } from "@argos/util/date";
 import clsx from "clsx";
 import {
   CheckIcon,
@@ -18,7 +19,6 @@ import {
   XIcon,
   type LucideIcon,
 } from "lucide-react";
-import moment from "moment";
 import { Heading, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
 
@@ -157,7 +157,7 @@ function getTrialPeriods() {
     Object.entries(PERIOD_DAYS).map(([key, days]) => [
       key,
       {
-        from: moment().subtract(days, "days").startOf("day").toDate(),
+        from: startOfDay(addDays(new Date(), -days)),
         label: `Last ${days} days`,
       },
     ]),

--- a/apps/frontend/src/ui/Charts.tsx
+++ b/apps/frontend/src/ui/Charts.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import * as React from "react";
+import { addUnit, startOfUnit, type TimeUnit } from "@argos/util/date";
 import { invariant } from "@argos/util/invariant";
 import NumberFlow from "@number-flow/react";
 import clsx from "clsx";
-import moment from "moment";
 import * as RechartsPrimitive from "recharts";
 
 // Format: { THEME_NAME: CSS_SELECTOR }
@@ -379,17 +379,12 @@ export function ChartLegendContent({
 /**
  * Get ticks for a given date range and unit.
  */
-export function getTimeTicks(
-  from: Date,
-  to: Date,
-  unit: moment.unitOfTime.Base,
-  step = 1,
-) {
+export function getTimeTicks(from: Date, to: Date, unit: TimeUnit, step = 1) {
   const ticks = [];
-  const current = moment(from).add(1, unit).startOf(unit);
-  while (current.isBefore(to)) {
-    ticks.push(current.toDate().getTime());
-    current.add(step, unit);
+  let current = startOfUnit(addUnit(from, 1, unit), unit);
+  while (current < to) {
+    ticks.push(current.getTime());
+    current = addUnit(current, step, unit);
   }
   return ticks;
 }

--- a/apps/frontend/src/ui/Time.tsx
+++ b/apps/frontend/src/ui/Time.tsx
@@ -1,11 +1,15 @@
 import { Children, useCallback, useLayoutEffect, useState } from "react";
-import moment from "moment";
+import {
+  formatDate,
+  formatRelativeDate,
+  type DateFormat,
+} from "@argos/util/date-format";
 
 import { Tooltip } from "./Tooltip";
 
 type TimeProps = React.ComponentPropsWithRef<"time"> & {
   date: string;
-  format?: string;
+  format?: DateFormat;
   tooltip?: "title" | "tooltip" | "none";
   children?: React.ReactNode;
 };
@@ -23,8 +27,8 @@ export function Time({
       hasChildren
         ? null
         : format
-          ? moment(date).format(format)
-          : moment(date).fromNow(),
+          ? formatDate(new Date(date), format)
+          : formatRelativeDate(new Date(date)),
     [hasChildren, format, date],
   );
   const [fromNow, setFromNow] = useState(getFormattedDate);
@@ -32,14 +36,13 @@ export function Time({
     const id = setInterval(() => setFromNow(getFormattedDate()), 1000);
     return () => clearInterval(id);
   }, [getFormattedDate]);
+  const fullDate = formatDate(new Date(date), "fullDateTime");
   return (
-    <Tooltip
-      content={tooltip === "tooltip" ? moment(date).format("LLLL") : null}
-    >
+    <Tooltip content={tooltip === "tooltip" ? fullDate : null}>
       <time
-        dateTime={moment(date).toISOString()}
+        dateTime={new Date(date).toISOString()}
         data-visual-test="transparent"
-        title={tooltip === "title" ? moment(date).format("LLLL") : undefined}
+        title={tooltip === "title" ? fullDate : undefined}
         {...props}
       >
         {children ?? fromNow}

--- a/knip.json
+++ b/knip.json
@@ -12,7 +12,7 @@
         "scripts/*.ts"
       ],
       "ignore": ["**/bin/**/*"],
-      "ignoreDependencies": ["@argos/knex-scripts", "moment", "pino-pretty"]
+      "ignoreDependencies": ["@argos/knex-scripts", "pino-pretty"]
     },
     "infra": {
       "entry": ["scripts/app.ts", "lambda/*.ts"],

--- a/packages/util/src/date-format.test.ts
+++ b/packages/util/src/date-format.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import { formatDate, formatDuration, formatRelativeDate } from "./date-format";
+
+// Built from local parts so the expectations hold in any time zone.
+const at = (
+  year: number,
+  month: number,
+  day: number,
+  hours = 0,
+  minutes = 0,
+  seconds = 0,
+) => new Date(year, month - 1, day, hours, minutes, seconds);
+
+describe("#formatDate", () => {
+  // 2026-09-04 is a Friday.
+  const date = at(2026, 9, 4, 15, 4, 5);
+
+  it("formats each preset", () => {
+    expect(formatDate(date, "monthDay")).toBe("Sep 4");
+    expect(formatDate(date, "month")).toBe("Sep");
+    expect(formatDate(date, "date")).toBe("Sep 4, 2026");
+    expect(formatDate(date, "longDate")).toBe("September 4, 2026");
+    expect(formatDate(date, "dateTime")).toBe("September 4, 2026 at 3:04 PM");
+    expect(formatDate(date, "fullDateTime")).toBe(
+      "Friday, September 4, 2026 at 3:04 PM",
+    );
+    expect(formatDate(date, "precise")).toBe("Sep 4, 2026, 15:04:05");
+    expect(formatDate(date, "preciseWeekday")).toBe(
+      "Fri, Sep 4, 2026, 15:04:05",
+    );
+  });
+
+  it("uses a 24-hour clock for the precise presets", () => {
+    const evening = at(2026, 9, 4, 21, 7, 9);
+    expect(formatDate(evening, "precise")).toBe("Sep 4, 2026, 21:07:09");
+    expect(formatDate(evening, "preciseWeekday")).toBe(
+      "Fri, Sep 4, 2026, 21:07:09",
+    );
+  });
+
+  it("honours an explicit locale", () => {
+    expect(formatDate(date, "longDate", { locale: "fr-FR" })).toBe(
+      "4 septembre 2026",
+    );
+  });
+
+  it("returns the same result on repeated calls, exercising the cache", () => {
+    expect(formatDate(date, "date")).toBe(formatDate(date, "date"));
+  });
+});
+
+describe("#formatRelativeDate", () => {
+  const now = at(2026, 9, 4, 12);
+  const ago = (ms: number) =>
+    formatRelativeDate(new Date(now.getTime() - ms), { now });
+  const ahead = (ms: number) =>
+    formatRelativeDate(new Date(now.getTime() + ms), { now });
+
+  it("describes the recent past", () => {
+    expect(ago(0)).toBe("now");
+    expect(ago(3_000)).toBe("3 seconds ago");
+    expect(ago(44_000)).toBe("44 seconds ago");
+  });
+
+  it("promotes to minutes past the seconds threshold", () => {
+    expect(ago(45_000)).toBe("1 minute ago");
+    expect(ago(30 * 60_000)).toBe("30 minutes ago");
+  });
+
+  it("rounds a half unit the same way in both directions", () => {
+    expect(ago(90_000)).toBe("2 minutes ago");
+    expect(ahead(90_000)).toBe("in 2 minutes");
+  });
+
+  it("promotes to hours past the minutes threshold", () => {
+    expect(ago(45 * 60_000)).toBe("1 hour ago");
+    expect(ago(5 * 3_600_000)).toBe("5 hours ago");
+  });
+
+  it("promotes to days past the hours threshold", () => {
+    expect(ago(22 * 3_600_000)).toBe("yesterday");
+    expect(ago(3 * 86_400_000)).toBe("3 days ago");
+  });
+
+  it("promotes to months and years", () => {
+    expect(ago(26 * 86_400_000)).toBe("last month");
+    expect(ago(90 * 86_400_000)).toBe("3 months ago");
+    expect(ago(400 * 86_400_000)).toBe("last year");
+    expect(ago(3 * 365 * 86_400_000)).toBe("3 years ago");
+  });
+
+  it("describes the future", () => {
+    expect(ahead(3_000)).toBe("in 3 seconds");
+    expect(ahead(5 * 3_600_000)).toBe("in 5 hours");
+    expect(ahead(3 * 86_400_000)).toBe("in 3 days");
+  });
+
+  it("honours an explicit locale", () => {
+    expect(
+      formatRelativeDate(new Date(now.getTime() - 3 * 86_400_000), {
+        now,
+        locale: "fr-FR",
+      }),
+    ).toBe("il y a 3 jours");
+  });
+
+  it("defaults to comparing against the current time", () => {
+    expect(formatRelativeDate(new Date())).toBe("now");
+  });
+});
+
+describe("#formatDuration", () => {
+  it("keeps one decimal below ten seconds", () => {
+    expect(formatDuration(1_400)).toBe("1.4s");
+    expect(formatDuration(9_990)).toBe("10s");
+  });
+
+  it("drops a trailing zero decimal", () => {
+    expect(formatDuration(3_000)).toBe("3s");
+  });
+
+  it("rounds to whole seconds between ten seconds and a minute", () => {
+    expect(formatDuration(10_000)).toBe("10s");
+    expect(formatDuration(45_400)).toBe("45s");
+    expect(formatDuration(59_400)).toBe("59s");
+  });
+
+  it("formats minutes and seconds", () => {
+    expect(formatDuration(60_000)).toBe("1m");
+    expect(formatDuration(83_000)).toBe("1m 23s");
+    expect(formatDuration(150_000)).toBe("2m 30s");
+  });
+
+  it("carries a rounded-up minute instead of showing 60s", () => {
+    expect(formatDuration(119_600)).toBe("2m");
+  });
+
+  it("formats hours and minutes", () => {
+    expect(formatDuration(3_600_000)).toBe("1h");
+    expect(formatDuration(3_900_000)).toBe("1h 5m");
+    expect(formatDuration(7_500_000)).toBe("2h 5m");
+  });
+
+  it("carries a rounded-up hour instead of showing 60m", () => {
+    expect(formatDuration(7_198_000)).toBe("2h");
+  });
+
+  it("clamps a negative duration to zero", () => {
+    expect(formatDuration(-5_000)).toBe("0s");
+  });
+
+  it("formats zero", () => {
+    expect(formatDuration(0)).toBe("0s");
+  });
+});

--- a/packages/util/src/date-format.ts
+++ b/packages/util/src/date-format.ts
@@ -1,0 +1,182 @@
+/**
+ * Date formatting built on the `Intl` APIs.
+ *
+ * Formats are named presets rather than token strings: `Intl` composes its
+ * output from an option bag, so the field order and separators come from the
+ * locale instead of being spelled out at the call site.
+ */
+
+/**
+ * Locale used when a caller does not pass one. Pinned so that output stays
+ * identical between the browser and the server, where the ambient locale
+ * depends on how the process was started.
+ */
+const DEFAULT_LOCALE = "en-US";
+
+export type DateFormat =
+  /** `Sep 4` */
+  | "monthDay"
+  /** `Sep` */
+  | "month"
+  /** `Sep 4, 2026` */
+  | "date"
+  /** `September 4, 2026` */
+  | "longDate"
+  /** `September 4, 2026 at 3:04 PM` */
+  | "dateTime"
+  /** `Friday, September 4, 2026 at 3:04 PM` */
+  | "fullDateTime"
+  /** `Sep 4, 2026, 15:04:05` */
+  | "precise"
+  /** `Fri, Sep 4, 2026, 15:04:05` */
+  | "preciseWeekday";
+
+const DATE_FORMAT_OPTIONS: Record<DateFormat, Intl.DateTimeFormatOptions> = {
+  monthDay: { month: "short", day: "numeric" },
+  month: { month: "short" },
+  date: { dateStyle: "medium" },
+  longDate: { dateStyle: "long" },
+  dateTime: { dateStyle: "long", timeStyle: "short" },
+  fullDateTime: { dateStyle: "full", timeStyle: "short" },
+  precise: { dateStyle: "medium", timeStyle: "medium", hourCycle: "h23" },
+  preciseWeekday: {
+    weekday: "short",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  },
+};
+
+type FormatOptions = {
+  /** BCP 47 locale tag. Defaults to `en-US`. */
+  locale?: string;
+};
+
+// `Intl` formatters are expensive to construct and cheap to reuse, and callers
+// re-render on a timer, so keep one per locale/format pair.
+const dateTimeFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function getDateTimeFormatter(format: DateFormat, locale: string) {
+  const key = `${locale}|${format}`;
+  const cached = dateTimeFormatters.get(key);
+  if (cached) {
+    return cached;
+  }
+  const formatter = new Intl.DateTimeFormat(
+    locale,
+    DATE_FORMAT_OPTIONS[format],
+  );
+  dateTimeFormatters.set(key, formatter);
+  return formatter;
+}
+
+/** Format an absolute date using one of the named presets. */
+export function formatDate(
+  date: Date,
+  format: DateFormat,
+  options?: FormatOptions,
+): string {
+  const locale = options?.locale ?? DEFAULT_LOCALE;
+  return getDateTimeFormatter(format, locale).format(date);
+}
+
+const MS_PER_SECOND = 1000;
+const MS_PER_MINUTE = 60 * MS_PER_SECOND;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+const MS_PER_MONTH = 30 * MS_PER_DAY;
+const MS_PER_YEAR = 365 * MS_PER_DAY;
+
+/**
+ * Unit cascade for relative phrasing: the first entry whose `max` the elapsed
+ * time is under wins, so 90 seconds reads as "2 minutes ago" rather than
+ * "90 seconds ago".
+ */
+const RELATIVE_UNITS: readonly {
+  unit: Intl.RelativeTimeFormatUnit;
+  ms: number;
+  max: number;
+}[] = [
+  { unit: "second", ms: MS_PER_SECOND, max: 45 * MS_PER_SECOND },
+  { unit: "minute", ms: MS_PER_MINUTE, max: 45 * MS_PER_MINUTE },
+  { unit: "hour", ms: MS_PER_HOUR, max: 22 * MS_PER_HOUR },
+  { unit: "day", ms: MS_PER_DAY, max: 26 * MS_PER_DAY },
+  { unit: "month", ms: MS_PER_MONTH, max: 11 * MS_PER_MONTH },
+  { unit: "year", ms: MS_PER_YEAR, max: Number.POSITIVE_INFINITY },
+];
+
+const relativeTimeFormatters = new Map<string, Intl.RelativeTimeFormat>();
+
+function getRelativeTimeFormatter(locale: string) {
+  const cached = relativeTimeFormatters.get(locale);
+  if (cached) {
+    return cached;
+  }
+  // "auto" lets the locale use idiomatic wording where it has some, so a day
+  // back reads as "yesterday" instead of "1 day ago".
+  const formatter = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+  relativeTimeFormatters.set(locale, formatter);
+  return formatter;
+}
+
+/**
+ * Describe `date` relative to now — "3 minutes ago", "yesterday", "in 2 months".
+ */
+export function formatRelativeDate(
+  date: Date,
+  options?: FormatOptions & {
+    /** Instant to compare against. Defaults to now. */
+    now?: Date;
+  },
+): string {
+  const now = options?.now ?? new Date();
+  const locale = options?.locale ?? DEFAULT_LOCALE;
+  const elapsed = date.getTime() - now.getTime();
+  const magnitude = Math.abs(elapsed);
+  const formatter = getRelativeTimeFormatter(locale);
+  for (const { unit, ms, max } of RELATIVE_UNITS) {
+    if (magnitude < max) {
+      // Round the magnitude and reapply the sign rather than rounding a signed
+      // value: `Math.round` breaks ties towards +Infinity, which would make a
+      // 90-second gap read as "1 minute ago" but "in 2 minutes".
+      const value = Math.round(magnitude / ms) * Math.sign(elapsed);
+      return formatter.format(value, unit);
+    }
+  }
+  // The cascade ends at an unbounded entry, so this is unreachable.
+  return formatter.format(Math.round(elapsed / MS_PER_YEAR), "year");
+}
+
+/**
+ * Format an elapsed duration in milliseconds as a compact, precise string —
+ * `1.4s`, `45s`, `2m 30s`, `1h 5m`. Sub-minute durations keep one decimal below
+ * ten seconds so that short builds do not all collapse to the same value.
+ */
+export function formatDuration(ms: number): string {
+  const total = Math.max(0, ms);
+  if (total < 10 * MS_PER_SECOND) {
+    const seconds = total / MS_PER_SECOND;
+    // Drop a trailing ".0" so whole seconds read as "3s", not "3.0s".
+    return `${Number(seconds.toFixed(1))}s`;
+  }
+  if (total < MS_PER_MINUTE) {
+    return `${Math.round(total / MS_PER_SECOND)}s`;
+  }
+  if (total < MS_PER_HOUR) {
+    const minutes = Math.floor(total / MS_PER_MINUTE);
+    const seconds = Math.round((total % MS_PER_MINUTE) / MS_PER_SECOND);
+    // Rounding can land on a full minute; carry it instead of showing "60s".
+    return seconds === 60 || seconds === 0
+      ? `${seconds === 60 ? minutes + 1 : minutes}m`
+      : `${minutes}m ${seconds}s`;
+  }
+  const hours = Math.floor(total / MS_PER_HOUR);
+  const minutes = Math.round((total % MS_PER_HOUR) / MS_PER_MINUTE);
+  return minutes === 60 || minutes === 0
+    ? `${minutes === 60 ? hours + 1 : hours}h`
+    : `${hours}h ${minutes}m`;
+}

--- a/packages/util/src/date.test.ts
+++ b/packages/util/src/date.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  addDays,
+  addHours,
+  addMonths,
+  addUnit,
+  addWeeks,
+  diffInCalendarDays,
+  endOfDay,
+  endOfWeek,
+  formatISODay,
+  isSameDay,
+  isSameYear,
+  parseISODay,
+  startOfDay,
+  startOfHour,
+  startOfMonth,
+  startOfUnit,
+  startOfWeek,
+} from "./date";
+
+// Dates are built from local parts so the expectations hold in any time zone.
+const at = (
+  year: number,
+  month: number,
+  day: number,
+  hours = 0,
+  minutes = 0,
+  seconds = 0,
+  ms = 0,
+) => new Date(year, month - 1, day, hours, minutes, seconds, ms);
+
+describe("#startOfHour", () => {
+  it("clears minutes, seconds and milliseconds", () => {
+    expect(startOfHour(at(2026, 9, 4, 15, 4, 5, 123))).toEqual(
+      at(2026, 9, 4, 15),
+    );
+  });
+
+  it("does not mutate its input", () => {
+    const date = at(2026, 9, 4, 15, 4, 5);
+    startOfHour(date);
+    expect(date).toEqual(at(2026, 9, 4, 15, 4, 5));
+  });
+});
+
+describe("#startOfDay", () => {
+  it("returns local midnight", () => {
+    expect(startOfDay(at(2026, 9, 4, 15, 4, 5, 123))).toEqual(at(2026, 9, 4));
+  });
+
+  it("is a no-op on a date already at midnight", () => {
+    expect(startOfDay(at(2026, 9, 4))).toEqual(at(2026, 9, 4));
+  });
+});
+
+describe("#endOfDay", () => {
+  it("returns the last millisecond of the day", () => {
+    expect(endOfDay(at(2026, 9, 4, 15, 4, 5))).toEqual(
+      at(2026, 9, 4, 23, 59, 59, 999),
+    );
+  });
+});
+
+describe("#startOfWeek", () => {
+  it("snaps back to Sunday", () => {
+    // 2026-09-04 is a Friday.
+    expect(startOfWeek(at(2026, 9, 4, 15))).toEqual(at(2026, 8, 30));
+  });
+
+  it("is a no-op on a Sunday", () => {
+    expect(startOfWeek(at(2026, 8, 30, 15))).toEqual(at(2026, 8, 30));
+  });
+
+  it("crosses a month boundary", () => {
+    // 2026-10-01 is a Thursday, so its week starts in September.
+    expect(startOfWeek(at(2026, 10, 1))).toEqual(at(2026, 9, 27));
+  });
+});
+
+describe("#endOfWeek", () => {
+  it("returns the last millisecond of the following Saturday", () => {
+    expect(endOfWeek(at(2026, 9, 4))).toEqual(at(2026, 9, 5, 23, 59, 59, 999));
+  });
+});
+
+describe("#startOfMonth", () => {
+  it("returns midnight on the first", () => {
+    expect(startOfMonth(at(2026, 9, 4, 15))).toEqual(at(2026, 9, 1));
+  });
+});
+
+describe("#addHours", () => {
+  it("shifts forward", () => {
+    expect(addHours(at(2026, 9, 4, 10), 5)).toEqual(at(2026, 9, 4, 15));
+  });
+
+  it("shifts backward and crosses the day boundary", () => {
+    expect(addHours(at(2026, 9, 4, 10), -24)).toEqual(at(2026, 9, 3, 10));
+  });
+});
+
+describe("#addDays", () => {
+  it("shifts forward across a month boundary", () => {
+    expect(addDays(at(2026, 8, 30), 5)).toEqual(at(2026, 9, 4));
+  });
+
+  it("shifts backward across a year boundary", () => {
+    expect(addDays(at(2026, 1, 2), -5)).toEqual(at(2025, 12, 28));
+  });
+
+  it("keeps the wall-clock time", () => {
+    expect(addDays(at(2026, 9, 4, 15, 30), 1)).toEqual(at(2026, 9, 5, 15, 30));
+  });
+});
+
+describe("#addWeeks", () => {
+  it("shifts by seven days per week", () => {
+    expect(addWeeks(at(2026, 9, 4), 2)).toEqual(at(2026, 9, 18));
+  });
+});
+
+describe("#addMonths", () => {
+  it("shifts forward keeping the day of the month", () => {
+    expect(addMonths(at(2026, 9, 4), 2)).toEqual(at(2026, 11, 4));
+  });
+
+  it("shifts backward across a year boundary", () => {
+    expect(addMonths(at(2026, 1, 15), -2)).toEqual(at(2025, 11, 15));
+  });
+
+  it("clamps to the last day when the target month is shorter", () => {
+    expect(addMonths(at(2026, 1, 31), 1)).toEqual(at(2026, 2, 28));
+  });
+
+  it("clamps to February 29 in a leap year", () => {
+    expect(addMonths(at(2028, 1, 31), 1)).toEqual(at(2028, 2, 29));
+  });
+
+  it("preserves the time of day while clamping", () => {
+    expect(addMonths(at(2026, 3, 31, 14, 30), -1)).toEqual(
+      at(2026, 2, 28, 14, 30),
+    );
+  });
+});
+
+describe("#startOfUnit", () => {
+  it("dispatches on the unit", () => {
+    const date = at(2026, 9, 4, 15, 4, 5);
+    expect(startOfUnit(date, "hour")).toEqual(at(2026, 9, 4, 15));
+    expect(startOfUnit(date, "day")).toEqual(at(2026, 9, 4));
+    expect(startOfUnit(date, "week")).toEqual(at(2026, 8, 30));
+    expect(startOfUnit(date, "month")).toEqual(at(2026, 9, 1));
+  });
+});
+
+describe("#addUnit", () => {
+  it("dispatches on the unit", () => {
+    const date = at(2026, 9, 4);
+    expect(addUnit(date, 2, "hour")).toEqual(at(2026, 9, 4, 2));
+    expect(addUnit(date, 2, "day")).toEqual(at(2026, 9, 6));
+    expect(addUnit(date, 2, "week")).toEqual(at(2026, 9, 18));
+    expect(addUnit(date, 2, "month")).toEqual(at(2026, 11, 4));
+  });
+});
+
+describe("#diffInCalendarDays", () => {
+  it("counts whole days between midnights", () => {
+    expect(diffInCalendarDays(at(2026, 9, 4), at(2026, 9, 1))).toBe(3);
+  });
+
+  it("ignores the time of day", () => {
+    expect(diffInCalendarDays(at(2026, 9, 4, 1), at(2026, 9, 1, 23))).toBe(3);
+  });
+
+  it("returns zero on the same day", () => {
+    expect(diffInCalendarDays(at(2026, 9, 4, 23), at(2026, 9, 4, 1))).toBe(0);
+  });
+
+  it("is negative when the left side is earlier", () => {
+    expect(diffInCalendarDays(at(2026, 9, 1), at(2026, 9, 4))).toBe(-3);
+  });
+
+  it("counts whole days across a DST transition", () => {
+    // Spans the US spring-forward date, a 23-hour day where a millisecond
+    // division would land on 29.96 and truncate to 29.
+    expect(diffInCalendarDays(at(2026, 3, 25), at(2026, 2, 23))).toBe(30);
+  });
+});
+
+describe("#isSameYear", () => {
+  it("is true within a year", () => {
+    expect(isSameYear(at(2026, 1, 1), at(2026, 12, 31))).toBe(true);
+  });
+
+  it("is false across years", () => {
+    expect(isSameYear(at(2026, 12, 31), at(2027, 1, 1))).toBe(false);
+  });
+});
+
+describe("#isSameDay", () => {
+  it("ignores the time of day", () => {
+    expect(isSameDay(at(2026, 9, 4, 0, 0, 1), at(2026, 9, 4, 23, 59))).toBe(
+      true,
+    );
+  });
+
+  it("is false one millisecond across midnight", () => {
+    expect(isSameDay(at(2026, 9, 4, 23, 59, 59), at(2026, 9, 5, 0, 0, 0))).toBe(
+      false,
+    );
+  });
+});
+
+describe("#parseISODay", () => {
+  it("parses a valid day to local midnight", () => {
+    expect(parseISODay("2026-09-04")).toEqual(at(2026, 9, 4));
+  });
+
+  it("parses February 29 in a leap year", () => {
+    expect(parseISODay("2028-02-29")).toEqual(at(2028, 2, 29));
+  });
+
+  it("rejects a day the month does not have", () => {
+    expect(parseISODay("2026-02-31")).toBeNull();
+    expect(parseISODay("2026-02-29")).toBeNull();
+  });
+
+  it("rejects an out-of-range month", () => {
+    expect(parseISODay("2026-13-01")).toBeNull();
+    expect(parseISODay("2026-00-01")).toBeNull();
+  });
+
+  it("rejects unpadded and malformed input", () => {
+    expect(parseISODay("2026-9-4")).toBeNull();
+    expect(parseISODay("2026/09/04")).toBeNull();
+    expect(parseISODay("")).toBeNull();
+    expect(parseISODay("not-a-date")).toBeNull();
+  });
+
+  it("rejects a datetime string", () => {
+    expect(parseISODay("2026-09-04T15:04:05Z")).toBeNull();
+  });
+
+  it("rejects years below 100 rather than remapping them", () => {
+    expect(parseISODay("0050-01-01")).toBeNull();
+  });
+});
+
+describe("#formatISODay", () => {
+  it("formats the local calendar day", () => {
+    expect(formatISODay(at(2026, 9, 4, 15, 4, 5))).toBe("2026-09-04");
+  });
+
+  it("pads month and day", () => {
+    expect(formatISODay(at(2026, 1, 2))).toBe("2026-01-02");
+  });
+
+  it("round-trips with parseISODay", () => {
+    expect(formatISODay(parseISODay("2026-09-04")!)).toBe("2026-09-04");
+  });
+
+  it("uses the local day even late in the evening", () => {
+    expect(formatISODay(at(2026, 9, 4, 23, 59, 59))).toBe("2026-09-04");
+  });
+});

--- a/packages/util/src/date.ts
+++ b/packages/util/src/date.ts
@@ -1,0 +1,178 @@
+/**
+ * Calendar arithmetic on native `Date`, in the runtime's local time zone.
+ *
+ * Hours are absolute durations (a fixed number of milliseconds) while days,
+ * weeks and months are calendar units that preserve the wall-clock time across
+ * DST transitions.
+ */
+
+const MS_PER_HOUR = 3_600_000;
+const MS_PER_DAY = 86_400_000;
+
+/** Units we snap to and step by, mostly to lay out chart axes. */
+export type TimeUnit = "hour" | "day" | "week" | "month";
+
+/**
+ * Day a week starts on, `0` being Sunday. Sunday keeps weeks aligned with the
+ * `en-US` calendar, which is what we display.
+ */
+const WEEK_STARTS_ON = 0;
+
+export function startOfHour(date: Date): Date {
+  const result = new Date(date);
+  result.setMinutes(0, 0, 0);
+  return result;
+}
+
+export function startOfDay(date: Date): Date {
+  const result = new Date(date);
+  result.setHours(0, 0, 0, 0);
+  return result;
+}
+
+export function endOfDay(date: Date): Date {
+  const result = new Date(date);
+  result.setHours(23, 59, 59, 999);
+  return result;
+}
+
+export function startOfWeek(date: Date): Date {
+  const result = startOfDay(date);
+  const offset = (result.getDay() - WEEK_STARTS_ON + 7) % 7;
+  result.setDate(result.getDate() - offset);
+  return result;
+}
+
+export function endOfWeek(date: Date): Date {
+  const result = startOfWeek(date);
+  result.setDate(result.getDate() + 6);
+  return endOfDay(result);
+}
+
+export function startOfMonth(date: Date): Date {
+  const result = startOfDay(date);
+  result.setDate(1);
+  return result;
+}
+
+/**
+ * Add an absolute number of hours. Unlike the calendar helpers this shifts the
+ * instant by exactly `amount * 3600s`, so the wall-clock hour may differ by one
+ * across a DST boundary.
+ */
+export function addHours(date: Date, amount: number): Date {
+  return new Date(date.getTime() + amount * MS_PER_HOUR);
+}
+
+export function addDays(date: Date, amount: number): Date {
+  const result = new Date(date);
+  result.setDate(result.getDate() + amount);
+  return result;
+}
+
+export function addWeeks(date: Date, amount: number): Date {
+  return addDays(date, amount * 7);
+}
+
+/**
+ * Add months, clamping to the last day of the target month so that a day number
+ * the target month does not have cannot spill into the following one — Jan 31
+ * plus one month is Feb 28, not Mar 3.
+ */
+export function addMonths(date: Date, amount: number): Date {
+  const result = new Date(date);
+  const day = result.getDate();
+  result.setDate(1);
+  result.setMonth(result.getMonth() + amount);
+  result.setDate(Math.min(day, getDaysInMonth(result)));
+  return result;
+}
+
+/** Number of days in the month `date` falls in. */
+function getDaysInMonth(date: Date): number {
+  // Day 0 of the next month is the last day of this one.
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
+}
+
+/** Snap `date` down to the start of the given unit. */
+export function startOfUnit(date: Date, unit: TimeUnit): Date {
+  switch (unit) {
+    case "hour":
+      return startOfHour(date);
+    case "day":
+      return startOfDay(date);
+    case "week":
+      return startOfWeek(date);
+    case "month":
+      return startOfMonth(date);
+  }
+}
+
+/** Add `amount` of the given unit to `date`. */
+export function addUnit(date: Date, amount: number, unit: TimeUnit): Date {
+  switch (unit) {
+    case "hour":
+      return addHours(date, amount);
+    case "day":
+      return addDays(date, amount);
+    case "week":
+      return addWeeks(date, amount);
+    case "month":
+      return addMonths(date, amount);
+  }
+}
+
+/**
+ * Whole calendar days from `right` to `left`, counting date boundaries crossed
+ * rather than elapsed milliseconds. A span crossing a DST change still counts
+ * as a whole number of days.
+ */
+export function diffInCalendarDays(left: Date, right: Date): number {
+  const elapsed = startOfDay(left).getTime() - startOfDay(right).getTime();
+  return Math.round(elapsed / MS_PER_DAY);
+}
+
+export function isSameYear(left: Date, right: Date): boolean {
+  return left.getFullYear() === right.getFullYear();
+}
+
+/** Whether both dates fall on the same local calendar day. */
+export function isSameDay(left: Date, right: Date): boolean {
+  return startOfDay(left).getTime() === startOfDay(right).getTime();
+}
+
+const ISO_DAY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * Parse a `YYYY-MM-DD` string into local midnight, strictly: anything that is
+ * not exactly that shape, or that names a day the month does not have, gives
+ * `null` rather than a shifted date.
+ */
+export function parseISODay(value: string): Date | null {
+  const match = ISO_DAY_PATTERN.exec(value);
+  if (!match) {
+    return null;
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(year, month - 1, day);
+  // Reject overflow ("2026-02-31" would roll into March) and the two-digit year
+  // remapping `Date` applies below year 100.
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+  return date;
+}
+
+/** Format `date` as `YYYY-MM-DD`, using its local calendar day. */
+export function formatISODay(date: Date): string {
+  const year = String(date.getFullYear()).padStart(4, "0");
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,9 +293,6 @@ importers:
       minimatch:
         specifier: ^10.2.5
         version: 10.2.5
-      moment:
-        specifier: ^2.30.1
-        version: 2.30.1
       node-cron:
         specifier: ^4.6.0
         version: 4.6.0
@@ -640,9 +637,6 @@ importers:
       memoize:
         specifier: ^11.0.0
         version: 11.0.0
-      moment:
-        specifier: ^2.30.1
-        version: 2.30.1
       motion:
         specifier: ^12.42.2
         version: 12.42.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -6937,9 +6931,6 @@ packages:
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
-
-  moment@2.30.1:
-    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
   motion-dom@12.42.2:
     resolution: {integrity: sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==}
@@ -14941,8 +14932,6 @@ snapshots:
       obliterator: 1.6.1
 
   module-details-from-path@1.0.4: {}
-
-  moment@2.30.1: {}
 
   motion-dom@12.42.2:
     dependencies:


### PR DESCRIPTION
## Why

`moment` shipped its own 59 kB chunk (19.7 kB gzip) to render English-only output that `Intl` produces natively — no locale file was ever imported anywhere. It was also declared twice in the backend (both `dependencies` and `devDependencies`).

`Intl` alone isn't enough, though: it's a formatting API with no date arithmetic, and roughly half the moment calls were `add`/`subtract`/`startOf`/`diff`. So this adds two modules to `@argos/util` — shared by the frontend and backend — rather than reaching for another dependency.

## What

**`@argos/util/date`** — calendar arithmetic on native `Date`. Hours are absolute durations; days, weeks and months are calendar units that preserve wall-clock time across DST, matching the semantics we relied on. Also replaces the `moment.unitOfTime.Base` type that had leaked into `getTimeTicks`' public signature with a local `TimeUnit`.

**`@argos/util/date-format`** — `Intl.DateTimeFormat` presets, `Intl.RelativeTimeFormat` for relative phrasing, and a compact duration formatter. Formatters are cached per locale/format pair since `Time` re-renders on a 1-second interval.

Formats are named presets instead of token strings, so field order and separators come from the locale rather than being spelled out at the call site. `Time`'s `format` prop takes a `DateFormat` union (`"date"`, `"longDate"`, `"dateTime"`, `"fullDateTime"`, `"precise"`, …) in place of a moment token string — 9 of the 52 `<Time>` call sites pass one.

`Intl.DurationFormat` would have covered the duration case natively, but `packages/tsconfig/node` sets `lib: ["es2025", …]` without `ESNext.Intl`, so its types don't resolve there. Hand-rolling that one helper avoided widening a shared tsconfig.

## Behaviour changes

Worth a look during review — most are fixes, but they are visible:

- **Build durations** now read `1m 23s` instead of moment's vague `humanize` output (`a minute`). This is the one deliberate display change; easy to revert if you'd rather keep the old wording.
- **Analytics weekly labels are localised.** The day and month labels already used `navigator.language` while the week label went through moment in English — all three now share one locale.
- **`diffInCalendarDays`** counts date boundaries instead of dividing milliseconds, so a range spanning a DST change no longer truncates to one day short.
- **PlanCard** skips the next-payment sentence when `periodEndDate` is null rather than rendering `Invalid date`. There was no guard before.
- **Relative phrasing** rounds the magnitude and reapplies the sign. `Math.round` breaks ties toward +Infinity, so a 90-second gap used to read `1 minute ago` but `in 2 minutes`; both are now `2 minutes`.

Relative timestamps also shift wording slightly (`a few seconds ago` → `3 seconds ago`, `a day ago` → `yesterday`). `Time` already sets `data-visual-test="transparent"`, so Argos snapshots are masked.

## Verification

- 63 new unit tests across both modules; full suite 507 passed
- `check-types` clean across all 7 packages
- `lint`, `check-format`, `knip` clean (`moment`'s stale knip ignore entry removed)
- `build` succeeds and the `moment-*.js` chunk is gone; `moment` is out of `pnpm-lock.yaml` and both `node_modules`

The e2e suite wasn't run — it needs a live database, and `staffTrialPipeline.e2e.test.ts` is among the changed files, so that one is worth a CI check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)