### PR TITLE
fix(media): drop the transparency checkerboard

### DIFF
--- a/.agents/skills/argos-cli/SKILL.md
+++ b/.agents/skills/argos-cli/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: argos-cli
+description: >
+  Operate Argos visual testing from the terminal with the `argos` CLI — inspect
+  builds and snapshot diffs, submit reviews, request reviewers, post comments,
+  inspect a test's flakiness and its recurring changes, ignore flaky test
+  changes, configure a project and its contributors, manage a team's members,
+  invites and email domains, manage automation rules, fetch analytics, upload
+  screenshots, and manage CI builds. Use whenever running `argos` commands or
+  working with Argos builds, snapshots, flakiness, projects, teams, or
+  visual-regression reviews from a shell, script, or CI pipeline.
+  Load before running `argos` — it covers the token model and JSON output
+  contract that prevent silent failures.
+license: MIT
+metadata:
+  author: argos-ci
+  homepage: https://argos-ci.com
+  source: https://github.com/argos-ci/argos-javascript
+argument-hint: Needs a token (ARGOS_TOKEN, --token, or `argos login`); add `--project owner/project` for build-number refs on review/comment commands, for every `change`, `project` and `automation` command, and for `test` commands unless the token is a project token; `--account <slug>` (or ARGOS_ACCOUNT) for every `account` command.
+---
+
+# Argos CLI
+
+Run `argos <command> --help` for the exact flags of any command. This skill
+covers only what `--help` can't: the token model, the output contract, and the
+command map.
+
+## Output contract (agents)
+
+- Pass `--json` whenever you parse stdout; commands print human-readable text
+  otherwise.
+- Errors go to **stderr** as `Error: <message>`. Exit `0` = success, `1` = failure.
+- Never print token values.
+
+## Authentication
+
+A `<buildReference>` is a build number (e.g. `72652`) or a full build URL. With a
+number, add `--project owner/project`; a URL already contains it. A `<changeId>`
+is not a build ref: it comes from a diff's `change.id` and does **not** carry the
+account, so every `change` command needs `--project owner/project` (or
+`ARGOS_PROJECT`). A `<testId>` comes from a diff's `test.id` and carries the
+project name but not the account, so `test` commands need the same
+`--project`/`ARGOS_PROJECT` — except with a project token, which already
+identifies its own project. `project` and `automation` commands take the same
+`--project owner/project`; `account` commands take `--account <slug>` (or
+`ARGOS_ACCOUNT`).
+
+Two token types — pick by command:
+
+| Commands                                                                                                                                                                                                                                                                                                         | Token                       | Resolution order                            |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- | ------------------------------------------- |
+| `build get`, `build snapshots`, `test list`, `test get`, `test changes`, `change list`, `project get`, `project deployments`, `project domain get`, `media get`, `media list`, `media versions`, `media update`, `media delete`                                                                                  | Project token               | `--token` › `ARGOS_TOKEN`                   |
+| `review *`, `comment *`, `test comment *`, `media comment *`, `test subscribe` / `unsubscribe`, `build subscribe` / `unsubscribe`, `change ignore` / `unignore`, `account *`, `project update`, `project transfer`, `project contributor *`, `project domain set`, `automation *`, `analytics`, `create-project` | Personal access token (PAT) | `--token` › `ARGOS_TOKEN` › `argos login`   |
+| `upload`, `finalize`, `skip`, `deploy`, `media upload`                                                                                                                                                                                                                                                           | CI / project token          | `--token` › `ARGOS_TOKEN` (or tokenless CI) |
+
+Project tokens read build data but **cannot** review, comment, ignore changes, or
+administer a project or team — those need a PAT. If no suitable token is
+available, ask the user. For these actions, if no PAT exists, report the
+conclusion and evidence instead of acting. `argos login` is for interactive
+humans, not CI.
+
+## Commands
+
+- **Inspect** — `build get <ref>` · `build snapshots <ref> [--needs-review] [--metrics-period 24h|3d|7d|30d|90d]` · `build subscribe|unsubscribe <ref>`
+- **Review** — `review list <ref>` · `review create <ref> --event <approve|reject|comment> [--body <md>]` · `review dismiss <ref> <reviewId>` · `review reviewer list <ref>` · `review reviewer add|remove <ref> <userId...>`
+- **Comment** — `comment list <ref>` · `comment create <ref> --body <md> [--reply-to <id>] [--diff <id>] [--draft]` · `comment get|edit|delete|resolve|unresolve|subscribe|unsubscribe <ref> <id>` · `comment react|unreact <ref> <id> <emoji>`
+- **Flakiness** — `test list [--build-name <name>] [--search <q>]` · `test get <testId>` · `test changes <testId> [--ignored true|false] [--metrics-period …]` · `test subscribe|unsubscribe <testId>` · `change list` · `change ignore|unignore <changeId> --project owner/project`
+- **Test comments** — `test comment list|create <testId>` · `test comment get|edit|delete|resolve|unresolve|subscribe|unsubscribe <testId> <id>` · `test comment react|unreact <testId> <id> <emoji>`
+- **Project** — `project get` · `project update [--name …] [--summary-check …] [--default-user-level …] [--ignore-changes true|false] [--deployments true|false] …` · `project transfer --to <slug>` · `project contributor list|set|remove` · `project deployments [--environment preview|production]` · `project domain get|set <domain>`
+- **Automation** — `automation list [--active true|false]` · `automation get <ruleId>` · `automation create|update [<ruleId>] --definition-file <path>` · `automation deactivate <ruleId>`
+- **Team** — `account get` · `account update --default-user-level <member|contributor>` · `account member list|set-level|remove` · `account invite list|create|cancel|reset-link` · `account domain list|add|remove`
+- **Account** — `analytics --account <slug>` · `create-project <name> --account <slug>` · `whoami`
+- **Media** — `media upload <files...> [--branch <b> | --pr <n>] [--state before|after] [--description <text>] [--visibility team|public] [--no-compress]` · `media list [--branch <b>] [--pr <n>] [--stage staged|published] [--search <q>] [--type image|video]` · `media get|delete|versions <mediaId>` · `media update <mediaId> [--name <n>] [--description <text>] [--branch <b>]`
+- **Media comments** — `media comment list <mediaId> [--all]` (open threads by default) · `media comment create <mediaId>` · `media comment get|edit|delete|resolve|unresolve|subscribe|unsubscribe <mediaId> <id>` · `media comment react|unreact <mediaId> <id> <emoji>`
+- **CI** — `upload <dir>` · `finalize` · `skip` · `deploy <dir>`
+- **Auth** — `login` · `logout`
+
+List commands (`test list`, `change list`, `account member list`, `project
+contributor list`, `project deployments`, `automation list`, `account invite
+list`) follow pagination up to `--limit` (default 100).
+
+`build snapshots --json` enriches each diff with `test.metrics` (flakiness:
+`stability`, `consistency`, `flakiness`, all 0–1) and, on a change, `change`
+(`id`, `ignored`, `occurrences`). High `occurrences` or `flakiness` flags a
+change worth ignoring; pass its `change.id` to `change ignore`.
+
+## Common flows
+
+Review a build (inspect with a project token, decide with a PAT):
+
+```bash
+ARGOS_TOKEN=<project-token> argos build snapshots <ref> --needs-review --json
+argos review create <ref> --token <pat> --event approve --json
+# regression: argos review create <ref> --token <pat> --event reject --body "..."
+```
+
+Silence a flaky change (inspect with a project token, ignore with a PAT).
+Ignored changes stop requiring review and are auto-approved on future builds:
+
+```bash
+ARGOS_TOKEN=<project-token> argos build snapshots <ref> --json   # read each diff's change.id + occurrences
+argos change ignore <changeId> --token <pat> --project owner/project
+# revert: argos change unignore <changeId> --token <pat> --project owner/project
+```
+
+Work through a project's flakiness backlog. `test list` returns the tests still
+running in the project, flakiest first, so the first page is what to stabilise;
+`change list` audits what has already been silenced:
+
+```bash
+ARGOS_TOKEN=<project-token> argos test list --project owner/project --json --limit 20
+ARGOS_TOKEN=<project-token> argos change list --project owner/project --json   # already ignored
+```
+
+Diagnose a flaky test before deciding whether to fix it or ignore it. `test get`
+reports how flaky it is; `test changes` lists the distinct changes most-frequent
+first, each with the diff, baseline and head image URLs to look at:
+
+```bash
+ARGOS_TOKEN=<project-token> argos test get <testId> --json          # flakiness, stability, consistency, series
+ARGOS_TOKEN=<project-token> argos test changes <testId> --json      # occurrences + diff/base/head URLs per change
+# a change with occurrences > 1 that nothing in the UI explains is flaky:
+argos change ignore <changeId> --token <pat> --project owner/project
+```
+
+Upload screenshots in CI:
+
+```bash
+argos upload ./screenshots --token $ARGOS_TOKEN
+```
+
+Parallel builds:
+
+```bash
+argos upload ./screenshots --parallel-nonce $ID --parallel-index $i --parallel-total $n
+argos finalize --parallel-nonce $ID
+```
+
+Onboard someone onto a team and a project. Team roles come from `account`,
+per-project access from `project contributor` — owners and members already reach
+every project, so contributors are the only ones that need a grant:
+
+```bash
+argos account invite create dev@acme.com --account acme --level contributor --json
+argos account member list --account acme --search dev --json          # read back user.id once they accept
+argos project contributor set <userId> --level reviewer --project acme/web --json
+```
+
+Configure a project. `project update` only changes the settings you pass, and
+prints the project back so you can check what it ended up with:
+
+```bash
+argos project get --project acme/web --json
+argos project update --project acme/web --summary-check auto --ignore-changes true --auto-ignore-after 3 --json
+```
+
+Ask for a review on a build, then check who is still on the hook:
+
+```bash
+argos review reviewer add <ref> <userId> --token <pat> --project acme/web
+argos review reviewer list <ref> --token <pat> --project acme/web --json
+```

