### PR TITLE
Auth.md: agent_auth metadata and /auth.md on the app origin

### DIFF
--- a/apps/backend/src/oauth/auth-md.ts
+++ b/apps/backend/src/oauth/auth-md.ts
@@ -1,0 +1,118 @@
+//
+// `/auth.md` (https://workos.com/auth-md): the procedural recipe an agent
+// follows to get credentials for Argos — discover, register, claim, exchange,
+// use, revoke.
+//
+// It is the document the `agent_auth.skill` field of the Authorization Server
+// metadata points at, and it is generated from the very same metadata and
+// scope catalog the server enforces, so the instructions cannot drift from the
+// endpoints. Served on the app origin; `argos-ci.com/auth.md` proxies it.
+//
+import {
+  getApiResourceUrl,
+  getAuthorizationServerMetadata,
+  getMcpResourceUrl,
+  getProtectedResourceMetadataUrl,
+} from "./metadata";
+import { OAUTH_SCOPES, OAUTH_SCOPE_LIST } from "./scopes";
+
+const API_DOCS_URL = "https://argos-ci.com/docs/api-reference";
+const MCP_DOCS_URL = "https://argos-ci.com/docs/agents/mcp-server";
+
+export function getAuthMd(): string {
+  const meta = getAuthorizationServerMetadata();
+  const apiUrl = getApiResourceUrl();
+  const mcpUrl = getMcpResourceUrl();
+  const scopeLines = OAUTH_SCOPE_LIST.map(
+    (scope) => `- \`${scope}\` — ${OAUTH_SCOPES[scope].description}`,
+  ).join("\n");
+
+  return `# Argos auth.md
+
+How AI agents and automated clients authenticate to [Argos](https://argos-ci.com),
+the visual testing platform.
+
+## Who this is for
+
+Agents calling the [Argos REST API](${API_DOCS_URL}) (\`${apiUrl}\`) or
+connecting to the [Argos MCP server](${MCP_DOCS_URL}) (\`${mcpUrl}\`). Both
+accept the same bearer tokens, issued by the Argos authorization server at
+\`${meta.issuer}\`.
+
+Argos accounts belong to people: an agent always acts on behalf of a user who
+signs in and grants it access. Registration is open to anonymous agents, and
+the resulting client can do nothing until a user claims it by granting consent.
+
+## 1. Discover
+
+- Authorization server metadata (RFC 8414): \`${meta.issuer}/.well-known/oauth-authorization-server\`
+- Protected resource metadata (RFC 9728): \`${getProtectedResourceMetadataUrl()}\` and \`${mcpUrl}/.well-known/oauth-protected-resource\`
+- API catalog (RFC 9727): \`https://argos-ci.com/.well-known/api-catalog\`
+- MCP server card: \`${mcpUrl}/.well-known/mcp/server-card.json\`
+
+## 2. Register
+
+\`POST ${meta.registration_endpoint}\` with your client metadata (RFC 7591
+dynamic client registration). No credentials or pre-existing identity are
+required. The response carries your \`client_id\`.
+
+\`\`\`http
+POST ${new URL(meta.registration_endpoint).pathname} HTTP/1.1
+Host: ${new URL(meta.issuer).host}
+Content-Type: application/json
+
+{
+  "client_name": "My Agent",
+  "redirect_uris": ["http://127.0.0.1:8976/callback"],
+  "grant_types": ["authorization_code", "refresh_token"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "none"
+}
+\`\`\`
+
+## 3. Claim
+
+Send the user to \`${meta.authorization_endpoint}\` to run the authorization
+code flow with PKCE (\`S256\`). They sign in, choose which organizations to
+share, and grant scopes. This is what turns an anonymous registration into an
+authorized client.
+
+## 4. Exchange
+
+\`POST ${meta.token_endpoint}\` with the authorization code and your PKCE
+verifier to receive an \`access_token\` and a \`refresh_token\`. Refresh tokens
+are supported; use them rather than sending the user through consent again.
+
+## 5. Use
+
+Send the token as a bearer credential:
+
+\`\`\`http
+Authorization: Bearer <access_token>
+\`\`\`
+
+### Scopes
+
+${scopeLines}
+
+Scopes only ever narrow what the authenticating user is already allowed to do —
+they never widen it.
+
+## 6. Revoke
+
+- Revoke a token at \`${meta.revocation_endpoint}\` (RFC 7009).
+- Users revoke an agent's access at any time from **Authorized applications**
+  in their Argos settings. Treat a \`401\` as "re-run the flow from step 3".
+
+## Alternative: personal access token
+
+Where OAuth is impractical, a user can create a personal access token in their
+Argos settings and hand it to the agent. It is used the same way (step 5). See
+the [API reference](${API_DOCS_URL}).
+
+## Support
+
+Rate limits are documented in the [API reference](${API_DOCS_URL}).
+Questions: contact@argos-ci.com or https://argos-ci.com/discord.
+`;
+}

