### PR TITLE
fix(frontend): stop relative dates from ticking every second

### DIFF
--- a/packages/util/src/date-format.test.ts
+++ b/packages/util/src/date-format.test.ts
@@ -57,14 +57,15 @@ describe("#formatRelativeDate", () => {
   const ahead = (ms: number) =>
     formatRelativeDate(new Date(now.getTime() + ms), { now });
 
-  it("describes the recent past", () => {
-    expect(ago(0)).toBe("now");
-    expect(ago(3_000)).toBe("3 seconds ago");
-    expect(ago(44_000)).toBe("44 seconds ago");
+  it("keeps the whole seconds bucket vague, so it does not tick", () => {
+    expect(ago(0)).toBe("a few seconds ago");
+    expect(ago(3_000)).toBe("a few seconds ago");
+    expect(ago(44_000)).toBe("a few seconds ago");
+    expect(ahead(3_000)).toBe("in a few seconds");
   });
 
   it("promotes to minutes past the seconds threshold", () => {
-    expect(ago(45_000)).toBe("1 minute ago");
+    expect(ago(45_000)).toBe("a minute ago");
     expect(ago(30 * 60_000)).toBe("30 minutes ago");
   });
 
@@ -74,8 +75,14 @@ describe("#formatRelativeDate", () => {
   });
 
   it("promotes to hours past the minutes threshold", () => {
-    expect(ago(45 * 60_000)).toBe("1 hour ago");
+    expect(ago(45 * 60_000)).toBe("an hour ago");
     expect(ago(5 * 3_600_000)).toBe("5 hours ago");
+  });
+
+  it("spells a lone unit out, but keeps larger counts numeric", () => {
+    expect(ahead(60_000)).toBe("in a minute");
+    expect(ahead(3_600_000)).toBe("in an hour");
+    expect(ago(2 * 3_600_000)).toBe("2 hours ago");
   });
 
   it("promotes to days past the hours threshold", () => {
@@ -91,7 +98,6 @@ describe("#formatRelativeDate", () => {
   });
 
   it("describes the future", () => {
-    expect(ahead(3_000)).toBe("in 3 seconds");
     expect(ahead(5 * 3_600_000)).toBe("in 5 hours");
     expect(ahead(3 * 86_400_000)).toBe("in 3 days");
   });
@@ -105,8 +111,17 @@ describe("#formatRelativeDate", () => {
     ).toBe("il y a 3 jours");
   });
 
+  it("falls back to the numeric wording for a locale without vague phrasing", () => {
+    expect(
+      formatRelativeDate(new Date(now.getTime() - 3_000), {
+        now,
+        locale: "fr-FR",
+      }),
+    ).toBe("il y a 3 secondes");
+  });
+
   it("defaults to comparing against the current time", () => {
-    expect(formatRelativeDate(new Date())).toBe("now");
+    expect(formatRelativeDate(new Date())).toBe("a few seconds ago");
   });
 });
 

--- a/packages/util/src/date-format.ts
+++ b/packages/util/src/date-format.ts
@@ -109,6 +109,45 @@ const RELATIVE_UNITS: readonly {
   { unit: "year", ms: MS_PER_YEAR, max: Number.POSITIVE_INFINITY },
 ];
 
+type VaguePhrasing = { past: string; future: string };
+
+/**
+ * Wording that stands in for a count. `Intl.RelativeTimeFormat` always emits
+ * one, and a count of seconds changes every second — enough to reflow whatever
+ * sits next to it. The whole seconds bucket therefore reads as one steady
+ * phrase, and a lone minute or hour matches that register. Bigger units already
+ * get idiomatic wording from `numeric: "auto"` ("yesterday", "last month").
+ *
+ * Keyed by language, since the phrases are not something `Intl` can derive.
+ * Languages missing from the table keep the numeric wording.
+ */
+const VAGUE_PHRASINGS: Record<
+  string,
+  Partial<Record<Intl.RelativeTimeFormatUnit, VaguePhrasing>>
+> = {
+  en: {
+    second: { past: "a few seconds ago", future: "in a few seconds" },
+    minute: { past: "a minute ago", future: "in a minute" },
+    hour: { past: "an hour ago", future: "in an hour" },
+  },
+};
+
+/**
+ * Vague wording for `value` `unit`s, or `null` when the count should be shown.
+ * Everything below a minute is vague; past that, only a lone unit is, so
+ * "5 minutes ago" keeps its number.
+ */
+function getVaguePhrasing(
+  locale: string,
+  unit: Intl.RelativeTimeFormatUnit,
+  value: number,
+): VaguePhrasing | null {
+  if (unit !== "second" && Math.abs(value) !== 1) {
+    return null;
+  }
+  return VAGUE_PHRASINGS[new Intl.Locale(locale).language]?.[unit] ?? null;
+}
+
 const relativeTimeFormatters = new Map<string, Intl.RelativeTimeFormat>();
 
 function getRelativeTimeFormatter(locale: string) {
@@ -124,7 +163,8 @@ function getRelativeTimeFormatter(locale: string) {
 }
 
 /**
- * Describe `date` relative to now — "3 minutes ago", "yesterday", "in 2 months".
+ * Describe `date` relative to now — "a few seconds ago", "3 minutes ago",
+ * "yesterday", "in 2 months".
  */
 export function formatRelativeDate(
   date: Date,
@@ -144,6 +184,10 @@ export function formatRelativeDate(
       // value: `Math.round` breaks ties towards +Infinity, which would make a
       // 90-second gap read as "1 minute ago" but "in 2 minutes".
       const value = Math.round(magnitude / ms) * Math.sign(elapsed);
+      const vague = getVaguePhrasing(locale, unit, value);
+      if (vague) {
+        return elapsed > 0 ? vague.future : vague.past;
+      }
       return formatter.format(value, unit);
     }
   }


### PR DESCRIPTION
## What

`formatRelativeDate` now returns vague wording for the buckets that would otherwise churn:

| elapsed | before | after |
|---|---|---|
| 0–44s | `now`, `3 seconds ago`, `26 seconds ago`… | `a few seconds ago` |
| 45s–89s | `1 minute ago` | `a minute ago` |
| 2–44 min | `30 minutes ago` | unchanged |
| ~1 hour | `1 hour ago` | `an hour ago` |
| 2h+ | `5 hours ago`, `yesterday`, `last month`… | unchanged |

## Why

A freshly posted comment rendered "26 seconds ago" and the count changed once a second, reflowing everything laid out next to it. Collapsing the whole seconds bucket to one phrase keeps the text still; spelling out a lone minute or hour matches that register.

## Notes for reviewers

- `Intl.RelativeTimeFormat` always emits a count, so the phrases can't come from `Intl`. They live in a small table keyed by language in `packages/util/src/date-format.ts`. English is the only entry (the app pins `en-US`); any other locale falls through to the numeric wording, so the existing `fr-FR` behaviour is unchanged — there's a test covering that fallback.
- `<Time>` needed no change: its 1s tick now computes the same string, and React bails out of the re-render.
- `knip` fails on this branch (`pg` unused dependency + migrations), but it fails the same way on a stashed tree — pre-existing and unrelated. `check-types`, `check-format`, `lint` and the 24 `date-format` tests are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)