--- a/.agents/skills/argos-cli/agents/openai.yaml
+++ b/.agents/skills/argos-cli/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Argos CLI"
+  short_description: "Use the Argos CLI safely and correctly"
+  default_prompt: "Use $argos-cli to run or interpret Argos CLI commands in this repository."

--- a/.agents/skills/argos-pr-review/SKILL.md
+++ b/.agents/skills/argos-pr-review/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: argos-pr-review
+description: >
+  Review Argos visual regression builds as one input to a pull request review.
+  Use when a PR has an Argos build link, an Argos status check, or a bot comment
+  pointing to an Argos build, and you need to decide whether the visual diffs
+  match the developer's intent before approving.
+---
+
+# Argos PR Review
+
+**Argos** is a visual testing platform: each CI build captures screenshots and
+compares them to a baseline, producing per-snapshot **diffs**. A build with
+`changes-detected` is waiting for a human (or you) to decide whether each change
+is intentional, a regression, or a flaky capture.
+
+Treat the Argos build as **one input** to the PR review, never the sole source of
+truth. Infer the intended UI change from the PR title, description, linked issue,
+and code diff _first_, then use Argos to confirm the rendered result matches.
+
+## Tooling & auth
+
+Drive Argos through the `argos` CLI — load the **argos-cli** skill for the token
+model and flags. In short: `build get` / `build snapshots` need a project token
+(`ARGOS_TOKEN`/`--token`); submitting a review or comment needs a **personal
+access token** (`--token` / `argos login`). Always use `--json` when parsing, and
+never print token values. If no PAT is available, give the user your conclusion
+and evidence instead of posting — the CLI can't submit the review.
+
+## Workflow
+
+1. **Inspect the build** — `argos build get <ref> --json`. Decide from status:
+
+   | Status                                      | Meaning / next step                                  |
+   | ------------------------------------------- | ---------------------------------------------------- |
+   | `accepted` / `no-changes`                   | Already approved / no visual diff — no review needed |
+   | `pending` / `progress`                      | Not ready — stop and report it can't be reviewed yet |
+   | `changes-detected`                          | Needs a decision — fetch snapshots                   |
+   | `rejected` / `error` / `aborted`/ `expired` | Don't approve until the cause is understood          |
+
+2. **Fetch what changed** — `argos build snapshots <ref> --needs-review --json`.
+   For each diff inspect `url` (diff mask), `base.url` (before), `head.url`
+   (after), and `head.metadata`, plus the flakiness signals `test.metrics` and,
+   on a change, `change.occurrences` / `change.ignored` (used in step 3).
+
+3. **Judge each diff** against the inferred intent:
+   - **Intentional** — matches the code change and renders cleanly.
+   - **Regression** — broken layout/overlap, clipping, wrong state/theme/route,
+     missing content, or a removed snapshot with no matching test removal.
+   - **Flaky** — weigh two independent signals; when they agree, call it flaky
+     with confidence:
+     - _Test history_ — `test.metrics.flakiness` (0 stable → 1 flaky) and
+       `change.occurrences` (how many times this **exact** diff has recurred over
+       the metrics period). A high flakiness score or a recurring change is strong
+       evidence the diff is environmental noise, not this PR's work; `stability`
+       (builds without a change), `consistency` (do changes repeat identically),
+       and `uniqueChanges` explain _why_ it scores that way. `change.ignored: true`
+       is already known-flaky and auto-approved — never read it as a regression.
+     - _This capture_ — a spinner/skeleton, async content not yet loaded,
+       mid-animation, drifting dynamic values, `head.metadata.test.retry > 0`, or
+       identical `score`/`head.url` across browsers (both captured the same
+       transient state). `retries` (the configured budget) is not itself a signal.
+
+     Conversely, a **stable** test (`flakiness`→0, high `stability`, a first-time
+     change) that changed is more likely intentional or a real regression — don't
+     dismiss it as flaky on the visuals alone. Tune the window with
+     `build snapshots --metrics-period <24h|3d|7d|30d|90d>` (default `7d`).
+
+4. **Comment on specific diffs — the highest-value output of an agent review.**
+   A binary approve/reject is cheap; specific, anchored feedback is what makes an
+   agent review worth reading. For each problem diff, post a comment that names
+   what's wrong and how to fix it, anchored to that snapshot:
+
+   ```bash
+   argos comment create <ref> --token <pat> --diff <screenshotDiffId> \
+     --body "Loader still visible — capture runs before data loads. Wait for settled content (or mark the loader aria-busy)."
+   ```
+
+   - `<screenshotDiffId>` is the diff `id` from `build snapshots --json`.
+   - Pin to a region with `--anchor-lines <from,to>` or `--anchor-point <x,y>`
+     (normalized 0–1); reply in a thread with `--reply-to <commentId>`.
+   - Use `--draft` to bundle comments into your pending review, then submit them
+     together in the next step.
+
+5. **Submit the review** (or report if no PAT is available):
+   - Approve: `argos review create <ref> --token <pat> --event approve`
+   - Request changes: `argos review create <ref> --token <pat> --event reject --body "<summary>"`
+   - Neutral note only: `--event comment --body "<summary>"`
+   - Add `--project owner/project` for build-number refs (not URLs).
+   - Silence a **confirmed recurring** flake so it stops blocking future builds:
+     `argos change ignore <change.id> --token <pat> --project owner/project`
+     (reverse with `change unignore`). Only ignore flakes the metrics confirm —
+     never to bypass a real diff; prefer a code fix
+     ([references/flaky-fixes.md](references/flaky-fixes.md)) when one exists.
+   - Lead with the inferred intent, the snapshots reviewed, and the evidence. In
+     the PR, cite the build URL and affected snapshot names; for flakes, name the
+     signal and recommend a fix.
+
+## References
+
+- [references/baseline.md](references/baseline.md) — baseline selection and
+  orphan-build semantics (load when the review depends on which baseline was used).
+- [references/flaky-fixes.md](references/flaky-fixes.md) — concrete code fixes for
+  flaky captures (`aria-busy`, `data-visual-test`, animation stabilization).