--- a/apps/backend/src/oauth/metadata.ts
+++ b/apps/backend/src/oauth/metadata.ts
@@ -79,6 +79,23 @@ export function getAuthorizationServerMetadata() {
       "client_secret_post",
     ],
     service_documentation: "https://argos-ci.com/docs/api-reference",
+    // Auth.md (https://workos.com/auth-md) agent-registration discovery. The
+    // `skill` document is the recipe agents actually follow — keep it in sync
+    // with these endpoints (it lives in the argos-ci.com repo). Argos maps to
+    // the profile's "anonymous" registration method: `register_uri` (RFC 7591
+    // dynamic client registration) is open to anonymous agents, and the
+    // registered client holds no credentials until a user claims it by
+    // granting consent at `claim_uri` (authorization code + PKCE).
+    agent_auth: {
+      skill: "https://argos-ci.com/auth.md",
+      register_uri: `${issuer}/oauth/register`,
+      identity_types_supported: ["anonymous"],
+      anonymous: {
+        credential_types_supported: ["access_token", "refresh_token"],
+      },
+      claim_uri: `${issuer}/oauth/authorize`,
+      revocation_uri: `${issuer}/oauth/revoke`,
+    },
   };
 }
 

--- a/apps/backend/src/oauth/oauth.test.ts
+++ b/apps/backend/src/oauth/oauth.test.ts
@@ -158,6 +158,21 @@ describe("metadata", () => {
     expect(meta.scopes_supported).toEqual(OAUTH_SCOPE_LIST);
   });
 
+  it("advertises the Auth.md agent-registration surface", () => {
+    const meta = getAuthorizationServerMetadata();
+    expect(meta.agent_auth.skill).toBe("https://argos-ci.com/auth.md");
+    // The agent_auth URLs are aliases of the standard endpoints — they must
+    // never drift apart.
+    expect(meta.agent_auth.register_uri).toBe(meta.registration_endpoint);
+    expect(meta.agent_auth.claim_uri).toBe(meta.authorization_endpoint);
+    expect(meta.agent_auth.revocation_uri).toBe(meta.revocation_endpoint);
+    expect(meta.agent_auth.identity_types_supported).toEqual(["anonymous"]);
+    expect(meta.agent_auth.anonymous.credential_types_supported).toEqual([
+      "access_token",
+      "refresh_token",
+    ]);
+  });
+
   it("exposes RFC 9728 protected resource metadata pointing at the AS", () => {
     const prm = getProtectedResourceMetadata();
     const as = getAuthorizationServerMetadata();

--- a/apps/backend/src/web/agent-discovery.test.ts
+++ b/apps/backend/src/web/agent-discovery.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { getServerCard } from "@/mcp/server-card";
 import {
   getApiResourceUrl,
+  getAuthorizationServerMetadata,
   getMcpResourceUrl,
   getProtectedResourceMetadata,
 } from "@/oauth/metadata";
@@ -51,5 +52,31 @@ describe("agent discovery routes", () => {
       .get("/.well-known/mcp/server-card.json")
       .expect(200);
     expect(res.body).toEqual(getServerCard());
+  });
+
+  describe("auth.md", () => {
+    it("serves markdown with the heading scanners look for", async () => {
+      const res = await request(app).get("/auth.md").expect(200);
+      expect(res.headers["content-type"]).toContain("text/markdown");
+      expect(res.headers["access-control-allow-origin"]).toBe("*");
+      expect(res.text.split("\n")[0]).toBe("# Argos auth.md");
+    });
+
+    it("documents the endpoints the authorization server actually advertises", async () => {
+      const res = await request(app).get("/auth.md").expect(200);
+      const meta = getAuthorizationServerMetadata();
+      // The recipe is worthless if it names endpoints the server doesn't serve.
+      for (const endpoint of [
+        meta.registration_endpoint,
+        meta.authorization_endpoint,
+        meta.token_endpoint,
+        meta.revocation_endpoint,
+      ]) {
+        expect(res.text).toContain(endpoint);
+      }
+      for (const scope of meta.scopes_supported) {
+        expect(res.text).toContain(`\`${scope}\``);
+      }
+    });
   });
 });

