### PR TITLE
Agent discovery: MCP server card + well-known documents on the app origin

### DIFF
--- a/apps/backend/src/mcp/README.md
+++ b/apps/backend/src/mcp/README.md
@@ -59,6 +59,17 @@ No operation needs it by default — eligibility is computed from `security`.
   (`assertOAuthScopes`); scope failures come back as `isError` tool results,
   not HTTP 401s, so clients don't needlessly re-authenticate.
 
+## Discovery
+
+`GET /.well-known/mcp/server-card.json` on the MCP origin serves the canonical
+[SEP-1649 Server Card](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127)
+(`server-card.ts`): endpoint, transport and OAuth entry point for
+pre-connection discovery. Its `serverInfo` is the same `MCP_SERVER_INFO`
+object the server hands to the SDK, and the e2e test checks the card against a
+live `initialize` response, so the card cannot drift from the running server.
+The marketing site serves a copy at
+`argos-ci.com/.well-known/mcp/server-card.json`.
+
 ## Local development
 
 The `mcp` subdomain must resolve to the backend (like `api` and `app`):

--- a/apps/backend/src/mcp/mcp.e2e.test.ts
+++ b/apps/backend/src/mcp/mcp.e2e.test.ts
@@ -37,6 +37,8 @@ type RpcResponse = {
     content?: { type: string; text: string }[];
     structuredContent?: Record<string, unknown>;
     isError?: boolean;
+    serverInfo?: Record<string, unknown>;
+    capabilities?: Record<string, unknown>;
   };
   error?: { code: number; message: string };
 };