--- a/.agents/skills/argos-pr-review/agents/openai.yaml
+++ b/.agents/skills/argos-pr-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Argos PR Review"
+  short_description: "Review Argos builds as part of PR review"
+  default_prompt: "Use $argos-pr-review to review this pull request when an Argos build is available."

--- a/.agents/skills/argos-pr-review/references/baseline.md
+++ b/.agents/skills/argos-pr-review/references/baseline.md
@@ -1,0 +1,73 @@
+# Baseline And Orphan Build Notes
+
+Load this file when an Argos PR review depends on baseline selection, orphan
+build semantics, or how approval affects future comparisons.
+
+---
+
+## Baseline Build
+
+The baseline is the screenshot Argos compares the new build against.
+
+**Approval vs. baseline:** approving a build makes it a candidate for future
+baseline selection. It does not directly overwrite the current baseline. The
+baseline is selected dynamically each time a new build runs.
+
+Do not say:
+
+```text
+Approving this build will update the baseline.
+```
+
+Say instead:
+
+```text
+Approving this build would make it eligible to be selected as a baseline for future builds on this branch.
+```
+
+## Baseline Selection Rules
+
+Argos picks the most recent build satisfying all of:
+
+1. Same build name as the triggered build
+2. All framework tests passed
+3. Not a subset build
+4. Status is auto-approved, manually approved, or orphan
+5. Its commit is an ancestor of the merge base between the new build's commit
+   and the baseline branch
+
+## Baseline Branch
+
+- Pull requests: the PR base branch
+- Push events: the project's configured default baseline branch, usually `main`
+
+## Baseline Overrides
+
+- `ARGOS_REFERENCE_BRANCH`: force a specific branch as baseline
+- `ARGOS_REFERENCE_COMMIT`: pin to a specific commit's build
+
+## CI Caveat
+
+If CI does not run on the default branch, the baseline becomes stale and diffs
+accumulate. Keep Argos running on the default branch too.
+
+## Orphan Builds
+
+An orphan build has no prior build to compare against, so all snapshots appear
+as `added` with `base: null`.
+
+This is expected for:
+
+- the first build in a project
+- a branch that has no approved ancestor build yet
+
+The absence of a baseline is not itself a regression signal.
+
+## Review Guidance
+
+When reviewing an orphan build:
+
+- inspect screenshots for obvious layout or rendering problems
+- do not treat every `added` snapshot as suspicious just because `base` is null
+- approve the build if the screenshots look correct and it is intended to seed a
+  future baseline

