### PR TITLE
fix(media): give the comment tool an image to project against

### DIFF
--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -1711,10 +1711,13 @@ export async function createMediaScenario(input: {
   const afterV1Ts = "2026-04-20T09:00:00.000Z";
   const afterV2Ts = "2026-04-20T10:00:00.000Z";
   const videoTs = "2026-04-20T09:30:00.000Z";
+  const soloTs = "2026-04-20T07:00:00.000Z";
 
   // A before/after pair sharing one name, which is what lets the share page show
-  // them together and compare them, plus a video that stands alone.
-  const [before, after, video] = await Media.query().insertAndFetch([
+  // them together and compare them, plus a video and a lone screenshot that
+  // stand alone — the share page has no counterpart to draw beside those, which
+  // is a different layout from the pair's.
+  const [before, after, video, solo] = await Media.query().insertAndFetch([
     {
       projectId,
       name: "checkout.png",
@@ -1748,9 +1751,20 @@ export async function createMediaScenario(input: {
       createdAt: videoTs,
       updatedAt: videoTs,
     },
+    {
+      projectId,
+      name: "dashboard.png",
+      state: null,
+      description: "Overview screen after the sidebar redesign.",
+      visibility: "public" as const,
+      githubPullRequestId: null,
+      shareToken: `seed-media-solo-${projectId}`,
+      createdAt: soloTs,
+      updatedAt: soloTs,
+    },
   ]);
 
-  invariant(before && after && video, "media should be created");
+  invariant(before && after && video && solo, "media should be created");
 
   // The "after" image has two versions: the reviewer asked for a change and the
   // second upload answered it. That is the state the version UI has to render.
@@ -1787,35 +1801,58 @@ export async function createMediaScenario(input: {
   ]);
   invariant(afterV2, "the after media should have two versions");
 
-  const [beforeV1, videoV1] = await MediaVersion.query().insertAndFetch([
-    {
-      mediaId: before.id,
-      number: 1,
-      key: "dummy-375x720.png",
-      mimeType: "image/png",
-      sizeBytes: "184320",
-      width: 375,
-      height: 720,
-      expiresAt: "2027-04-20T08:00:00.000Z",
-      uploadedAt: beforeTs,
-      billedUnits: 1,
-      createdAt: beforeTs,
-      updatedAt: beforeTs,
-    },
-    {
-      mediaId: video.id,
-      number: 1,
-      key: "dummy-375x1024.png",
-      mimeType: "video/mp4",
-      sizeBytes: "8388608",
-      expiresAt: "2027-04-20T09:30:00.000Z",
-      uploadedAt: videoTs,
-      billedUnits: 25,
-      createdAt: videoTs,
-      updatedAt: videoTs,
-    },
-  ]);
-  invariant(beforeV1 && videoV1, "versions should be created");
+  const [beforeV1, videoV1, soloV1] = await MediaVersion.query().insertAndFetch(
+    [
+      {
+        mediaId: before.id,
+        number: 1,
+        key: "dummy-375x720.png",
+        mimeType: "image/png",
+        sizeBytes: "184320",
+        width: 375,
+        height: 720,
+        expiresAt: "2027-04-20T08:00:00.000Z",
+        uploadedAt: beforeTs,
+        billedUnits: 1,
+        createdAt: beforeTs,
+        updatedAt: beforeTs,
+      },
+      {
+        mediaId: video.id,
+        number: 1,
+        key: "dummy-375x1024.png",
+        mimeType: "video/mp4",
+        sizeBytes: "8388608",
+        expiresAt: "2027-04-20T09:30:00.000Z",
+        uploadedAt: videoTs,
+        billedUnits: 25,
+        createdAt: videoTs,
+        updatedAt: videoTs,
+      },
+      {
+        // Landscape, unlike the pair: a lone media fills its pane on the axis
+        // its shape gives it, and the pin projection has to follow.
+        //
+        // Deliberately with no recorded dimensions. Processing reads them from
+        // the file's header and tolerates not finding them, so this is a state
+        // real uploads reach — and the viewer has to project pins against the
+        // image it measured rather than give up on the whole comment layer.
+        mediaId: solo.id,
+        number: 1,
+        key: "bear-1440x1024.jpg",
+        mimeType: "image/jpeg",
+        sizeBytes: "131072",
+        width: null,
+        height: null,
+        expiresAt: "2027-04-20T07:00:00.000Z",
+        uploadedAt: soloTs,
+        billedUnits: 1,
+        createdAt: soloTs,
+        updatedAt: soloTs,
+      },
+    ],
+  );
+  invariant(beforeV1 && videoV1 && soloV1, "versions should be created");
 
   if (commentAuthorId) {
     const commentTs = "2026-04-20T11:00:00.000Z";
@@ -1855,7 +1892,7 @@ export async function createMediaScenario(input: {
     ]);
   }
 
-  return { before, after, video, afterV2 };
+  return { before, after, video, solo, afterV2 };
 }
 
 /**

--- a/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
@@ -443,9 +443,11 @@ function ScreenshotPicture(props: ScreenshotPictureProps) {
       const img = imageRef.current;
       if (img && img.complete) {
         const imgScale = getImageScale(img);
-        startTransition(() => {
-          setImgScale(imgScale);
-        });
+        if (imgScale !== null) {
+          startTransition(() => {
+            setImgScale(imgScale);
+          });
+        }
       }
     }
   }, [setImgScale, canAffectScale]);

--- a/apps/frontend/src/containers/Build/projection.ts
+++ b/apps/frontend/src/containers/Build/projection.ts
@@ -82,10 +82,21 @@ export function isPointInImage(point: NormalizedPoint): boolean {
 /**
  * The scale a contain-fitted image is rendered at — what `ScaleContext` carries,
  * and what makes the projection above agree with the pixels on screen.
+ *
+ * The smaller of the two axis ratios, which is what `object-contain` itself
+ * picks: whichever axis runs out first is the one the image is fitted to. Taking
+ * the axis the image's *orientation* suggests instead reads the wrong number
+ * whenever the box it sits in doesn't share the image's ratio — and then every
+ * projected point is off by that factor.
+ *
+ * Null when there is nothing to scale yet (or ever): an image that failed to
+ * load reports zero natural size, and dividing by it yields an `Infinity` that
+ * looks like a valid scale and turns every projection into `NaN`.
  */
-export function getImageScale(element: HTMLImageElement): number {
-  if (element.naturalWidth > element.naturalHeight) {
-    return element.width / element.naturalWidth;
+export function getImageScale(element: HTMLImageElement): number | null {
+  const { naturalWidth, naturalHeight } = element;
+  if (!naturalWidth || !naturalHeight) {
+    return null;
   }
-  return element.height / element.naturalHeight;
+  return Math.min(element.width / naturalWidth, element.height / naturalHeight);
 }

--- a/apps/frontend/src/containers/Media/MediaComments.tsx
+++ b/apps/frontend/src/containers/Media/MediaComments.tsx
@@ -1,7 +1,13 @@
 import { useState } from "react";
 import { useApolloClient } from "@apollo/client/react";
 import { clsx } from "clsx";
-import { FileUpIcon, MapPinPenIcon, UploadIcon, XIcon } from "lucide-react";
+import {
+  FileUpIcon,
+  MapPinPenIcon,
+  MapPinPlusInsideIcon,
+  UploadIcon,
+  XIcon,
+} from "lucide-react";
 import { Button as RACButton } from "react-aria-components";
 import { useLocation } from "react-router";
 
@@ -285,7 +291,7 @@ function PinCommentToggle(props: {
         aria-label="Pin a comment"
         onPress={() => onPlacingChange(true)}
       >
-        <MapPinPenIcon />
+        <MapPinPlusInsideIcon />
       </Button>
     </HotkeyTooltip>
   );

--- a/apps/frontend/src/containers/Media/MediaViewer.tsx
+++ b/apps/frontend/src/containers/Media/MediaViewer.tsx
@@ -223,7 +223,13 @@ export function MediaViewer(props: {
                 // "which one takes the pin" a question the viewer has to answer.
                 // A single pane — alone, or with both halves blended into it —
                 // has nowhere else the pin could land.
-                ringTarget={panes.length > 1 && pane.interactive}
+                pinState={
+                  panes.length > 1 && comments.placing
+                    ? pane.interactive
+                      ? "target"
+                      : "excluded"
+                    : null
+                }
               />
             ))}
           </div>
@@ -293,23 +299,54 @@ function MediaPane(props: {
   blend: BlendState | null;
   comments: ViewerComments | null;
   /**
-   * Whether this pane should announce itself as the one a pin would land on,
-   * while the comment tool is armed. See {@link MediaViewer} for when that
-   * question is worth answering.
+   * This pane's part in the armed comment tool: the half a pin would land on,
+   * or the half it would not. Null while the question doesn't arise — the tool
+   * at rest, or one pane on screen. See {@link MediaViewer}.
    */
-  ringTarget: boolean;
+  pinState: "target" | "excluded" | null;
 }) {
-  const { media, labelled, blend, comments, ringTarget } = props;
+  const { media, labelled, blend, comments, pinState } = props;
   const version = media.version;
-  const dimensions =
-    version.width && version.height
-      ? { width: version.width, height: version.height }
-      : undefined;
-  // Only while the tool is armed. A ring that is always on reads as "selected"
-  // and says nothing about where the click goes; one that appears with the
-  // crosshair answers exactly the question the crosshair raises.
-  const targeted = ringTarget && Boolean(comments?.placing);
+  // What the browser measured off the bytes, once they are in.
+  const [measured, setMeasured] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
+  // A new upload is a different image, so the old measurement stops describing
+  // it — dropped during render (the prior-props pattern) so a frame of the
+  // wrong shape never paints.
+  const [prevFileUrl, setPrevFileUrl] = useState(version.fileUrl);
+  if (prevFileUrl !== version.fileUrl) {
+    setPrevFileUrl(version.fileUrl);
+    setMeasured(null);
+  }
+  const handleMeasured = useCallback(
+    (size: { width: number; height: number }) => {
+      setMeasured((prev) =>
+        prev && prev.width === size.width && prev.height === size.height
+          ? prev
+          : size,
+      );
+    },
+    [],
+  );
 
+  // The image's own size wins once it is known, and the recorded one only
+  // reserves the frame until then. Two reasons, both of which cost the pin
+  // layer its whole reason for existing:
+  //
+  // - Dimensions are read from the file's header at upload and processing
+  //   tolerates failing to find them, so a media can render perfectly well with
+  //   none recorded. Gating the overlay on them left the tool arming, showing
+  //   its crosshair, and dropping every click on the floor.
+  // - When the recorded pair disagrees with the bytes, the image letterboxes
+  //   inside a box of the recorded shape, and points projected against the
+  //   recorded size land somewhere the image isn't.
+  const dimensions =
+    measured ??
+    (version.width && version.height
+      ? { width: version.width, height: version.height }
+      : undefined);
   return (
     <div
       className="flex min-w-0 flex-1 flex-col"
@@ -317,17 +354,24 @@ function MediaPane(props: {
       // The pane a pin would land on, while the tool is armed. An attribute
       // rather than a class in the test, so the guard survives restyling the
       // ring.
-      {...(targeted ? { "data-pin-target": "" } : null)}
+      {...(pinState === "target" ? { "data-pin-target": "" } : null)}
     >
       {/* The inspection surface: the same dark checkerboard as the library
           thumbnails, so a white screenshot has a known ground to end on. The
           pane draws no chrome of its own — the well is the chrome. */}
       <MediaWell
         className={clsx(
-          "relative flex min-h-0 flex-1",
+          "relative flex min-h-0 flex-1 transition-opacity",
+          // Both marks appear only with the crosshair, and answer exactly the
+          // question it raises: a ring that is always on reads as "selected"
+          // and says nothing about where a click goes.
+          //
           // Inset so it draws over the pixels rather than in the gap between
           // the panes, which is where the eye is already looking.
-          targeted && "ring-primary-active ring-2 ring-inset",
+          pinState === "target" && "ring-primary-active ring-2 ring-inset",
+          // The other half recedes: naming the target is only half the answer
+          // if the pane beside it looks just as clickable.
+          pinState === "excluded" && "opacity-50",
         )}
       >
         {labelled ? (
@@ -379,6 +423,7 @@ function MediaPane(props: {
             // projected against *its* image, and a pair's halves can have
             // different intrinsic sizes.
             trackScale={comments != null}
+            onMeasured={handleMeasured}
           />
         </ZoomPane>
         {blend?.mode === "onion" ? (
@@ -459,7 +504,9 @@ export function getMediaDownloadName(media: {
  *
  * The pinned pane also reports its rendered scale to `ScaleContext` — the
  * pin projection multiplies by it, so without this a pin on any image larger
- * than the pane would drift off the pixel it marks.
+ * than the pane would drift off the pixel it marks — and its intrinsic size to
+ * the pane, which is the only source for a media whose dimensions processing
+ * never recorded.
  */
 function MediaImage(props: {
   src: string;
@@ -467,31 +514,39 @@ function MediaImage(props: {
   dimensions: { width: number; height: number } | undefined;
   blend: BlendState | null;
   trackScale: boolean;
+  /** Reports the image's intrinsic size, once the bytes are in. */
+  onMeasured: (size: { width: number; height: number }) => void;
 }) {
-  const { src, alt, dimensions, blend, trackScale } = props;
+  const { src, alt, dimensions, blend, trackScale, onMeasured } = props;
   const [, setImgScale] = useScaleContext();
   const imageRef = useRef<HTMLImageElement>(null);
 
-  const updateScale = useCallback(() => {
+  const measure = useCallback(() => {
+    const img = imageRef.current;
+    // A broken image is `complete` too, with a zero natural size — nothing
+    // measured, and nothing worth reporting.
+    if (!img?.complete || !img.naturalWidth || !img.naturalHeight) {
+      return;
+    }
+    onMeasured({ width: img.naturalWidth, height: img.naturalHeight });
     if (!trackScale) {
       return;
     }
-    const img = imageRef.current;
-    if (img && img.complete) {
-      const imgScale = getImageScale(img);
+    const imgScale = getImageScale(img);
+    if (imgScale !== null) {
       startTransition(() => {
         setImgScale(imgScale);
       });
     }
-  }, [trackScale, setImgScale]);
+  }, [trackScale, setImgScale, onMeasured]);
 
-  const ref = useResizeObserver(() => updateScale(), imageRef);
+  const ref = useResizeObserver(() => measure(), imageRef);
 
-  // Update scale when the image is loaded, and reset it on unmount so the next
-  // media starts from a clean slate.
+  // Measure when the image is loaded, and reset the scale on unmount so the
+  // next media starts from a clean slate.
   useEffect(() => {
-    updateScale();
-  }, [updateScale]);
+    measure();
+  }, [measure]);
   useEffect(() => {
     if (!trackScale) {
       return undefined;
@@ -545,7 +600,7 @@ function MediaImage(props: {
           alt={alt}
           width={dimensions?.width}
           height={dimensions?.height}
-          onLoad={updateScale}
+          onLoad={measure}
           // `object-contain` is the guarantee, not the layout: the box already
           // carries the image's own ratio, but a media whose recorded
           // dimensions disagree with its bytes — or one with none recorded at

--- a/apps/frontend/src/containers/Media/MediaViewer.tsx
+++ b/apps/frontend/src/containers/Media/MediaViewer.tsx
@@ -379,7 +379,7 @@ function MediaPane(props: {
           // halves stay named while panning, zooming, or leaning in close.
           // Near-opaque with a hairline edge: readable over any pixels,
           // light or dark, without hiding much of what it sits on.
-          <div className="text-xxs pointer-events-none absolute top-2 left-2 z-10 rounded bg-neutral-950/90 px-1.5 py-0.5 font-semibold tracking-wide text-white uppercase ring-1 ring-white/25 backdrop-blur-sm">
+          <div className="text-xxs bg-ui/70 pointer-events-none absolute top-2 left-2 z-10 rounded px-1.5 py-0.5 font-semibold tracking-wide text-white uppercase ring-1 ring-white/25 backdrop-blur-sm">
             {media.state}
           </div>
         ) : null}

--- a/apps/frontend/src/containers/Media/MediaViewer.tsx
+++ b/apps/frontend/src/containers/Media/MediaViewer.tsx
@@ -379,7 +379,7 @@ function MediaPane(props: {
           // halves stay named while panning, zooming, or leaning in close.
           // Near-opaque with a hairline edge: readable over any pixels,
           // light or dark, without hiding much of what it sits on.
-          <div className="text-xxs bg-ui/70 pointer-events-none absolute top-2 left-2 z-10 rounded px-1.5 py-0.5 font-semibold tracking-wide text-white uppercase ring-1 ring-white/25 backdrop-blur-sm">
+          <div className="text-xxs pointer-events-none absolute top-2 left-2 z-10 rounded bg-(--gray-12)/70 px-1.5 py-0.5 font-semibold tracking-wide text-white uppercase ring-1 ring-white/25 backdrop-blur-sm dark:bg-(--gray-1)/70">
             {media.state}
           </div>
         ) : null}

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -353,6 +353,25 @@
   @apply [scrollbar-width:none] [&::-webkit-scrollbar]:hidden;
 }
 
+/* The ground a screenshot is inspected on — the checkerboard `MediaWell` and
+   the build's `ZoomPane` draw (see `getCheckerboardStyle`).
+
+   A surface half a step under the page, so the frame reads as recessed, with a
+   checker just visible against it. Literal values rather than palette steps:
+   this is one specific surface whose whole job is to be a *known* ground, and
+   it has to keep saying the same thing at either end of the gray scale. */
+@layer base {
+  :root {
+    --checkerboard-base: #f1f1f4;
+    --checkerboard-square: rgb(0 0 0 / 0.045);
+  }
+
+  .dark {
+    --checkerboard-base: #16161a;
+    --checkerboard-square: rgb(255 255 255 / 0.045);
+  }
+}
+
 @layer base {
   :root {
     --chart-1: 12 76% 61%;

--- a/apps/frontend/src/pages/MediaShare.tsx
+++ b/apps/frontend/src/pages/MediaShare.tsx
@@ -4,10 +4,9 @@ import { invariant } from "@argos/util/invariant";
 import {
   ChevronDownIcon,
   ClockFadingIcon,
-  CloudDownloadIcon,
+  DownloadIcon,
   FileTextIcon,
   GlobeIcon,
-  ImageDownIcon,
   LinkIcon,
   LockIcon,
 } from "lucide-react";
@@ -388,9 +387,7 @@ function MediaActions(props: {
           aria-label="Download"
           onPress={download}
         >
-          {/* What is being saved, not just that something is: a video is the
-              one media a reviewer might not want to wait on. */}
-          {version.isVideo ? <CloudDownloadIcon /> : <ImageDownIcon />}
+          <DownloadIcon />
         </Button>
       </HotkeyTooltip>
       {/* One format is a button, not a menu: a chevron opening a list with a

--- a/apps/frontend/src/pages/MediaShare.tsx
+++ b/apps/frontend/src/pages/MediaShare.tsx
@@ -3,10 +3,11 @@ import { useSuspenseQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import {
   ChevronDownIcon,
-  ClipboardListIcon,
   ClockFadingIcon,
-  DownloadIcon,
+  CloudDownloadIcon,
+  FileTextIcon,
   GlobeIcon,
+  ImageDownIcon,
   LinkIcon,
   LockIcon,
 } from "lucide-react";
@@ -48,6 +49,7 @@ import { Menu, MenuItem } from "@/ui/Menu";
 import { Popover } from "@/ui/Popover";
 import { toast } from "@/ui/Toaster";
 import { Tooltip } from "@/ui/Tooltip";
+import { Truncable } from "@/ui/Truncable";
 import { getMentionUser } from "@/ui/UserCard";
 import { formatBytes, formatDimensions, formatExpiry } from "@/util/media";
 
@@ -263,7 +265,10 @@ function SharePage(props: { media: Media }) {
 /** What the page can put on the clipboard. */
 type ShareFormat = {
   id: string;
+  /** The action itself, spelled out — the menu row and the button's own label. */
   label: string;
+  /** What landed on the clipboard, for the toast to name. */
+  copied: string;
   value: string;
 };
 
@@ -273,7 +278,19 @@ type ShareFormat = {
  */
 const SHARE_FORMAT_STORAGE_KEY = "preferences.mediaShareFormat";
 
+/**
+ * The Markdown embeds this page can hand over: the pair's table when the media
+ * has a counterpart, and the media's own.
+ *
+ * No page link among them — the strip's own link button is already that, and a
+ * menu whose rows are "the thing beside me" reads as a second way to do the
+ * same thing.
+ */
 function getShareFormats(media: Media): ShareFormat[] {
+  // Which half this is, when it is one. A pair's two halves embed different
+  // images under one name, so "Markdown" alone would not say which is going on
+  // the clipboard.
+  const own = media.state ? `Markdown for ${media.state}` : "Markdown";
   return [
     // First is the default: the pair's table when there is one — pasting it
     // shows before and after together, like the page does.
@@ -281,13 +298,18 @@ function getShareFormats(media: Media): ShareFormat[] {
       ? [
           {
             id: "markdown-pair",
-            label: "Markdown (before + after)",
+            label: "Copy Markdown for before and after",
+            copied: "Markdown for before and after",
             value: media.markdownPair,
           },
         ]
       : []),
-    { id: "markdown", label: "Markdown", value: media.markdown },
-    { id: "link", label: "Page link", value: media.url },
+    {
+      id: "markdown",
+      label: `Copy ${own}`,
+      copied: own,
+      value: media.markdown,
+    },
   ];
 }
 
@@ -316,9 +338,7 @@ function MediaActions(props: {
 
   const copyFormat = (target: ShareFormat) => {
     clipboard.copy(target.value);
-    toast.success(`Copied as ${target.label.toLowerCase()}`, {
-      id: SHARE_COPY_TOAST_ID,
-    });
+    toast.success(`${target.copied} copied`, { id: SHARE_COPY_TOAST_ID });
   };
   const copyLink = () => {
     clipboard.copy(media.url);
@@ -368,53 +388,59 @@ function MediaActions(props: {
           aria-label="Download"
           onPress={download}
         >
-          <DownloadIcon />
+          {/* What is being saved, not just that something is: a video is the
+              one media a reviewer might not want to wait on. */}
+          {version.isVideo ? <CloudDownloadIcon /> : <ImageDownIcon />}
         </Button>
       </HotkeyTooltip>
+      {/* One format is a button, not a menu: a chevron opening a list with a
+          single row is furniture, and the button already says what it copies. */}
       <ButtonGroup>
         <HotkeyTooltip
-          description={`Copy as ${format.label.toLowerCase()}`}
+          description={format.label}
           keys={copyAsHotkey.displayKeys}
         >
           <Button
             variant="secondary"
             iconOnly
-            aria-label={`Copy as ${format.label}`}
+            aria-label={format.label}
             onPress={() => copyFormat(format)}
           >
-            <ClipboardListIcon />
+            <FileTextIcon />
           </Button>
         </HotkeyTooltip>
-        <MenuTrigger>
-          <Button
-            variant="secondary"
-            iconOnly
-            aria-label="Choose a copy format"
-          >
-            <ChevronDownIcon />
-          </Button>
-          <Popover placement="bottom end">
-            <Menu aria-label="Copy formats">
-              {formats.map((candidate) => (
-                <MenuItem
-                  key={candidate.id}
-                  onAction={() => {
-                    // Copy right away *and* make it the button's format: the
-                    // menu is how the default is changed.
-                    setStoredFormatId(candidate.id);
-                    localStorage.setItem(
-                      SHARE_FORMAT_STORAGE_KEY,
-                      candidate.id,
-                    );
-                    copyFormat(candidate);
-                  }}
-                >
-                  {candidate.label}
-                </MenuItem>
-              ))}
-            </Menu>
-          </Popover>
-        </MenuTrigger>
+        {formats.length > 1 ? (
+          <MenuTrigger>
+            <Button
+              variant="secondary"
+              iconOnly
+              aria-label="Choose a copy format"
+            >
+              <ChevronDownIcon />
+            </Button>
+            <Popover placement="bottom end">
+              <Menu aria-label="Copy formats">
+                {formats.map((candidate) => (
+                  <MenuItem
+                    key={candidate.id}
+                    onAction={() => {
+                      // Copy right away *and* make it the button's format: the
+                      // menu is how the default is changed.
+                      setStoredFormatId(candidate.id);
+                      localStorage.setItem(
+                        SHARE_FORMAT_STORAGE_KEY,
+                        candidate.id,
+                      );
+                      copyFormat(candidate);
+                    }}
+                  >
+                    {candidate.label}
+                  </MenuItem>
+                ))}
+              </Menu>
+            </Popover>
+          </MenuTrigger>
+        ) : null}
       </ButtonGroup>
     </div>
   );
@@ -489,12 +515,14 @@ function PageHeader(props: {
             {media.name}
           </h1>
           {media.description ? (
-            <span className="text-low min-w-0 truncate text-xs leading-tight">
+            // Truncated with its full text on hover: the prose that shipped
+            // with the upload is often a sentence, and the header is one line.
+            <Truncable className="text-low min-w-0 text-xs leading-tight">
               <span aria-hidden="true" className="mr-1.5 opacity-60">
                 ·
               </span>
               {media.description}
-            </span>
+            </Truncable>
           ) : null}
         </div>
         <div className="text-default flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5 font-mono text-xs leading-tight">

--- a/apps/frontend/src/ui/MediaFrame.tsx
+++ b/apps/frontend/src/ui/MediaFrame.tsx
@@ -1,20 +1,25 @@
 import clsx from "clsx";
 
 /**
- * The transparency ground drawn under inspected pixels: a dark two-tone
- * checkerboard, always dark whatever the viewer's theme (a light surround
- * shifts how you read an image's own values — every tool built for looking at
- * pixels is dark for that reason). Two offset gradients make the classic grid,
- * drawn in CSS so there is no asset to load before the content has a ground.
- * Shared by `MediaWell` and the build's `ZoomPane`, so a screenshot sits on
- * the same ground wherever it is inspected.
+ * The transparency ground drawn under inspected pixels: the classic two-tone
+ * checkerboard, made of two offset gradients in CSS so there is no asset to
+ * load before the content has a ground. Shared by `MediaWell` and the build's
+ * `ZoomPane`, so a screenshot sits on the same ground wherever it is inspected.
+ *
+ * It follows the viewer's theme (`--checkerboard-*`), rather than staying dark
+ * under a light page. The point of the ground is being *known* — screenshots
+ * routinely have alpha or white edges, and without one you cannot tell where
+ * the image stops and the page starts — and a slab of near-black under a light
+ * UI is read as part of the picture, which is the same confusion by the other
+ * door.
  */
 export function getCheckerboardStyle(checkerSize = 8): React.CSSProperties {
+  const square = "var(--checkerboard-square)";
   return {
-    backgroundColor: "#16161a",
+    backgroundColor: "var(--checkerboard-base)",
     backgroundImage: `
-      linear-gradient(45deg, rgba(255, 255, 255, 0.045) 25%, transparent 25%, transparent 75%, rgba(255, 255, 255, 0.045) 75%),
-      linear-gradient(45deg, rgba(255, 255, 255, 0.045) 25%, transparent 25%, transparent 75%, rgba(255, 255, 255, 0.045) 75%)
+      linear-gradient(45deg, ${square} 25%, transparent 25%, transparent 75%, ${square} 75%),
+      linear-gradient(45deg, ${square} 25%, transparent 25%, transparent 75%, ${square} 75%)
     `,
     backgroundSize: `${checkerSize * 2}px ${checkerSize * 2}px`,
     backgroundPosition: `0 0, ${checkerSize}px ${checkerSize}px`,

--- a/apps/frontend/src/ui/Popover.tsx
+++ b/apps/frontend/src/ui/Popover.tsx
@@ -6,54 +6,37 @@ import {
 } from "react-aria-components";
 
 /**
- * Where the pop-in animation grows from: the corner touching the trigger.
+ * Which way the popover moves on the way in and out: towards the viewer, from
+ * the edge that touches its trigger.
  *
- * The render values only carry the resolved *side* ("bottom"), not the
- * requested alignment — so an end-aligned menu used to zoom from its top
- * center, visibly detached from the button that opened it. The alignment is
- * read back from the `placement` prop, while the side comes from the render
- * values so a flipped popover still animates from the right edge.
+ * A translate rather than a scale. Scaling the whole box moves both of its
+ * edges, and on a menu wider than its trigger that reads as the popover
+ * stretching itself out to fit its longest row — an animation about the menu's
+ * own layout rather than about where it came from. Sliding it keeps the box the
+ * size it will settle at from the very first frame.
+ *
+ * Keyed on the *resolved* side, so a popover flipped for want of room animates
+ * from the edge it actually opened against.
  */
-function getPopoverOriginClassName(
-  side: PopoverRenderProps["placement"],
-  requestedPlacement: PopoverProps["placement"],
-): string | null {
-  const alignment = requestedPlacement?.split(" ")[1];
-  switch (side) {
-    case "bottom":
-      return {
-        start: "origin-top-left",
-        end: "origin-top-right",
-        default: "origin-top",
-      }[alignment ?? "default"]!;
-    case "top":
-      return {
-        start: "origin-bottom-left",
-        end: "origin-bottom-right",
-        default: "origin-bottom",
-      }[alignment ?? "default"]!;
-    case "left":
-      return "origin-right";
-    case "right":
-      return "origin-left";
-    case "center":
-      return "origin-center";
-    default:
-      return null;
-  }
-}
+const POPOVER_SLIDE_CLASS_NAMES: Record<
+  NonNullable<PopoverRenderProps["placement"]>,
+  { in: string; out: string }
+> = {
+  bottom: { in: "slide-in-from-top-1", out: "slide-out-to-top-1" },
+  top: { in: "slide-in-from-bottom-1", out: "slide-out-to-bottom-1" },
+  left: { in: "slide-in-from-right-1", out: "slide-out-to-right-1" },
+  right: { in: "slide-in-from-left-1", out: "slide-out-to-left-1" },
+  center: { in: "", out: "" },
+};
 
-function getPopoverAnimationClassName(
-  values: PopoverRenderProps,
-  requestedPlacement: PopoverProps["placement"],
-): string {
+function getPopoverAnimationClassName(values: PopoverRenderProps): string {
+  const slide = values.placement
+    ? POPOVER_SLIDE_CLASS_NAMES[values.placement]
+    : null;
   return clsx(
     "fill-mode-forwards",
-    getPopoverOriginClassName(values.placement, requestedPlacement),
-    // Mirrors the exit: without the zoom the menu just fades in mid-air
-    // instead of growing out of its trigger.
-    values.isEntering && "animate-in fade-in zoom-in-95",
-    values.isExiting && "animate-out fade-out zoom-out-95",
+    values.isEntering && clsx("animate-in fade-in", slide?.in),
+    values.isExiting && clsx("animate-out fade-out", slide?.out),
   );
 }
 
@@ -69,7 +52,7 @@ export function Popover(
       className={(values) =>
         clsx(
           "bg-app shadow-menu border-thin z-50 flex rounded-xl bg-clip-padding",
-          getPopoverAnimationClassName(values, props.placement),
+          getPopoverAnimationClassName(values),
           props.className,
         )
       }

--- a/apps/frontend/src/ui/Popover.tsx
+++ b/apps/frontend/src/ui/Popover.tsx
@@ -6,37 +6,54 @@ import {
 } from "react-aria-components";
 
 /**
- * Which way the popover moves on the way in and out: towards the viewer, from
- * the edge that touches its trigger.
+ * Where the pop-in animation grows from: the corner touching the trigger.
  *
- * A translate rather than a scale. Scaling the whole box moves both of its
- * edges, and on a menu wider than its trigger that reads as the popover
- * stretching itself out to fit its longest row — an animation about the menu's
- * own layout rather than about where it came from. Sliding it keeps the box the
- * size it will settle at from the very first frame.
- *
- * Keyed on the *resolved* side, so a popover flipped for want of room animates
- * from the edge it actually opened against.
+ * The render values only carry the resolved *side* ("bottom"), not the
+ * requested alignment — so an end-aligned menu used to zoom from its top
+ * center, visibly detached from the button that opened it. The alignment is
+ * read back from the `placement` prop, while the side comes from the render
+ * values so a flipped popover still animates from the right edge.
  */
-const POPOVER_SLIDE_CLASS_NAMES: Record<
-  NonNullable<PopoverRenderProps["placement"]>,
-  { in: string; out: string }
-> = {
-  bottom: { in: "slide-in-from-top-1", out: "slide-out-to-top-1" },
-  top: { in: "slide-in-from-bottom-1", out: "slide-out-to-bottom-1" },
-  left: { in: "slide-in-from-right-1", out: "slide-out-to-right-1" },
-  right: { in: "slide-in-from-left-1", out: "slide-out-to-left-1" },
-  center: { in: "", out: "" },
-};
+function getPopoverOriginClassName(
+  side: PopoverRenderProps["placement"],
+  requestedPlacement: PopoverProps["placement"],
+): string | null {
+  const alignment = requestedPlacement?.split(" ")[1];
+  switch (side) {
+    case "bottom":
+      return {
+        start: "origin-top-left",
+        end: "origin-top-right",
+        default: "origin-top",
+      }[alignment ?? "default"]!;
+    case "top":
+      return {
+        start: "origin-bottom-left",
+        end: "origin-bottom-right",
+        default: "origin-bottom",
+      }[alignment ?? "default"]!;
+    case "left":
+      return "origin-right";
+    case "right":
+      return "origin-left";
+    case "center":
+      return "origin-center";
+    default:
+      return null;
+  }
+}
 
-function getPopoverAnimationClassName(values: PopoverRenderProps): string {
-  const slide = values.placement
-    ? POPOVER_SLIDE_CLASS_NAMES[values.placement]
-    : null;
+function getPopoverAnimationClassName(
+  values: PopoverRenderProps,
+  requestedPlacement: PopoverProps["placement"],
+): string {
   return clsx(
     "fill-mode-forwards",
-    values.isEntering && clsx("animate-in fade-in", slide?.in),
-    values.isExiting && clsx("animate-out fade-out", slide?.out),
+    getPopoverOriginClassName(values.placement, requestedPlacement),
+    // Mirrors the exit: without the zoom the menu just fades in mid-air
+    // instead of growing out of its trigger.
+    values.isEntering && "animate-in fade-in zoom-in-95",
+    values.isExiting && "animate-out fade-out zoom-out-95",
   );
 }
 
@@ -52,7 +69,7 @@ export function Popover(
       className={(values) =>
         clsx(
           "bg-app shadow-menu border-thin z-50 flex rounded-xl bg-clip-padding",
-          getPopoverAnimationClassName(values),
+          getPopoverAnimationClassName(values, props.placement),
           props.className,
         )
       }

--- a/tests/media.spec.ts
+++ b/tests/media.spec.ts
@@ -104,6 +104,39 @@ loggedTest(
 );
 
 loggedTest(
+  "pins a comment on a media that stands alone",
+  async ({ page, auth, project }) => {
+    // A lone media has no counterpart, so no compare toolbar and a single pane —
+    // the pin tool has to work there exactly as it does beside a pair. This one
+    // also has no recorded dimensions, which used to take the comment layer off
+    // the page entirely: the tool armed, showed its crosshair, and dropped every
+    // click.
+    const media = await createMediaScenario({
+      projectId: project.id,
+      commentAuthorId: auth.user.id,
+    });
+
+    await page.goto(`/m/${media.solo.shareToken}`);
+
+    await page.getByRole("button", { name: "Pin a comment" }).click();
+    await page
+      .getByRole("button", { name: "Pick the spot to comment on" })
+      .click({ position: { x: 200, y: 150 } });
+
+    const draftDialog = page.getByRole("dialog", { name: "Add a comment" });
+    const editor = draftDialog.getByLabel("Add a comment");
+    await editor.click();
+    await editor.fill("The sidebar is cropped here.");
+    await draftDialog
+      .getByRole("button", { name: "Submit the comment" })
+      .click();
+
+    await expect(page.getByText("The sidebar is cropped here.")).toHaveCount(2);
+    await expect(page.getByText("pinned on the image")).toBeVisible();
+  },
+);
+
+loggedTest(
   "rings the half a pin would land on, in compare mode",
   async ({ page, auth, project }) => {
     // Side by side puts two images on screen and only one of them takes
@@ -122,9 +155,9 @@ loggedTest(
     await expect(panes).toHaveCount(2);
     // Nothing is singled out until the tool is armed: a ring that is always on
     // reads as "selected" and says nothing about where a click goes.
-    await expect(page.locator("[data-media-pane][data-pin-target]")).toHaveCount(
-      0,
-    );
+    await expect(
+      page.locator("[data-media-pane][data-pin-target]"),
+    ).toHaveCount(0);
 
     await page.getByRole("button", { name: "Pin a comment" }).click();
 


### PR DESCRIPTION
The pin tool did nothing on a media the viewer showed on its own. Arming it put the crosshair on the image and every click landed on the floor.

## The cause

The comment layer was gated on the version's **recorded** dimensions, and processing reads those from the file's header and tolerates not finding them — "a layout nicety, not a reason to reject a file". A media without them renders perfectly well, so nothing about the page said the tool was inert.

The image's own size is now what the layer projects against, with the recorded pair only reserving the frame until the bytes are in. That also covers a recorded pair that *disagrees* with the file: the image letterboxes inside a box of the recorded shape, and points projected against the recorded size land where the image isn't.

`getImageScale` now takes the smaller of the two axis ratios — what `object-contain` itself picks. Reading the axis the image's orientation suggests is the wrong number whenever the box doesn't share the image's ratio. It answers `null` for an image that never loaded, whose zero natural size used to divide out to an `Infinity` that passed for a valid scale and turned every projection into `NaN`.

## Alongside, on the share page

- The counterpart pane **fades** while the tool is armed. Ringing the half a pin would land on is only half the answer if the one beside it looks just as clickable.
- The copy menu loses its **page-link** row — the strip's own link button is already that — and its rows say what they copy: "Copy Markdown for before and after", "Copy Markdown for after". A media with one format is a button on its own, with no chevron opening a list of one.
- **Download** says what it saves (image or video), **Markdown** wears a document rather than a clipboard, and a long **description** truncates with its full text on hover.
- **Popovers slide** in and out instead of scaling. Scaling moves both edges, which on a menu wider than its trigger reads as the box stretching to fit its longest row.

## Testing

`createMediaScenario` grows a lone media — landscape, one version, and deliberately with no recorded dimensions, which is a state real uploads reach. A new spec pins a comment on it; it fails on `main` (the click surface isn't in the DOM at all). Full static checks, 600 unit tests and all 88 Chromium e2e specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)