@@ -154,6 +156,35 @@ describe("MCP server", () => {
       .expect(200);
     expect(res.body.resource).toBe(getMcpResourceUrl());
     expect(res.body.authorization_servers).toHaveLength(1);
+  });
+
+  test("serves a server card consistent with the live initialize response", async ({
+    patToken,
+  }) => {
+    const cardRes = await request(app)
+      .get("/.well-known/mcp/server-card.json")
+      .expect(200);
+    const card = cardRes.body;
+    expect(card.endpoint).toBe(getMcpResourceUrl());
+    expect(card.transport).toEqual({
+      type: "streamable-http",
+      endpoint: getMcpResourceUrl(),
+    });
+    expect(card.remotes[0].authentication).toEqual({
+      type: "oauth2",
+      resourceMetadata: `${getMcpResourceUrl()}/.well-known/oauth-protected-resource`,
+    });
+    // The card is advisory (SEP-1649): what it declares must match what the
+    // server actually reports during the MCP handshake.
+    const res = await rpc(patToken, "initialize", {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "test-client", version: "0.0.0" },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as RpcResponse;
+    expect(card.serverInfo).toEqual(body.result!.serverInfo);
+    expect(card.capabilities).toEqual(body.result!.capabilities);
   });
 
   test("mirrors the authorization server metadata for legacy MCP clients", async () => {

--- a/apps/backend/src/mcp/router.ts
+++ b/apps/backend/src/mcp/router.ts
@@ -6,6 +6,8 @@
  * - `GET /` — humans and non-MCP clients are redirected to the documentation.
  * - `GET /.well-known/oauth-protected-resource` — RFC 9728 metadata pointing
  *   MCP clients at the Authorization Server (the OAuth discovery handshake).
+ * - `GET /.well-known/mcp/server-card.json` — SEP-1649 Server Card for
+ *   pre-connection discovery.
  *
  * Requests are authenticated with a personal access token or an OAuth access
  * token. Unauthenticated requests get a `401` with a `WWW-Authenticate` header
@@ -33,8 +35,7 @@ import { createRedisStore } from "@/util/rate-limit";
 
 import { asyncHandler } from "../web/util";
 import { createMcpServer } from "./server";
-
-const MCP_DOCS_URL = "https://argos-ci.com/docs/agents/mcp-server";
+import { getServerCard, MCP_DOCS_URL } from "./server-card";
 
 const router: Router = Router();
 
@@ -64,6 +65,12 @@ router.get("/.well-known/oauth-protected-resource", (_req, res) => {
 // following the Protected Resource Metadata to the AS.
 router.get("/.well-known/oauth-authorization-server", (_req, res) => {
   res.json(getAuthorizationServerMetadata());
+});
+
+// SEP-1649 MCP Server Card: pre-connection discovery of the endpoint,
+// transport and OAuth entry point.
+router.get("/.well-known/mcp/server-card.json", (_req, res) => {
+  res.json(getServerCard());
 });
 
 // Humans and non-MCP clients land here (the MCP protocol only POSTs).

--- a/apps/backend/src/mcp/server-card.ts
+++ b/apps/backend/src/mcp/server-card.ts
@@ -1,0 +1,64 @@
+/**
+ * MCP Server Card (SEP-1649): a static discovery document served at
+ * `/.well-known/mcp/server-card.json` on the MCP origin, letting clients find
+ * the endpoint, transport and OAuth entry point before connecting.
+ *
+ * The card format is still being standardized
+ * (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127), so
+ * the document carries both the SEP-1649 fields (`serverInfo`, `endpoint`,
+ * `transport`, `capabilities`) and the MCP registry `server.json` style fields
+ * (`name`, `remotes`). This is the canonical card: the marketing site serves a
+ * copy at `argos-ci.com/.well-known/mcp/server-card.json`.
+ *
+ * `serverInfo` is the very object the server hands to the SDK, and the e2e
+ * test pins `serverInfo` and `capabilities` to a live `initialize` response,
+ * so the card cannot drift from runtime behavior.
+ */
+import {
+  getMcpProtectedResourceMetadataUrl,
+  getMcpResourceUrl,
+} from "@/oauth/metadata";
+
+import { MCP_SERVER_INFO } from "./server";
+
+export const MCP_DOCS_URL = "https://argos-ci.com/docs/agents/mcp-server";
+
+export function getServerCard() {
+  const endpoint = getMcpResourceUrl();
+  return {
+    name: `com.argos-ci/${MCP_SERVER_INFO.name}`,
+    title: MCP_SERVER_INFO.title,
+    description:
+      "Official MCP server for Argos, the visual testing platform. Exposes the Argos REST API as tools: inspect builds and screenshot diffs, approve or reject reviews, manage teams, projects, and automations.",
+    version: MCP_SERVER_INFO.version,
+    websiteUrl: "https://argos-ci.com",
+    documentationUrl: MCP_DOCS_URL,
+    repository: {
+      url: "https://github.com/argos-ci/argos",
+      source: "github",
+    },
+    serverInfo: MCP_SERVER_INFO,
+    endpoint,
+    transport: {
+      type: "streamable-http",
+      endpoint,
+    },
+    remotes: [
+      {
+        type: "streamable-http",
+        url: endpoint,
+        authentication: {
+          type: "oauth2",
+          resourceMetadata: getMcpProtectedResourceMetadataUrl(),
+        },
+      },
+    ],
+    // What `initialize` actually reports: the SDK declares `listChanged` for
+    // registered tools and resources (even though the stateless transport
+    // never delivers change notifications).
+    capabilities: {
+      tools: { listChanged: true },
+      resources: { listChanged: true },
+    },
+  };
+}

--- a/apps/backend/src/mcp/server.ts
+++ b/apps/backend/src/mcp/server.ts
@@ -25,14 +25,24 @@ Call "getMe" first: it returns the authenticated user and the accounts (personal
 Projects are identified by an "owner" (account slug) and a "project" (project name), as in the URL https://app.argos-ci.com/{owner}/{project}. Builds are identified by their per-project "buildNumber". List endpoints are paginated with "page" and "perPage" arguments.`;
 
 /**
+ * The implementation info the server reports on `initialize`. Also embedded in
+ * the Server Card (`server-card.ts`) as its `serverInfo`, so the discovery
+ * document can never disagree with the running server.
+ */
+export const MCP_SERVER_INFO = {
+  name: "argos",
+  title: "Argos",
+  version: "2.0.0",
+} as const;
+
+/**
  * Create an MCP server bound to the caller's authorization. One instance per
  * request (the transport is stateless).
  */
 export function createMcpServer(context: { authorization: string }): McpServer {
-  const server = new McpServer(
-    { name: "argos", title: "Argos", version: "2.0.0" },
-    { instructions: MCP_INSTRUCTIONS },
-  );
+  const server = new McpServer(MCP_SERVER_INFO, {
+    instructions: MCP_INSTRUCTIONS,
+  });
 
   for (const tool of mcpTools) {
     server.registerTool(

--- a/apps/backend/src/web/agent-discovery.test.ts
+++ b/apps/backend/src/web/agent-discovery.test.ts
@@ -1,0 +1,55 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getServerCard } from "@/mcp/server-card";
+import {
+  getApiResourceUrl,
+  getMcpResourceUrl,
+  getProtectedResourceMetadata,
+} from "@/oauth/metadata";
+
+import { installAgentDiscoveryRoutes } from "./agent-discovery";
+
+describe("agent discovery routes", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    const router = express.Router();
+    installAgentDiscoveryRoutes(router);
+    app.use(router);
+  });
+
+  it("serves the API catalog as a linkset", async () => {
+    const res = await request(app).get("/.well-known/api-catalog").expect(200);
+    expect(res.headers["content-type"]).toContain("application/linkset+json");
+    expect(res.headers["access-control-allow-origin"]).toBe("*");
+    const anchors = res.body.linkset.map(
+      (entry: { anchor: string }) => entry.anchor,
+    );
+    expect(anchors).toEqual([getApiResourceUrl(), getMcpResourceUrl()]);
+    const [api] = res.body.linkset;
+    expect(api["service-desc"]).toEqual([
+      { href: `${getApiResourceUrl()}/openapi.yaml`, type: "application/yaml" },
+    ]);
+    // The health endpoint lives at the API origin root, not under /v2.
+    expect(api.status[0].href).toBe(
+      new URL("/status", getApiResourceUrl()).toString(),
+    );
+  });
+
+  it("serves the REST API protected resource metadata", async () => {
+    const res = await request(app)
+      .get("/.well-known/oauth-protected-resource")
+      .expect(200);
+    expect(res.body).toEqual(getProtectedResourceMetadata());
+  });
+
+  it("serves the MCP server card", async () => {
+    const res = await request(app)
+      .get("/.well-known/mcp/server-card.json")
+      .expect(200);
+    expect(res.body).toEqual(getServerCard());
+  });
+});

--- a/apps/backend/src/web/agent-discovery.ts
+++ b/apps/backend/src/web/agent-discovery.ts
@@ -1,0 +1,92 @@
+/**
+ * Agent-discovery documents on the app origin. `argos-ci.com` redirects
+ * `/.well-known/*` here, so these are the documents agents find when they
+ * probe the marketing domain:
+ *
+ * - `/.well-known/api-catalog` (RFC 9727): a linkset (RFC 9264) of the Argos
+ *   APIs — the REST API and the MCP server — with their OpenAPI description,
+ *   documentation, status and OAuth metadata.
+ * - `/.well-known/oauth-protected-resource` (RFC 9728): the REST API's
+ *   Protected Resource Metadata (the API origin serves the canonical copy).
+ * - `/.well-known/mcp/server-card.json` (SEP-1649): the MCP Server Card (the
+ *   MCP origin serves the canonical copy).
+ *
+ * Everything is derived from config and the shared oauth/mcp modules, so the
+ * documents cannot disagree with the servers they describe. Mounted on the app
+ * subdomain BEFORE the SPA static handler and catch-all.
+ */
+import cors from "cors";
+import { Router } from "express";
+
+import { getServerCard, MCP_DOCS_URL } from "@/mcp/server-card";
+import {
+  getApiResourceUrl,
+  getMcpProtectedResourceMetadataUrl,
+  getMcpResourceUrl,
+  getProtectedResourceMetadata,
+  getProtectedResourceMetadataUrl,
+} from "@/oauth/metadata";
+
+const API_DOCS_URL = "https://argos-ci.com/docs/api-reference";
+
+/** RFC 9727 API catalog, as an RFC 9264 linkset. */
+function getApiCatalog() {
+  const apiUrl = getApiResourceUrl();
+  const mcpUrl = getMcpResourceUrl();
+  // The API health endpoint lives at the origin root, not under /v2.
+  const statusUrl = new URL("/status", apiUrl).toString();
+  return {
+    linkset: [
+      {
+        anchor: apiUrl,
+        "service-desc": [
+          { href: `${apiUrl}/openapi.yaml`, type: "application/yaml" },
+        ],
+        "service-doc": [{ href: API_DOCS_URL, type: "text/html" }],
+        "service-meta": [
+          { href: getProtectedResourceMetadataUrl(), type: "application/json" },
+        ],
+        status: [{ href: statusUrl }],
+      },
+      {
+        anchor: mcpUrl,
+        "service-doc": [{ href: MCP_DOCS_URL, type: "text/html" }],
+        "service-meta": [
+          {
+            href: `${mcpUrl}/.well-known/mcp/server-card.json`,
+            type: "application/json",
+          },
+          {
+            href: getMcpProtectedResourceMetadataUrl(),
+            type: "application/json",
+          },
+        ],
+        status: [{ href: statusUrl }],
+      },
+    ],
+  };
+}
+
+export function installAgentDiscoveryRoutes(router: Router): void {
+  const wellKnown = Router();
+
+  wellKnown.use(cors({ origin: "*" }));
+
+  wellKnown.get("/api-catalog", (_req, res) => {
+    res.setHeader("Cache-Control", "public, max-age=3600");
+    res.type("application/linkset+json");
+    res.json(getApiCatalog());
+  });
+
+  wellKnown.get("/oauth-protected-resource", (_req, res) => {
+    res.setHeader("Cache-Control", "public, max-age=3600");
+    res.json(getProtectedResourceMetadata());
+  });
+
+  wellKnown.get("/mcp/server-card.json", (_req, res) => {
+    res.setHeader("Cache-Control", "public, max-age=3600");
+    res.json(getServerCard());
+  });
+
+  router.use("/.well-known", wellKnown);
+}

--- a/apps/backend/src/web/app-router.ts
+++ b/apps/backend/src/web/app-router.ts
@@ -22,6 +22,7 @@ import { createRedisStore } from "@/util/rate-limit";
 
 import { getEmailPreviewMiddleware } from "../email/express";
 import { getNotificationPreviewMiddleware } from "../notification/express";
+import { installAgentDiscoveryRoutes } from "./agent-discovery";
 import samlAuthRouter from "./auth-saml";
 import deploymentAccessRouter from "./deployment-access";
 import { requireCsrf } from "./middlewares/csrf";
@@ -225,6 +226,10 @@ export const installAppRouter = async (app: express.Application) => {
   // before the static handler and SPA catch-all so `/.well-known/agent-skills/*`
   // returns the index / repo redirects instead of the SPA shell.
   installSkillsRoutes(router);
+
+  // Agent-discovery documents (API catalog, protected resource metadata, MCP
+  // server card) — `argos-ci.com` redirects `/.well-known/*` here.
+  installAgentDiscoveryRoutes(router);
 
   router.use(getSlackMiddleware());
 


### PR DESCRIPTION
Companion to [argos-ci.com#348](https://github.com/argos-ci/argos-ci.com/pull/348): the marketing site keeps redirecting `/.well-known/*` to app.argos-ci.com, and the backend now answers those URLs. One commit per subject.

## feat(mcp): serve the SEP-1649 server card on the MCP origin

`GET https://mcp.argos-ci.com/.well-known/mcp/server-card.json` describes the server for pre-connection discovery ([SEP-1649](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127)): endpoint, streamable-http transport, OAuth entry point. `serverInfo` is the same `MCP_SERVER_INFO` object handed to the SDK, and the e2e test pins `serverInfo` and `capabilities` to a live `initialize` response, so the card cannot drift from the running server. (Carried over from the parallel session that drafted it — it had not been committed.)

## feat(backend): serve agent-discovery documents on the app origin

app.argos-ci.com (where `argos-ci.com/.well-known/*` lands) now serves:

- `/.well-known/api-catalog` (RFC 9727, `application/linkset+json`) — the REST API and the MCP server, with OpenAPI description (`/v2/openapi.yaml`), docs, `/status` health endpoint, and OAuth metadata links.
- `/.well-known/oauth-protected-resource` (RFC 9728) — the REST API's metadata via the existing `getProtectedResourceMetadata()` (canonical copy stays on the api origin).
- `/.well-known/mcp/server-card.json` — the same `getServerCard()` document (canonical copy on the mcp origin).

Mounted like the agent-skills routes: on the app subdomain before the static handler and SPA catch-all, CORS-open, cacheable for an hour. Everything is derived from config and the shared oauth/mcp modules — no hardcoded origins.

## Test plan

- `pnpm test:unit src/web/agent-discovery.test.ts` — 3/3 (content type, CORS, linkset anchors/links, PRM and card equality with their source functions).
- `pnpm test:integration src/mcp/mcp.e2e.test.ts` — 18/18, including the new card-vs-`initialize` consistency test.
- `pnpm run static-checks` green (check-types, check-format, lint, knip).

## Deploy notes

- The `/.well-known/*` redirect already live on argos-ci.com makes these documents reachable from the marketing domain as soon as this deploys — no ordering constraint with argos-ci.com#348.
- The `agent_auth` block in the authorization server metadata is a separate in-flight branch (`greg/oauth-agent-auth`) and intentionally not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)