--- a/.agents/skills/argos-pr-review/references/flaky-fixes.md
+++ b/.agents/skills/argos-pr-review/references/flaky-fixes.md
@@ -1,0 +1,125 @@
+# Flaky Fix Code Examples
+
+Code examples for each flakiness fix. Load this file when you need to give a developer the exact implementation for a fix identified during build review.
+
+---
+
+## 1. Loaders / async data — `aria-busy`
+
+For SDKs that enable `waitForAriaBusy`, `argosScreenshot()` waits until no
+element with `aria-busy` is present or truthy before capturing. Apply it to
+loader components in those integrations.
+
+```jsx
+// while data is loading
+<Loader aria-busy={true} />
+
+// once data is ready, remove the attribute or set to false
+<Loader aria-busy={false} />
+```
+
+Plain HTML:
+
+```html
+<div class="spinner" aria-busy="true"></div>
+```
+
+---
+
+## 2. Dynamic dates and times
+
+**Option A — hide the element (preserves layout):**
+
+```html
+<time data-visual-test="transparent">10 oct, 2012</time>
+```
+
+**Option B — freeze dates in test seeds:**
+Run a normalization script before the E2E suite that sets all date fields to a fixed value. This is preferable when the date drives layout (e.g. affects column widths or sort order).
+
+---
+
+## 3. Dynamic content — `data-visual-test` attributes
+
+| Attribute                        | CSS effect              | When to use                                                                |
+| -------------------------------- | ----------------------- | -------------------------------------------------------------------------- |
+| `data-visual-test="transparent"` | `visibility: hidden`    | Hide content, keep layout space                                            |
+| `data-visual-test="removed"`     | `display: none`         | Hide content and collapse layout space                                     |
+| `data-visual-test="blackout"`    | Black mask overlay      | Obscure sensitive or dynamic content (Playwright, Cypress, Storybook only) |
+| `data-visual-test-no-radius`     | Removes `border-radius` | Fix cross-browser rounding glitches                                        |
+
+```html
+<!-- hide a dynamic avatar but preserve its space -->
+<img src="..." data-visual-test="transparent" />
+
+<!-- remove an ad entirely -->
+<div id="ad-slot" data-visual-test="removed"></div>
+
+<!-- mask a user photo -->
+<img src="..." data-visual-test="blackout" />
+
+<!-- fix border-radius rendering differences -->
+<button class="rounded-lg" data-visual-test-no-radius>Submit</button>
+```
+
+---
+
+## 4. Animations and transitions
+
+The Argos SDK automatically stabilizes CSS animations (pauses them at a consistent frame before capture). For JS-driven animations that are still causing flakiness, hide the element:
+
+```html
+<div class="animated-chart" data-visual-test="removed"></div>
+```
+
+Or disable the animation in test via CSS injection:
+
+```ts
+await argosScreenshot(page, "my-page", {
+  argosCSS:
+    "*, *::before, *::after { animation: none !important; transition: none !important; }",
+});
+```
+
+---
+
+## 5. Border-radius glitches
+
+Cross-browser and cross-OS rendering can produce 1px differences around rounded corners. Strip the radius for the screenshot:
+
+```html
+<button class="rounded" data-visual-test-no-radius>My button</button>
+```
+
+---
+
+## 6. `argosScreenshot` stabilization options (Playwright)
+
+The stabilization behavior can be customized per screenshot:
+
+```ts
+await argosScreenshot(page, "name", {
+  stabilize: {
+    waitForAriaBusy: true, // wait for aria-busy to clear (default: true)
+    waitForFonts: true, // wait for fonts to load (default: true)
+    waitForImages: true, // wait for images to load (default: true)
+    hideScrollbars: true, // hide scrollbars (default: true)
+    hideCarets: true, // hide text carets (default: true)
+    fontAntialiasing: true, // force consistent font antialiasing (default: true)
+    stabilizeSticky: true, // make sticky/fixed elements position:absolute (default: true)
+  },
+});
+```
+
+To debug a specific test by running it multiple times to surface inconsistencies:
+
+```sh
+npx playwright test --repeat-each 5
+```
+
+## 7. Framework caveat
+
+`aria-busy` is not a universal fix across every Argos integration. For example,
+some integrations may disable `waitForAriaBusy` by default, so waiting for
+settled content explicitly can be a more portable recommendation than relying
+only on `aria-busy`.

