### PR TITLE
feat(media): rework the pull request comment layout

### DIFF
--- a/apps/backend/src/graphql/definitions/Media.ts
+++ b/apps/backend/src/graphql/definitions/Media.ts
@@ -12,7 +12,7 @@ import {
   getMediaFileUrl,
   getMediaPosterUrl,
 } from "@/media/serve";
-import { getMediaMarkdown, getMediaTableMarkdown } from "@/media/url";
+import { getMediaBlockMarkdown, getMediaMarkdown } from "@/media/url";
 import { getLatestMediaVersion } from "@/media/version";
 import { getProjectMemberIds } from "@/project/members";
 
@@ -97,9 +97,9 @@ export const typeDefs = gql`
     """
     markdown: String!
     """
-    Ready-to-paste Markdown table showing the before/after pair side by side —
-    the same rendering the managed pull request comment uses. Null when this
-    media is not half of an uploaded pair.
+    Ready-to-paste Markdown block showing the before/after pair side by side under
+    its name and description — the same rendering the managed pull request comment
+    uses. Null when this media is not half of an uploaded pair.
     """
     markdownPair: String
     "The newest uploaded version — what the share page and the comment show"
@@ -207,7 +207,7 @@ export const resolvers: IResolvers = {
       );
     },
     markdownPair: async (media, _args, ctx) => {
-      // The pair's side-by-side table — the exact rendering the managed pull
+      // The pair's side-by-side block — the exact rendering the managed pull
       // request comment uses — so pasting it by hand shows before and after
       // together, like the page does.
       const counterpart = media.state
@@ -238,16 +238,18 @@ export const resolvers: IResolvers = {
         media.state === "before"
           ? [embed, counterpartEmbed]
           : [counterpartEmbed, embed];
-      return getMediaTableMarkdown([
-        {
-          name: media.name,
-          // The description belongs to the pair, not to either half.
-          description:
-            afterMedia.description ?? beforeMedia.description ?? null,
-          before,
-          after,
-        },
-      ]);
+      const afterVersion =
+        media.state === "before" ? counterpartVersion : version;
+      return getMediaBlockMarkdown({
+        name: media.name,
+        // The description belongs to the pair, not to either half.
+        description: afterMedia.description ?? beforeMedia.description ?? null,
+        // The badges describe the half on show, which for a pair is the after.
+        versionNumber: afterVersion.number,
+        teamOnly: afterMedia.visibility !== "public",
+        before,
+        after,
+      });
     },
     project: async (media, _args, ctx) => {
       const project = await ctx.loaders.Project.load(media.projectId);

--- a/apps/backend/src/graphql/tests/mediaShare.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/mediaShare.e2e.test.ts
@@ -173,13 +173,18 @@ describe("mediaByShareToken", () => {
 
     // The single embed shows this half's bytes and links to its page — an embed
     // built from the share URL alone renders as a broken image. The pair snippet
-    // is the same side-by-side table the managed pull request comment renders.
+    // is the same side-by-side block the managed pull request comment renders,
+    // each half reachable from its own header.
     expect(result.markdown).toBe(
       `[![checkout.png](${result.latestVersion.fileUrl})](${result.url})`,
     );
-    expect(result.markdownPair).toContain("| Name | Before | After |");
-    expect(result.markdownPair).toContain(result.url);
-    expect(result.markdownPair).toContain(result.counterpart.url);
+    expect(result.markdownPair).toContain(
+      `| [Before ↗](${result.counterpart.url}) | [After ↗](${result.url}) |`,
+    );
+    expect(result.markdownPair).toContain(result.latestVersion.fileUrl);
+    expect(result.markdownPair).toContain(
+      result.counterpart.latestVersion.fileUrl,
+    );
 
     const pinned = result.comments.find(
       (comment: { anchor: unknown }) => comment.anchor !== null,

--- a/apps/backend/src/media/pull-request-comment.test.ts
+++ b/apps/backend/src/media/pull-request-comment.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import { Media, MediaVersion } from "@/database/models";
+
+import { buildCommentBody } from "./pull-request-comment";
+
+/**
+ * Rows built in memory rather than through the factory: the body is a pure
+ * render, and everything it reads is on the two models.
+ */
+function createMedia(props: Partial<Media> = {}): Media {
+  return Media.fromJson(
+    {
+      id: "1",
+      projectId: "1",
+      name: "dashboard.png",
+      visibility: "public",
+      shareToken: "tok1",
+      ...props,
+    },
+    { skipValidation: true },
+  );
+}
+
+function createVersion(props: Partial<MediaVersion> = {}): MediaVersion {
+  return MediaVersion.fromJson(
+    {
+      id: "1",
+      mediaId: "1",
+      number: 1,
+      key: "media/1/a.png",
+      mimeType: "image/png",
+      sizeBytes: "1024",
+      width: 1440,
+      height: 900,
+      expiresAt: null,
+      ...props,
+    },
+    { skipValidation: true },
+  );
+}
+
+function buildBody(
+  pairs: { media: Media; version: MediaVersion }[],
+  args: { total?: number } = {},
+): string {
+  return buildCommentBody(
+    pairs.map((pair) => pair.media),
+    new Map(pairs.map((pair) => [pair.media.id, pair.version])),
+    { total: args.total ?? pairs.length },
+  );
+}
+
+describe("buildCommentBody", () => {
+  it("spends the first line on what the comment holds", () => {
+    // The only line that survives into an email notification and into the
+    // collapsed view of a long thread.
+    const body = buildBody([
+      { media: createMedia({ id: "1" }), version: createVersion({ id: "1" }) },
+      { media: createMedia({ id: "2" }), version: createVersion({ id: "2" }) },
+    ]);
+
+    expect(body.split("\n")[0]).toBe("**2 screenshots uploaded by Argos**");
+  });
+
+  it("counts recordings apart from screenshots", () => {
+    const body = buildBody([
+      { media: createMedia({ id: "1" }), version: createVersion({ id: "1" }) },
+      {
+        media: createMedia({ id: "2" }),
+        version: createVersion({ id: "2", mimeType: "video/mp4" }),
+      },
+    ]);
+
+    expect(body.split("\n")[0]).toBe(
+      "**1 screenshot and 1 recording uploaded by Argos**",
+    );
+  });
+
+  it("says when the list is not the whole list", () => {
+    // A truncated list that does not announce itself reads as a complete one,
+    // and a reviewer trusts it.
+    const body = buildBody(
+      [{ media: createMedia(), version: createVersion() }],
+      { total: 26 },
+    );
+
+    expect(body).toContain("Showing the 1 most recent of 26 media.");
+  });
+
+  it("stays quiet when it is showing everything", () => {
+    const body = buildBody([
+      { media: createMedia(), version: createVersion() },
+    ]);
+
+    expect(body).not.toContain("most recent of");
+  });
+
+  it("dates the expiry from the media that dies first", () => {
+    // Retention is stamped per version at upload, so a comment holding uploads
+    // from different weeks loses its pictures one by one — the first date is
+    // when it starts being wrong.
+    const body = buildBody([
+      {
+        media: createMedia({ id: "1" }),
+        version: createVersion({
+          id: "1",
+          expiresAt: "2026-10-02T00:00:00.000Z",
+        }),
+      },
+      {
+        media: createMedia({ id: "2" }),
+        version: createVersion({
+          id: "2",
+          expiresAt: "2026-09-10T00:00:00.000Z",
+        }),
+      },
+    ]);
+
+    expect(body).toContain("Media expire on September 10, 2026.");
+  });
+
+  it("promises no expiry it has no date for", () => {
+    const body = buildBody([
+      { media: createMedia(), version: createVersion() },
+    ]);
+
+    expect(body).not.toContain("Media expire on");
+  });
+
+  it("collapses a before/after pair into one block", () => {
+    const body = buildBody([
+      {
+        media: createMedia({ id: "1", state: "before", shareToken: "before" }),
+        version: createVersion({ id: "1" }),
+      },
+      {
+        media: createMedia({ id: "2", state: "after", shareToken: "after" }),
+        version: createVersion({ id: "2" }),
+      },
+    ]);
+
+    expect(body.split("\n")[0]).toBe("**1 screenshot uploaded by Argos**");
+    expect(body).toContain("| [Before ↗](");
+  });
+
+  it("badges a media the share page will not open for everyone", () => {
+    // The bytes render for any reader whatever the visibility, so nothing else
+    // in the comment hints that the page behind them needs a session.
+    const body = buildBody([
+      { media: createMedia({ visibility: "team" }), version: createVersion() },
+    ]);
+
+    expect(body).toContain("`Team-only`");
+  });
+});

--- a/apps/backend/src/media/pull-request-comment.ts
+++ b/apps/backend/src/media/pull-request-comment.ts
@@ -15,7 +15,7 @@ import { redisLock } from "@/util/redis";
 import { uploadedVersions } from "./query";
 import { getMediaEmbedArgs } from "./serve";
 import {
-  getMediaTableMarkdown,
+  getMediaListMarkdown,
   type MediaEmbedArgs,
   type MediaMarkdownGroup,
 } from "./url";
@@ -23,6 +23,31 @@ import { getLatestMediaVersions } from "./version";
 
 /** How many media the comment lists before it stops growing. */
 const MAX_LISTED_MEDIA = 20;
+
+const expiryFormatter = Intl.DateTimeFormat("en-US", {
+  dateStyle: "long",
+  timeZone: "UTC",
+});
+
+/** Every media this pull request should currently be showing. */
+function pullRequestMediaQuery(githubPullRequestId: string) {
+  return (
+    Media.query()
+      .where("githubPullRequestId", githubPullRequestId)
+      .whereExists(uploadedVersions())
+      // The setting the build and deployment paths both honour, and the media
+      // path did not: an owner who turned Argos pull request comments off was
+      // still getting them. Per project, because one pull request can carry media
+      // from several — the ones that opted out drop out of the list rather than
+      // suppressing the whole comment.
+      .whereExists(
+        Project.query()
+          .select(1)
+          .whereColumn("projects.id", "media.projectId")
+          .where("projects.prCommentEnabled", true),
+      )
+  );
+}
 
 /**
  * Rebuild the comment for a pull request from every media currently attached to
@@ -40,26 +65,24 @@ export async function updatePullRequestComment(
 
   const { pullRequest, octokit, owner, repo } = context;
 
-  const media = await Media.query()
-    .where("githubPullRequestId", githubPullRequestId)
-    .whereExists(uploadedVersions())
-    // The setting the build and deployment paths both honour, and the media
-    // path did not: an owner who turned Argos pull request comments off was
-    // still getting them. Per project, because one pull request can carry media
-    // from several — the ones that opted out drop out of the table rather than
-    // suppressing the whole comment.
-    .whereExists(
-      Project.query()
-        .select(1)
-        .whereColumn("projects.id", "media.projectId")
-        .where("projects.prCommentEnabled", true),
-    )
-    .orderBy("createdAt", "asc")
-    .limit(MAX_LISTED_MEDIA);
+  // Newest first to decide what the cap keeps, then reversed for display. Taking
+  // the oldest would drop precisely the media the pull request is being updated
+  // for — the one just uploaded — while keeping twenty stale ones.
+  const [total, newestFirst] = await Promise.all([
+    pullRequestMediaQuery(githubPullRequestId).resultSize(),
+    pullRequestMediaQuery(githubPullRequestId)
+      .orderBy("createdAt", "desc")
+      // Same-timestamp uploads would otherwise sort arbitrarily, and the cap
+      // would keep a different subset on every rebuild.
+      .orderBy("id", "desc")
+      .limit(MAX_LISTED_MEDIA),
+  ]);
 
-  if (media.length === 0) {
+  if (newestFirst.length === 0) {
     return;
   }
+
+  const media = newestFirst.toReversed();
 
   // The comment always shows the newest upload of each media, which is what makes
   // re-uploading after a review update the pull request without touching it.
@@ -67,7 +90,7 @@ export async function updatePullRequestComment(
     media.map((item) => item.id),
   );
 
-  const body = buildCommentBody(media, latestVersions);
+  const body = buildCommentBody(media, latestVersions, { total });
 
   // Two uploads finishing at once would otherwise both read "no comment yet" and
   // both create one.
@@ -125,16 +148,17 @@ export async function updatePullRequestComment(
 /**
  * Render the comment.
  *
- * A before/after pair shares a name, so the two are shown in one row side by side
- * — which is the whole reason `state` exists, and reads far better than two
- * unrelated rows a reviewer has to match up themselves.
+ * A before/after pair shares a name, so the two are shown side by side — which is
+ * the whole reason `state` exists, and reads far better than two unrelated blocks
+ * a reviewer has to match up themselves.
  *
- * Each cell is a CDN picture linked to its share page; {@link getMediaMarkdown}
+ * Every picture is a CDN file linked to its share page; {@link getMediaMarkdown}
  * owns why it is built that way.
  */
-function buildCommentBody(
+export function buildCommentBody(
   media: Media[],
   latestVersions: Map<string, MediaVersion>,
+  args: { total: number },
 ): string {
   const embed = (item: Media | null): MediaEmbedArgs | null => {
     if (!item) {
@@ -152,38 +176,94 @@ function buildCommentBody(
   };
 
   const groups = groupByPair(media).flatMap((group): MediaMarkdownGroup[] => {
-    const item = group.after ?? group.before;
-    invariant(item, "a group has at least one media");
     const before = embed(group.before);
     const after = embed(group.after);
     if (!before && !after) {
       return [];
     }
+    // The half whose bytes are on show — the one the badges have to describe.
+    const item = after ? group.after : group.before;
+    invariant(item, "an embedded group has the media it was embedded from");
+    const version = latestVersions.get(item.id);
+    invariant(version, "an embedded media has an uploaded version");
     return [
       {
         name: item.name,
         // The description belongs to the pair, not to either half.
         description:
           group.after?.description ?? group.before?.description ?? null,
+        versionNumber: version.number,
+        teamOnly: item.visibility !== "public",
         before,
         after,
       },
     ];
   });
 
-  const versionNote = media.some(
-    (item) => (latestVersions.get(item.id)?.number ?? 1) > 1,
-  )
-    ? " Re-uploading a screenshot adds a version, and this comment always shows the newest."
+  // Stated rather than left to be discovered: the media outlive neither the pull
+  // request nor the comment, so a reader coming back to a merged pull request
+  // months later would otherwise find dead pictures and no explanation.
+  const expiresAt = getEarliestExpiry(media, latestVersions);
+  const expiryNote = expiresAt
+    ? ` Media expire on ${expiryFormatter.format(expiresAt)}.`
     : "";
 
   return [
-    "**Media uploaded by Argos**",
+    `**${getUploadCount(groups)} uploaded by Argos**`,
     "",
-    getMediaTableMarkdown(groups),
+    getMediaListMarkdown(groups),
     "",
-    `<sub>Uploaded with [Argos ↗︎](https://argos-ci.com/docs/learn/media/standalone-media-upload). This comment is updated in place.${versionNote}</sub>`,
+    // A truncated list that does not say so reads as a complete one, which is
+    // worse than the truncation.
+    ...(args.total > media.length
+      ? [`Showing the ${media.length} most recent of ${args.total} media.`, ""]
+      : []),
+    `<sub>Uploaded with [Argos ↗︎](https://argos-ci.com/docs/learn/media/standalone-media-upload). This comment is updated in place.${expiryNote}</sub>`,
   ].join("\n");
