### PR TITLE
feat(media): pitch media sharing on the unavailable page

### DIFF
--- a/apps/frontend/src/containers/EmptyStateIllustrations.tsx
+++ b/apps/frontend/src/containers/EmptyStateIllustrations.tsx
@@ -1,4 +1,4 @@
-import { FlagOffIcon, GitBranchIcon, LockIcon } from "lucide-react";
+import { FlagOffIcon, GitBranchIcon, LinkIcon, LockIcon } from "lucide-react";
 
 import {
   ACCENT,
@@ -644,6 +644,125 @@ export function AutomationsIllustration(props: IllustrationProps) {
         gap={9}
         height={4}
         fill={CONTENT}
+      />
+    </Frame>
+  );
+}
+
+/**
+ * A shared recording embedded in a pull-request comment: the media itself,
+ * a review comment pinned to its pixels, and the share link that carries it
+ * around.
+ */
+export function MediaSharingIllustration(props: IllustrationProps) {
+  return (
+    <Frame className={props.className}>
+      <defs>
+        <linearGradient id="media-share-hero" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor={ACCENT_MID} />
+          <stop offset="100%" stopColor={ACCENT_SOFT} />
+        </linearGradient>
+      </defs>
+
+      {/* The pull-request comment the media lives in. */}
+      <rect
+        x={36}
+        y={16}
+        width={248}
+        height={176}
+        rx={10}
+        fill={SURFACE}
+        stroke={LINE}
+      />
+
+      {/* Author line. */}
+      <circle cx={62} cy={41} r={10} fill={CONTENT} />
+      <rect
+        x={78}
+        y={34}
+        width={52}
+        height={5}
+        rx={2.5}
+        fill={CONTENT_STRONG}
+      />
+      <rect x={136} y={34} width={26} height={5} rx={2.5} fill={LINE_SOFT} />
+      <rect x={78} y={44} width={118} height={4} rx={2} fill={CONTENT} />
+
+      {/* The embedded media — a recording, poster frame and play button. */}
+      <rect
+        x={52}
+        y={64}
+        width={216}
+        height={96}
+        rx={7}
+        fill="url(#media-share-hero)"
+        stroke={ACCENT_LINE}
+        strokeOpacity={0.4}
+      />
+      <circle cx={84} cy={90} r={8} fill={ACCENT} opacity={0.55} />
+      <path d="M58 156l38-32 24 20 18-15 36 27Z" fill={ACCENT} opacity={0.35} />
+      <circle cx={160} cy={112} r={16} fill={ACCENT} />
+      <path d="M155 104.5 169 112l-14 7.5Z" fill="var(--violet-1)" />
+
+      {/* A review comment, pinned to the pixels it is about. */}
+      <circle
+        cx={246}
+        cy={86}
+        r={9}
+        fill={SURFACE}
+        stroke={ACCENT}
+        strokeWidth={1.5}
+      />
+      <circle cx={246} cy={86} r={3} fill={ACCENT} />
+
+      {/* Caption and the version the pin lives on. */}
+      <rect x={52} y={170} width={110} height={5} rx={2.5} fill={CONTENT} />
+      <rect
+        x={232}
+        y={165}
+        width={36}
+        height={15}
+        rx={7.5}
+        fill={SURFACE_SUNKEN}
+        stroke={LINE}
+      />
+      <rect
+        x={241}
+        y={170}
+        width={18}
+        height={5}
+        rx={2.5}
+        fill={CONTENT_STRONG}
+      />
+
+      {/* The share link itself, resolving to the embed. */}
+      <path
+        d="M254 26c0 16-78 12-94 38"
+        stroke={LINE}
+        strokeWidth={1.6}
+        strokeDasharray="4 4"
+        fill="none"
+      />
+      <rect
+        x={208}
+        y={2}
+        width={94}
+        height={24}
+        rx={12}
+        fill={SURFACE}
+        stroke={LINE}
+      />
+      {/* Centred in the 24-unit chip: 24 * 0.5 = 12 tall. */}
+      <g transform="translate(220, 8) scale(0.5)">
+        <LinkIcon width={24} height={24} stroke={ACCENT} strokeWidth={2.4} />
+      </g>
+      <rect
+        x={238}
+        y={11.5}
+        width={52}
+        height={5}
+        rx={2.5}
+        fill={CONTENT_STRONG}
       />
     </Frame>
   );

--- a/apps/frontend/src/pages/MediaShare.tsx
+++ b/apps/frontend/src/pages/MediaShare.tsx
@@ -3,16 +3,18 @@ import { useSuspenseQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import {
   ChevronDownIcon,
-  ClockFadingIcon,
   DownloadIcon,
   FileTextIcon,
+  GitPullRequestIcon,
   GlobeIcon,
   LinkIcon,
   LockIcon,
+  MessagesSquareIcon,
+  TerminalIcon,
 } from "lucide-react";
-import { MenuTrigger } from "react-aria-components";
+import { Heading, MenuTrigger, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
-import { useParams } from "react-router";
+import { useLocation, useParams } from "react-router";
 import { useClipboard } from "use-clipboard-copy";
 
 import {
@@ -27,6 +29,7 @@ import {
 } from "@/containers/Build/ScreenshotActions";
 import { MentionableUsersProvider } from "@/containers/Comment/MentionableUsersContext";
 import { useCommentRoleScope } from "@/containers/Comment/useCommentRoleScope";
+import { MediaSharingIllustration } from "@/containers/EmptyStateIllustrations";
 import { MediaComments } from "@/containers/Media/MediaComments";
 import { MediaVersions } from "@/containers/Media/MediaVersions";
 import {
@@ -39,10 +42,19 @@ import { PullRequestButton } from "@/containers/PullRequestButton";
 import { DocumentType, graphql } from "@/gql";
 import { MediaVisibility } from "@/gql/graphql";
 import { BrandShield } from "@/ui/BrandShield";
-import { Button } from "@/ui/Button";
+import { Button, LinkButton } from "@/ui/Button";
 import { ButtonGroup } from "@/ui/ButtonGroup";
 import { Chip } from "@/ui/Chip";
+import { Code } from "@/ui/Code";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
+import {
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateIllustration,
+  EmptyStateLearnMore,
+  EmptyStateStep,
+  EmptyStateSteps,
+} from "@/ui/Layout";
 import { Link } from "@/ui/Link";
 import { Menu, MenuItem } from "@/ui/Menu";
 import { Popover } from "@/ui/Popover";
@@ -585,31 +597,73 @@ function PageFooter() {
  * One state for every reason a link stops working — expired, deleted, never
  * finished uploading, or never valid at all.
  *
- * Deliberately does not say which. Telling them apart would let anyone holding a
- * token learn whether it ever pointed at something, and for the person reading it
- * the answer is the same either way. The footer keeps its login control: for a
- * team-only media, signing in *is* the fix.
+ * Deliberately does not say which. Telling them apart would let anyone holding
+ * a token learn whether it ever pointed at something, and for the person
+ * reading it the answer is the same either way. What the page does say is what
+ * the link *was* — media shared through Argos — because the two people who
+ * land here need different exits: a teammate signs in and gets the media back,
+ * anyone else gets to find out what their own team could be sharing.
  */
 function UnavailableState() {
+  const { pathname } = useLocation();
   return (
     <div className="flex min-h-dvh flex-col">
       <Helmet>
         <title>Media unavailable</title>
         <meta name="robots" content="noindex, nofollow" />
       </Helmet>
-      <div className="bg-subtle flex flex-1 flex-col items-center justify-center p-8">
-        <div className="flex max-w-md flex-col items-center text-center">
-          <div className="text-low mb-4">
-            <ClockFadingIcon className="size-8" strokeWidth={1.5} />
-          </div>
-          <h1 className="mb-2 text-base font-medium">
-            This media is no longer available
-          </h1>
-          <p className="text-low text-sm text-balance">
+      <div className="bg-subtle flex flex-1 flex-col justify-center py-8">
+        <EmptyState>
+          <EmptyStateIllustration>
+            <MediaSharingIllustration />
+          </EmptyStateIllustration>
+          {/* Still the page's `h1`: the empty state is the whole document. */}
+          <Heading level={1}>This media is no longer available</Heading>
+          <Text slot="description">
             The link has expired, the file was deleted, or you need to be signed
-            in to a team that has access to it.
-          </p>
-        </div>
+            in to a team that has access to it. Links like this one are how
+            teams on Argos share screenshots and recordings in their pull
+            requests.
+          </Text>
+          <EmptyStateActions>
+            <LinkButton
+              variant="secondary"
+              href={`/login?r=${encodeURIComponent(pathname)}`}
+            >
+              Sign in
+            </LinkButton>
+            <LinkButton href="/signup">Try Argos for free</LinkButton>
+          </EmptyStateActions>
+          <EmptyStateLearnMore href="https://argos-ci.com/docs/learn/media/standalone-media-upload">
+            Learn how media sharing works
+          </EmptyStateLearnMore>
+          <EmptyStateSteps>
+            <EmptyStateStep
+              icon={<TerminalIcon />}
+              step="From your terminal"
+              title="Upload a screenshot or recording"
+            >
+              One <Code>argos upload</Code> from a shell or a CI job hosts the
+              file and hands back a link with ready-to-paste Markdown.
+            </EmptyStateStep>
+            <EmptyStateStep
+              icon={<GitPullRequestIcon />}
+              step="In your pull request"
+              title="Embed it where you review"
+            >
+              Drop the Markdown into a pull request, an issue or a changelog —
+              before and after render side by side.
+            </EmptyStateStep>
+            <EmptyStateStep
+              icon={<MessagesSquareIcon />}
+              step="With your team"
+              title="Review it together"
+            >
+              Teammates pin comments straight onto the pixels, follow new
+              versions, and choose who can open the link.
+            </EmptyStateStep>
+          </EmptyStateSteps>
+        </EmptyState>
       </div>
       <PageFooter />
     </div>


### PR DESCRIPTION
## Summary

The media share dead end (`/m/<token>` when the media is expired, deleted, or team-only) was a bare error card — often the first thing a non-Argos user ever sees of the product, since it's where expired links in pull requests land. This turns it into an invitation to try the feature:

- **New `MediaSharingIllustration`** in the shared empty-state illustration language: a recording embedded in a PR comment, a review comment pinned to its pixels, and the share link that carries it around.
- **Same neutral message** — the page still never says *which* reason applies (that would leak whether a token ever pointed at something), but now says what the link *was*.
- **Two exits for two audiences**: `Sign in` (the actual fix for team-only media, with a redirect back to the share URL) and `Try Argos for free` → `/signup`.
- **Three-step feature pitch** using the existing `EmptyStateSteps` teaching primitives (same as Deployments/Tests empty states): upload from the terminal → embed in the PR → review together.
- Docs link to [standalone media upload](https://argos-ci.com/docs/learn/media/standalone-media-upload).

Dark mode and mobile come free via the Radix illustration tokens and the shared layout primitives (screenshots in the Argos media comment below).

## Test plan

- `pnpm run static-checks` ✅
- e2e: `media share page for an unknown token` still passes (heading unchanged) ✅
- Visual check of light/dark/mobile on the built app ✅ — the `media-share-unavailable` Argos baseline will change, as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)