--- a/.agents/skills/argos-upload/SKILL.md
+++ b/.agents/skills/argos-upload/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: argos-upload
+description: >
+  Upload a screenshot, an image or a screen recording to Argos and get a
+  shareable URL plus ready-to-paste Markdown, so it can be embedded in a pull
+  request, an issue, a changelog or a chat message — or attached to a branch or
+  pull request, where Argos posts and maintains the comment itself. Use whenever
+  you have produced a visual artifact — a Playwright video or trace screenshot, a
+  before/after of a UI change, a recording of a reproduction — and need it visible
+  to a human who cannot run your shell. GitHub has no public API for comment
+  attachments, so this is how an agent working from a terminal gets an image into
+  a pull request at all. Also covers reading back the comments a human pinned to
+  those screenshots, so you can act on visual feedback you cannot see.
+license: MIT
+metadata:
+  author: argos-ci
+  homepage: https://argos-ci.com
+  source: https://github.com/argos-ci/argos-javascript
+argument-hint: Needs a token (ARGOS_TOKEN, --token, or `argos login`); add `--project <owner/project>` when using a personal access token.
+---
+
+# Argos media upload
+
+`argos media upload <files...>` uploads standalone images and videos — not tied
+to a build or a test run — and prints a share URL and a Markdown embed for each.
+
+```bash
+argos media upload checkout-before.png checkout-after.png --branch feat/checkout
+```
+
+Run `argos media --help` for exact flags. This skill covers the parts `--help`
+cannot: when to upload, how the result reaches a human, and how to read back what
+they say about it.
+
+## When to upload
+
+Upload when a change is **visual** and a human has to see it to judge it:
+
+- You changed UI and are working on a branch or a pull request. A before/after
+  pair saves the reviewer from checking out your branch.
+- You recorded a Playwright video or a screen recording of a bug reproduction.
+- You are reporting a rendering problem that a code snippet cannot convey.
+
+Do **not** upload when text does the job. A stack trace, a diff, a log excerpt
+and a list of failing test names are all better as text: searchable, quotable,
+and readable in a terminal. An unnecessary screenshot is noise in the review.
+
+Do not upload build screenshots that Argos already has. If a visual test run
+produced them, they are already in the build and linked from the pull request —
+use `argos build snapshots` instead.
+
+## Getting it into a pull request
+
+Name where the media belongs and Argos does the posting. It keeps **one** comment
+per pull request listing every media attached to it, edited in place rather than
+appended to.
+
+```bash
+argos media upload after.png --pr 1234              # the pull request exists
+argos media upload after.png --branch feat/checkout # it does not, yet
+```
+
+`--branch` is the one to reach for while working. The media is **staged**: it has
+its share URL immediately, and the moment a pull request opens for that branch
+Argos attaches it and posts the comment on its own. You do not have to come back
+and connect the two. `--pr` publishes straight away.
+
+Passing neither uploads a loose media: a share URL and nothing else. That is the
+right call for a chat message or an issue, where you paste the Markdown yourself.
+Neither flag is inferred from the environment, CI included — an upload does not
+post to a pull request unless you asked it to. Two consequences worth knowing
+before you leave them off: nothing will ever attach that media to a pull request,
+and since a loose media's identity is only its name, uploading `shot.png` from two
+different branches makes them versions of one media rather than two.
+
+Commenting needs the project connected to GitHub, and pull request comments
+enabled on it (`argos project get`). Without that the upload still succeeds and
+you paste the Markdown yourself.
+
+Two things `--branch` will not do: publish to a pull request opened **from a
+fork** (a fork's branch name is chosen by an outsider, so Argos never matches
+staged media against it), and publish anything whose bytes never landed.
+
+## Embedding the result
+
+The command prints, per file:
+
+```
+checkout.png (after)
+  ID: 4821
+  staged on feat/checkout
+  image/webp · 184 KB · 1440x900 · public · ready
+  URL: https://app.argos-ci.com/m/kQ8vN2pXr4tYw7...
+  File: https://media.argos-ci.com/media/12/a1b2c3.webp
+  Markdown: ![checkout.png](https://app.argos-ci.com/m/kQ8vN2pXr4tYw7...)
+```
+
+**Paste the `Markdown` line verbatim.** Do not hand-write the embed:
+
+- For an **image**, the Markdown is a plain `![alt](url)`.
+- For a **video**, it is the **poster frame wrapped in a link** to the share
+  page. GitHub renders an inline player only for media it hosts itself, so a
+  `<video>` tag or a bare `.mp4` link pointing at Argos renders as a dead link.
+  The poster-in-a-link is the form that actually shows something.
+
+`URL` is the share page, for a human. `File` is the image or video itself, for
+you: fetch it when you want to look at what you just uploaded. Use `--json` when
+you parse the output.
+
+## Before/after pairs
+
+A file name ending in `-before` or `-after` is read as a label, not as part of the
+name: `checkout-before.png` and `checkout-after.png` both upload as `checkout.png`,
+one as each half of a pair, and the pull request comment shows them side by side
+for comparison. That is the whole reason to name them that way.
+
+```bash
+argos media upload checkout-before.png checkout-after.png --branch feat/checkout
+```
+
+`--state before|after` sets it explicitly, for files that are not named that way.
+It applies to every file in the command, so do not pass it to a pair — both halves
+would land on the same name and state, and the second would replace the first.
+The CLI refuses that rather than doing it.
+
+`--description "<prose>"` adds a line under the media in the comment. Use it to
+say what the reviewer is looking at when the image does not speak for itself.
+
+## Re-uploading: versions, and one stable link
+
+Uploading the same **name** again on the same branch or pull request adds a
+**version** rather than creating a second media. The share URL does not change
+and always shows the newest version, so Markdown already posted to a pull request
+picks up the new image with nothing to edit — re-run your command after a fix and
+the review updates itself.
+
+Byte-identical bytes are not a new version, and cost nothing: Argos recognizes
+the file and skips both the transfer and the meter.
+
+A media's name and branch are its identity, so they are fixed once it is
+published. While it is still staged you can correct them:
+
+```bash
+argos media update 4821 --name checkout.png --branch feat/checkout
+argos media update 4821 --no-branch          # detach: nothing will publish it
+```
+
+## Reading the feedback you were given
+
+A human can comment on an uploaded screenshot and pin a comment to a **spot** on
+it. That is how you get told "this button is misaligned" about a pixel you cannot
+look at. Find the media, then read its threads:
+
+```bash
+argos media list --branch feat/checkout --json      # or --pr 1234
+argos media comment list 4821 --json                # open threads; --all for settled ones
+```
+
+`media comment list` shows **open threads only**, so what comes back is what is
+left to do. Add `--all` to see the ones already dealt with.
+
+Each comment carries the pin as `Pinned: point x,y` in normalized 0–1 coordinates
+of the image (`0.62,0.34` is 62% across, 34% down), and the media's `File:` URL is
+what you fetch to go and look. A comment also carries the **media version** it was
+written against: if `versionCount` is above 1, the pin describes the bytes of
+_that_ upload, so resolve it before trusting the coordinates.
+
+```bash
+argos media versions 4821 --json   # match the comment's media version ID, use its file
+```
+
+Then close the loop on each thread:
+
+```bash
+argos media comment create 4821 --reply-to <threadId> --body "Fixed in abc1234."
+argos media comment resolve 4821 <threadId>
+```
+
+Resolve only what you actually fixed. Resolving something you skipped is how
+feedback gets silently dropped — reply explaining why instead, and leave it open.
+
+## Compression
+
+Images are converted to **WebP** before upload, which is where the speed comes
+from: a 1440x900 PNG screenshot goes from ~1 MB to well under 100 KB. The media
+keeps the name you gave it (`checkout.png`), because that name is its identity and
+must not move when Argos changes how it compresses.
+
+Argos leaves a file alone when converting would not help — a video, an
+already-efficient WebP or AVIF, an animated GIF, an image too large for the WebP
+encoder (over 16383px on a side, which a long full-page capture reaches), or bytes
+that came out no smaller. `--no-compress` uploads exactly what you have.
+
+One consequence worth knowing: converting drops the file's metadata, so a photo's
+EXIF — including GPS, if the camera recorded it — does not reach Argos. With
+`--no-compress`, or for a format that is left alone, it does.
+
+## Visibility, and what it does not cover
+
+`--visibility` controls the **share page** — `team` requires an Argos session,
+`public` does not. It defaults to the most private option the plan allows: `team`
+on Pro, and `public` on the free plan, which cannot do `team` at all.
+
+It does **not** protect the file: media files are always reachable at an
+unguessable CDN URL, because GitHub fetches embedded images server-side with no
+session and could not render them otherwise.
+
+So treat an uploaded file as "anyone with the link". If a screenshot must never be
+reachable by someone who obtains its URL, don't upload it — say so instead of
+uploading it anyway.
+
+## Authentication
+
+Media belongs to a **project**, so it inherits that project's access — including
+transferring with it. With a personal access token, pass `--project
+<owner/project>` (or set `ARGOS_PROJECT`); a project token already identifies its
+own project.
+
+| Command                         | Token                                                                    |
+| ------------------------------- | ------------------------------------------------------------------------ |
+| `media upload`, `update`        | Project token (`ARGOS_TOKEN`, or tokenless CI) or PAT with review access |
+| `media get`, `list`, `versions` | Project token or PAT with access to the project                          |
+| `media delete`                  | Project token or PAT with project admin                                  |
+| `media comment …`               | Personal access token (a comment has an author)                          |
+
+Every `media comment` command needs a personal access token, reading included: a
+project token can list the media a review is about but not the review itself.
+
+## What it costs
+
+Uploads draw on the same screenshot allowance as visual tests — there is no
+separate quota to track. One image is 1 screenshot; one video is 25, because it
+costs more to store and serve. Uploading the same file twice is free.
+
+Files are kept 30 days on the free plan and a year on Pro, then deleted, per
+version — the plan decides it, there is nothing to pass. An expired link renders
+an "unavailable" page, so a pull request embed degrades visibly rather than into a
+broken image.
+
+## Limits worth knowing before you upload
+
+- **Accepted formats** — PNG, JPEG, WebP, AVIF, GIF, MP4, WebM, MOV. Anything
+  else is refused before the upload starts.
+- **Size** — 50 MB on the free plan, 500 MB on Pro. A long screen recording is
+  the usual thing that trips this; trim it before uploading.
+- **Video codecs** — Argos does not transcode. Most MP4/WebM plays fine, as does
+  the H.264 that screen recorders produce; ProRes and some HEVC exports won't play
+  inline and the viewer gets a download. Export to H.264 if you need playback.
+- **Comment size** — the managed pull request comment lists up to 20 media.
+- **No waiting** — a media is fully usable the moment the upload finishes. The
+  poster frame is derived by the CDN on request, so a video's Markdown embed is
+  correct immediately.

