### PR TITLE
refactor: rename getTwicPicsUrl to getImageKitUrl

### DIFF
--- a/apps/backend/src/api/schema/primitives/snapshot-diff.ts
+++ b/apps/backend/src/api/schema/primitives/snapshot-diff.ts
@@ -9,7 +9,7 @@ import {
   type File as FileModel,
 } from "@/database/models";
 import { getChangesTotalOccurrences, getTestAllMetrics } from "@/metrics/test";
-import { getPublicFileUrl, getPublicUrl, getTwicPicsUrl } from "@/storage";
+import { getImageKitUrl, getPublicFileUrl, getPublicUrl } from "@/storage";
 import { formatTestChangeId, formatTestId } from "@/util/test-id";
 
 import { ChangeSchema } from "./change";
@@ -171,7 +171,7 @@ export async function getSnapshotDiffUrl(diff: ScreenshotDiff) {
     return getPublicFileUrl(file);
   }
   if (diff.s3Id) {
-    return getTwicPicsUrl(diff.s3Id);
+    return getImageKitUrl(diff.s3Id);
   }
   return null;
 }

--- a/apps/backend/src/graphql/definitions/ScreenshotDiff.ts
+++ b/apps/backend/src/graphql/definitions/ScreenshotDiff.ts
@@ -2,7 +2,7 @@ import { invariant } from "@argos/util/invariant";
 import gqlTag from "graphql-tag";
 
 import { getStartDateFromPeriod } from "@/metrics/test";
-import { getPublicFileUrl, getTwicPicsUrl } from "@/storage";
+import { getImageKitUrl, getPublicFileUrl } from "@/storage";
 
 import {
   IResolvers,
@@ -139,7 +139,7 @@ export const resolvers: IResolvers = {
         if (!screenshotDiff.s3Id) {
           return null;
         }
-        return getTwicPicsUrl(screenshotDiff.s3Id);
+        return getImageKitUrl(screenshotDiff.s3Id);
       }
       const file = await ctx.loaders.File.load(screenshotDiff.fileId);
       invariant(file, "File not found");

--- a/apps/backend/src/slack/unfurl.ts
+++ b/apps/backend/src/slack/unfurl.ts
@@ -7,7 +7,7 @@ import { getBuildLabel } from "@/build/label";
 import { getStatsMessage } from "@/build/stats";
 import { Build, ScreenshotDiff, Test } from "@/database/models";
 import { getTestAllMetrics } from "@/metrics/test";
-import { getPublicFileUrl, getTwicPicsUrl } from "@/storage";
+import { getImageKitUrl, getPublicFileUrl } from "@/storage";
 import { safeParseTestId } from "@/util/test-id";
 
 type BuildMatchParams = {
@@ -61,7 +61,7 @@ export async function unfurlBuild(
       return null;
     }
     if (!screenshot.file) {
-      return getTwicPicsUrl(screenshot.s3Id);
+      return getImageKitUrl(screenshot.s3Id);
     }
     return getPublicFileUrl(screenshot.file);
   })();
@@ -139,7 +139,7 @@ export async function unfurlTest(
       return null;
     }
     if (!screenshot.file) {
-      return getTwicPicsUrl(screenshot.s3Id);
+      return getImageKitUrl(screenshot.s3Id);
     }
     return getPublicFileUrl(screenshot.file);
   })();

--- a/apps/backend/src/storage/public-url.ts
+++ b/apps/backend/src/storage/public-url.ts
@@ -41,7 +41,7 @@ function getPixelsInFile(file: FileModel) {
   return null;
 }
 
-export function getTwicPicsUrl(key: string) {
+export function getImageKitUrl(key: string) {
   return new URL(key, config.get("s3.publicImageBaseUrl")).href;
 }
 
@@ -49,7 +49,7 @@ export async function getPublicImageFileUrl(file: FileModel) {
   if (config.get("s3.publicImageBaseUrl")) {
     const pixels = getPixelsInFile(file);
     if (pixels !== null && pixels < IMAGEKIT_PIXELS_LIMIT) {
-      return getTwicPicsUrl(file.key);
+      return getImageKitUrl(file.key);
     }
   }
 


### PR DESCRIPTION
`getTwicPicsUrl` was named after TwicPics, but Argos serves images through ImageKit. The name was the last thing still pointing at the old provider:

- `IMAGEKIT_PIXELS_LIMIT` — the constant directly above it in the same file
- `ImageKitPicture` — the frontend helper, using ImageKit's `?tr=` transformation syntax
- `checkIsImageKitUrl` — matches on `files.argos-ci.com`

Renamed to `getImageKitUrl` rather than a provider-neutral `getCdnUrl` to stay consistent with those three, which all name ImageKit explicitly.

Call sites updated: `graphql/definitions/ScreenshotDiff.ts`, `api/schema/primitives/snapshot-diff.ts`, `slack/unfurl.ts`. The three barrel imports were re-alphabetized, since oxfmt sorts import statements but not named members.

Pure rename, no behaviour change — `git grep getTwicPicsUrl` is now empty.

## Verification

- `pnpm run static-checks` — 18/18 tasks passing
- `pnpm test:unit` — 577 tests across 63 files passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)