### PR TITLE
Show each build's comment count in the builds list

### DIFF
--- a/apps/backend/src/graphql/definitions/Build.ts
+++ b/apps/backend/src/graphql/definitions/Build.ts
@@ -135,6 +135,8 @@ export const typeDefs = gql`
     viewerHasSubmittedReview: Boolean!
     "Comments visible to the current user (excludes other users' pending-review drafts)"
     comments: [Comment!]!
+    "Number of comments visible to the current user, replies included"
+    commentsCount: Int!
     "Previous approved diffs from a build with the same branch"
     branchApprovedDiffs: [ID!]!
     "Build is triggered in a merge queue"
@@ -428,6 +430,12 @@ export const resolvers: IResolvers = {
     },
     comments: async (build, _args, ctx) => {
       return ctx.loaders.BuildPublishedComments.load({
+        buildId: build.id,
+        viewerUserId: ctx.auth?.user.id ?? null,
+      });
+    },
+    commentsCount: async (build, _args, ctx) => {
+      return ctx.loaders.BuildCommentsCount.load({
         buildId: build.id,
         viewerUserId: ctx.auth?.user.id ?? null,
       });

--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -976,6 +976,43 @@ function createBuildPublishedCommentsLoader() {
 }
 
 /**
+ * Counts the comments visible to a given viewer on a build, replies included.
+ * The build list only needs the number, so it counts in SQL rather than
+ * reusing {@link createBuildPublishedCommentsLoader}, which would ship every
+ * comment's content for a page of builds.
+ */
+function createBuildCommentsCountLoader() {
+  return new DataLoader<
+    { buildId: string; viewerUserId: string | null },
+    number,
+    string
+  >(
+    async (inputs) => {
+      const buildIds = inputs.map((input) => input.buildId);
+      // A single request carries one viewer, so all inputs share it.
+      const viewerUserId = inputs[0]?.viewerUserId ?? null;
+      const rows = (await filterVisibleComments(
+        Comment.query().whereIn("buildId", buildIds),
+        viewerUserId,
+      )
+        .select("buildId")
+        .count("* as count")
+        .groupBy("buildId")) as unknown as Array<{
+        buildId: string;
+        count: string | number;
+      }>;
+      const counts = new Map(
+        rows.map((row) => [row.buildId, Number(row.count) || 0]),
+      );
+      return inputs.map((input) => counts.get(input.buildId) ?? 0);
+    },
+    {
+      cacheKeyFn: (input) => `${input.buildId}:${input.viewerUserId ?? ""}`,
+    },
+  );
+}
+
+/**
  * Loads the comments posted on a test, capped per test — see
  * {@link getVisibleTestCommentsQuery}, shared with the REST endpoint.
  */
@@ -1641,6 +1678,7 @@ export const createLoaders = () => ({
   AccountSubscriptionStatusByAccountId:
     createAccountSubscriptionStatusByAccountIdLoader(),
   BuildPublishedComments: createBuildPublishedCommentsLoader(),
+  BuildCommentsCount: createBuildCommentsCountLoader(),
   TestComments: createTestCommentsLoader(),
   CommentReactions: createCommentReactionsLoader(),
   CommentMentionedUserIds: createCommentMentionedUserIdsLoader(),

--- a/apps/backend/src/graphql/tests/queryProjectBuilds.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/queryProjectBuilds.e2e.test.ts
@@ -1,7 +1,7 @@
 import request from "supertest";
 import { beforeEach, describe, expect, it } from "vitest";
 
-import type { Account, Project } from "@/database/models";
+import type { Account, Build, Project } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
 
 import { apolloServer, createApolloMiddleware } from "../apollo";
@@ -20,6 +20,7 @@ describe("GraphQL", () => {
     let userAccount: Account;
     let teamAccount: Account;
     let project: Project;
+    let builds: Build[];
 
     beforeEach(async () => {
       userAccount = await factory.UserAccount.create();
@@ -40,7 +41,7 @@ describe("GraphQL", () => {
           { projectId: project.id, branch: "feat/search-box" },
           { projectId: project.id, branch: "fix/login" },
         ]);
-      await factory.Build.createMany(3, [
+      builds = await factory.Build.createMany(3, [
         {
           projectId: project.id,
           name: "default",
@@ -65,6 +66,7 @@ describe("GraphQL", () => {
       after?: number;
       search?: string;
       withTotalCount?: boolean;
+      withCommentsCount?: boolean;
     }) {
       const app = await createApolloServerApp(
         apolloServer,
@@ -90,6 +92,7 @@ describe("GraphQL", () => {
                     name
                     branch
                     commit
+                    ${args.withCommentsCount ? "commentsCount" : ""}
                   }
                 }
               }
@@ -178,6 +181,45 @@ describe("GraphQL", () => {
       const builds = await queryBuilds({ search: "does-not-exist" });
       expect(builds.edges).toEqual([]);
       expect(builds.pageInfo).toEqual({ hasNextPage: false, isEmpty: true });
+    });
+
+    it("counts the comments visible to the viewer", async () => {
+      const build = builds[0]!;
+      const otherUser = await factory.User.create();
+      const pendingReview = await factory.BuildReview.create({
+        buildId: build.id,
+        userId: otherUser.id,
+        state: "pending",
+      });
+      await factory.Comment.createMany(4, [
+        { buildId: build.id, userId: userAccount.userId! },
+        { buildId: build.id, userId: otherUser.id },
+        // Hidden: another user's draft comment.
+        {
+          buildId: build.id,
+          userId: otherUser.id,
+          buildReviewId: pendingReview.id,
+        },
+        // Hidden: soft-deleted.
+        {
+          buildId: build.id,
+          userId: otherUser.id,
+          deletedAt: new Date().toISOString(),
+        },
+      ]);
+
+      const result = await queryBuilds({ withCommentsCount: true });
+      const counts = Object.fromEntries(
+        result.edges.map(
+          (edge: { branch: string; commentsCount: number }) =>
+            [edge.branch, edge.commentsCount] as const,
+        ),
+      );
+      expect(counts).toEqual({
+        main: 2,
+        "feat/search-box": 0,
+        "fix/login": 0,
+      });
     });
 
     it("escapes LIKE wildcards in the search", async () => {

--- a/apps/frontend/src/pages/Project/Builds.tsx
+++ b/apps/frontend/src/pages/Project/Builds.tsx
@@ -14,7 +14,7 @@ import {
 import { invariant } from "@argos/util/invariant";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { clsx } from "clsx";
-import { BoxesIcon, SearchIcon } from "lucide-react";
+import { BoxesIcon, MessageSquareIcon, SearchIcon } from "lucide-react";
 import { parseAsString, useQueryStates } from "nuqs";
 import { Heading, Text } from "react-aria-components";
 import { useResolvedPath } from "react-router";
@@ -41,6 +41,7 @@ import {
 import { List, ListRowLink, ListRowLoader } from "@/ui/List";
 import { TextInput, TextInputGroup, TextInputIcon } from "@/ui/TextInput";
 import { Time } from "@/ui/Time";
+import { Tooltip } from "@/ui/Tooltip";
 import { Truncable } from "@/ui/Truncable";
 import { useEventCallback } from "@/ui/useEventCallback";
 import { checkAreDefaultValues } from "@/util/search-params";
@@ -103,6 +104,7 @@ const ProjectBuildsQuery = graphql(`
           mode
           mergeQueue
           subset
