### PR TITLE
fix(media): make embeds render, unfurl public share links, stop distorting media

### DIFF
--- a/apps/backend/src/api/handlers/media.e2e.test.ts
+++ b/apps/backend/src/api/handlers/media.e2e.test.ts
@@ -140,7 +140,11 @@ describe("createMedia", () => {
     // The share URL exists before the bytes do, so a caller can print it
     // without waiting on a large upload.
     expect(res.body.media.url).toMatch(/\/m\/.+/);
-    expect(res.body.media.markdown).toContain(res.body.media.url);
+    // The embed shows the file and links to the page. Pointing the image part at
+    // the share URL renders as a broken image wherever it is pasted.
+    expect(res.body.media.markdown).toBe(
+      `[![before.png](${res.body.media.fileUrl})](${res.body.media.url})`,
+    );
     expect(res.body.upload).toMatchObject({
       url: "https://s3.example.com/bucket",
     });

--- a/apps/backend/src/api/schema/primitives/media.ts
+++ b/apps/backend/src/api/schema/primitives/media.ts
@@ -8,7 +8,11 @@ import {
 import { z } from "zod";
 
 import type { Media, MediaVersion } from "@/database/models";
-import { getMediaFileUrl, getMediaPosterUrl } from "@/media/serve";
+import {
+  getMediaEmbedArgs,
+  getMediaFileUrl,
+  getMediaPosterUrl,
+} from "@/media/serve";
 import { getMediaMarkdown } from "@/media/url";
 import { SHA256_REGEX } from "@/util/validation";
 
@@ -88,7 +92,7 @@ export const MediaSchema = z
     }),
     markdown: z.string().meta({
       description:
-        "Ready-to-paste Markdown. Images embed directly; videos embed their poster frame linked to the share page, because GitHub only renders inline players for media it hosts itself.",
+        "Ready-to-paste Markdown: the picture — the image itself, or a video's poster frame — embedded from the CDN and linked to the share page. Embed this rather than building your own from `url`: that is an HTML page, and an image embed pointing at it renders as a broken image.",
     }),
     version: z.number().meta({
       description:
@@ -222,12 +226,9 @@ export function serializeMedia(
     branch: media.branch,
     prNumber,
     url: media.url,
-    markdown: getMediaMarkdown({
-      name: media.name,
-      shareUrl: media.url,
-      posterUrl,
-      isVideo: version.isVideo(),
-    }),
+    markdown: getMediaMarkdown(
+      getMediaEmbedArgs({ name: media.name, shareUrl: media.url, version }),
+    ),
     version: version.number,
     versionCount,
     fileUrl: getMediaFileUrl(version),

--- a/apps/backend/src/graphql/definitions/Media.ts
+++ b/apps/backend/src/graphql/definitions/Media.ts
@@ -7,7 +7,11 @@ import {
   getMediaPermissions,
   type MediaPermission,
 } from "@/media/permissions";
-import { getMediaFileUrl, getMediaPosterUrl } from "@/media/serve";
+import {
+  getMediaEmbedArgs,
+  getMediaFileUrl,
+  getMediaPosterUrl,
+} from "@/media/serve";
 import { getMediaMarkdown, getMediaTableMarkdown } from "@/media/url";
 import { getLatestMediaVersion } from "@/media/version";
 import { getProjectMemberIds } from "@/project/members";
@@ -85,7 +89,12 @@ export const typeDefs = gql`
     description: String
     "Share page URL, the one to paste into a pull request"
     url: String!
-    "Ready-to-paste Markdown embed, always pointing at the newest version"
+    """
+    Ready-to-paste Markdown embed, always pointing at the newest version: the
+    picture served from the CDN, linked to the share page. Never built from
+    \`url\` — that is an HTML page, and an image embed pointing at it renders as
+    a broken image.
+    """
     markdown: String!
     """
     Ready-to-paste Markdown table showing the before/after pair side by side —
@@ -193,12 +202,9 @@ export const resolvers: IResolvers = {
     markdown: async (media, _args, ctx) => {
       const version = await ctx.loaders.LatestMediaVersion.load(media.id);
       invariant(version, "media has no uploaded version");
-      return getMediaMarkdown({
-        name: media.name,
-        shareUrl: media.url,
-        posterUrl: getMediaPosterUrl(version),
-        isVideo: version.isVideo(),
-      });
+      return getMediaMarkdown(
+        getMediaEmbedArgs({ name: media.name, shareUrl: media.url, version }),
+      );
     },
     markdownPair: async (media, _args, ctx) => {
       // The pair's side-by-side table — the exact rendering the managed pull
@@ -216,18 +222,16 @@ export const resolvers: IResolvers = {
 
       const version = await ctx.loaders.LatestMediaVersion.load(media.id);
       invariant(version, "media has no uploaded version");
-      const embed = {
+      const embed = getMediaEmbedArgs({
         name: media.name,
         shareUrl: media.url,
-        posterUrl: getMediaPosterUrl(version),
-        isVideo: version.isVideo(),
-      };
-      const counterpartEmbed = {
+        version,
+      });
+      const counterpartEmbed = getMediaEmbedArgs({
         name: counterpart.name,
         shareUrl: counterpart.url,
-        posterUrl: getMediaPosterUrl(counterpartVersion),
-        isVideo: counterpartVersion.isVideo(),
-      };
+        version: counterpartVersion,
+      });
       const [beforeMedia, afterMedia] =
         media.state === "before" ? [media, counterpart] : [counterpart, media];
       const [before, after] =

--- a/apps/backend/src/graphql/tests/mediaShare.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/mediaShare.e2e.test.ts
@@ -171,9 +171,12 @@ describe("mediaByShareToken", () => {
     expect(result.counterpart.state).toBe("before");
     expect(result.counterpart.latestVersion.fileUrl).toContain("http");
 
-    // The single embed points at this half; the pair snippet is the same
-    // side-by-side table the managed pull request comment renders.
-    expect(result.markdown).toBe(`![checkout.png](${result.url})`);
+    // The single embed shows this half's bytes and links to its page — an embed
+    // built from the share URL alone renders as a broken image. The pair snippet
+    // is the same side-by-side table the managed pull request comment renders.
+    expect(result.markdown).toBe(
+      `[![checkout.png](${result.latestVersion.fileUrl})](${result.url})`,
+    );
     expect(result.markdownPair).toContain("| Name | Before | After |");
     expect(result.markdownPair).toContain(result.url);
     expect(result.markdownPair).toContain(result.counterpart.url);

--- a/apps/backend/src/media/oembed.test.ts
+++ b/apps/backend/src/media/oembed.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import { getMediaOEmbed } from "./oembed";
+import type { MediaShareMeta } from "./share-meta";
+
+const NO_CONSTRAINTS = { maxWidth: null, maxHeight: null };
+
+function meta(overrides?: Partial<MediaShareMeta>): MediaShareMeta {
+  return {
+    name: "checkout.png",
+    description: null,
+    shareUrl: "https://app.argos-ci.dev/m/abc123",
+    image: {
+      url: "https://ik.example.com/media/1/abc.webp",
+      width: 800,
+      height: 600,
+      contentType: "image/webp",
+    },
+    video: null,
+    ...overrides,
+  };
+}
+
+describe("getMediaOEmbed", () => {
+  it("answers for an image as a photo, which is what a consumer renders", () => {
+    expect(getMediaOEmbed(meta(), NO_CONSTRAINTS)).toMatchObject({
+      version: "1.0",
+      type: "photo",
+      title: "checkout.png",
+      provider_name: "Argos",
+      url: "https://ik.example.com/media/1/abc.webp",
+      width: 800,
+      height: 600,
+    });
+  });
+
+  it("answers for a video as a link with a still", () => {
+    // The `video` type requires an `html` iframe payload, and the app sends
+    // `frame-ancestors 'none'` — claiming a player nobody may frame renders as
+    // an empty box.
+    const response = getMediaOEmbed(
+      meta({
+        name: "checkout.mp4",
+        video: {
+          url: "https://ik.example.com/media/1/clip.mp4",
+          contentType: "video/mp4",
+        },
+      }),
+      NO_CONSTRAINTS,
+    );
+
+    expect(response).toMatchObject({
+      type: "link",
+      thumbnail_url: "https://ik.example.com/media/1/abc.webp",
+      thumbnail_width: 800,
+      thumbnail_height: 600,
+    });
+    expect(response).not.toHaveProperty("html");
+  });
+
+  it("falls back to a link when the dimensions were never recorded", () => {
+    // `photo` requires them, and inventing a size lays the image out at the
+    // wrong shape in every consumer.
+    expect(
+      getMediaOEmbed(
+        meta({
+          image: {
+            url: "https://ik.example.com/media/1/abc.webp",
+            width: null,
+            height: null,
+            contentType: "image/webp",
+          },
+        }),
+        NO_CONSTRAINTS,
+      ),
+    ).toMatchObject({ type: "link" });
+  });
+
+  it("honours maxwidth by asking the CDN for smaller bytes", () => {
+    // A consumer asking for 400px is saying what it will download. Reporting a
+    // smaller size for the same file wastes exactly what it was avoiding.
+    expect(
+      getMediaOEmbed(meta(), { maxWidth: 400, maxHeight: null }),
+    ).toMatchObject({
+      type: "photo",
+      url: "https://ik.example.com/media/1/abc.webp?tr=w-400",
+      width: 400,
+      height: 300,
+    });
+  });
+
+  it("turns maxheight into the width that produces it", () => {
+    // 300px tall on a 4:3 image is 400px wide, and width is the dimension the
+    // transformation takes — resizing on it keeps the ratio either way.
+    expect(
+      getMediaOEmbed(meta(), { maxWidth: null, maxHeight: 300 }),
+    ).toMatchObject({ width: 400, height: 300 });
+  });
+
+  it("respects whichever bound binds first", () => {
+    expect(
+      getMediaOEmbed(meta(), { maxWidth: 600, maxHeight: 300 }),
+    ).toMatchObject({ width: 400, height: 300 });
+  });
+
+  it("leaves an image alone when it already fits the bounds", () => {
+    expect(
+      getMediaOEmbed(meta(), { maxWidth: 2000, maxHeight: 2000 }),
+    ).toMatchObject({
+      url: "https://ik.example.com/media/1/abc.webp",
+      width: 800,
+      height: 600,
+    });
+  });
+});

--- a/apps/backend/src/media/oembed.ts
+++ b/apps/backend/src/media/oembed.ts
@@ -1,0 +1,116 @@
+import config from "@/config";
+
+import { resizePreview, type MediaShareMeta } from "./share-meta";
+
+/** What every oEmbed response carries, whatever its type. */
+type OEmbedBase = {
+  version: "1.0";
+  title: string;
+  provider_name: string;
+  provider_url: string;
+};
+
+/**
+ * An oEmbed response, as
+ * [the spec](https://oembed.com/#section2.3) defines it.
+ *
+ * Two of the four types are used. An image answers as `photo`, which is what
+ * lets a consumer render the picture itself at a size it chooses. A video
+ * answers as `link` with a thumbnail rather than as `video`: the `video` type
+ * requires an `html` payload, which means an iframe, and the app sends
+ * `frame-ancestors 'none'` — a player nobody may frame is a promise the
+ * response cannot keep, and a consumer that believes it renders an empty box.
+ */
+export type OEmbedResponse =
+  | (OEmbedBase & {
+      type: "photo";
+      url: string;
+      width: number;
+      height: number;
+    })
+  | (OEmbedBase & {
+      type: "link";
+      thumbnail_url: string;
+      thumbnail_width?: number;
+      thumbnail_height?: number;
+    });
+
+/** Consumer-supplied bounds on the returned photo. */
+export type OEmbedConstraints = {
+  maxWidth: number | null;
+  maxHeight: number | null;
+};
+
+/**
+ * Build the oEmbed answer for a share link.
+ *
+ * `maxwidth` / `maxheight` are honoured by asking the CDN for a smaller
+ * rendition, not by reporting a smaller size for the same bytes: a consumer
+ * that asked for 400px is telling us what it is willing to download, and
+ * answering with a 4K file scaled down in CSS wastes exactly what it was trying
+ * to avoid.
+ */
+export function getMediaOEmbed(
+  meta: MediaShareMeta,
+  constraints: OEmbedConstraints,
+): OEmbedResponse {
+  const base: OEmbedBase = {
+    version: "1.0",
+    title: meta.name,
+    provider_name: "Argos",
+    provider_url: config.get("server.url"),
+  };
+
+  const image = constrainImage(meta.image, constraints);
+
+  // A video is a link with a still. Also the fallback for an upload whose
+  // dimensions were never recorded: `photo` requires them, and inventing a size
+  // makes every consumer lay the image out at the wrong shape.
+  if (meta.video || !image.width || !image.height) {
+    return {
+      ...base,
+      type: "link",
+      thumbnail_url: image.url,
+      ...(image.width && image.height
+        ? { thumbnail_width: image.width, thumbnail_height: image.height }
+        : null),
+    };
+  }
+
+  return {
+    ...base,
+    type: "photo",
+    url: image.url,
+    width: image.width,
+    height: image.height,
+  };
+}
+
+/**
+ * Apply the consumer's bounds.
+ *
+ * `maxheight` is turned into the width that produces it, because that is the
+ * only dimension the CDN transformation takes here — resizing on width keeps
+ * the ratio, which is the point of both bounds.
+ */
+function constrainImage(
+  image: MediaShareMeta["image"],
+  constraints: OEmbedConstraints,
+): MediaShareMeta["image"] {
+  const { width, height } = image;
+  const bounds: number[] = [];
+
+  if (constraints.maxWidth) {
+    bounds.push(constraints.maxWidth);
+  }
+
+  if (constraints.maxHeight && width && height) {
+    bounds.push((constraints.maxHeight * width) / height);
+  }
+
+  if (bounds.length === 0) {
+    return image;
+  }
+
+  return resizePreview(image, Math.floor(Math.min(...bounds)));
+}

--- a/apps/backend/src/media/pull-request-comment.ts
+++ b/apps/backend/src/media/pull-request-comment.ts
@@ -13,7 +13,7 @@ import logger from "@/logger";
 import { redisLock } from "@/util/redis";
 
 import { uploadedVersions } from "./query";
-import { getMediaPosterUrl } from "./serve";
+import { getMediaEmbedArgs } from "./serve";
 import {
   getMediaTableMarkdown,
   type MediaEmbedArgs,
@@ -129,11 +129,8 @@ export async function updatePullRequestComment(
  * — which is the whole reason `state` exists, and reads far better than two
  * unrelated rows a reviewer has to match up themselves.
  *
- * Videos embed their poster frame wrapped in a link to the share page, because
- * GitHub renders an inline player only for media it hosts itself — pointing a
- * `<video>` tag at Argos produces a blank box, which is the single easiest way to
- * make this feature look broken. The poster is a CDN URL, so it needs no session:
- * GitHub fetches embedded images server-side, with no cookie of ours.
+ * Each cell is a CDN picture linked to its share page; {@link getMediaMarkdown}
+ * owns why it is built that way.
  */
 function buildCommentBody(
   media: Media[],
@@ -147,12 +144,11 @@ function buildCommentBody(
     if (!version) {
       return null;
     }
-    return {
+    return getMediaEmbedArgs({
       name: item.name,
       shareUrl: item.url,
-      posterUrl: getMediaPosterUrl(version),
-      isVideo: version.isVideo(),
-    };
+      version,
+    });
   };
 
   const groups = groupByPair(media).flatMap((group): MediaMarkdownGroup[] => {

--- a/apps/backend/src/media/serve.ts
+++ b/apps/backend/src/media/serve.ts
@@ -1,6 +1,8 @@
 import type { MediaVersion } from "@/database/models";
 import { getImageKitUrl } from "@/storage";
 
+import type { MediaEmbedArgs } from "./url";
+
 /**
  * Seconds into a video to grab the poster frame from.
  *
@@ -45,4 +47,28 @@ export function getMediaPosterUrl(version: MediaVersion): string | null {
   url.pathname = `${url.pathname}/ik-thumbnail.jpg`;
   url.searchParams.set("tr", `so-${POSTER_SEEK_SECONDS}`);
   return url.href;
+}
+
+/**
+ * Everything a Markdown embed of a media needs, read off the version whose bytes
+ * it should show.
+ *
+ * One helper because every caller that renders an embed — the pull request
+ * comment, the REST response, the share page's copy formats — has to derive the
+ * same three URLs from a version, and a caller that derives them itself is a
+ * caller that can point the embed at the share page again.
+ */
+export function getMediaEmbedArgs(args: {
+  name: string;
+  shareUrl: string;
+  version: MediaVersion;
+}): MediaEmbedArgs {
+  const { name, shareUrl, version } = args;
+  return {
+    name,
+    shareUrl,
+    fileUrl: getMediaFileUrl(version),
+    posterUrl: getMediaPosterUrl(version),
+    isVideo: version.isVideo(),
+  };
 }

--- a/apps/backend/src/media/share-meta.e2e.test.ts
+++ b/apps/backend/src/media/share-meta.e2e.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { factory, setupDatabase } from "@/database/testing";
+
+import { getPublicMediaShareMeta } from "./share-meta";
+
+describe("getPublicMediaShareMeta", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  it("describes a public image so it can unfurl", async () => {
+    const { media, version } = await factory.createMediaWithVersion({
+      media: {
+        name: "checkout.png",
+        description: "Checkout after the spacing fix.",
+        visibility: "public",
+      },
+      version: { mimeType: "image/webp", width: 800, height: 600 },
+    });
+
+    const meta = await getPublicMediaShareMeta(media.shareToken);
+
+    expect(meta).toMatchObject({
+      name: "checkout.png",
+      description: "Checkout after the spacing fix.",
+      shareUrl: media.url,
+      image: { width: 800, height: 600, contentType: "image/webp" },
+      // An image is not a video, and saying otherwise makes a consumer render a
+      // player over a still.
+      video: null,
+    });
+    expect(meta?.image.url).toContain(version.key);
+  });
+
+  it("refuses a team media, whose name alone is private", async () => {
+    // Unfurl metadata is served to a crawler, which carries no session — so
+    // everything in it is public to anyone holding the link. A `team` media's
+    // link is exactly the one that must not answer.
+    const { media } = await factory.createMediaWithVersion({
+      media: { name: "unreleased-pricing.png", visibility: "team" },
+    });
+
+    await expect(getPublicMediaShareMeta(media.shareToken)).resolves.toBeNull();
+  });
+
+  it("refuses a media whose bytes never landed", async () => {
+    // An unfurl advertising an image that 404s is worse than no unfurl.
+    const media = await factory.Media.create({ visibility: "public" });
+    await factory.MediaVersion.create({
+      mediaId: media.id,
+      number: 1,
+      uploadedAt: null,
+      billedUnits: 0,
+    });
+
+    await expect(getPublicMediaShareMeta(media.shareToken)).resolves.toBeNull();
+  });
+
+  it("refuses an unknown token without saying so", async () => {
+    await expect(getPublicMediaShareMeta("not-a-token")).resolves.toBeNull();
+  });
+
+  it("shows a video's poster frame, and offers the file itself", async () => {
+    const { media } = await factory.createMediaWithVersion({
+      media: { name: "checkout.mp4", visibility: "public" },
+      version: {
+        key: "media/test/clip.mp4",
+        mimeType: "video/mp4",
+        width: 1280,
+        height: 720,
+      },
+    });
+
+    const meta = await getPublicMediaShareMeta(media.shareToken);
+
+    // The card shows a still: a consumer that cannot play the video still
+    // renders one, and a card with no image renders as a bare link.
+    expect(meta?.image.url).toContain("ik-thumbnail.jpg");
+    expect(meta?.image.contentType).toBe("image/jpeg");
+    expect(meta?.video).toMatchObject({ contentType: "video/mp4" });
+  });
+
+  it("caps an oversized preview at the CDN rather than sending 4K to a crawler", async () => {
+    // Twitter drops an image over 5 MB, so an uncapped screenshot unfurls with
+    // no image at all.
+    const { media } = await factory.createMediaWithVersion({
+      media: { visibility: "public" },
+      version: { width: 3840, height: 2160 },
+    });
+
+    const meta = await getPublicMediaShareMeta(media.shareToken);
+
+    expect(meta?.image.url).toContain("tr=w-1200");
+    // The declared size has to describe the bytes that are actually served.
+    expect(meta?.image).toMatchObject({ width: 1200, height: 675 });
+  });
+
+  it("keeps the poster's frame selection when it also has to resize it", async () => {
+    // The poster arrives with `tr=so-1` on it; overwriting that asks the CDN to
+    // resize the whole video instead of the frame, and gets back nothing.
+    const { media } = await factory.createMediaWithVersion({
+      media: { visibility: "public" },
+      version: {
+        key: "media/test/clip.mp4",
+        mimeType: "video/mp4",
+        width: 3840,
+        height: 2160,
+      },
+    });
+
+    const meta = await getPublicMediaShareMeta(media.shareToken);
+
+    expect(meta?.image.url).toContain("tr=so-1%2Cw-1200");
+  });
+
+  it("leaves a preview alone when it already fits", async () => {
+    const { media } = await factory.createMediaWithVersion({
+      media: { visibility: "public" },
+      version: { width: 800, height: 600 },
+    });
+
+    const meta = await getPublicMediaShareMeta(media.shareToken);
+
+    expect(meta?.image.url).not.toContain("tr=");
+  });
+});

--- a/apps/backend/src/media/share-meta.ts
+++ b/apps/backend/src/media/share-meta.ts
@@ -1,0 +1,163 @@
+import { Media, type MediaVersion } from "@/database/models";
+
+import { getMediaFileUrl, getMediaPosterUrl } from "./serve";
+import { getMediaShareUrl } from "./url";
+import { getLatestMediaVersion } from "./version";
+
+/**
+ * The widest an unfurled preview is served at.
+ *
+ * 1200px is the width every unfurler is built around, and the cap is not
+ * cosmetic: a crawler fetches the image itself and drops one that is too large
+ * (Twitter refuses over 5 MB), so an uncapped 4K screenshot unfurls as no image
+ * at all. The CDN does the resize, so nothing is stored twice.
+ */
+const PREVIEW_MAX_WIDTH = 1200;
+
+/** The picture an unfurler shows, and how big it is. */
+type PreviewImage = {
+  url: string;
+  /** Null when the upload's dimensions were never recorded. */
+  width: number | null;
+  height: number | null;
+  contentType: string;
+};
+
+/**
+ * Everything needed to unfurl a share link, resolved for an anonymous visitor.
+ *
+ * Shared by the OpenGraph tags injected into the share page and by the oEmbed
+ * endpoint, because the two describe the same thing and drifting apart means one
+ * of them is wrong.
+ */
+export type MediaShareMeta = {
+  name: string;
+  description: string | null;
+  shareUrl: string;
+  image: PreviewImage;
+  /** The file itself, for a video. Null for an image. */
+  video: { url: string; contentType: string } | null;
+};
+
+/**
+ * Resolve what a share link unfurls to, or `null` when it must not unfurl at
+ * all.
+ *
+ * **Public media only.** Unfurl metadata is served to whoever asks — a crawler
+ * carries no session, so there is nobody to authorize — which means everything
+ * in it is public by construction. A `team` media's name alone can be the
+ * unreleased information the link was kept private for, so it gets no tags and
+ * no oEmbed answer, and the page it serves is the plain shell that asks the
+ * visitor to sign in.
+ *
+ * A media whose bytes never landed resolves to `null` too: there is no picture
+ * to show, and an unfurl advertising an image that 404s is worse than none.
+ */
+export async function getPublicMediaShareMeta(
+  shareToken: string,
+): Promise<MediaShareMeta | null> {
+  const media = await Media.query().findOne({ shareToken });
+
+  if (!media || media.visibility !== "public") {
+    return null;
+  }
+
+  const version = await getLatestMediaVersion(media.id);
+
+  if (!version) {
+    return null;
+  }
+
+  const image = getPreviewImage(version);
+
+  if (!image) {
+    return null;
+  }
+
+  return {
+    name: media.name,
+    description: media.description,
+    shareUrl: getMediaShareUrl(media.shareToken),
+    image,
+    video: version.isVideo()
+      ? { url: getMediaFileUrl(version), contentType: version.mimeType }
+      : null,
+  };
+}
+
+/**
+ * The still to unfurl: the image itself, or a video's poster frame.
+ *
+ * Null for a video whose poster cannot be derived — the same degradation the
+ * Markdown embed makes, for the same reason.
+ */
+function getPreviewImage(version: MediaVersion): PreviewImage | null {
+  const isVideo = version.isVideo();
+  const sourceUrl = isVideo
+    ? getMediaPosterUrl(version)
+    : getMediaFileUrl(version);
+
+  if (!sourceUrl) {
+    return null;
+  }
+
+  return resizePreview(
+    {
+      url: sourceUrl,
+      width: version.width,
+      height: version.height,
+      // The poster comes off ImageKit's `ik-thumbnail.jpg` endpoint whatever the
+      // video's own container, so it is a JPEG regardless of `mimeType`.
+      contentType: isVideo ? "image/jpeg" : version.mimeType,
+    },
+    PREVIEW_MAX_WIDTH,
+  );
+}
+
+/**
+ * Constrain a preview to a maximum width, letting the CDN do the resize.
+ *
+ * Returned unchanged when it already fits, or when its dimensions were never
+ * recorded: asking for a width we cannot report back would leave the declared
+ * size disagreeing with the bytes, which is what makes an unfurl render at the
+ * wrong shape.
+ */
+export function resizePreview(
+  image: PreviewImage,
+  maxWidth: number,
+): PreviewImage {
+  const { width, height } = image;
+
+  if (!width || !height || width <= maxWidth) {
+    return image;
+  }
+
+  return {
+    ...image,
+    url: withImageKitTransformation(image.url, `w-${maxWidth}`),
+    width: maxWidth,
+    // Rounded rather than floored so the reported shape stays as close to the
+    // real one as the integers allow.
+    height: Math.round((height * maxWidth) / width),
+  };
+}
+
+/**
+ * Add a transformation to an ImageKit URL, keeping any it already carries.
+ *
+ * A video poster arrives with `tr=so-1` on it already; overwriting that would
+ * ask for a resize of the whole video rather than of the frame, and get back
+ * nothing.
+ */
+function withImageKitTransformation(
+  url: string,
+  transformation: string,
+): string {
+  const parsed = new URL(url);
+  const existing = parsed.searchParams.get("tr");
+  parsed.searchParams.set(
+    "tr",
+    existing ? `${existing},${transformation}` : transformation,
+  );
+  return parsed.href;
+}

--- a/apps/backend/src/media/url.test.ts
+++ b/apps/backend/src/media/url.test.ts
@@ -3,18 +3,35 @@ import { describe, expect, it } from "vitest";
 import { getMediaMarkdown, getMediaTableMarkdown } from "./url";
 
 const shareUrl = "https://app.argos-ci.dev/m/abc123";
+const fileUrl = "https://files.example.com/media/abc123.webp";
 const posterUrl = "https://files.example.com/poster.webp";
 
 describe("getMediaMarkdown", () => {
-  it("embeds an image directly", () => {
+  it("embeds the file and links it to the share page", () => {
+    // The embed must point at the bytes, not at the share page: `![](page)`
+    // renders as a broken image everywhere it is pasted, which is exactly what
+    // it used to do.
     expect(
       getMediaMarkdown({
         name: "before.png",
         shareUrl,
+        fileUrl,
         posterUrl: null,
         isVideo: false,
       }),
-    ).toBe(`![before.png](${shareUrl})`);
+    ).toBe(`[![before.png](${fileUrl})](${shareUrl})`);
+  });
+
+  it("never points an image embed at the share page", () => {
+    const markdown = getMediaMarkdown({
+      name: "before.png",
+      shareUrl,
+      fileUrl,
+      posterUrl: null,
+      isVideo: false,
+    });
+
+    expect(markdown).not.toContain(`![before.png](${shareUrl})`);
   });
 
   it("wraps a video's poster in a link to the share page", () => {
@@ -25,6 +42,7 @@ describe("getMediaMarkdown", () => {
       getMediaMarkdown({
         name: "checkout.mp4",
         shareUrl,
+        fileUrl,
         posterUrl,
         isVideo: true,
       }),
@@ -32,12 +50,13 @@ describe("getMediaMarkdown", () => {
   });
 
   it("degrades a video with no poster yet to a plain link", () => {
-    // Better than an image tag pointing at a poster that does not exist: that
-    // renders as a broken-image icon in the comment.
+    // Better than an image tag pointing at the video file: that renders as a
+    // broken-image icon in the comment.
     expect(
       getMediaMarkdown({
         name: "checkout.mp4",
         shareUrl,
+        fileUrl,
         posterUrl: null,
         isVideo: true,
       }),
@@ -49,10 +68,11 @@ describe("getMediaMarkdown", () => {
       getMediaMarkdown({
         name: "before [v2].png",
         shareUrl,
+        fileUrl,
         posterUrl: null,
         isVideo: false,
       }),
-    ).toBe(`![before \\[v2\\].png](${shareUrl})`);
+    ).toBe(`[![before \\[v2\\].png](${fileUrl})](${shareUrl})`);
   });
 });
 
@@ -66,12 +86,14 @@ describe("getMediaTableMarkdown", () => {
           before: {
             name: "checkout.png",
             shareUrl: "https://app/m/before",
+            fileUrl: "https://files/before.webp",
             posterUrl: null,
             isVideo: false,
           },
           after: {
             name: "checkout.png",
             shareUrl: "https://app/m/after",
+            fileUrl: "https://files/after.webp",
             posterUrl: null,
             isVideo: false,
           },
@@ -81,7 +103,7 @@ describe("getMediaTableMarkdown", () => {
       [
         "| Name | Before | After | Notes |",
         "| --- | --- | --- | --- |",
-        "| checkout.png | ![checkout.png](https://app/m/before) | ![checkout.png](https://app/m/after) | Checkout after the spacing fix. |",
+        "| checkout.png | [![checkout.png](https://files/before.webp)](https://app/m/before) | [![checkout.png](https://files/after.webp)](https://app/m/after) | Checkout after the spacing fix. |",
       ].join("\n"),
     );
   });
@@ -96,6 +118,7 @@ describe("getMediaTableMarkdown", () => {
           after: {
             name: "dashboard.png",
             shareUrl,
+            fileUrl,
             posterUrl: null,
             isVideo: false,
           },
@@ -105,7 +128,7 @@ describe("getMediaTableMarkdown", () => {
       [
         "| Name | Preview |",
         "| --- | --- |",
-        `| dashboard.png | ![dashboard.png](${shareUrl}) |`,
+        `| dashboard.png | [![dashboard.png](${fileUrl})](${shareUrl}) |`,
       ].join("\n"),
     );
   });
@@ -117,7 +140,13 @@ describe("getMediaTableMarkdown", () => {
           name: "a|b.png",
           description: null,
           before: null,
-          after: { name: "a|b.png", shareUrl, posterUrl: null, isVideo: false },
+          after: {
+            name: "a|b.png",
+            shareUrl,
+            fileUrl,
+            posterUrl: null,
+            isVideo: false,
+          },
         },
       ]),
     ).toBe(
@@ -126,7 +155,7 @@ describe("getMediaTableMarkdown", () => {
         "| --- | --- |",
         // Both cells: the pipe is escaped in the name column and again inside
         // the embed's alt text, which is a cell of its own.
-        `| a\\|b.png | ![a\\|b.png](${shareUrl}) |`,
+        `| a\\|b.png | [![a\\|b.png](${fileUrl})](${shareUrl}) |`,
       ].join("\n"),
     );
   });
@@ -143,6 +172,7 @@ describe("getMediaTableMarkdown", () => {
           after: {
             name: "dashboard.png",
             shareUrl,
+            fileUrl,
             posterUrl: null,
             isVideo: false,
           },
@@ -164,6 +194,7 @@ describe("getMediaTableMarkdown", () => {
           after: {
             name: "dashboard.png",
             shareUrl,
+            fileUrl,
             posterUrl: null,
             isVideo: false,
           },
@@ -181,7 +212,13 @@ describe("getMediaTableMarkdown", () => {
         name: "a\nb.png",
         description: null,
         before: null,
-        after: { name: "a\nb.png", shareUrl, posterUrl: null, isVideo: false },
+        after: {
+          name: "a\nb.png",
+          shareUrl,
+          fileUrl,
+          posterUrl: null,
+          isVideo: false,
+        },
       },
     ]);
 
@@ -189,7 +226,7 @@ describe("getMediaTableMarkdown", () => {
       [
         "| Name | Preview |",
         "| --- | --- |",
-        `| a<br>b.png | ![a<br>b.png](${shareUrl}) |`,
+        `| a<br>b.png | [![a<br>b.png](${fileUrl})](${shareUrl}) |`,
       ].join("\n"),
     );
     // One row per group, whatever the name contains.
@@ -206,6 +243,7 @@ describe("getMediaTableMarkdown", () => {
           after: {
             name: "dashboard.png",
             shareUrl,
+            fileUrl,
             posterUrl: null,
             isVideo: false,
           },

--- a/apps/backend/src/media/url.ts
+++ b/apps/backend/src/media/url.ts
@@ -15,6 +15,12 @@ export function getMediaShareUrl(shareToken: string): string {
 export type MediaEmbedArgs = {
   name: string;
   shareUrl: string;
+  /**
+   * CDN URL of the bytes. This — never the share URL — is what an image embed
+   * points at: the share URL is an HTML page, and `![](page)` renders as a
+   * broken image everywhere it is pasted.
+   */
+  fileUrl: string;
   posterUrl: string | null;
   isVideo: boolean;
 };
@@ -22,25 +28,30 @@ export type MediaEmbedArgs = {
 /**
  * Markdown ready to paste into a pull request comment.
  *
- * Images embed directly. Videos embed their **poster frame** wrapped in a link to
- * the share page, because GitHub only renders an inline video player for media it
- * hosts itself — an `<video>` tag or a bare `.mp4` link pointing at Argos would
- * render as a dead link. A video whose poster hasn't been extracted yet
- * degrades to a plain link rather than an image that 404s.
+ * A picture wrapped in a link to the share page: the embed shows the media
+ * inline, and clicking it lands on the page where it can be compared, versioned
+ * and commented on.
+ *
+ * The picture is the file itself for an image, and the **poster frame** for a
+ * video — GitHub only renders an inline player for media it hosts itself, so a
+ * `<video>` tag or a bare `.mp4` link pointing at Argos renders as a dead link.
+ * Both come from the image CDN, which serves them unauthenticated: GitHub
+ * fetches embedded images server-side through its camo proxy, carrying no
+ * session of ours, so an embed that needed one could not render at all.
+ *
+ * A video whose poster hasn't been extracted yet degrades to a plain link rather
+ * than an image that 404s.
  */
 export function getMediaMarkdown(args: MediaEmbedArgs): string {
-  const { name, shareUrl, posterUrl, isVideo } = args;
+  const { name, shareUrl, fileUrl, posterUrl, isVideo } = args;
   const alt = escapeMarkdownText(name);
+  const previewUrl = isVideo ? posterUrl : fileUrl;
 
-  if (!isVideo) {
-    return `![${alt}](${shareUrl})`;
+  if (!previewUrl) {
+    return `[▶ ${alt}](${shareUrl})`;
   }
 
-  if (posterUrl) {
-    return `[![${alt}](${posterUrl})](${shareUrl})`;
-  }
-
-  return `[▶ ${alt}](${shareUrl})`;
+  return `[![${alt}](${previewUrl})](${shareUrl})`;
 }
 
 /** One row of the media table: a pair's two halves, or a lone media. */

--- a/apps/backend/src/web/app-router.ts
+++ b/apps/backend/src/web/app-router.ts
@@ -24,6 +24,7 @@ import { getEmailPreviewMiddleware } from "../email/express";
 import { getNotificationPreviewMiddleware } from "../notification/express";
 import samlAuthRouter from "./auth-saml";
 import deploymentAccessRouter from "./deployment-access";
+import { installMediaShareRoutes } from "./media-share";
 import { requireCsrf } from "./middlewares/csrf";
 import { createAppSecurityHeaders } from "./security-headers";
 import { asyncHandler, subdomain } from "./util";
@@ -260,6 +261,12 @@ export const installAppRouter = async (app: express.Application) => {
     }
     res.sendFile(join(distDir, "index.html"));
   };
+
+  // Ahead of the catch-all, and after the security headers so an unfurled share
+  // page carries the same ones as every other: a share link has to arrive at a
+  // crawler with its OpenGraph tags already in the HTML, which the SPA shell
+  // cannot do. Anything it declines to handle falls through to the shell below.
+  installMediaShareRoutes(router, { shell: shell?.html ?? null });
 
   router.get("/{*splat}", sendAppShell);
 

--- a/apps/backend/src/web/media-share.e2e.test.ts
+++ b/apps/backend/src/web/media-share.e2e.test.ts
@@ -1,0 +1,202 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import config from "@/config";
+import { factory, setupDatabase } from "@/database/testing";
+
+import { installMediaShareRoutes } from "./media-share";
+
+/**
+ * A stand-in for the built SPA shell. The real one is read off disk at startup
+ * and is not present in a test run; all this code does to it is splice tags in
+ * before `</head>`, so a minimal head is enough to assert on.
+ */
+const SHELL = "<!doctype html><html><head><title>Argos</title></head><body>";
+
+/** The shell as served when the route declines to handle a request. */
+const FALLTHROUGH = "fell through to the SPA";
+
+function createApp() {
+  const app = express();
+  installMediaShareRoutes(app, { shell: SHELL });
+  // Stands in for the SPA catch-all the real router mounts after this one.
+  app.use((_req, res) => {
+    res.status(200).type("html").send(FALLTHROUGH);
+  });
+  return request(app);
+}
+
+async function createPublicMedia(attributes?: {
+  name?: string;
+  description?: string | null;
+}) {
+  const { media } = await factory.createMediaWithVersion({
+    media: {
+      name: attributes?.name ?? "checkout.png",
+      description: attributes?.description ?? null,
+      visibility: "public",
+    },
+    version: { mimeType: "image/webp", width: 800, height: 600 },
+  });
+  return media;
+}
+
+describe("share page unfurling", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  it("serves OpenGraph tags in the HTML, where an unfurler can read them", async () => {
+    // No unfurler runs JavaScript, so tags the React app sets on mount are tags
+    // nobody sees. This is the whole point of the route.
+    const media = await createPublicMedia({
+      description: "Checkout after the spacing fix.",
+    });
+
+    const res = await createApp().get(`/m/${media.shareToken}`).expect(200);
+
+    expect(res.text).toContain(
+      '<meta property="og:title" content="checkout.png" />',
+    );
+    expect(res.text).toContain(
+      '<meta property="og:description" content="Checkout after the spacing fix." />',
+    );
+    expect(res.text).toContain(
+      `<meta property="og:url" content="${media.url}" />`,
+    );
+    expect(res.text).toContain('<meta property="og:image:width" content="800"');
+    expect(res.text).toContain(
+      '<meta name="twitter:card" content="summary_large_image" />',
+    );
+    // The tags land inside the head, not after the document.
+    expect(res.text).toContain("</head>");
+    expect(res.text.indexOf("og:title")).toBeLessThan(
+      res.text.indexOf("</head>"),
+    );
+  });
+
+  it("advertises the oEmbed endpoint for consumers that would rather ask", async () => {
+    const media = await createPublicMedia();
+
+    const res = await createApp().get(`/m/${media.shareToken}`).expect(200);
+
+    expect(res.text).toContain('type="application/json+oembed"');
+    // The discovery link points back at this media, url-encoded into the query.
+    expect(res.text).toContain(`/oembed?url=${encodeURIComponent(media.url)}`);
+    expect(res.text).toContain("format=json");
+  });
+
+  it("escapes a file name so it cannot break out of the attribute", async () => {
+    // A media's name is caller-controlled and lands in the page head verbatim.
+    // A bare `"` closes the attribute and `<` opens a tag — both are ordinary
+    // characters in a file name.
+    const media = await createPublicMedia({
+      name: '"><script>alert(1)</script>.png',
+    });
+
+    const res = await createApp().get(`/m/${media.shareToken}`).expect(200);
+
+    expect(res.text).not.toContain("<script>alert(1)</script>");
+    expect(res.text).toContain("&quot;&gt;&lt;script&gt;");
+  });
+
+  it("keeps a team media out of the tags entirely", async () => {
+    // The tags are served to anyone who asks. A team-only media's name is
+    // exactly the thing its link was kept private for.
+    const { media } = await factory.createMediaWithVersion({
+      media: { name: "unreleased-pricing.png", visibility: "team" },
+    });
+
+    const res = await createApp().get(`/m/${media.shareToken}`).expect(200);
+
+    expect(res.text).toBe(FALLTHROUGH);
+    expect(res.text).not.toContain("unreleased-pricing.png");
+  });
+
+  it("leaves an unknown token to the SPA", async () => {
+    const res = await createApp().get("/m/not-a-token").expect(200);
+
+    expect(res.text).toBe(FALLTHROUGH);
+  });
+});
+
+describe("oEmbed endpoint", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  it("answers for a public share URL", async () => {
+    const media = await createPublicMedia();
+
+    const res = await createApp()
+      .get("/oembed")
+      .query({ url: media.url })
+      .expect(200);
+
+    expect(res.body).toMatchObject({
+      version: "1.0",
+      type: "photo",
+      title: "checkout.png",
+      provider_name: "Argos",
+      width: 800,
+      height: 600,
+    });
+  });
+
+  it("honours maxwidth", async () => {
+    const media = await createPublicMedia();
+
+    const res = await createApp()
+      .get("/oembed")
+      .query({ url: media.url, maxwidth: "400" })
+      .expect(200);
+
+    expect(res.body).toMatchObject({ width: 400, height: 300 });
+  });
+
+  it("refuses a URL on another host", async () => {
+    // `url` is caller-controlled. Answering for someone else's host would let
+    // any site claim our media as its own oEmbed content.
+    const media = await createPublicMedia();
+    const foreign = new URL(media.url);
+
+    const res = await createApp()
+      .get("/oembed")
+      .query({ url: `https://evil.example${foreign.pathname}` });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("refuses a team media the same way it refuses a missing one", async () => {
+    // Same 404 for both: telling them apart tells an anonymous caller that a
+    // private media is behind the token.
+    const { media } = await factory.createMediaWithVersion({
+      media: { visibility: "team" },
+    });
+
+    const team = await createApp().get("/oembed").query({ url: media.url });
+    const missing = await createApp()
+      .get("/oembed")
+      .query({ url: new URL("/m/not-a-token", config.get("server.url")).href });
+
+    expect(team.status).toBe(404);
+    expect(missing.status).toBe(404);
+  });
+
+  it("rejects a request with no url at all", async () => {
+    const res = await createApp().get("/oembed");
+
+    expect(res.status).toBe(400);
+  });
+
+  it("reports the xml format as not implemented, as the spec asks", async () => {
+    const media = await createPublicMedia();
+
+    const res = await createApp()
+      .get("/oembed")
+      .query({ url: media.url, format: "xml" });
+
+    expect(res.status).toBe(501);
+  });
+});

--- a/apps/backend/src/web/media-share.ts
+++ b/apps/backend/src/web/media-share.ts
@@ -1,0 +1,257 @@
+import type { Router } from "express";
+import { z } from "zod";
+
+import config from "@/config";
+import { getMediaOEmbed } from "@/media/oembed";
+import {
+  getPublicMediaShareMeta,
+  type MediaShareMeta,
+} from "@/media/share-meta";
+
+import { asyncHandler } from "./util";
+
+/** Where a consumer asks what a share URL embeds as. */
+const OEMBED_PATH = "/oembed";
+
+/**
+ * Serve share links so they unfurl.
+ *
+ * The share page is a single-page app: its `<head>` is written by React once the
+ * bundle has run, and no unfurler runs JavaScript. Slack, GitHub, Discord,
+ * Notion and every other consumer fetch the HTML and read what is in it — so a
+ * link to a screenshot pastes as a bare URL unless the tags are already in the
+ * bytes the server sends. That is what this does: the same shell as always, with
+ * the media's OpenGraph tags injected for the crawler, plus the oEmbed endpoint
+ * the richer consumers ask for after finding its discovery link.
+ *
+ * Public media only, and {@link getPublicMediaShareMeta} owns why.
+ */
+export function installMediaShareRoutes(
+  router: Router,
+  options: {
+    /**
+     * The built SPA shell to inject into, or `null` in development — where Vite
+     * serves its own `index.html` and there is nothing here to rewrite. Sharing
+     * a `localhost` link is not a thing anyone does, so the route simply falls
+     * through to the SPA.
+     */
+    shell: string | null;
+  },
+) {
+  const { shell } = options;
+
+  router.get(
+    OEMBED_PATH,
+    asyncHandler(async (req, res) => {
+      const params = OEmbedQuerySchema.safeParse(req.query);
+
+      if (!params.success) {
+        res.status(400).json({ error: "Invalid oEmbed request" });
+        return;
+      }
+
+      const { url, format, maxwidth, maxheight } = params.data;
+
+      // The spec's own answer for a format we do not produce. Only JSON is
+      // produced: XML exists in the spec for consumers written before JSON was
+      // universal, and none of them are asking.
+      if (format === "xml") {
+        res.status(501).json({ error: "Only the json format is supported" });
+        return;
+      }
+
+      const shareToken = readShareToken(url);
+      const meta = shareToken
+        ? await getPublicMediaShareMeta(shareToken)
+        : null;
+
+      if (!meta) {
+        // Not "forbidden": a 404 is the only answer that does not tell an
+        // anonymous caller whether a private media is behind the token.
+        res.status(404).json({ error: "Not found" });
+        return;
+      }
+
+      // Public data, no credentials, so any origin may read it — a browser-side
+      // consumer would otherwise need a proxy to ask a question whose answer is
+      // already public.
+      res.setHeader("Access-Control-Allow-Origin", "*");
+      res.setHeader("Cache-Control", "public, max-age=300");
+      res.json(
+        getMediaOEmbed(meta, {
+          maxWidth: maxwidth ?? null,
+          maxHeight: maxheight ?? null,
+        }),
+      );
+    }),
+  );
+
+  router.get(
+    "/m/:shareToken",
+    asyncHandler(async (req, res, next) => {
+      if (!shell) {
+        next();
+        return;
+      }
+
+      const { shareToken } = req.params;
+      const meta =
+        typeof shareToken === "string"
+          ? await getPublicMediaShareMeta(shareToken)
+          : null;
+
+      if (!meta) {
+        // Team-only, expired, or never a token at all: the SPA answers, and its
+        // own "unavailable or sign in" state is the right one.
+        next();
+        return;
+      }
+
+      // Same caching rule as the plain shell: it names content-hashed assets.
+      res.setHeader("Cache-Control", "no-cache");
+      res.setHeader("Vary", "Accept-Encoding");
+      res.type("html").send(injectShareMeta(shell, meta));
+    }),
+  );
+}
+
+/**
+ * `maxwidth` / `maxheight` are the consumer's bounds, and the spec sends them as
+ * strings. Coerced rather than parsed by hand, and floored at 1 so a `0` or a
+ * negative cannot ask the CDN for a zero-width image.
+ */
+const OEmbedDimension = z.coerce.number().int().min(1).max(10_000).optional();
+
+const OEmbedQuerySchema = z.object({
+  url: z.string(),
+  format: z.enum(["json", "xml"]).default("json"),
+  maxwidth: OEmbedDimension,
+  maxheight: OEmbedDimension,
+});
+
+/**
+ * The share token in a URL a consumer handed us, or `null` when the URL is not
+ * one of ours.
+ *
+ * The host is checked, not just the path: `url` is caller-controlled, and
+ * answering for `https://evil.example/m/<token>` would let any site claim our
+ * media as its own oEmbed content.
+ */
+function readShareToken(url: string): string | null {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+
+  const serverUrl = new URL(config.get("server.url"));
+
+  if (parsed.host !== serverUrl.host) {
+    return null;
+  }
+
+  const match = /^\/m\/([^/]+)\/?$/.exec(parsed.pathname);
+  return match?.[1] ?? null;
+}
+
+/**
+ * Splice the unfurl tags into the shell's `<head>`.
+ *
+ * Appended at the end of the head so they win over the static shell's generic
+ * Argos description, which describes the product rather than this picture.
+ */
+function injectShareMeta(shell: string, meta: MediaShareMeta): string {
+  return shell.replace("</head>", `${renderShareMeta(meta)}</head>`);
+}
+
+/**
+ * The tags themselves: OpenGraph for most consumers, the Twitter card set for
+ * the ones that only read those, and the oEmbed discovery link for the ones that
+ * would rather ask.
+ *
+ * `og:image` is a picture in both cases — the file for an image, the poster
+ * frame for a video — because a consumer that cannot play the video still
+ * renders the card, and one with no image renders as a bare link.
+ */
+function renderShareMeta(meta: MediaShareMeta): string {
+  const description = meta.description ?? `Shared with Argos · ${meta.name}`;
+
+  // OpenGraph is addressed by `property`, the Twitter card set by `name`. Most
+  // parsers forgive the wrong one; Twitter's does not.
+  const properties: [string, string][] = [
+    ["og:type", meta.video ? "video.other" : "website"],
+    ["og:site_name", "Argos"],
+    ["og:title", meta.name],
+    ["og:description", description],
+    ["og:url", meta.shareUrl],
+    ["og:image", meta.image.url],
+    ["og:image:type", meta.image.contentType],
+    ["og:image:alt", meta.name],
+    // A card with an image but no dimensions is laid out at a guessed shape and
+    // reflows once the bytes arrive.
+    ...numericTags("og:image:width", meta.image.width),
+    ...numericTags("og:image:height", meta.image.height),
+    ...(meta.video
+      ? ([
+          ["og:video", meta.video.url],
+          ["og:video:secure_url", meta.video.url],
+          ["og:video:type", meta.video.contentType],
+        ] satisfies [string, string][])
+      : []),
+  ];
+
+  const names: [string, string][] = [
+    // `summary_large_image` for both: a video would want `player`, which needs a
+    // frameable player URL, and the app refuses to be framed.
+    ["twitter:card", "summary_large_image"],
+    ["twitter:title", meta.name],
+    ["twitter:description", description],
+    ["twitter:image", meta.image.url],
+    ["twitter:image:alt", meta.name],
+    // Restated here rather than left to the static shell's `noindex`: this
+    // response *is* the shell, and the two would otherwise have to agree by
+    // accident. `/m/` is crawlable (see `robots.txt`) precisely so this is read.
+    ["robots", "noindex, nofollow"],
+  ];
+
+  const oembedUrl = new URL(OEMBED_PATH, config.get("server.url"));
+  oembedUrl.searchParams.set("url", meta.shareUrl);
+  oembedUrl.searchParams.set("format", "json");
+
+  return [
+    ...properties.map(
+      ([property, content]) =>
+        `<meta property="${escapeHtmlAttribute(property)}" content="${escapeHtmlAttribute(content)}" />`,
+    ),
+    ...names.map(
+      ([name, content]) =>
+        `<meta name="${escapeHtmlAttribute(name)}" content="${escapeHtmlAttribute(content)}" />`,
+    ),
+    `<link rel="alternate" type="application/json+oembed" href="${escapeHtmlAttribute(oembedUrl.href)}" title="${escapeHtmlAttribute(meta.name)}" />`,
+  ].join("");
+}
+
+function numericTags(
+  property: string,
+  value: number | null,
+): [string, string][] {
+  return value === null ? [] : [[property, String(value)]];
+}
+
+/**
+ * Escape a value for an HTML double-quoted attribute.
+ *
+ * A media's name and description are caller-controlled and land in the page's
+ * `<head>` as-is: a `"` alone closes the attribute, and `<` opens a tag. Both
+ * are ordinary characters in a file name.
+ */
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/apps/frontend/public/robots.txt
+++ b/apps/frontend/public/robots.txt
@@ -1,2 +1,16 @@
+# The app is not a site to crawl — it is behind a login, and nothing in it
+# belongs in a search result.
+#
+# Share pages are the exception, and only so they can be *unfurled*: Slackbot,
+# facebookexternalhit and LinkedIn all check robots.txt before fetching a link
+# somebody pasted, so a blanket disallow means a shared screenshot arrives as a
+# bare URL. `/oembed` is allowed for the same reason.
+#
+# They stay out of search results all the same: every share page serves
+# `<meta name="robots" content="noindex, nofollow">`, and a crawler has to be
+# allowed to fetch a page before it can be told not to index it. Blocking the
+# fetch is what leaves a URL indexable on links alone.
 User-agent: *
+Allow: /m/
+Allow: /oembed
 Disallow: /

--- a/apps/frontend/src/containers/Media/MediaComments.tsx
+++ b/apps/frontend/src/containers/Media/MediaComments.tsx
@@ -444,7 +444,9 @@ function MediaPinnedReference(props: {
     >
       {thumbnailUrl ? (
         <MediaWell checkerSize={3} className="size-6 shrink-0">
-          <img src={thumbnailUrl} alt="" className="size-full object-cover" />
+          {/* Contained rather than cropped, like the version rows: a crop out
+              of a wide screenshot's middle identifies nothing. */}
+          <img src={thumbnailUrl} alt="" className="size-full object-contain" />
         </MediaWell>
       ) : null}
       <span className="min-w-0 flex-1 truncate font-medium">{label}</span>

--- a/apps/frontend/src/containers/Media/MediaVersions.tsx
+++ b/apps/frontend/src/containers/Media/MediaVersions.tsx
@@ -62,10 +62,15 @@ export function MediaVersions(props: {
                 <>
                   {thumbnailUrl ? (
                     <MediaWell checkerSize={3} className="size-8 shrink-0">
+                      {/* Contained, not cropped: what this thumbnail is for is
+                          telling one version from another at a glance, and a
+                          square crop out of the middle of a wide screenshot
+                          shows the same patch of background for every one of
+                          them. The checkerboard is the letterbox. */}
                       <img
                         src={thumbnailUrl}
                         alt=""
-                        className="size-full object-cover"
+                        className="size-full object-contain"
                       />
                     </MediaWell>
                   ) : null}

--- a/apps/frontend/src/containers/Media/MediaViewer.tsx
+++ b/apps/frontend/src/containers/Media/MediaViewer.tsx
@@ -219,6 +219,11 @@ export function MediaViewer(props: {
                 // this is. Drawing them on the counterpart would attach feedback
                 // to the wrong image.
                 comments={pane.interactive ? comments : null}
+                // Only side by side puts two panes on screen, and only then is
+                // "which one takes the pin" a question the viewer has to answer.
+                // A single pane — alone, or with both halves blended into it —
+                // has nowhere else the pin could land.
+                ringTarget={panes.length > 1 && pane.interactive}
               />
             ))}
           </div>
@@ -287,20 +292,44 @@ function MediaPane(props: {
   labelled: boolean;
   blend: BlendState | null;
   comments: ViewerComments | null;
+  /**
+   * Whether this pane should announce itself as the one a pin would land on,
+   * while the comment tool is armed. See {@link MediaViewer} for when that
+   * question is worth answering.
+   */
+  ringTarget: boolean;
 }) {
-  const { media, labelled, blend, comments } = props;
+  const { media, labelled, blend, comments, ringTarget } = props;
   const version = media.version;
   const dimensions =
     version.width && version.height
       ? { width: version.width, height: version.height }
       : undefined;
+  // Only while the tool is armed. A ring that is always on reads as "selected"
+  // and says nothing about where the click goes; one that appears with the
+  // crosshair answers exactly the question the crosshair raises.
+  const targeted = ringTarget && Boolean(comments?.placing);
 
   return (
-    <div className="flex min-w-0 flex-1 flex-col">
+    <div
+      className="flex min-w-0 flex-1 flex-col"
+      data-media-pane=""
+      // The pane a pin would land on, while the tool is armed. An attribute
+      // rather than a class in the test, so the guard survives restyling the
+      // ring.
+      {...(targeted ? { "data-pin-target": "" } : null)}
+    >
       {/* The inspection surface: the same dark checkerboard as the library
           thumbnails, so a white screenshot has a known ground to end on. The
           pane draws no chrome of its own — the well is the chrome. */}
-      <MediaWell className="relative flex min-h-0 flex-1">
+      <MediaWell
+        className={clsx(
+          "relative flex min-h-0 flex-1",
+          // Inset so it draws over the pixels rather than in the gap between
+          // the panes, which is where the eye is already looking.
+          targeted && "ring-primary-active ring-2 ring-inset",
+        )}
+      >
         {labelled ? (
           // Floating over the pixels rather than above the frame, so the two
           // halves stay named while panning, zooming, or leaning in close.
@@ -479,7 +508,7 @@ function MediaImage(props: {
     : undefined;
 
   return (
-    <div className="flex h-full min-w-0 items-center">
+    <div className="flex h-full min-w-0 items-center justify-center">
       <div
         className="relative max-h-full min-h-0 max-w-full min-w-0"
         style={
@@ -497,7 +526,12 @@ function MediaImage(props: {
             alt=""
             draggable={false}
             className={clsx(
-              "absolute inset-0 size-full",
+              // `object-contain`, because the box carries the *base* half's
+              // aspect ratio and a pair's halves need not share one — a
+              // 16:9 "before" against a 4:3 "after" would otherwise be
+              // stretched to fit, comparing two differently-shaped renderings
+              // of the same pixels.
+              "absolute inset-0 size-full object-contain",
               // The "after" paints on top of the base; z-10 clears the base's
               // own stacking position.
               blend.counterpartIsAfter && "z-10",
@@ -512,7 +546,13 @@ function MediaImage(props: {
           width={dimensions?.width}
           height={dimensions?.height}
           onLoad={updateScale}
-          className="relative size-full"
+          // `object-contain` is the guarantee, not the layout: the box already
+          // carries the image's own ratio, but a media whose recorded
+          // dimensions disagree with its bytes — or one with none recorded at
+          // all — must letterbox rather than stretch. A distorted screenshot is
+          // worse than a small one: it is a picture of something that never
+          // rendered.
+          className="relative size-full object-contain"
           style={blend && !blend.counterpartIsAfter ? afterStyle : undefined}
         />
       </div>

--- a/tests/media.spec.ts
+++ b/tests/media.spec.ts
@@ -103,6 +103,43 @@ loggedTest(
   },
 );
 
+loggedTest(
+  "rings the half a pin would land on, in compare mode",
+  async ({ page, auth, project }) => {
+    // Side by side puts two images on screen and only one of them takes
+    // comments. Arming the tool without saying which is which leaves the
+    // reviewer to click and find out.
+    const media = await createMediaScenario({
+      projectId: project.id,
+      commentAuthorId: auth.user.id,
+    });
+
+    await page.goto(`/m/${media.after.shareToken}`);
+    await page.getByRole("button", { name: "Compare" }).click();
+    await page.getByRole("button", { name: "Side by side" }).click();
+
+    const panes = page.locator("[data-media-pane]");
+    await expect(panes).toHaveCount(2);
+    // Nothing is singled out until the tool is armed: a ring that is always on
+    // reads as "selected" and says nothing about where a click goes.
+    await expect(page.locator("[data-media-pane][data-pin-target]")).toHaveCount(
+      0,
+    );
+
+    await page.getByRole("button", { name: "Pin a comment" }).click();
+
+    const target = page.locator("[data-media-pane][data-pin-target]");
+    await expect(target).toHaveCount(1);
+    // The commentable half is this media's own — the "after" — not the
+    // counterpart drawn beside it.
+    await expect(
+      target.getByRole("img", { name: "checkout.png (after)" }),
+    ).toBeVisible();
+
+    await screenshot(page, "media-share-pin-target");
+  },
+);
+
 loggedTest("media share page for a video", async ({ page, project }) => {
   const media = await createMediaScenario({
     projectId: project.id,


### PR DESCRIPTION
Follow-ups from testing the standalone media upload flow end to end.

## The embeds rendered as broken images

`getMediaMarkdown` pointed the image part at the **share URL**, which is an HTML page — so `![x.png](https://app.argos-ci.com/m/…)` produced a broken image everywhere it was pasted: the managed pull request comment, the CLI's `Markdown:` line, and the share page's copy formats.

The embed is now the picture linked to its page — `[![alt](fileUrl)](url)` — which is the shape the video case already had, and for the same reason: the bytes come from the CDN unauthenticated because GitHub fetches embedded images server-side with no session of ours. `getMediaEmbedArgs` derives the three URLs from a version in one place, so no caller can point an embed at the share page by hand again.

## Public share links now unfurl

The share page is an SPA, and no unfurler runs JavaScript, so the tags React sets on mount were tags nobody saw — a link pasted into Slack, Discord, Notion or an issue arrived as a bare URL.

The server injects OpenGraph and Twitter card tags into the shell it already serves, and answers oEmbed at `/oembed`. Images answer as `photo`; videos answer as `link` with a thumbnail, because a `video` response promises a frameable player and the app sends `frame-ancestors 'none'`.

**Public media only.** That metadata is served to a crawler carrying no session, so everything in it is public to whoever holds the link — a `team` media's file name is often exactly what the link was protecting. Team links fall through to the SPA's own sign-in state.

Two things worth a look in review:

- **`robots.txt`** allowed nothing. Slackbot, `facebookexternalhit` and LinkedIn all check it before fetching a pasted link, so `Disallow: /` was stopping the unfurl outright. `/m/` and `/oembed` are now allowed; share pages stay out of search results on their `noindex` tag, which a crawler has to be *allowed to fetch* before it can honour.
- **Previews are capped at 1200px** by the CDN. A crawler drops an image that is too large (Twitter refuses over 5 MB), so an uncapped 4K screenshot unfurled with no image at all.

## Media no longer distorts, and the pin target is obvious

`object-contain` on both viewer layers, pane centered. The box already carries the image's ratio, so this is the guarantee rather than the layout — but it matters in a blended pane, where the counterpart was stretched to the *base* half's ratio: a 16:9 "before" against a 4:3 "after" compared two differently-shaped renderings of the same pixels. Thumbnails go from `cover` to `contain` too; a square crop out of a wide screenshot's middle identifies nothing.

Side by side puts two images on screen and only one takes comments, so arming the pin tool left you to click and find out which. The commentable half now takes a ring — only while the tool is armed, since an always-on ring reads as "selected" and says nothing about where a click goes.

## Verification

- `pnpm run static-checks` clean; 592 unit tests, 123 media integration tests, 6 media Playwright tests pass.
- The ring guard was verified to fail with the fix reverted.
- Checked against a running server: tags injected for a public media, absent for a team one, oEmbed returns a valid `photo` and honours `maxwidth` (375×720 → 200×384), a foreign `url` host 404s, static assets still served.

The `media-share-page` baseline will change — images are centered and letterboxed now.

Companion PRs: CLI-side `gh` detection and combined Markdown in argos-javascript, plus the docs update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)