--- a/.agents/skills/argos-upload/agents/openai.yaml
+++ b/.agents/skills/argos-upload/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Argos Media Upload"
+  short_description: "Share a screenshot or video by link, embeddable in a PR"
+  default_prompt: "Use $argos-upload to upload a screenshot or recording and embed it in this pull request."

--- a/.claude/skills/argos-cli
+++ b/.claude/skills/argos-cli
@@ -1,0 +1,1 @@
+../../.agents/skills/argos-cli

--- a/.claude/skills/argos-pr-review
+++ b/.claude/skills/argos-pr-review
@@ -1,0 +1,1 @@
+../../.agents/skills/argos-pr-review

--- a/.claude/skills/argos-upload
+++ b/.claude/skills/argos-upload
@@ -1,0 +1,1 @@
+../../.agents/skills/argos-upload

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,8 @@ flight — never track that with a local `loading` boolean.
   `role="alertdialog"`, `variant="destructive"` for destructive actions, and
   `toast.success(...)` on completion.
 
+If possible, put some screenshots or videos using `/argos-upload` skill.
+
 ## Notifications
 
 Two-stage async pipeline in `apps/backend/src/notification/`:

--- a/apps/frontend/src/containers/Build/Zoomer.tsx
+++ b/apps/frontend/src/containers/Build/Zoomer.tsx
@@ -21,7 +21,6 @@ import { useObjectRef } from "react-aria";
 
 import { Button } from "@/ui/Button";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
