### PR TITLE
fix(frontend): don't assume requestIdleCallback exists

### DIFF
--- a/apps/frontend/src/containers/RoutePreloader.tsx
+++ b/apps/frontend/src/containers/RoutePreloader.tsx
@@ -30,6 +30,36 @@ const started = new WeakSet<RouteObject>();
 const HOVER_INTENT_DELAY = 65;
 
 /**
+ * How long a visible link waits before being preloaded anyway, idle or not.
+ */
+const IDLE_TIMEOUT = 2000;
+
+/**
+ * Safari still doesn't ship `requestIdleCallback` — it exists only behind a
+ * preference in Technology Preview — so it can't be called unguarded. Without
+ * it, fall back to waiting out the same deadline the idle version is given:
+ * there is no idle signal to time against, and this is the opportunistic half
+ * of the preloader anyway — the intent signals below still fire immediately and
+ * cover the click that matters.
+ */
+const supportsIdleCallback = typeof window.requestIdleCallback === "function";
+
+function requestIdle(callback: () => void): number {
+  return supportsIdleCallback
+    ? window.requestIdleCallback(callback, { timeout: IDLE_TIMEOUT })
+    : window.setTimeout(callback, IDLE_TIMEOUT);
+}
+
+/** Cancels a handle returned by {@link requestIdle}. */
+function cancelIdle(handle: number): void {
+  if (supportsIdleCallback) {
+    window.cancelIdleCallback(handle);
+  } else {
+    window.clearTimeout(handle);
+  }
+}
+
+/**
  * Preloading spends bandwidth on a guess, which is the wrong trade on a metered
  * or slow connection.
  */
@@ -153,7 +183,7 @@ export function RoutePreloader() {
 
     const scheduleFlush = () => {
       if (idleHandle === undefined && visible.size > 0) {
-        idleHandle = requestIdleCallback(flushVisible, { timeout: 2000 });
+        idleHandle = requestIdle(flushVisible);
       }
     };
 
@@ -195,7 +225,7 @@ export function RoutePreloader() {
     return () => {
       clearHoverTimeout();
       if (idleHandle !== undefined) {
-        cancelIdleCallback(idleHandle);
+        cancelIdle(idleHandle);
       }
       document.removeEventListener("pointerover", handlePointerOver);
       document.removeEventListener("pointerout", clearHoverTimeout);


### PR DESCRIPTION
Follow-up to #2446.

`RoutePreloader` called `requestIdleCallback` / `cancelIdleCallback` unguarded. Safari doesn't implement them — [MDN's compat data](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback) has them behind a preference in Technology Preview only, on desktop and iOS alike, which is why the feature is flagged "Limited availability" rather than Baseline.

So on every Safari visit, `scheduleFlush()` threw a `ReferenceError` inside the `IntersectionObserver` callback: the entries were already unobserved by then, so the visible links were dropped instead of preloaded, and each batch surfaced an uncaught error. The visibility signal was simply dead there.

## Fix

Feature-detect once, and fall back to a plain `setTimeout` on the same 2s deadline the idle callback was already given. With no idle signal to time against there is nothing better to wait for, and this is the opportunistic half of the preloader — the intent signals (hover, focus, touch) fire immediately and were never affected.

`cancelIdle` branches on the same flag, so the handle is always released by the API that created it.

Chromium and Firefox keep the exact previous behaviour.

## Checks

`check-types`, `check-format` and `lint` pass. `knip` fails identically on a clean checkout of this branch point (it flags every migration plus `pg`), so it's unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)