### PR TITLE
Run integration tests in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2]
     env:
       NODE_ENV: test
       TZ: utc
@@ -168,7 +168,7 @@ jobs:
           BUILD_MODE: production
 
       - name: Test
-        run: pnpm run test:integration --shard=${{ matrix.shard }}/4
+        run: pnpm run test:integration --shard=${{ matrix.shard }}/2
 
   e2e-test:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,8 +48,10 @@ models. To add or change a column:
    `jsonSchema.properties` (nullable → `{ type: ["string", "null"] }`, dates are
    ISO strings) and the typed class field. `createdAt`/`updatedAt` come from the
    base `Model`.
-4. Reset the test DB before running e2e tests:
+4. Reset the test DB before running the Playwright tests:
    `NODE_ENV=test pnpm run --filter @argos/backend db:reset`.
+   `pnpm test:integration` needs nothing — it rebuilds its own databases
+   whenever `structure.sql` changes.
 
 **Idempotent inserts:** never gate an insert on a prior existence check — two
 concurrent requests can both pass it and race on the primary key. Insert
@@ -127,6 +129,12 @@ never the label; labels are resolved at render time on both sides.
   in parallel. Avoid large shared setups and avoid mocking unless the behavior
   can't be tested realistically.
 - Test API endpoints with `createTestHandlerApp` + `supertest`.
