### PR TITLE
feat(media): render the PR comment as an HTML table

### DIFF
--- a/apps/backend/src/graphql/definitions/Media.ts
+++ b/apps/backend/src/graphql/definitions/Media.ts
@@ -144,9 +144,10 @@ export const typeDefs = gql`
     """
     markdown: String!
     """
-    Ready-to-paste Markdown table showing the before/after pair side by side —
-    the same rendering the managed pull request comment uses. Null when this
-    media is not half of an uploaded pair.
+    Ready-to-paste table showing the before/after pair side by side — the same
+    rendering the managed pull request comment uses (an HTML table, which
+    GitHub-flavored Markdown renders as-is). Null when this media is not half
+    of an uploaded pair.
     """
     markdownPair: String
     "The newest uploaded version — what the share page and the comment show"

--- a/apps/backend/src/graphql/tests/mediaShare.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/mediaShare.e2e.test.ts
@@ -185,7 +185,9 @@ describe("mediaByShareToken", () => {
     expect(result.markdown).toBe(
       `[![checkout.png](${result.latestVersion.fileUrl})](${result.url})`,
     );
-    expect(result.markdownPair).toContain("| Name | Before | After |");
+    expect(result.markdownPair).toContain(
+      "<tr><th>Name</th><th>Before</th><th>After</th></tr>",
+    );
     expect(result.markdownPair).toContain(result.url);
     expect(result.markdownPair).toContain(result.counterpart.url);
 

--- a/apps/backend/src/media/pull-request-comment.ts
+++ b/apps/backend/src/media/pull-request-comment.ts
@@ -129,8 +129,8 @@ export async function updatePullRequestComment(
  * — which is the whole reason `state` exists, and reads far better than two
  * unrelated rows a reviewer has to match up themselves.
  *
- * Each cell is a CDN picture linked to its share page; {@link getMediaMarkdown}
- * owns why it is built that way.
+ * Each cell is a CDN picture linked to its share page;
+ * {@link getMediaTableMarkdown} owns why it is built that way.
  */
 function buildCommentBody(
   media: Media[],
@@ -178,12 +178,33 @@ function buildCommentBody(
     : "";
 
   return [
-    "**Media uploaded by Argos**",
+    formatCommentTitle(groups),
     "",
     getMediaTableMarkdown(groups),
     "",
-    `<sub>Uploaded with [Argos ↗︎](https://argos-ci.com/docs/learn/media/standalone-media-upload). This comment is updated in place.${versionNote}</sub>`,
+    `<sub>Uploaded with <a href="https://argos-ci.com/docs/learn/media/standalone-media-upload">Argos ↗︎</a>. This comment is updated in place.${versionNote}</sub>`,
   ].join("\n");
+}
+
+/**
+ * The headline counts the table's rows, not the uploads: a before/after pair is
+ * one screenshot to a reviewer, whatever the upload count says. The noun
+ * follows the content — "videos" when that is all there is, the generic
+ * "media" only for a mix.
+ */
+function formatCommentTitle(groups: MediaMarkdownGroup[]): string {
+  const embeds = groups.flatMap((group) =>
+    [group.before, group.after].filter((embed) => embed !== null),
+  );
+  const noun = embeds.every((embed) => embed.isVideo)
+    ? "video"
+    : embeds.some((embed) => embed.isVideo)
+      ? "media"
+      : "screenshot";
+  const count = groups.length;
+  // "media" is its own plural; the others take an "s" past one.
+  const label = noun === "media" || count === 1 ? noun : `${noun}s`;
+  return `**${count} ${label} uploaded by Argos**`;
 }
 
 type MediaPair = { before: Media | null; after: Media | null };