+}
+
+/**
+ * What the comment is showing, counted by kind — "3 screenshots", "2 screenshots
+ * and 1 recording".
+ *
+ * The first line of a comment is the only part that survives into an email
+ * notification and into the collapsed view of a long thread, so spending it on a
+ * label that says nothing wastes the one place a reader is guaranteed to look.
+ */
+function getUploadCount(groups: MediaMarkdownGroup[]): string {
+  const recordings = groups.filter(
+    (group) => (group.after ?? group.before)?.isVideo,
+  ).length;
+  const screenshots = groups.length - recordings;
+  return [
+    ...(screenshots > 0 ? [pluralize(screenshots, "screenshot")] : []),
+    ...(recordings > 0 ? [pluralize(recordings, "recording")] : []),
+  ].join(" and ");
+}
+
+function pluralize(count: number, noun: string): string {
+  return `${count} ${noun}${count > 1 ? "s" : ""}`;
+}
+
+/**
+ * When the first of the listed media stops resolving.
+ *
+ * The earliest of them, because that is the date the comment starts being wrong:
+ * retention is stamped per version at upload, so a comment holding uploads from
+ * different weeks has its pictures die one by one.
+ */
+function getEarliestExpiry(
+  media: Media[],
+  latestVersions: Map<string, MediaVersion>,
+): Date | null {
+  const dates = media.flatMap((item) => {
+    const expiresAt = latestVersions.get(item.id)?.expiresAt;
+    return expiresAt ? [new Date(expiresAt)] : [];
+  });
+  if (dates.length === 0) {
+    return null;
+  }
+  return dates.reduce((earliest, date) => (date < earliest ? date : earliest));
 }
 
 type MediaPair = { before: Media | null; after: Media | null };