+- `test:integration` runs in parallel, and every test truncates the whole
+  database, so each worker owns a `test_<workerId>` database, a Redis database
+  and a queue prefix — set up by `vitest/vitest.e2e.global-setup.mts` (see
+  `apps/backend/src/database/testing/workers.ts`). Nothing to create by hand:
+  worker databases are built from `db/structure.sql` and rebuilt whenever it
+  changes. The `test` database is left alone, it belongs to Playwright.
 - If `db:reset` reports `database "test" is being accessed by other users`:
 
   ```bash

--- a/apps/backend/src/config/index.ts
+++ b/apps/backend/src/config/index.ts
@@ -634,6 +634,14 @@ export function createConfig() {
     loadDatabaseConfigFromURL(process.env["DATABASE_URL"], config);
   }
 
+  // Applied after the URL so it overrides the database it carries. Integration
+  // tests use it to point each worker at its own database without having to
+  // rebuild the whole connection URL.
+  const pgDatabase = process.env["PG_DATABASE"];
+  if (pgDatabase) {
+    config.set("pg.connection.database", pgDatabase);
+  }
+
   config.validate();
 
   return config;

--- a/apps/backend/src/database/testing/workers.ts
+++ b/apps/backend/src/database/testing/workers.ts
@@ -1,0 +1,185 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import createKnex, { type Knex } from "knex";
+import { createClient } from "redis";
+
+import config from "@/config";
+import { getKnexConfig } from "@/config/database";
+import { resolveFromPackageRoot } from "@/util/paths";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Maximum number of workers: each one takes a Redis logical database, and Redis
+ * exposes 16 of them (0-15) by default.
+ */
+const MAX_WORKERS = 15;
+
+/**
+ * The schema loaded in the worker databases, the same file `db:load` uses.
+ */
+const STRUCTURE_PATH = resolveFromPackageRoot("db/structure.sql");
+
+/**
+ * Both setups below wipe everything they touch, so make sure they can only run
+ * against the test infrastructure.
+ */
+function assertCanSetupWorkers(workerCount: number): void {
+  if (config.get("env") !== "test") {
+    throw new Error("Test workers can only be set up in test environment");
+  }
+
+  if (workerCount < 1 || workerCount > MAX_WORKERS) {
+    throw new Error(`Worker count must be between 1 and ${MAX_WORKERS}`);
+  }
+}
+
+/**
+ * Name of the database owned by a test worker.
+ */
+export function getWorkerDatabaseName(workerId: number): string {
+  return `${config.get("pg.connection.database")}_${workerId}`;
+}
+
+type WorkerEnv = {
+  PG_DATABASE: string;
+  REDIS_URL: string;
+  AMQP_QUEUE_PREFIX: string;
+};
+
+/**
+ * Environment variables isolating a test worker from the other ones. They must
+ * be applied before any module reads the configuration.
+ */
+export function getWorkerEnv(workerId: number): WorkerEnv {
+  const redisUrl = new URL(config.get("redis.url"));
+  // Redis databases are named by index, one per worker. Ids start at 1 so the
+  // default database (0) is never used.
+  redisUrl.pathname = `/${workerId}`;
+  return {
+    PG_DATABASE: getWorkerDatabaseName(workerId),
+    REDIS_URL: redisUrl.href,
+    AMQP_QUEUE_PREFIX: `${config.get("amqp.queuePrefix")}${workerId}:`,
+  };
+}
+
+function getConnectionConfig(): Knex.PgConnectionConfig {
+  return getKnexConfig(config).connection as Knex.PgConnectionConfig;
+}
+
+/**
+ * Load `db/structure.sql` into a database, the way `db:load` does. It goes
+ * through `psql`: the file contains meta-commands the server cannot run.
+ */
+async function loadStructure(database: string): Promise<void> {
+  const connection = getConnectionConfig();
+  const args = ["--quiet", "--no-psqlrc", "-v", "ON_ERROR_STOP=1"];
+
+  if (connection.host) {
+    args.push("--host", connection.host);
+  }
+
+  if (connection.port) {
+    args.push("--port", String(connection.port));
+  }
+
+  if (connection.user) {
+    args.push("--username", connection.user);
+  }
+
+  args.push("--file", STRUCTURE_PATH, database);
+
+  const password =
+    typeof connection.password === "string" ? connection.password : null;
+
+  await execFileAsync("psql", args, {
+    env: password ? { ...process.env, PGPASSWORD: password } : process.env,
+  });
+}
+
+/**
+ * Set up one database per test worker.
+ *
+ * Integration tests truncate every table between tests, so they can only run in
+ * parallel if each worker owns its database. Those databases are built from
+ * `db/structure.sql` rather than copied from the `test` database: copying it
+ * would fail as soon as anything else is connected to it, which the dev server
+ * and the Playwright suite both do.
+ *
+ * A database is rebuilt only when the schema it holds is outdated — tests
+ * truncate it anyway, so an up-to-date one is reused as is.
+ */
+export async function setupWorkerDatabases(workerCount: number): Promise<void> {
+  assertCanSetupWorkers(workerCount);
+
+  const structure = await readFile(STRUCTURE_PATH);
+  // Hexadecimal, so it can be inlined in the statement below: utility
+  // statements take no bound parameter.
+  const structureHash = createHash("sha256").update(structure).digest("hex");
+
+  const knexConfig = getKnexConfig(config);
+  const knex = createKnex({
+    ...knexConfig,
+    // "postgres" is the maintenance database: a database cannot be created from
+    // a connection opened on itself.
+    connection: { ...getConnectionConfig(), database: "postgres" },
+    pool: { min: 0, max: 1 },
+  });
+
+  try {
+    const outdated: string[] = [];
+
+    for (let workerId = 1; workerId <= workerCount; workerId++) {
+      const database = getWorkerDatabaseName(workerId);
+      // The hash of the schema a database was built from is stored as its
+      // comment.
+      const result = await knex.raw<{ rows: { hash: string | null }[] }>(
+        "SELECT shobj_description(oid, 'pg_database') AS hash FROM pg_database WHERE datname = ?",
+        [database],
+      );
+
+      if (result.rows[0]?.hash === structureHash) {
+        continue;
+      }
+
+      // FORCE closes the connections left by an interrupted run.
+      await knex.raw("DROP DATABASE IF EXISTS ?? WITH (FORCE)", [database]);
+      await knex.raw("CREATE DATABASE ??", [database]);
+      outdated.push(database);
+    }
+
+    await Promise.all(outdated.map(loadStructure));
+
+    for (const database of outdated) {
+      await knex.raw(`COMMENT ON DATABASE ?? IS '${structureHash}'`, [
+        database,
+      ]);
+    }
+  } finally {
+    await knex.destroy();
+  }
+}
+
+/**
+ * Flush the Redis database of each test worker, so that a run never sees the
+ * keys left by the previous one.
+ */
+export async function flushWorkerRedisDatabases(
+  workerCount: number,
+): Promise<void> {
+  assertCanSetupWorkers(workerCount);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async (_, index) => {
+      const client = createClient({ url: getWorkerEnv(index + 1).REDIS_URL });
+      await client.connect();
+      try {
+        await client.flushDb();
+      } finally {
+        await client.close();
+      }
+    }),
+  );
+}

--- a/knip.json
+++ b/knip.json
@@ -8,6 +8,7 @@
         "src/build/bin/*.ts",
         "src/database/bin/*.ts",
         "src/database/testing/index.ts",
+        "src/database/testing/workers.ts",
         "src/graphql/definitions/*.ts",
         "scripts/*.ts"
       ],
@@ -22,6 +23,9 @@
   "ignore": [
     "tests/truncate.setup.ts",
     "vitest/vitest.e2e.config.mts",
+    "vitest/vitest.e2e.global-setup.mts",
+    "vitest/vitest.e2e.setup.mts",
+    "vitest/vitest.e2e.workers.mts",
     "vitest/vitest.unit.config.mts"
   ],
   "ignoreBinaries": ["stripe", "ngrok", "op"],

--- a/vitest/vitest.e2e.config.mts
+++ b/vitest/vitest.e2e.config.mts
@@ -1,13 +1,22 @@
 import { defineConfig, mergeConfig } from "vitest/config";
 
 import baseConfig from "./vitest.base.config.mjs";
+import { E2E_WORKERS } from "./vitest.e2e.workers.mjs";
 
 export default mergeConfig(
   baseConfig,
   defineConfig({
     test: {
-      maxWorkers: 1,
-      fileParallelism: false,
+      // Appended to the global setup of the base config.
+      globalSetup: ["./vitest/vitest.e2e.global-setup.mts"],
+      setupFiles: ["./vitest/vitest.e2e.setup.mts"],
+      // Tests truncate the database between each of them, so a worker can only
+      // run one file at a time, and needs a database of its own.
+      maxWorkers: E2E_WORKERS,
+      // Workers compete for the same CPU and Postgres server, so a test takes
+      // longer than it would alone. Well above what the slowest one needs, and
+      // still short enough to catch something that hangs.
+      testTimeout: 15_000,
       include: ["**/*.e2e.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
     },
   }),

--- a/vitest/vitest.e2e.global-setup.mts
+++ b/vitest/vitest.e2e.global-setup.mts
@@ -1,0 +1,19 @@
+import { E2E_WORKERS, WORKERS_ENV_VAR } from "./vitest.e2e.workers.mjs";
+
+export const setup = async () => {
+  // Imported here rather than at the top of the file: Vitest loads every global
+  // setup file before running any of them, and reading the configuration loads
+  // `.env`, which must happen after the base global setup defined its
+  // environment variables.
+  const { setupWorkerDatabases, flushWorkerRedisDatabases, getWorkerEnv } =
+    await import("../apps/backend/src/database/testing/workers");
+
+  await setupWorkerDatabases(E2E_WORKERS);
+  await flushWorkerRedisDatabases(E2E_WORKERS);
+
+  // Workers inherit this process environment, each one picks the entry matching
+  // its own id.
+  process.env[WORKERS_ENV_VAR] = JSON.stringify(
+    Array.from({ length: E2E_WORKERS }, (_, index) => getWorkerEnv(index + 1)),
+  );
+};

--- a/vitest/vitest.e2e.setup.mts
+++ b/vitest/vitest.e2e.setup.mts
@@ -1,0 +1,22 @@
+import { WORKERS_ENV_VAR } from "./vitest.e2e.workers.mjs";
+
+// Runs before the test file is imported, and must not import anything reading
+// the configuration: the worker environment has to be applied before the
+// configuration module is evaluated.
+
+const rawWorkersEnv = process.env[WORKERS_ENV_VAR];
+
+if (!rawWorkersEnv) {
+  throw new Error(`Missing ${WORKERS_ENV_VAR}, the global setup did not run`);
+}
+
+// Vitest gives each worker an id between 1 and `maxWorkers`.
+const workerId = Number(process.env["VITEST_POOL_ID"] ?? "1");
+const workersEnv = JSON.parse(rawWorkersEnv) as Record<string, string>[];
+const workerEnv = workersEnv[workerId - 1];
+
+if (!workerEnv) {
+  throw new Error(`No environment defined for worker ${workerId}`);
+}
+
+Object.assign(process.env, workerEnv);

--- a/vitest/vitest.e2e.workers.mts
+++ b/vitest/vitest.e2e.workers.mts
@@ -1,0 +1,18 @@
+import { availableParallelism } from "node:os";
+
+/**
+ * Number of workers running integration tests in parallel.
+ *
+ * Each worker gets its own database, Redis database and queue namespace, so
+ * more workers also means more databases to copy before the run starts.
+ */
+export const E2E_WORKERS = Math.max(1, Math.min(4, availableParallelism() - 1));
+
+/**
+ * Environment variable carrying the environment of every worker, as JSON,
+ * from the global setup down to the workers.
+ *
+ * @see vitest.e2e.global-setup.mts
+ * @see vitest.e2e.setup.mts
+ */
+export const WORKERS_ENV_VAR = "ARGOS_TEST_WORKERS_ENV";


### PR DESCRIPTION
Integration tests (`pnpm test:integration`) ran with `maxWorkers: 1` and `fileParallelism: false`, because every test truncates the whole database in `beforeEach` — a second worker on the same database would wipe the first one's data mid-test.

**~7m30 → ~1m40** locally for the 135 files / 880 tests (10 cores → 4 workers).

## What changed

Each Vitest worker (`VITEST_POOL_ID`) gets its own infrastructure, the way each Playwright test gets its own seeds:

- **Postgres**: a `test_<workerId>` database
- **Redis**: its own logical database (index = worker id)
- **AMQP**: its own queue prefix (`test:<workerId>:`)

`vitest/vitest.e2e.global-setup.mts` prepares them and publishes the per-worker environment; `vitest/vitest.e2e.setup.mts` applies the entry matching its worker id before the test file — and therefore the configuration module — is imported. The new `PG_DATABASE` variable points the connection at the worker database without rebuilding the whole URL.

CI shards the job in two instead of four, since each shard is now parallel on its own.

## Notes for the reviewer

- **Redis isolation is not cosmetic.** Several tests call `client.flushDb()` between tests (`util/redis/testing.ts`), which would wipe the other workers' keys. Primary keys also repeat across worker databases, so `redisLock.coalesce(["conclude-build", buildId])` and cached entries would collide across workers.
- **Worker databases are built from `db/structure.sql`, not copied from `test`.** The first implementation used `CREATE DATABASE … TEMPLATE test`, which fails with `source database "test" is being accessed by other users` as soon as anything is connected to it — the dev server and the Playwright suite both are. Nothing touches `test` anymore; it stays the Playwright database.
- **Databases are reused between runs.** Each one stores the hash of the schema it was built from as its database comment, and is only dropped and rebuilt when `db/structure.sql` changes. Cold start ~10s, warm runs ~0. Tests truncate everything anyway, so a reused database is as clean as a fresh one. This also means no manual `db:reset` after pulling migrations, for integration tests.
- **`testTimeout` raised to 15s.** Under four workers, two GraphQL tests hit the 5s default on a loaded machine.
- Worker count is `min(4, cores - 1)` — capped because each worker takes one of the 16 Redis logical databases.

## Test plan

- `pnpm test:integration` — 135 files / 880 tests, 6 clean full runs
- `pnpm --dir apps/backend run check-types`, `lint`, `pnpm run knip`, `prettier --check`