+          commentsCount
           stats {
             ...BuildStatsIndicator_BuildStats
           }
@@ -122,6 +124,24 @@ const ProjectBuildsQuery = graphql(`
 type ProjectBuildsDocument = DocumentType<typeof ProjectBuildsQuery>;
 type Builds = NonNullable<ProjectBuildsDocument["project"]>["builds"];
 type Build = Builds["edges"][0];
+
+/**
+ * Number of comments posted on a build, hidden when there is none: an empty
+ * counter on every row would be noise.
+ */
+function BuildCommentsCount({ count }: { count: number }) {
+  if (count === 0) {
+    return null;
+  }
+  return (
+    <Tooltip content={count === 1 ? "1 comment" : `${count} comments`}>
+      <div className="text-low flex items-center gap-1 tabular-nums">
+        <MessageSquareIcon className="size-4" />
+        <span className="text-xs">{count}</span>
+      </div>
+    </Tooltip>
+  );
+}
 
 function BuildRow({
   build,
@@ -155,7 +175,7 @@ function BuildRow({
         <BuildTestStatusChip build={build} scale="sm" />
         <BuildBaselineEligibilityChip build={build} scale="sm" />
       </div>
-      <div className="flex grow">
+      <div className="flex grow items-center gap-3">
         <div className="hidden lg:flex">
           {build.stats ? (
             <BuildStatsIndicator
@@ -165,6 +185,7 @@ function BuildRow({
             />
           ) : null}
         </div>
+        <BuildCommentsCount count={build.commentsCount} />
       </div>
       <div className="hidden gap-2 xl:flex xl:w-56 2xl:w-96">
         <div className="w-6.5">


### PR DESCRIPTION
Each row of the builds page now shows how many comments the build has, next to the diff stats.

The count comes from a new `Build.commentsCount` field, backed by a dedicated loader that counts in SQL with the same visibility rules as `Build.comments` — so other users' pending-review drafts and deleted comments stay out, without shipping every comment's content for a page of builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)