--- a/apps/backend/src/media/url.test.ts
+++ b/apps/backend/src/media/url.test.ts
@@ -101,9 +101,18 @@ describe("getMediaTableMarkdown", () => {
       ]),
     ).toBe(
       [
-        "| Name | Before | After | Notes |",
-        "| --- | --- | --- | --- |",
-        "| checkout.png | [![checkout.png](https://files/before.webp)](https://app/m/before) | [![checkout.png](https://files/after.webp)](https://app/m/after) | Checkout after the spacing fix. |",
+        "<table>",
+        "<thead>",
+        "<tr><th>Name</th><th>Before</th><th>After</th></tr>",
+        "</thead>",
+        "<tbody>",
+        "<tr>",
+        "<td><strong>checkout.png</strong><br>Checkout after the spacing fix.</td>",
+        '<td><a href="https://app/m/before"><img src="https://files/before.webp" alt="checkout.png"></a></td>',
+        '<td><a href="https://app/m/after"><img src="https://files/after.webp" alt="checkout.png"></a></td>',
+        "</tr>",
+        "</tbody>",
+        "</table>",
       ].join("\n"),
     );
   });
@@ -126,65 +135,112 @@ describe("getMediaTableMarkdown", () => {
       ]),
     ).toBe(
       [
-        "| Name | Preview |",
-        "| --- | --- |",
-        `| dashboard.png | [![dashboard.png](${fileUrl})](${shareUrl}) |`,
+        "<table>",
+        "<thead>",
+        "<tr><th>Name</th><th>Preview</th></tr>",
+        "</thead>",
+        "<tbody>",
+        "<tr>",
+        "<td><strong>dashboard.png</strong></td>",
+        `<td><a href="${shareUrl}"><img src="${fileUrl}" alt="dashboard.png"></a></td>`,
+        "</tr>",
+        "</tbody>",
+        "</table>",
       ].join("\n"),
     );
   });
 