--- a/apps/backend/src/web/agent-discovery.ts
+++ b/apps/backend/src/web/agent-discovery.ts
@@ -10,6 +10,8 @@
  *   Protected Resource Metadata (the API origin serves the canonical copy).
  * - `/.well-known/mcp/server-card.json` (SEP-1649): the MCP Server Card (the
  *   MCP origin serves the canonical copy).
+ * - `/auth.md`: the agent-registration recipe (`argos-ci.com/auth.md` proxies
+ *   it), pointed at by `agent_auth.skill` in the authorization server metadata.
  *
  * Everything is derived from config and the shared oauth/mcp modules, so the
  * documents cannot disagree with the servers they describe. Mounted on the app
@@ -19,6 +21,7 @@ import cors from "cors";
 import { Router } from "express";
 
 import { getServerCard, MCP_DOCS_URL } from "@/mcp/server-card";
+import { getAuthMd } from "@/oauth/auth-md";
 import {
   getApiResourceUrl,
   getMcpProtectedResourceMetadataUrl,
@@ -89,4 +92,12 @@ export function installAgentDiscoveryRoutes(router: Router): void {
   });
 
   router.use("/.well-known", wellKnown);
+
+  // Auth.md: the registration recipe `agent_auth.skill` points at.
+  // `argos-ci.com/auth.md` proxies this document.
+  router.get("/auth.md", cors({ origin: "*" }), (_req, res) => {
+    res.setHeader("Cache-Control", "public, max-age=3600");
+    res.type("text/markdown");
+    res.send(getAuthMd());
+  });
 }


### PR DESCRIPTION
Follow-up to #2449, closing the `authMd` gap an [isitagentready.com](https://isitagentready.com) scan reports: *"auth.md exists but agent_auth metadata was not found."* Companion PR on the site: [argos-ci.com#350](https://github.com/argos-ci/argos-ci.com/pull/350). One commit per subject.

## feat(oauth): advertise agent registration with an `agent_auth` block

The scanner (and any Auth.md-aware agent) reads `agent_auth` from `/.well-known/oauth-authorization-server` — we published `/auth.md` without it, so detection stopped at "exists". Argos maps to the profile's **anonymous** method, which is what we actually do:

- `register_uri` → `/oauth/register`, open RFC 7591 dynamic client registration, no prior identity needed
- `claim_uri` → `/oauth/authorize`, where a user turns that anonymous registration into an authorized client by granting consent
- `revocation_uri` → `/oauth/revoke`
- `anonymous.credential_types_supported` → the access and refresh tokens the AS issues

These are aliases of the standard endpoints, so the test pins each one to its `*_endpoint` counterpart — they cannot drift apart. (Carried over from the parallel session that drafted it; it was never committed.)

## feat(oauth): serve `/auth.md` on the app origin

`auth.md` moves out of the argos-ci.com repo, where it was a hand-written copy of endpoints that live here. It is now **generated** from `getAuthorizationServerMetadata()` and the scope catalog, laid out as the recipe the spec asks for: discover → register → claim → exchange → use → revoke.

That kills a whole class of rot: the test walks the metadata and asserts every advertised endpoint and every supported scope appears in the document, so a new scope or a moved endpoint updates the recipe automatically instead of silently making it wrong.

`argos-ci.com/auth.md` proxies this document (rewrite, not redirect), so the public URL in `agent_auth.skill` is unchanged.

## Test plan

- `pnpm test:unit src/web/agent-discovery.test.ts src/oauth/oauth.test.ts` — 27/27, including the new auth.md content-type/heading checks, the metadata-consistency walk, and the `agent_auth` alias assertions.
- `pnpm run static-checks` green (check-types, check-format, lint, knip).
- Scanner expectations verified against the live `/api/scan` evidence: it wants `skill`, `register_uri`, `identity_types_supported: ["anonymous"]`, `anonymous.credential_types_supported`, and `claim_uri` — all present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