--- a/apps/backend/src/media/serve.ts
+++ b/apps/backend/src/media/serve.ts
@@ -70,5 +70,7 @@ export function getMediaEmbedArgs(args: {
     fileUrl: getMediaFileUrl(version),
     posterUrl: getMediaPosterUrl(version),
     isVideo: version.isVideo(),
+    width: version.width,
+    height: version.height,
   };
 }

--- a/apps/backend/src/media/url.test.ts
+++ b/apps/backend/src/media/url.test.ts
@@ -1,35 +1,57 @@
 import { describe, expect, it } from "vitest";
 
-import { getMediaMarkdown, getMediaTableMarkdown } from "./url";
+import {
+  getMediaBlockMarkdown,
+  getMediaListMarkdown,
+  getMediaMarkdown,
+  type MediaEmbedArgs,
+  type MediaMarkdownGroup,
+} from "./url";
 
 const shareUrl = "https://app.argos-ci.dev/m/abc123";
 const fileUrl = "https://files.example.com/media/abc123.webp";
 const posterUrl = "https://files.example.com/poster.webp";
+
+/** A landscape screenshot: wider than a comment, so never capped. */
+function embed(overrides: Partial<MediaEmbedArgs> = {}): MediaEmbedArgs {
+  return {
+    name: "dashboard.png",
+    shareUrl,
+    fileUrl,
+    posterUrl: null,
+    isVideo: false,
+    width: 1440,
+    height: 900,
+    ...overrides,
+  };
+}
+
+function group(
+  overrides: Partial<MediaMarkdownGroup> = {},
+): MediaMarkdownGroup {
+  return {
+    name: "dashboard.png",
+    description: null,
+    versionNumber: 1,
+    teamOnly: false,
+    before: null,
+    after: embed(),
+    ...overrides,
+  };
+}
 
 describe("getMediaMarkdown", () => {
   it("embeds the file and links it to the share page", () => {
     // The embed must point at the bytes, not at the share page: `![](page)`
     // renders as a broken image everywhere it is pasted, which is exactly what
     // it used to do.
-    expect(
-      getMediaMarkdown({
-        name: "before.png",
-        shareUrl,
-        fileUrl,
-        posterUrl: null,
-        isVideo: false,
-      }),
-    ).toBe(`[![before.png](${fileUrl})](${shareUrl})`);
+    expect(getMediaMarkdown(embed({ name: "before.png" }))).toBe(
+      `[![before.png](${fileUrl})](${shareUrl})`,
+    );
   });
 
   it("never points an image embed at the share page", () => {
-    const markdown = getMediaMarkdown({
-      name: "before.png",
-      shareUrl,
-      fileUrl,
-      posterUrl: null,
-      isVideo: false,
-    });
+    const markdown = getMediaMarkdown(embed({ name: "before.png" }));
 
     expect(markdown).not.toContain(`![before.png](${shareUrl})`);
   });
@@ -39,13 +61,9 @@ describe("getMediaMarkdown", () => {
     // embed as a clickable still. Getting this wrong is what makes the feature
     // look broken.
     expect(
-      getMediaMarkdown({
-        name: "checkout.mp4",
-        shareUrl,
-        fileUrl,
-        posterUrl,
-        isVideo: true,
-      }),
+      getMediaMarkdown(
+        embed({ name: "checkout.mp4", posterUrl, isVideo: true }),
+      ),
     ).toBe(`[![checkout.mp4](${posterUrl})](${shareUrl})`);
   });
 
@@ -53,202 +71,205 @@ describe("getMediaMarkdown", () => {
     // Better than an image tag pointing at the video file: that renders as a
     // broken-image icon in the comment.
     expect(
-      getMediaMarkdown({
-        name: "checkout.mp4",
-        shareUrl,
-        fileUrl,
-        posterUrl: null,
-        isVideo: true,
-      }),
+      getMediaMarkdown(embed({ name: "checkout.mp4", isVideo: true })),
     ).toBe(`[▶ checkout.mp4](${shareUrl})`);
   });
 
   it("escapes brackets in a file name so they cannot truncate the label", () => {
-    expect(
-      getMediaMarkdown({
-        name: "before [v2].png",
-        shareUrl,
-        fileUrl,
-        posterUrl: null,
-        isVideo: false,
-      }),
-    ).toBe(`[![before \\[v2\\].png](${fileUrl})](${shareUrl})`);
+    expect(getMediaMarkdown(embed({ name: "before [v2].png" }))).toBe(
+      `[![before \\[v2\\].png](${fileUrl})](${shareUrl})`,
+    );
   });
 });
 