-  it("escapes pipes so a name cannot break out of its cell", () => {
-    expect(
-      getMediaTableMarkdown([
-        {
-          name: "a|b.png",
-          description: null,
-          before: null,
-          after: {
-            name: "a|b.png",
-            shareUrl,
-            fileUrl,
-            posterUrl: null,
-            isVideo: false,
-          },
+  it("spans a lone media across both columns of a table that has pairs", () => {
+    // Without the colspan the lone media sits in one column with a hole beside
+    // it, reading as a pair whose other half went missing.
+    const table = getMediaTableMarkdown([
+      {
+        name: "checkout.png",
+        description: null,
+        before: {
+          name: "checkout.png",
+          shareUrl: "https://app/m/before",
+          fileUrl: "https://files/before.webp",
+          posterUrl: null,
+          isVideo: false,
         },
-      ]),
-    ).toBe(
-      [
-        "| Name | Preview |",
-        "| --- | --- |",
-        // Both cells: the pipe is escaped in the name column and again inside
-        // the embed's alt text, which is a cell of its own.
-        `| a\\|b.png | [![a\\|b.png](${fileUrl})](${shareUrl}) |`,
-      ].join("\n"),
+        after: {
+          name: "checkout.png",
+          shareUrl: "https://app/m/after",
+          fileUrl: "https://files/after.webp",
+          posterUrl: null,
+          isVideo: false,
+        },
+      },
+      {
+        name: "dashboard.png",
+        description: null,
+        before: null,
+        after: {
+          name: "dashboard.png",
+          shareUrl,
+          fileUrl,
+          posterUrl: null,
+          isVideo: false,
+        },
+      },
+    ]);
+
+    expect(table).toContain(
+      `<td colspan="2"><a href="${shareUrl}"><img src="${fileUrl}" alt="dashboard.png"></a></td>`,
     );
   });
 
-  it("escapes a trailing backslash so it cannot escape the pipe escape", () => {
-    // `a\` + `|` naively escaped gives `a\\|`, which renders a literal backslash
-    // followed by a live pipe — a new column, from a file name.
-    expect(
-      getMediaTableMarkdown([
-        {
-          name: "a\\|b.png",
-          description: null,
-          before: null,
-          after: {
-            name: "dashboard.png",
-            shareUrl,
-            fileUrl,
-            posterUrl: null,
-            isVideo: false,
-          },
+  it("escapes a name so it cannot inject markup into the table", () => {
+    // The whole table is raw HTML to GitHub, so an unescaped name is markup —
+    // in the label as a tag, in the alt attribute by closing the quote.
+    const table = getMediaTableMarkdown([
+      {
+        name: '<img src=x> "b.png',
+        description: null,
+        before: null,
+        after: {
+          name: '<img src=x> "b.png',
+          shareUrl,
+          fileUrl,
+          posterUrl: null,
+          isVideo: false,
         },
-      ]),
-    ).toContain("| a\\\\\\|b.png |");
+      },
+    ]);
+
+    expect(table).toContain(
+      "<td><strong>&lt;img src=x&gt; &quot;b.png</strong></td>",
+    );
+    expect(table).toContain('alt="&lt;img src=x&gt; &quot;b.png"');
+    expect(table).not.toContain("<img src=x>");
   });
 
-  it("collapses a lone carriage return, which also ends a row", () => {
-    // CommonMark and GFM treat a bare `\r` as a line ending, so matching only
-    // `\r?\n` leaves it to end the row and drop the rest into the comment as
-    // top-level Markdown.
+  it("keeps a blank line in a note from ending the HTML block", () => {
+    // GFM resumes Markdown parsing after a blank line inside an HTML block, so
+    // an unescaped one dumps the rest of the table into the comment as text.
+    const table = getMediaTableMarkdown([
+      {
+        name: "dashboard.png",
+        description: "First.\n\nSecond.",
+        before: null,
+        after: {
+          name: "dashboard.png",
+          shareUrl,
+          fileUrl,
+          posterUrl: null,
+          isVideo: false,
+        },
+      },
+    ]);
+
+    expect(table).toContain("First.<br><br>Second.");
+    expect(table).not.toContain("\n\n");
+  });
+
+  it("collapses a lone carriage return, which is also a line ending", () => {
+    // CommonMark and GFM treat a bare `\r` as a line ending too, so matching
+    // only `\r?\n` leaves it able to form the blank line that ends the block.
     expect(
       getMediaTableMarkdown([
         {
@@ -200,13 +256,10 @@ describe("getMediaTableMarkdown", () => {
           },
         },
       ]),
-    ).toContain("| First.<br>Second. |");
+    ).toContain("First.<br>Second.");
   });
 
-  it("collapses a newline in a name, which sits inside the embed", () => {
-    // The alt text is a cell of its own that `escapeTableCell` cannot reach, so
-    // a raw newline there ends the row mid-embed and leaks the rest as body
-    // text — the break the cell escaping exists to stop.
+  it("collapses a newline in a name, in the label and in the alt attribute", () => {
     const table = getMediaTableMarkdown([
       {
         name: "a\nb.png",
@@ -222,33 +275,28 @@ describe("getMediaTableMarkdown", () => {
       },
     ]);
 
-    expect(table).toBe(
-      [
-        "| Name | Preview |",
-        "| --- | --- |",
-        `| a<br>b.png | [![a<br>b.png](${fileUrl})](${shareUrl}) |`,
-      ].join("\n"),
-    );
-    // One row per group, whatever the name contains.
-    expect(table.split("\n")).toHaveLength(3);
+    expect(table).toContain("<td><strong>a<br>b.png</strong></td>");
+    // A `<br>` means nothing inside an attribute, so there the newline becomes
+    // a space instead.
+    expect(table).toContain('alt="a b.png"');
   });
 
-  it("turns a newline in a note into a line break instead of a new row", () => {
+  it("degrades a poster-less video cell to a plain link", () => {
     expect(
       getMediaTableMarkdown([
         {
-          name: "dashboard.png",
-          description: "First line.\nSecond line.",
+          name: "checkout.mp4",
+          description: null,
           before: null,
           after: {
-            name: "dashboard.png",
+            name: "checkout.mp4",
             shareUrl,
             fileUrl,
             posterUrl: null,
-            isVideo: false,
+            isVideo: true,
           },
         },
       ]),
-    ).toContain("| First line.<br>Second line. |");
+    ).toContain(`<td><a href="${shareUrl}">▶ checkout.mp4</a></td>`);
   });
 });

--- a/apps/backend/src/media/url.ts
+++ b/apps/backend/src/media/url.ts
@@ -57,65 +57,115 @@ export function getMediaMarkdown(args: MediaEmbedArgs): string {
 /** One row of the media table: a pair's two halves, or a lone media. */
 export type MediaMarkdownGroup = {
   name: string;
-  /** The pair's note — shown in a Notes column when any group has one. */
+  /** The pair's note — shown under the name in the Name cell. */
   description: string | null;
   before: MediaEmbedArgs | null;
   after: MediaEmbedArgs | null;
 };
 
 /**
- * The Markdown table presenting media, a before/after pair side by side in one
- * row. One rendering shared by the managed pull request comment and by the
- * share page's copyable snippet, so what a reviewer pastes by hand shows up
- * exactly like what the bot posts.
+ * The table presenting media, a before/after pair side by side in one row. One
+ * rendering shared by the managed pull request comment and by the share page's
+ * copyable snippet, so what a reviewer pastes by hand shows up exactly like
+ * what the bot posts.
+ *
+ * An HTML table rather than a pipe table, for two things Markdown cannot say:
+ * the description sits under the name in the same cell instead of in a Notes
+ * column at the far end, and a lone media in a table that has pairs spans both
+ * columns with `colspan` instead of leaving a hole. GitHub does not process
+ * Markdown inside an HTML block, so every cell — embeds included — is written
+ * as HTML.
  */
 export function getMediaTableMarkdown(groups: MediaMarkdownGroup[]): string {
   const hasPairs = groups.some((group) => group.before && group.after);
-  const hasNotes = groups.some((group) => group.description);
 
   const rows = groups.flatMap((group) => {
     const solo = group.after ?? group.before;
     if (!solo) {
       return [];
     }
-    const cells = hasPairs
-      ? [
-          escapeTableCell(group.name),
-          group.before ? getMediaMarkdown(group.before) : "",
-          group.after ? getMediaMarkdown(group.after) : "",
-        ]
-      : [escapeTableCell(group.name), getMediaMarkdown(solo)];
-    if (group.description) {
-      cells.push(escapeTableCell(group.description));
-    } else if (hasNotes) {
-      cells.push("");
-    }
-    return [`| ${cells.join(" | ")} |`];
+    const name = `<strong>${escapeHtmlText(group.name)}</strong>`;
+    const label = group.description
+      ? `${name}<br>${escapeHtmlText(group.description)}`
+      : name;
+    const cells =
+      group.before && group.after
+        ? [
+            `<td>${getMediaCellHtml(group.before)}</td>`,
+            `<td>${getMediaCellHtml(group.after)}</td>`,
+          ]
+        : [
+            hasPairs
+              ? `<td colspan="2">${getMediaCellHtml(solo)}</td>`
+              : `<td>${getMediaCellHtml(solo)}</td>`,
+          ];
+    return [["<tr>", `<td>${label}</td>`, ...cells, "</tr>"].join("\n")];
   });
 
-  const headers = hasPairs ? ["Name", "Before", "After"] : ["Name", "Preview"];
-  if (hasNotes) {
-    headers.push("Notes");
-  }
+  const headers = hasPairs
+    ? "<tr><th>Name</th><th>Before</th><th>After</th></tr>"
+    : "<tr><th>Name</th><th>Preview</th></tr>";
 
   return [
-    `| ${headers.join(" | ")} |`,
-    `| ${headers.map(() => "---").join(" | ")} |`,
+    "<table>",
+    "<thead>",
+    headers,
+    "</thead>",
+    "<tbody>",
     ...rows,
+    "</tbody>",
+    "</table>",
   ].join("\n");
 }
 
 /**
- * Escape a value so it stays inside its table cell.
- *
- * Backslashes go first, and skipping them is not cosmetic: escaping turns `|`
- * into `\|`, so a value already ending in a backslash would have that backslash
- * escaped by ours and let the pipe through — the very break this prevents. A
- * newline has no escape at all, since it ends the row outright, so it becomes the
- * `<br>` GitHub renders a line break with inside a cell.
+ * The embed for one table cell: the picture linked to its share page, mirroring
+ * {@link getMediaMarkdown} — same preview choice (the file for an image, the
+ * poster frame for a video, a plain link for a video with no poster yet) —
+ * spelled as HTML because Markdown is inert inside the table.
  */
-function escapeTableCell(value: string): string {
-  return collapseLineBreaks(value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|"));
+function getMediaCellHtml(args: MediaEmbedArgs): string {
+  const { name, shareUrl, fileUrl, posterUrl, isVideo } = args;
+  const previewUrl = isVideo ? posterUrl : fileUrl;
+  const href = escapeHtmlAttribute(shareUrl);
+
+  if (!previewUrl) {
+    return `<a href="${href}">▶ ${escapeHtmlText(name)}</a>`;
+  }
+
+  return `<a href="${href}"><img src="${escapeHtmlAttribute(previewUrl)}" alt="${escapeHtmlAttribute(name)}"></a>`;
+}
+
+/**
+ * Escape the characters HTML assigns meaning to. `"` is in the set so the same
+ * escaping is safe inside double-quoted attribute values, where a stray quote
+ * would close the attribute and let a file name inject markup.
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Escape a value for a cell's text content. Line endings become `<br>`: a
+ * blank line anywhere inside the table ends the HTML block — GFM resumes
+ * Markdown parsing after one — and dumps the rest of the table into the
+ * comment as body text.
+ */
+function escapeHtmlText(value: string): string {
+  return collapseLineBreaks(escapeHtml(value));
+}
+
+/**
+ * Escape a value for an attribute. Line endings become spaces rather than
+ * `<br>` — a tag means nothing inside `alt="…"` — but they still have to go,
+ * because a blank line ends the HTML block even mid-attribute.
+ */
+function escapeHtmlAttribute(value: string): string {
+  return escapeHtml(value).replace(/\r\n|[\r\n]/g, " ");
 }
 
 /**
@@ -136,10 +186,10 @@ function collapseLineBreaks(value: string): string {
  * the rest as body text.
  *
  * `|` is in the set, and line endings are collapsed, even though neither means
- * anything to a link: these labels are rendered into table cells, where a raw
- * pipe opens a column mid-embed and a raw newline ends the row outright. The
- * cell escaping cannot reach them — by then the label is glued to a URL that
- * must not be escaped — so the label has to arrive already safe.
+ * anything to a link: this snippet exists to be pasted, and a pipe-table cell
+ * is one of the places it lands — where a raw pipe opens a column mid-embed
+ * and a raw newline ends the row outright — so the label has to arrive
+ * already safe.
  */
 function escapeMarkdownText(value: string): string {
   return collapseLineBreaks(value.replace(/([[\]\\|])/g, "\\$1"));


### PR DESCRIPTION
## What changed

The managed media pull request comment is now rendered as an HTML table instead of a Markdown pipe table:

- The headline is counted — `**3 screenshots uploaded by Argos**` — counting table rows, so a before/after pair counts once. The noun follows the content: "video(s)" when that's all there is, "media" for a mix.
- The description sits under the bolded name in the Name cell (`<strong>name</strong><br>description`) instead of a Notes column at the far end.
- A lone media in a table that has pairs spans both columns with `colspan="2"` instead of leaving a hole beside it.
- Embeds are HTML (`<a href="share"><img src="cdn" alt="name">`), with the same preview choice as before: file for an image, poster frame for a video, plain `▶ name` link for a poster-less video.
- The footer link is an HTML anchor.

## Why

The pipe table read poorly: notes far from the name they describe, and single screenshots looking like pairs with a missing half. HTML says both things Markdown cannot (`colspan`, description under the name).

## Notes for review

- GitHub does not process Markdown inside an HTML block, so every cell is written as HTML. Escaping accordingly moved from pipe-table escaping to HTML entities (`"` included, so file names can't break out of `alt="…"`).
- Line endings still collapse (`<br>` in text, a space in attributes): a blank line anywhere inside the table ends the GFM HTML block and dumps the rest of the table into the comment as body text.
- `getMediaTableMarkdown` stays shared with the share page's copyable `markdownPair` snippet, preserving the invariant that a hand-pasted table is byte-identical to the bot's comment. The GraphQL field description was updated; `pnpm run codegen` produced no changes (descriptions aren't emitted).
- Tests rewritten for the new rendering, with new guards for markup injection via file names, blank lines in descriptions, and the colspan behavior. `pnpm run static-checks` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)