### PR TITLE
fix(billing): never report a negative screenshot count

### DIFF
--- a/apps/backend/db/migrations/20260808120000_fix-storybook-count-overflow.js
+++ b/apps/backend/db/migrations/20260808120000_fix-storybook-count-overflow.js
@@ -1,0 +1,40 @@
+/**
+ * A bucket's Storybook screenshots are a subset of its screenshots, so
+ * `storybookScreenshotCount` can never exceed `screenshotCount`. Buckets
+ * finalized while the two were counted by two separate queries can break that:
+ * a screenshot inserted between the queries was seen by the second one only.
+ * The neutral count derived from the pair (`screenshotCount -
+ * storybookScreenshotCount`) then goes negative.
+ *
+ * Clamp the affected buckets back to the invariant. Batched to keep each
+ * statement short rather than locking the table in one pass.
+ *
+ * @param {import('knex').Knex} knex
+ */
+export const up = async (knex) => {
+  while (true) {
+    const result = await knex.raw(`
+      WITH buckets AS (
+        SELECT id
+        FROM screenshot_buckets
+        WHERE "storybookScreenshotCount" > "screenshotCount"
+        LIMIT 1000
+      )
+      UPDATE screenshot_buckets sb
+      SET "storybookScreenshotCount" = sb."screenshotCount"
+      FROM buckets
+      WHERE sb.id = buckets.id
+      RETURNING sb.id;
+    `);
+    if (result.rowCount === 0) {
+      break;
+    }
+  }
+};
+
+/**
+ * The counts the buckets held were wrong; there is nothing to restore.
+ */
+export const down = async () => {};
+
+export const config = { transaction: false };

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict NCWaxg9ST6yzu49EdXJQgn0VVLYuBuCa1kVx30782FUnwQbDu43cyD2URwP6Qg7
+\restrict SkPe5timWpcdrDbEShqT7aRRHqHrPjsFg2tSEhkLUMc9f7x0grLW4jP7bn9O18G
 
 -- Dumped from database version 18.4
 -- Dumped by pg_dump version 18.4 (Homebrew)
@@ -5856,7 +5856,7 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-\unrestrict NCWaxg9ST6yzu49EdXJQgn0VVLYuBuCa1kVx30782FUnwQbDu43cyD2URwP6Qg7
+\unrestrict SkPe5timWpcdrDbEShqT7aRRHqHrPjsFg2tSEhkLUMc9f7x0grLW4jP7bn9O18G
 
 -- Knex migrations
 