-import { getCheckerboardStyle } from "@/ui/MediaFrame";
 import { Tooltip } from "@/ui/Tooltip";
 import { useResizeObserver } from "@/ui/useResizeObserver";
 
@@ -506,12 +505,12 @@ export function ZoomPane(props: {
         // (the media page's `MediaWell`) owns the border and the corner clip,
         // and a second rounding inside it would nick the ground through at
         // every corner.
-        surface === "app" && "border-thin rounded-md shadow-xs",
+        // The ground under the content, so a screenshot with alpha or white
+        // edges ends somewhere known (see `MediaWell`, which is how the media
+        // share page draws the same ground).
+        surface === "app" &&
+          "border-thin rounded-md bg-(--media-ground) shadow-xs",
       )}
-      // The transparency checkerboard under the content: the universal mark
-      // for "these are the actual pixels, nothing added" (see `MediaWell`,
-      // which is how the media share page draws the same ground).
-      style={surface === "app" ? getCheckerboardStyle() : undefined}
     >
       <div
         className="flex min-h-0 min-w-0 flex-1 origin-top-left justify-center"

--- a/apps/frontend/src/containers/Media/MediaComments.tsx
+++ b/apps/frontend/src/containers/Media/MediaComments.tsx
@@ -449,7 +449,7 @@ function MediaPinnedReference(props: {
       className="text-low rac-focus flex w-full cursor-pointer items-center gap-2 rounded-t-md px-2 py-1.5 text-left text-xs select-none"
     >
       {thumbnailUrl ? (
-        <MediaWell checkerSize={3} className="size-6 shrink-0">
+        <MediaWell className="size-6 shrink-0">
           {/* Contained rather than cropped, like the version rows: a crop out
               of a wide screenshot's middle identifies nothing. */}
           <img src={thumbnailUrl} alt="" className="size-full object-contain" />

--- a/apps/frontend/src/containers/Media/MediaVersions.tsx
+++ b/apps/frontend/src/containers/Media/MediaVersions.tsx
@@ -61,12 +61,12 @@ export function MediaVersions(props: {
               {({ isSelected }) => (
                 <>
                   {thumbnailUrl ? (
-                    <MediaWell checkerSize={3} className="size-8 shrink-0">
+                    <MediaWell className="size-8 shrink-0">
                       {/* Contained, not cropped: what this thumbnail is for is
                           telling one version from another at a glance, and a
                           square crop out of the middle of a wide screenshot
                           shows the same patch of background for every one of
-                          them. The checkerboard is the letterbox. */}
+                          them. The well's ground is the letterbox. */}
                       <img
                         src={thumbnailUrl}
                         alt=""

--- a/apps/frontend/src/containers/Media/MediaViewer.tsx
+++ b/apps/frontend/src/containers/Media/MediaViewer.tsx
@@ -356,9 +356,9 @@ function MediaPane(props: {
       // ring.
       {...(pinState === "target" ? { "data-pin-target": "" } : null)}
     >
-      {/* The inspection surface: the same dark checkerboard as the library
-          thumbnails, so a white screenshot has a known ground to end on. The
-          pane draws no chrome of its own — the well is the chrome. */}
+      {/* The inspection surface: the same ground as the library thumbnails, so
+          a white screenshot has a known ground to end on. The pane draws no
+          chrome of its own — the well is the chrome. */}
       <MediaWell
         className={clsx(
           "relative flex min-h-0 flex-1 transition-opacity",

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -353,22 +353,23 @@
   @apply [scrollbar-width:none] [&::-webkit-scrollbar]:hidden;
 }
 
-/* The ground a screenshot is inspected on — the checkerboard `MediaWell` and
-   the build's `ZoomPane` draw (see `getCheckerboardStyle`).
+/* The ground a screenshot is inspected on — the surface `MediaWell` and the
+   build's `ZoomPane` draw under the pixels.
 
-   A surface half a step under the page, so the frame reads as recessed, with a
-   checker just visible against it. Literal values rather than palette steps:
-   this is one specific surface whose whole job is to be a *known* ground, and
-   it has to keep saying the same thing at either end of the gray scale. */
+   A surface half a step under the page, so the frame reads as recessed. Flat
+   rather than the transparency checkerboard it used to be: the checker showed
+   through anything with alpha and competed with the screenshot's own content,
+   which is the opposite of what a ground is for. Literal values rather than
+   palette steps: this is one specific surface whose whole job is to be a
+   *known* ground, and it has to keep saying the same thing at either end of
+   the gray scale. */
 @layer base {
   :root {
-    --checkerboard-base: #f1f1f4;
-    --checkerboard-square: rgb(0 0 0 / 0.045);
+    --media-ground: #f1f1f4;
   }
 
   .dark {
-    --checkerboard-base: #16161a;
-    --checkerboard-square: rgb(255 255 255 / 0.045);
+    --media-ground: #16161a;
   }
 }
 

--- a/apps/frontend/src/ui/MediaFrame.tsx
+++ b/apps/frontend/src/ui/MediaFrame.tsx
@@ -1,44 +1,20 @@
 import clsx from "clsx";
 
 /**
- * The transparency ground drawn under inspected pixels: the classic two-tone
- * checkerboard, made of two offset gradients in CSS so there is no asset to
- * load before the content has a ground. Shared by `MediaWell` and the build's
- * `ZoomPane`, so a screenshot sits on the same ground wherever it is inspected.
+ * The surface a media is inspected on: the flat `--media-ground` under the
+ * build pane's hairline-and-shadow chrome, so the image zone reads identically
+ * on both pages. Screenshots routinely have alpha or white edges, and without a
+ * known ground you cannot tell where the image stops and the page starts. It
+ * carries across from the share page to the library thumbnails so the feature
+ * reads as one thing.
  *
- * It follows the viewer's theme (`--checkerboard-*`), rather than staying dark
- * under a light page. The point of the ground is being *known* — screenshots
- * routinely have alpha or white edges, and without one you cannot tell where
- * the image stops and the page starts — and a slab of near-black under a light
- * UI is read as part of the picture, which is the same confusion by the other
- * door.
- */
-export function getCheckerboardStyle(checkerSize = 8): React.CSSProperties {
-  const square = "var(--checkerboard-square)";
-  return {
-    backgroundColor: "var(--checkerboard-base)",
-    backgroundImage: `
-      linear-gradient(45deg, ${square} 25%, transparent 25%, transparent 75%, ${square} 75%),
-      linear-gradient(45deg, ${square} 25%, transparent 25%, transparent 75%, ${square} 75%)
-    `,
-    backgroundSize: `${checkerSize * 2}px ${checkerSize * 2}px`,
-    backgroundPosition: `0 0, ${checkerSize}px ${checkerSize}px`,
-  };
-}
-
-/**
- * The surface a media is inspected on: the checkerboard ground (see
- * {@link getCheckerboardStyle}) under the build pane's hairline-and-shadow
- * chrome, so the image zone reads identically on both pages. Screenshots
- * routinely have alpha or white edges, and without a known ground you cannot
- * tell where the image stops and the page starts. It carries across from the
- * share page to the library thumbnails so the feature reads as one thing.
+ * The ground follows the viewer's theme rather than staying dark under a light
+ * page: a slab of near-black under a light UI is read as part of the picture,
+ * which is the same confusion the ground exists to remove.
  */
 export function MediaWell(props: {
   children: React.ReactNode;
   className?: string;
-  /** Checker square size in pixels. Smaller for thumbnails. */
-  checkerSize?: number;
   /**
    * Intrinsic dimensions of the media, when known.
    *
@@ -49,19 +25,18 @@ export function MediaWell(props: {
    */
   aspectRatio?: { width: number; height: number } | null;
 }) {
-  const { children, className, checkerSize = 8, aspectRatio } = props;
+  const { children, className, aspectRatio } = props;
   return (
     <div
       className={clsx(
-        "border-thin relative overflow-hidden rounded-md shadow-xs",
+        "border-thin relative overflow-hidden rounded-md bg-(--media-ground) shadow-xs",
         className,
       )}
-      style={{
-        ...(aspectRatio
+      style={
+        aspectRatio
           ? { aspectRatio: `${aspectRatio.width} / ${aspectRatio.height}` }
-          : null),
-        ...getCheckerboardStyle(checkerSize),
-      }}
+          : undefined
+      }
     >
       {children}
     </div>

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,27 @@
 {
   "version": 1,
   "skills": {
+    "argos-cli": {
+      "source": "argos-ci.com",
+      "sourceUrl": "https://argos-ci.com",
+      "sourceType": "well-known",
+      "computedHash": "75a8ec5a57174ee40b14ac0c1dcbbc9eaf29ffa6b9474316025dd9268f1b0ee6",
+      "wellKnownDigest": "sha256:10da94bb43b0cb32f5312e367c3733cefbb99e005547238882791b9a2f6a61cf"
+    },
+    "argos-pr-review": {
+      "source": "argos-ci.com",
+      "sourceUrl": "https://argos-ci.com",
+      "sourceType": "well-known",
+      "computedHash": "16d35f86c5573ac68e2aae45a40dbf25527ef6edeb871c0a79f36538cf4f7315",
+      "wellKnownDigest": "sha256:e343537b1757b4de8391e7fea67e9febc4b02187500dcca7dd199758b6e70286"
+    },
+    "argos-upload": {
+      "source": "argos-ci.com",
+      "sourceUrl": "https://argos-ci.com",
+      "sourceType": "well-known",
+      "computedHash": "4af4d8471ef047f40043a4fcb363478f00e457c1b4fef08aa737d7f02e4f6e34",
+      "wellKnownDigest": "sha256:76196f8559bba88f4d4c94098f457fe82af333fdbd6c53ab8571ac39d5302d76"
+    },
     "frontend-design": {
       "source": "anthropics/skills",
       "sourceType": "github",


### PR DESCRIPTION
The checkerboard under inspected pixels hurt legibility rather than helping it: the checker showed through anything with alpha and competed with the screenshot's own content, which is the opposite of what a ground is for. A flat surface still answers the question the ground exists to answer — where the image stops and the page starts.

## Changes

- Removed `getCheckerboardStyle` and the two offset 45° gradients it drew.
- `--checkerboard-base` / `--checkerboard-square` → a single flat, still theme-aware `--media-ground`.
- `MediaWell` loses its now-meaningless `checkerSize` prop, and applies the ground as `bg-(--media-ground)` instead of an inline style object; both thumbnail call sites drop the prop.
- The build page's `ZoomPane` draws the same ground through the same class.

Affects the build page's snapshot pane, the media share viewer, and the version / pinned-comment thumbnails — all of which shared the one ground. Before/after captures are in the Argos media comment below.

## Also on this branch

- Argos agent skills under `.agents/skills` (`argos-cli`, `argos-pr-review`, `argos-upload`), with `.claude/skills/*` symlinked to them and `skills-lock.json` pinning the set.
- AGENTS.md now asks for screenshots or videos via `/argos-upload` when a change is visual.

`pnpm run static-checks` passes (18 tasks). Argos will show the visual diff for every affected surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)