-describe("getMediaTableMarkdown", () => {
-  it("shows a pair side by side — the pull request comment's own rendering", () => {
+describe("getMediaBlockMarkdown", () => {
+  it("gives a lone media the whole width, under a heading linked to its page", () => {
+    expect(getMediaBlockMarkdown(group())).toBe(
+      [
+        `**[dashboard.png](${shareUrl})** · \`1440 × 900\``,
+        "",
+        "<table><tr><td>",
+        `<a href="${shareUrl}"><img src="${fileUrl}" alt="dashboard.png"></a>`,
+        "</td></tr></table>",
+      ].join("\n"),
+    );
+  });
+
+  it("shows a pair side by side, each half linked from its header", () => {
+    // The one thing a table is for. Name and description stay out of it: a table
+    // sizes its columns from their content, and a text column next to an image
+    // column collapses onto its longest word.
     expect(
-      getMediaTableMarkdown([
-        {
+      getMediaBlockMarkdown(
+        group({
           name: "checkout.png",
           description: "Checkout after the spacing fix.",
-          before: {
-            name: "checkout.png",
-            shareUrl: "https://app/m/before",
-            fileUrl: "https://files/before.webp",
-            posterUrl: null,
-            isVideo: false,
-          },
-          after: {
-            name: "checkout.png",
-            shareUrl: "https://app/m/after",
-            fileUrl: "https://files/after.webp",
-            posterUrl: null,
-            isVideo: false,
-          },
-        },
-      ]),
+          before: embed({ shareUrl: "https://app/m/before" }),
+          after: embed({ shareUrl: "https://app/m/after" }),
+        }),
+      ),
     ).toBe(
       [
-        "| Name | Before | After | Notes |",
-        "| --- | --- | --- | --- |",
-        "| checkout.png | [![checkout.png](https://files/before.webp)](https://app/m/before) | [![checkout.png](https://files/after.webp)](https://app/m/after) | Checkout after the spacing fix. |",
+        "**checkout.png** · `1440 × 900`<br>",
+        "Checkout after the spacing fix.",
+        "",
+        "| [Before ↗](https://app/m/before) | [After ↗](https://app/m/after) |",
+        "| --- | --- |",
+        `| [![Before — Checkout after the spacing fix.](${fileUrl})](https://app/m/before) | [![After — Checkout after the spacing fix.](${fileUrl})](https://app/m/after) |`,
       ].join("\n"),
     );
   });
 
-  it("keeps a lone media to a single preview column", () => {
+  it("does not link a pair's name, which would have to pick a half", () => {
+    const markdown = getMediaBlockMarkdown(
+      group({ before: embed(), after: embed() }),
+    );
+
+    expect(markdown).toContain("**dashboard.png**");
+    expect(markdown).not.toContain(`**[dashboard.png](${shareUrl})**`);
+  });
+
+  it("describes the media with the badges it can prove", () => {
     expect(
-      getMediaTableMarkdown([
-        {
-          name: "dashboard.png",
-          description: null,
-          before: null,
-          after: {
-            name: "dashboard.png",
-            shareUrl,
-            fileUrl,
-            posterUrl: null,
-            isVideo: false,
-          },
-        },
-      ]),
+      getMediaBlockMarkdown(
+        group({
+          versionNumber: 3,
+          teamOnly: true,
+          after: embed({ posterUrl, isVideo: true }),
+        }),
+      ),
+    ).toContain("· `1440 × 900` · `video` · `v3` · `Team-only`");
+  });
+
+  it("badges nothing it has nothing to say about", () => {
+    // A badge that is always there stops being worth a glance, and the heading
+    // stops being the scannable layer it exists to be.
+    const heading = getMediaBlockMarkdown(
+      group({ after: embed({ width: null, height: null }) }),
+    ).split("\n")[0];
+
+    expect(heading).toBe(`**[dashboard.png](${shareUrl})**`);
+  });
+
+  it("uses the description as alt text, which says more than a file name", () => {
+    expect(
+      getMediaBlockMarkdown(group({ description: "The empty dashboard." })),
+    ).toContain('alt="The empty dashboard."');
+  });
+
+  it("caps a phone screenshot, which would otherwise render at full height", () => {
+    // 375 wide is narrower than a comment, so nothing scales it down and its
+    // 1086 pixels of height land in the thread whole.
+    expect(
+      getMediaBlockMarkdown(
+        group({ after: embed({ width: 375, height: 1086 }) }),
+      ),
+    ).toContain('width="242"');
+  });
+
+  it("leaves a landscape screenshot alone", () => {
+    // It is wider than the comment, so it arrives already scaled to about 500
+    // pixels tall — capping it would shrink a preview that reads fine.
+    expect(getMediaBlockMarkdown(group())).not.toContain("width=");
+  });
+
+  it("caps nothing when the bytes never gave up their size", () => {
+    expect(
+      getMediaBlockMarkdown(
+        group({ after: embed({ width: null, height: null }) }),
+      ),
+    ).not.toContain("width=");
+  });
+
+  it("leaves a posterless video unframed, since a frame cannot hold Markdown", () => {
+    // Markdown is not parsed inside an HTML block, so the link fallback has to
+    // stay outside the one-cell table the other previews get.
+    expect(
+      getMediaBlockMarkdown(
+        group({
+          name: "checkout.mp4",
+          after: embed({ name: "checkout.mp4", isVideo: true }),
+        }),
+      ),
     ).toBe(
       [
-        "| Name | Preview |",
-        "| --- | --- |",
-        `| dashboard.png | [![dashboard.png](${fileUrl})](${shareUrl}) |`,
+        `**[checkout.mp4](${shareUrl})** · \`1440 × 900\` · \`video\``,
+        "",
+        `[▶ checkout.mp4](${shareUrl})`,
       ].join("\n"),
     );
   });
 
-  it("escapes pipes so a name cannot break out of its cell", () => {
+  it("escapes an HTML attribute so a name cannot close it", () => {
+    // The name reaches an `alt` attribute, where a quote ends the attribute and
+    // everything after it becomes markup GitHub is happy to keep.
     expect(
-      getMediaTableMarkdown([
-        {
-          name: "a|b.png",
-          description: null,
-          before: null,
-          after: {
-            name: "a|b.png",
-            shareUrl,
-            fileUrl,
-            posterUrl: null,
-            isVideo: false,
-          },
-        },
-      ]),
-    ).toBe(
-      [
-        "| Name | Preview |",
-        "| --- | --- |",
-        // Both cells: the pipe is escaped in the name column and again inside
-        // the embed's alt text, which is a cell of its own.
-        `| a\\|b.png | [![a\\|b.png](${fileUrl})](${shareUrl}) |`,
-      ].join("\n"),
-    );
+      getMediaBlockMarkdown(
+        group({
+          name: '" onerror="x',
+          after: embed({ name: '" onerror="x', width: 375, height: 1086 }),
+        }),
+      ),
+    ).toContain('alt="&quot; onerror=&quot;x"');
+  });
+
+  it("escapes an ampersand before the entities it writes itself", () => {
+    // Escaping `&` last would turn the `&quot;` the quote pass just wrote into
+    // `&amp;quot;`, printing the entity instead of the character.
+    expect(
+      getMediaBlockMarkdown(
+        group({
+          name: '&"',
+          after: embed({ name: '&"', width: 375, height: 1086 }),
+        }),
+      ),
+    ).toContain('alt="&amp;&quot;"');
+  });
+
+  it("escapes pipes so a name cannot break out of a pair's cell", () => {
+    expect(
+      getMediaBlockMarkdown(
+        group({ name: "a|b.png", before: embed(), after: embed() }),
+      ),
+    ).toContain("| [![Before — a\\|b.png]");
   });
 
   it("escapes a trailing backslash so it cannot escape the pipe escape", () => {
     // `a\` + `|` naively escaped gives `a\\|`, which renders a literal backslash
     // followed by a live pipe — a new column, from a file name.
     expect(
-      getMediaTableMarkdown([
-        {
-          name: "a\\|b.png",
-          description: null,
-          before: null,
-          after: {
-            name: "dashboard.png",
-            shareUrl,
-            fileUrl,
-            posterUrl: null,
-            isVideo: false,
-          },
-        },
-      ]),
-    ).toContain("| a\\\\\\|b.png |");
+      getMediaBlockMarkdown(
+        group({ name: "a\\|b.png", before: embed(), after: embed() }),
+      ),
+    ).toContain("Before — a\\\\\\|b.png");
   });
 
-  it("collapses a lone carriage return, which also ends a row", () => {
+  it("collapses a lone carriage return in a description", () => {
     // CommonMark and GFM treat a bare `\r` as a line ending, so matching only
-    // `\r?\n` leaves it to end the row and drop the rest into the comment as
-    // top-level Markdown.
+    // `\r?\n` leaves it to split the block in two.
     expect(
-      getMediaTableMarkdown([
-        {
-          name: "dashboard.png",
-          description: "First.\rSecond.",
-          before: null,
-          after: {
-            name: "dashboard.png",
-            shareUrl,
-            fileUrl,
-            posterUrl: null,
-            isVideo: false,
-          },
-        },
-      ]),
-    ).toContain("| First.<br>Second. |");
+      getMediaBlockMarkdown(group({ description: "First.\rSecond." })),
+    ).toContain("First.<br>Second.");
   });
 
-  it("collapses a newline in a name, which sits inside the embed", () => {
-    // The alt text is a cell of its own that `escapeTableCell` cannot reach, so
-    // a raw newline there ends the row mid-embed and leaks the rest as body
-    // text — the break the cell escaping exists to stop.
-    const table = getMediaTableMarkdown([
-      {
-        name: "a\nb.png",
-        description: null,
-        before: null,
-        after: {
-          name: "a\nb.png",
-          shareUrl,
-          fileUrl,
-          posterUrl: null,
-          isVideo: false,
-        },
-      },
+  it("turns a newline in a description into a line break", () => {
+    expect(
+      getMediaBlockMarkdown(
+        group({ description: "First line.\nSecond line." }),
+      ),
+    ).toContain("First line.<br>Second line.");
+  });
+});
+
+describe("getMediaListMarkdown", () => {
+  it("separates blocks with a blank line", () => {
+    const list = getMediaListMarkdown([
+      group({ name: "one.png" }),
+      group({ name: "two.png" }),
     ]);
 
-    expect(table).toBe(
-      [
-        "| Name | Preview |",
-        "| --- | --- |",
-        `| a<br>b.png | [![a<br>b.png](${fileUrl})](${shareUrl}) |`,
-      ].join("\n"),
+    expect(list).toBe(
+      `${getMediaBlockMarkdown(group({ name: "one.png" }))}\n\n${getMediaBlockMarkdown(group({ name: "two.png" }))}`,
     );
-    // One row per group, whatever the name contains.
-    expect(table.split("\n")).toHaveLength(3);
-  });
-
-  it("turns a newline in a note into a line break instead of a new row", () => {
-    expect(
-      getMediaTableMarkdown([
-        {
-          name: "dashboard.png",
-          description: "First line.\nSecond line.",
-          before: null,
-          after: {
-            name: "dashboard.png",
-            shareUrl,
-            fileUrl,
-            posterUrl: null,
-            isVideo: false,
-          },
-        },
-      ]),
-    ).toContain("| First line.<br>Second line. |");
   });
 });

--- a/apps/backend/src/media/url.ts
+++ b/apps/backend/src/media/url.ts
@@ -11,6 +11,26 @@ export function getMediaShareUrl(shareToken: string): string {
   return new URL(`/m/${shareToken}`, config.get("server.url")).href;
 }
 
+/**
+ * Tallest a preview is allowed to render, in CSS pixels.
+ *
+ * Applied by constraining the **width**, never the height: GitHub styles embedded
+ * images with `max-width: 100%` and no `height: auto`, so a fixed height attribute
+ * survives on a wide screen and stretches the image on a narrow one.
+ */
+const MAX_PREVIEW_HEIGHT = 700;
+
+/**
+ * Roughly how wide a pull request comment renders, and the only reason the cap
+ * can be applied at all: an embed's height on screen is not the file's height,
+ * it is the file's height after `max-width: 100%` has scaled it down to fit.
+ *
+ * Deliberately an estimate — GitHub's body width is responsive and we render one
+ * Markdown string for every reader. Erring low is the safe direction: it can only
+ * make the cap trigger on an image that would have been slightly under it.
+ */
+const COMMENT_WIDTH = 800;
+
 /** What embedding a media in Markdown needs to know about it. */
 export type MediaEmbedArgs = {
   name: string;
@@ -23,6 +43,9 @@ export type MediaEmbedArgs = {
   fileUrl: string;
   posterUrl: string | null;
   isVideo: boolean;
+  /** Pixel size of the bytes, when it could be read off them. */
+  width: number | null;
+  height: number | null;
 };
 
 /**
@@ -54,77 +77,252 @@ export function getMediaMarkdown(args: MediaEmbedArgs): string {
   return `[![${alt}](${previewUrl})](${shareUrl})`;
 }
 
-/** One row of the media table: a pair's two halves, or a lone media. */
+/** One block of the media list: a pair's two halves, or a lone media. */
 export type MediaMarkdownGroup = {
   name: string;
-  /** The pair's note — shown in a Notes column when any group has one. */
+  /** What the uploader said the media shows. Belongs to the pair, not to a half. */
   description: string | null;
+  /**
+   * Version of the media on show. Badged from 2 up — that a first upload is its
+   * own first version is not worth a reader's attention.
+   */
+  versionNumber: number;
+  /**
+   * Whether opening the **share page** needs a session. The embedded bytes are
+   * served unauthenticated whatever this says (see `getMediaFileUrl`), so this
+   * is the one thing a reader cannot infer from the comment: the picture renders
+   * for everyone, the page behind it does not.
+   */
+  teamOnly: boolean;
   before: MediaEmbedArgs | null;
   after: MediaEmbedArgs | null;
 };
 
 /**
- * The Markdown table presenting media, a before/after pair side by side in one
- * row. One rendering shared by the managed pull request comment and by the
- * share page's copyable snippet, so what a reviewer pastes by hand shows up
- * exactly like what the bot posts.
+ * The media list presented as blocks, one per media, joined by a blank line.
+ *
+ * One rendering shared by the managed pull request comment and by the share
+ * page's copyable snippet, so what a reviewer pastes by hand shows up exactly
+ * like what the bot posts.
  */
-export function getMediaTableMarkdown(groups: MediaMarkdownGroup[]): string {
-  const hasPairs = groups.some((group) => group.before && group.after);
-  const hasNotes = groups.some((group) => group.description);
+export function getMediaListMarkdown(groups: MediaMarkdownGroup[]): string {
+  return groups.map(getMediaBlockMarkdown).join("\n\n");
+}
 
-  const rows = groups.flatMap((group) => {
-    const solo = group.after ?? group.before;
-    if (!solo) {
-      return [];
-    }
-    const cells = hasPairs
-      ? [
-          escapeTableCell(group.name),
-          group.before ? getMediaMarkdown(group.before) : "",
-          group.after ? getMediaMarkdown(group.after) : "",
-        ]
-      : [escapeTableCell(group.name), getMediaMarkdown(solo)];
-    if (group.description) {
-      cells.push(escapeTableCell(group.description));
-    } else if (hasNotes) {
-      cells.push("");
-    }
-    return [`| ${cells.join(" | ")} |`];
-  });
+/**
+ * One media, as a heading carrying its name and badges, the description it was
+ * uploaded with, and the preview.
+ *
+ * Name and description are lines of prose rather than table columns, which is
+ * what lets the picture have the comment's full width: a table sizes its columns
+ * from their content, and an image cell is intrinsically far wider than a
+ * sentence, so text columns collapse onto their longest word while the preview
+ * gets squeezed all the same. A table is kept for the one thing it is actually
+ * for — putting a pair's two halves side by side to be compared.
+ */
+export function getMediaBlockMarkdown(group: MediaMarkdownGroup): string {
+  const heading = getBlockHeading(group);
+  const description = group.description
+    ? `<br>\n${collapseLineBreaks(group.description)}`
+    : "";
+  return `${heading}${description}\n\n${getBlockPreview(group)}`;
+}
 
-  const headers = hasPairs ? ["Name", "Before", "After"] : ["Name", "Preview"];
-  if (hasNotes) {
-    headers.push("Notes");
+/**
+ * The heading line: the name, then the badges.
+ *
+ * A lone media links its name to its share page. A pair does not — it has two
+ * share pages and no reason to prefer one, and its halves carry the links in the
+ * table headers right below.
+ */
+function getBlockHeading(group: MediaMarkdownGroup): string {
+  const solo =
+    group.before && group.after ? null : (group.after ?? group.before);
+  const name = escapeMarkdownText(group.name);
+  const label = solo ? `**[${name}](${solo.shareUrl})**` : `**${name}**`;
+  const badges = getBlockBadges(group);
+  if (badges.length === 0) {
+    return label;
+  }
+  return `${label} · ${badges.map((badge) => `\`${badge}\``).join(" · ")}`;
+}
+
+/**
+ * The badges, in the order a reader needs them.
+ *
+ * Every one of them is a fact Argos holds, and every one is conditional. Both
+ * halves of that matter: a badge nobody can contradict is worth glancing at, and
+ * a badge that only shows up when it has something to say stays worth glancing
+ * at. The moment badges become decoration — always there, or filled with
+ * whatever the uploader typed — the heading stops being scannable and the
+ * description is where the reading was supposed to happen anyway.
+ */
+function getBlockBadges(group: MediaMarkdownGroup): string[] {
+  const primary = group.after ?? group.before;
+  const badges: string[] = [];
+  if (primary?.width && primary.height) {
+    badges.push(`${primary.width} × ${primary.height}`);
+  }
+  if (primary?.isVideo) {
+    // A poster frame is indistinguishable from a screenshot, so nothing else in
+    // the comment says there is something to play.
+    badges.push("video");
+  }
+  if (group.versionNumber > 1) {
+    badges.push(`v${group.versionNumber}`);
+  }
+  if (group.teamOnly) {
+    badges.push("Team-only");
+  }
+  return badges;
+}
+
+/** The pair's table, or the lone media's framed preview. */
+function getBlockPreview(group: MediaMarkdownGroup): string {
+  const { before, after } = group;
+  if (before && after) {
+    const headers = [
+      `[Before ↗](${before.shareUrl})`,
+      `[After ↗](${after.shareUrl})`,
+    ];
+    return [
+      `| ${headers.join(" | ")} |`,
+      "| --- | --- |",
+      `| ${getCellEmbed(before, prefixAlt("Before", group))} | ${getCellEmbed(after, prefixAlt("After", group))} |`,
+    ].join("\n");
   }
 
-  return [
-    `| ${headers.join(" | ")} |`,
-    `| ${headers.map(() => "---").join(" | ")} |`,
-    ...rows,
-  ].join("\n");
+  const solo = after ?? before;
+  if (!solo) {
+    return "";
+  }
+  const previewUrl = getPreviewUrl(solo);
+  if (!previewUrl) {
+    return getPosterlessMarkdown(solo);
+  }
+  return frame(getEmbedHtml(solo, previewUrl, group.description ?? solo.name));
 }
 
 /**
- * Escape a value so it stays inside its table cell.
+ * Wrap a preview in a one-cell table.
  *
- * Backslashes go first, and skipping them is not cosmetic: escaping turns `|`
- * into `\|`, so a value already ending in a backslash would have that backslash
- * escaped by ours and let the pipe through — the very break this prevents. A
- * newline has no escape at all, since it ends the row outright, so it becomes the
- * `<br>` GitHub renders a line break with inside a cell.
+ * Purely for the border GitHub draws around a table, which is the only way to
+ * give an embed an edge: a light screenshot on a light comment background has
+ * none of its own, and a reader cannot tell where the image starts. A pair gets
+ * this for free from the table it is already in.
+ *
+ * The content has to be HTML, and the cell has to hold no blank line: Markdown
+ * is not parsed inside an HTML block, so an image written as `![]()` in there
+ * would render as its own source text.
  */
-function escapeTableCell(value: string): string {
-  return collapseLineBreaks(value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|"));
+function frame(html: string): string {
+  return `<table><tr><td>\n${html}\n</td></tr></table>`;
 }
 
 /**
- * Replace every line ending with the `<br>` GitHub renders one with inside a
- * cell.
+ * The picture to show for a media: the file itself for an image, the poster frame
+ * for a video, and `null` for a video whose poster hasn't been extracted yet.
+ */
+function getPreviewUrl(embed: MediaEmbedArgs): string | null {
+  return embed.isVideo ? embed.posterUrl : embed.fileUrl;
+}
+
+/** What stands in for a video that has no poster: a link, never a broken image. */
+function getPosterlessMarkdown(embed: MediaEmbedArgs): string {
+  return `[▶ ${escapeMarkdownText(embed.name)}](${embed.shareUrl})`;
+}
+
+/**
+ * The clickable picture as HTML, which is the only form a framed preview can
+ * take: Markdown is not parsed inside an HTML block, so `![]()` in a `<td>`
+ * renders as its own source text.
+ */
+function getEmbedHtml(
+  embed: MediaEmbedArgs,
+  previewUrl: string,
+  alt: string,
+): string {
+  const width = getPreviewWidth(embed);
+  return [
+    `<a href="${escapeHtmlAttribute(embed.shareUrl)}">`,
+    `<img src="${escapeHtmlAttribute(previewUrl)}"`,
+    ` alt="${escapeHtmlAttribute(alt)}"`,
+    width === null ? "" : ` width="${width}"`,
+    "></a>",
+  ].join("");
+}
+
+/**
+ * The clickable picture for a pair's cell: Markdown when nothing needs
+ * constraining, HTML when the preview has to be capped — `width` is an
+ * attribute, and Markdown has no way to spell one. Both parse inside a table
+ * cell, which unlike a framed preview is still Markdown.
+ */
+function getCellEmbed(embed: MediaEmbedArgs, alt: string): string {
+  const previewUrl = getPreviewUrl(embed);
+  if (!previewUrl) {
+    return getPosterlessMarkdown(embed);
+  }
+  if (getPreviewWidth(embed) === null) {
+    return `[![${escapeMarkdownText(alt)}](${previewUrl})](${embed.shareUrl})`;
+  }
+  return getEmbedHtml(embed, previewUrl, alt);
+}
+
+/**
+ * The width that brings a preview back under {@link MAX_PREVIEW_HEIGHT}, or
+ * `null` when it already is — or when the bytes never gave up their size, in
+ * which case constraining on a guess would be worse than leaving it alone.
+ *
+ * A landscape screenshot is wider than the comment, so it arrives already scaled
+ * down and is never touched: a 1440×900 lands around 500px tall. What is left is
+ * the two shapes that otherwise take over the thread — a phone capture, narrow
+ * enough to render at its full height, and a full-page capture, tall enough that
+ * even scaled to the comment's width it runs to thousands of pixels.
+ */
+function getPreviewWidth(embed: MediaEmbedArgs): number | null {
+  const { width, height } = embed;
+  if (!width || !height) {
+    return null;
+  }
+  const renderedHeight = (height * Math.min(width, COMMENT_WIDTH)) / width;
+  if (renderedHeight <= MAX_PREVIEW_HEIGHT) {
+    return null;
+  }
+  return Math.max(1, Math.round((MAX_PREVIEW_HEIGHT * width) / height));
+}
+
+/**
+ * Alt text for one half of a pair. The description covers the pair as a whole,
+ * so the half it belongs to has to be said, or a screen reader hears the same
+ * sentence twice with nothing telling the two pictures apart.
+ */
+function prefixAlt(state: string, group: MediaMarkdownGroup): string {
+  return `${state} — ${group.description ?? group.name}`;
+}
+
+/**
+ * Escape a value so it stays inside an HTML attribute.
+ *
+ * `&` goes first, for the same reason the backslash does when escaping a table
+ * cell: escaping introduces `&`-prefixed entities, so escaping it last would
+ * mangle the ones the earlier passes just wrote.
+ */
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Replace every line ending with the `<br>` GitHub renders one with.
  *
  * All three forms, not just `\n`: CommonMark and GFM treat a lone carriage
- * return as a line ending too, so matching `\r?\n` alone leaves `\r` to end the
- * row and drop everything after it into the comment as top-level Markdown.
+ * return as a line ending too. In a table cell a raw line ending would end the
+ * row outright and drop the rest into the comment as top-level Markdown; in the
+ * description it would split a block in two.
  */
 function collapseLineBreaks(value: string): string {
   return value.replace(/\r\n|[\r\n]/g, "<br>");
@@ -136,10 +334,10 @@ function collapseLineBreaks(value: string): string {
  * the rest as body text.
  *
  * `|` is in the set, and line endings are collapsed, even though neither means
- * anything to a link: these labels are rendered into table cells, where a raw
+ * anything to a link: these labels are also rendered into table cells, where a raw
  * pipe opens a column mid-embed and a raw newline ends the row outright. The
- * cell escaping cannot reach them — by then the label is glued to a URL that
- * must not be escaped — so the label has to arrive already safe.
+ * cell has no escaping of its own to fall back on — by then the label is glued to
+ * a URL that must not be escaped — so it has to arrive already safe.
  */
 function escapeMarkdownText(value: string): string {
   return collapseLineBreaks(value.replace(/([[\]\\|])/g, "\\$1"));


### PR DESCRIPTION
The media table gave its width to the wrong things: a file name wrapped over four lines while the screenshot it labelled was squeezed into a third of the comment, and a lone media was pushed into an "After" column with an empty "Before" beside it. Media are now blocks — name and description as prose above a full-width framed picture — and the table is kept for the one thing it is for, putting a before/after pair side by side.

The heading carries badges Argos can prove rather than notes typed by hand: pixel size, `v2` on a re-upload, `video`, and `Team-only` when the share page needs a session the embedded bytes never did. Previews are capped by width so a phone or full-page capture stops eating the thread, the footer states when the media expire, and a truncated list says so — the cap also keeps the twenty newest media now instead of the twenty oldest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)