@@ -6095,3 +6095,4 @@ INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('2026073
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260801120000_discord-webhooks.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260801130000_builds-number-counter.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260801130001_builds-number-unique.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260808120000_fix-storybook-count-overflow.js', 1, NOW());

--- a/apps/backend/src/build/finalizeBuild.e2e.test.ts
+++ b/apps/backend/src/build/finalizeBuild.e2e.test.ts
@@ -1,0 +1,105 @@
+import { test as base, describe, expect } from "vitest";
+
+import { knex } from "@/database";
+import type { Build } from "@/database/models";
+import { ScreenshotBucket } from "@/database/models";
+import { factory } from "@/database/testing";
+import { setupDatabase } from "@/database/testing/util";
+import { ARGOS_STORYBOOK_SDK_NAME } from "@/util/argos-sdk";
+
+import { finalizeBuild } from "./finalizeBuild";
+
+const test = base.extend<{ build: Build }>({
+  build: async ({}, use) => {
+    await setupDatabase();
+    const build = await factory.Build.create();
+    // Counts nothing like what the bucket holds, so the assertions below can
+    // only pass if the finalization recomputed them.
+    await build.$relatedQuery("compareScreenshotBucket").patch({
+      complete: false,
+      screenshotCount: 99,
+      storybookScreenshotCount: 99,
+    });
+    await use(build);
+  },
+});
+
+function screenshotMetadata(sdkName: string) {
+  return {
+    sdk: { name: sdkName, version: "1.0.0" },
+    automationLibrary: { name: "playwright", version: "1.0.0" },
+  };
+}
+
+function getCompareBucket(build: Build) {
+  return ScreenshotBucket.query()
+    .findById(build.compareScreenshotBucketId)
+    .throwIfNotFound();
+}
+
+describe("#finalizeBuild", () => {
+  test("counts the screenshots of the compare bucket, split by SDK", async ({
+    build,
+  }) => {
+    await factory.Screenshot.createMany(2, {
+      screenshotBucketId: build.compareScreenshotBucketId,
+      metadata: screenshotMetadata(ARGOS_STORYBOOK_SDK_NAME),
+    });
+    await factory.Screenshot.createMany(3, {
+      screenshotBucketId: build.compareScreenshotBucketId,
+      metadata: screenshotMetadata("@argos-ci/playwright"),
+    });
+
+    await finalizeBuild({ build });
+
+    const bucket = await getCompareBucket(build);
+    expect(bucket.complete).toBe(true);
+    expect(bucket.screenshotCount).toBe(5);
+    expect(bucket.storybookScreenshotCount).toBe(2);
+  });
+
+  test("reads both counts in a single query", async ({ build }) => {
+    // The two counts must share one `READ COMMITTED` snapshot. Taken by two
+    // queries, a screenshot inserted in between is seen by the second one
+    // only, and the bucket ends up holding more Storybook screenshots than
+    // screenshots — making the neutral count derived from the pair negative.
+    await factory.Screenshot.createMany(3, {
+      screenshotBucketId: build.compareScreenshotBucketId,
+      metadata: screenshotMetadata(ARGOS_STORYBOOK_SDK_NAME),
+    });
+
+    const countQueries: string[] = [];
+    const onQuery = (query: { sql: string }) => {
+      if (query.sql.includes(`from "screenshots"`)) {
+        countQueries.push(query.sql);
+      }
+    };
+    knex.on("query", onQuery);
+    try {
+      await finalizeBuild({ build });
+    } finally {
+      knex.off("query", onQuery);
+    }
+
+    expect(countQueries).toHaveLength(1);
+  });
+
+  test("uses the pre-computed counts when they are given", async ({
+    build,
+  }) => {
+    await factory.Screenshot.create({
+      screenshotBucketId: build.compareScreenshotBucketId,
+      metadata: screenshotMetadata(ARGOS_STORYBOOK_SDK_NAME),
+    });
+
+    await finalizeBuild({
+      build,
+      metadata: null,
+      screenshotCount: { all: 0, storybook: 0 },
+    });
+
+    const bucket = await getCompareBucket(build);
+    expect(bucket.screenshotCount).toBe(0);
+    expect(bucket.storybookScreenshotCount).toBe(0);
+  });
+});

--- a/apps/backend/src/build/finalizeBuild.ts
+++ b/apps/backend/src/build/finalizeBuild.ts
@@ -1,7 +1,8 @@
 import { BuildMetadata } from "@argos/schemas/build-metadata";
-import { ref, TransactionOrKnex } from "objection";
+import { invariant } from "@argos/util/invariant";
+import { TransactionOrKnex } from "objection";
 
-import { transaction } from "@/database";
+import { raw, transaction } from "@/database";
 import { Build, BuildShard, Screenshot } from "@/database/models";
 import { ARGOS_STORYBOOK_SDK_NAME } from "@/util/argos-sdk";
 
@@ -69,6 +70,40 @@ function aggregateMetadata(allMetatada: (BuildMetadata | null)[]) {
 }
 
 /**
+ * Count the screenshots of a bucket, split between all of them and the ones
+ * uploaded by the Storybook SDK.
+ *
+ * Both numbers come out of a single aggregate on purpose. Counting them with
+ * two queries gives them two `READ COMMITTED` snapshots, so a screenshot
+ * inserted in between — another shard of the same build, a retried upload
+ * racing a manual finalization — is seen by the second query only. The bucket
+ * then stores more Storybook screenshots than screenshots, and the neutral
+ * count derived from them (`screenshotCount - storybookScreenshotCount`) goes
+ * negative.
+ */
+async function countBucketScreenshots(params: {
+  screenshotBucketId: string;
+  trx: TransactionOrKnex | undefined;
+}): Promise<{ all: number; storybook: number }> {
+  const result = await Screenshot.query(params.trx)
+    .where("screenshotBucketId", params.screenshotBucketId)
+    .select(
+      raw(`count(*)::int as "all"`),
+      raw(
+        `count(*) filter (where metadata->'sdk'->>'name' = ?)::int as "storybook"`,
+        [ARGOS_STORYBOOK_SDK_NAME],
+      ),
+    )
+    .first()
+    .castTo<{ all: number; storybook: number } | undefined>();
+
+  // An aggregate without `group by` always yields exactly one row.
+  invariant(result, "Screenshot count not found");
+
+  return result;
+}
+
+/**
  * Finalize a build.
  * - Count the number of screenshots in the compare bucket.
  * - Check if the build is considered valid.
@@ -99,22 +134,16 @@ export async function finalizeBuild(input: {
 }) {
   const { trx, build, screenshotCount } = input;
   const hasExplicitMetadata = input.metadata !== undefined;
-  const countQuery = Screenshot.query(trx).where(
-    "screenshotBucketId",
-    build.compareScreenshotBucketId,
-  );
-  const [screenshotCountResult, storybookScreenshotCount, shards] =
-    await Promise.all([
-      screenshotCount?.all ?? countQuery.resultSize(),
-      screenshotCount?.storybook ??
-        countQuery
-          .clone()
-          .where(ref("metadata:sdk.name").castText(), ARGOS_STORYBOOK_SDK_NAME)
-          .resultSize(),
-      hasExplicitMetadata
-        ? []
-        : BuildShard.query(trx).select("metadata").where("buildId", build.id),
-    ]);
+  const [counts, shards] = await Promise.all([
+    screenshotCount ??
+      countBucketScreenshots({
+        screenshotBucketId: build.compareScreenshotBucketId,
+        trx,
+      }),
+    hasExplicitMetadata
+      ? []
+      : BuildShard.query(trx).select("metadata").where("buildId", build.id),
+  ]);
 
   const buildData: Partial<Pick<Build, "metadata" | "finalizedAt">> = {
     finalizedAt: new Date().toISOString(),
@@ -137,8 +166,8 @@ export async function finalizeBuild(input: {
       build.$clone().$query(trx).patch(buildData),
       build.$relatedQuery("compareScreenshotBucket", trx).patch({
         complete: true,
-        screenshotCount: screenshotCountResult,
-        storybookScreenshotCount,
+        screenshotCount: counts.all,
+        storybookScreenshotCount: counts.storybook,
         valid,
       }),
     ]);

--- a/apps/backend/src/database/models/Account.e2e.test.ts
+++ b/apps/backend/src/database/models/Account.e2e.test.ts
@@ -172,6 +172,21 @@ describe("Account", () => {
       expect(consumption.all).toBe(0);
       expect(consumption.storybook).toBe(0);
     });
+
+    it("never reports a negative neutral count", async ({ fixture }) => {
+      // Buckets finalized while the two counts were read by two separate
+      // queries can hold more Storybook screenshots than screenshots.
+      await fixture.bucket1.$query().patch({
+        complete: true,
+        screenshotCount: 10,
+        storybookScreenshotCount: 12,
+      });
+      const manager = fixture.account.$getSubscriptionManager();
+      const consumption = await manager.getCurrentPeriodScreenshots();
+      expect(consumption.all).toBe(10);
+      expect(consumption.storybook).toBe(10);
+      expect(consumption.neutral).toBe(0);
+    });
   });
 
   describe("#checkIsOutOfCapacity", () => {

--- a/apps/backend/src/database/models/Account.ts
+++ b/apps/backend/src/database/models/Account.ts
@@ -3,7 +3,7 @@ import { assertNever } from "@argos/util/assertNever";
 import { invariant } from "@argos/util/invariant";
 import { slugJsonSchema } from "@argos/util/slug";
 import { memoize } from "lodash-es";
-import type { Pojo, RelationMappings } from "objection";
+import { raw, type Pojo, type RelationMappings } from "objection";
 
 import { computeAdditionalScreenshots } from "../services/additional-screenshots";
 import { Model } from "../util/model";
@@ -718,7 +718,16 @@ export class Account extends Model {
   }> {
     const query = ScreenshotBucket.query()
       .sum("screenshot_buckets.screenshotCount as all")
-      .sum("screenshot_buckets.storybookScreenshotCount as storybook")
+      // A bucket's Storybook count is clamped to its total before being summed.
+      // The two used to be counted by two separate queries, so buckets written
+      // back then can hold more Storybook screenshots than screenshots, which
+      // would make `neutral` negative.
+      .select(
+        raw(`sum(least(coalesce(??, 0), coalesce(??, 0))) as "storybook"`, [
+          "screenshot_buckets.storybookScreenshotCount",
+          "screenshot_buckets.screenshotCount",
+        ]),
+      )
       .leftJoinRelated("project")
       .where("screenshot_buckets.createdAt", ">=", from.toISOString())
       .where("project.accountId", this.id)
@@ -732,12 +741,11 @@ export class Account extends Model {
       query.where("project.id", options.projectId);
     }
 
-    const result = (await query) as unknown as {
-      all: string | null;
-      storybook: string | null;
-    };
-    const all = result.all ? Number(result.all) : 0;
-    const storybook = result.storybook ? Number(result.storybook) : 0;
+    const result = await query.castTo<
+      { all: string | null; storybook: string | null } | undefined
+    >();
+    const all = result?.all ? Number(result.all) : 0;
+    const storybook = result?.storybook ? Number(result.storybook) : 0;
     const neutral = all - storybook;
     return { all, neutral, storybook };
   }

--- a/apps/backend/src/database/services/period-usage.e2e.test.ts
+++ b/apps/backend/src/database/services/period-usage.e2e.test.ts
@@ -161,6 +161,29 @@ describe("getAccountPeriodUsages", () => {
     expect(usage?.storybookCount).toBe(1000);
   });
 
+  it("clamps a bucket's Storybook count to its total", async () => {
+    await createUsageBasedSubscription();
+    // Buckets finalized while the two counts were read by two separate queries
+    // can hold more Storybook screenshots than screenshots. Left alone, the
+    // neutral count derived from the pair goes negative.
+    await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      createdAt: new Date(inPeriod.getTime() + 1000).toISOString(),
+      screenshotCount: 1500,
+      storybookScreenshotCount: 1600,
+    });
+
+    const usage = await getAccountPeriodUsages([account]).then((usages) =>
+      usages.get(account.id),
+    );
+
+    // Read as 1500 Storybook and 0 neutral: 1000 absorb the quota and 500 are
+    // billed at $0.10.
+    expect(usage?.additionalScreenshotCost).toBeCloseTo(50);
+    expect(usage?.storybookRatio).toBe(1);
+    expect(usage?.storybookCount).toBe(1500);
+  });
+
   it("ignores screenshots uploaded before the period started", async () => {
     await createUsageBasedSubscription();
     await factory.ScreenshotBucket.create({

--- a/apps/backend/src/database/services/period-usage.ts
+++ b/apps/backend/src/database/services/period-usage.ts
@@ -40,6 +40,9 @@ type ScreenshotTotals = {
   allTimeStorybook: number;
 };
 
+/** A bucket's Storybook count, never above the bucket's own total. */
+const CLAMPED_STORYBOOK_COUNT = `least(coalesce(sb."storybookScreenshotCount", 0), coalesce(sb."screenshotCount", 0))`;
+
 /**
  * Sum screenshots per account in a single pass.
  *
@@ -74,12 +77,17 @@ async function getScreenshotTotals(
       knex.raw(
         `coalesce(sum(sb."screenshotCount") filter (where sb."createdAt" >= v."periodStart"), 0) as "periodAll"`,
       ),
+      // A bucket's Storybook count is clamped to its total before being summed.
+      // The two used to be counted by two separate queries, so buckets written
+      // back then can hold more Storybook screenshots than screenshots, which
+      // would make the neutral count negative. Mirrors
+      // `Account.$getScreenshotCountBetween`.
       knex.raw(
-        `coalesce(sum(sb."storybookScreenshotCount") filter (where sb."createdAt" >= v."periodStart"), 0) as "periodStorybook"`,
+        `coalesce(sum(${CLAMPED_STORYBOOK_COUNT}) filter (where sb."createdAt" >= v."periodStart"), 0) as "periodStorybook"`,
       ),
       knex.raw(`coalesce(sum(sb."screenshotCount"), 0) as "allTimeAll"`),
       knex.raw(
-        `coalesce(sum(sb."storybookScreenshotCount"), 0) as "allTimeStorybook"`,
+        `coalesce(sum(${CLAMPED_STORYBOOK_COUNT}), 0) as "allTimeStorybook"`,
       ),
     )
     .from(


### PR DESCRIPTION
## The bug

The plan card renders a negative screenshot count for some projects:

> 3,113,108 Storybook + **-298** classic

`neutral` is never stored — it is derived as `screenshotCount - storybookScreenshotCount`. It goes negative whenever a bucket holds *more* Storybook screenshots than screenshots.

## Root cause

`finalizeBuild` took the two counts with **two separate queries**:

```ts
Promise.all([
  countQuery.resultSize(),                                 // count all
  countQuery.clone().where(sdk = storybook).resultSize(),  // count storybook
])
```

Under `READ COMMITTED` each statement gets its own snapshot, so a screenshot inserted between the two is seen by the second query only. That window is reachable in production: shard uploads are serialized by a per-build Redis lock, but `POST /builds/finalize` and the partial-build resync (`build/partial.ts`) call `finalizeBuild` **outside** it, so a late shard can commit rows mid-count. On a nearly-100%-Storybook project every extra row lands on the Storybook side — hence `3,113,108 > 3,112,810`.

Billing happens to be unaffected (the error cancels out inside `computeAdditionalScreenshots`), but the UI renders the number verbatim.

## What changed

1. **Root cause** — `finalizeBuild` now reads both counts from one aggregate (`count(*)` + `count(*) filter (…)`), so they share a single snapshot and `storybook <= all` holds by construction. Also one round-trip instead of two.
2. **Existing bad rows** — a migration clamps every affected bucket back to the invariant, batched at 1000 rows with `transaction: false`.
3. **Defense at the read sites** — `Account.$getScreenshotCountBetween` and `getAccountPeriodUsages` clamp each bucket's Storybook count to its own total before summing, so `neutral >= 0` while `all = neutral + storybook` still holds.

## Verification

Three guard tests added; each was confirmed to fail without its fix by reverting it:

| Test | Failure without the fix |
| --- | --- |
| `reads both counts in a single query` | 2 queries instead of 1 |
| `never reports a negative neutral count` | `expected 12 to be 10` |
| `clamps a bucket's Storybook count to its total` | `expected 1.066… to be 1` |

The migration was checked against a hand-inserted bad row (10/12 → 10/10) with a valid row (10/4) left untouched.

`pnpm run static-checks` is clean and **1032/1032** integration tests pass. One unit test fails (`storage/checkIfExists.test.ts`) — pre-existing on `main`, confirmed by stashing the change.

## Reviewer notes

- `raw` is imported from `objection` rather than `@/database` in `Account.ts` to avoid a circular import (models are imported by `@/database`).
- `least(coalesce(…, 0), coalesce(…, 0))` rather than bare `least(…)`: Postgres' `LEAST` skips NULLs, which would let a half-written pair slip through.
- The migration's `down` is a no-op — the counts it replaces were wrong, there is nothing to restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)