### PR TITLE
feat(media): list a pull request's media beside the one being viewed

### DIFF
--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -1724,9 +1724,10 @@ export async function createMediaScenario(input: {
   /** When given, seeds a pinned thread and a plain comment on the "after" image. */
   commentAuthorId?: string;
   /**
-   * Publish the pair to a pull request, creating the GitHub rows it needs — a
-   * seeded project is not connected to a repository. What the share header's
-   * pull request button needs to have something to show.
+   * Publish all four media to a pull request, creating the GitHub rows they
+   * need — a seeded project is not connected to a repository. What the share
+   * page's pull request button and its sidebar both need to have something to
+   * show: three entries, since the pair counts once.
    */
   withPullRequest?: boolean;
 }) {
@@ -1773,7 +1774,7 @@ export async function createMediaScenario(input: {
       state: null,
       description: null,
       visibility: "public" as const,
-      githubPullRequestId: null,
+      githubPullRequestId,
       shareToken: `seed-media-video-${projectId}`,
       createdAt: videoTs,
       updatedAt: videoTs,
@@ -1784,7 +1785,7 @@ export async function createMediaScenario(input: {
       state: null,
       description: "Overview screen after the sidebar redesign.",
       visibility: "public" as const,
-      githubPullRequestId: null,
+      githubPullRequestId,
       shareToken: `seed-media-solo-${projectId}`,
       createdAt: soloTs,
       updatedAt: soloTs,

--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -1800,7 +1800,7 @@ export async function createMediaScenario(input: {
   // Its newest version is deliberately a different file — and a different shape
   // — from the "before": a pair of identical bytes compares to nothing, and the
   // page's whole compare surface would have no changes to mark.
-  const [, afterV2] = await MediaVersion.query().insertAndFetch([
+  const [afterV1, afterV2] = await MediaVersion.query().insertAndFetch([
     {
       mediaId: after.id,
       number: 1,
@@ -1831,7 +1831,7 @@ export async function createMediaScenario(input: {
       updatedAt: afterV2Ts,
     },
   ]);
-  invariant(afterV2, "the after media should have two versions");
+  invariant(afterV1 && afterV2, "the after media should have two versions");
 
   const [beforeV1, videoV1, soloV1] = await MediaVersion.query().insertAndFetch(
     [
@@ -1891,17 +1891,37 @@ export async function createMediaScenario(input: {
   // no bucket to write to, so the finished row is seeded with a mask that really
   // is the diff of these two dummies — 375×1024, the union of a 720-tall
   // "before" and a 1024-tall "after".
-  await MediaDiff.query().insert({
-    beforeMediaVersionId: beforeV1.id,
-    afterMediaVersionId: afterV2.id,
-    jobStatus: "complete",
-    score: 0.3,
-    key: "diff-1024-to-720.png",
-    width: 375,
-    height: 1024,
-    createdAt: afterV2Ts,
-    updatedAt: afterV2Ts,
-  });
+  await MediaDiff.query().insert([
+    {
+      beforeMediaVersionId: beforeV1.id,
+      afterMediaVersionId: afterV2.id,
+      jobStatus: "complete",
+      score: 0.3,
+      key: "diff-1024-to-720.png",
+      width: 375,
+      height: 1024,
+      createdAt: afterV2Ts,
+      updatedAt: afterV2Ts,
+    },
+    // The first upload's own comparison, kept as history: v1 was compared
+    // against the same "before" when it landed, and picking v1 in the version
+    // list has to show *that* result rather than the newest one.
+    //
+    // No mask, because there is nothing to mark: this seed gives v1 the same
+    // file as the "before", and two identical uploads compare to a score of 0
+    // and no mask — what `computeMediaDiff` short-circuits to when the two keys
+    // match. So the reviewer switching to v1 sees the pair without an overlay,
+    // and switching back to v2 sees the changed pixels again.
+    {
+      beforeMediaVersionId: beforeV1.id,
+      afterMediaVersionId: afterV1.id,
+      jobStatus: "complete",
+      score: 0,
+      key: null,
+      createdAt: afterV1Ts,
+      updatedAt: afterV1Ts,
+    },
+  ]);
 
   if (commentAuthorId) {
     const commentTs = "2026-04-20T11:00:00.000Z";

--- a/apps/backend/src/graphql/definitions/Media.ts
+++ b/apps/backend/src/graphql/definitions/Media.ts
@@ -8,6 +8,7 @@ import {
   getMediaPermissions,
   type MediaPermission,
 } from "@/media/permissions";
+import { queryProjectMedia } from "@/media/query";
 import {
   getMediaDiffUrl,
   getMediaEmbedArgs,
@@ -26,6 +27,15 @@ import {
 import type { Context } from "../context";
 
 const { gql } = gqlTag;
+
+/**
+ * How many of a pull request's media the share page's sidebar lists.
+ *
+ * The list is not paginated — it is a sidebar the reviewer scrolls — so the cap
+ * is what keeps a pull request with hundreds of uploads from being one enormous
+ * response. Well above what a pull request realistically carries.
+ */
+const MAX_PULL_REQUEST_MEDIAS = 100;
 
 /** The service's permission names, as the schema's enum members. */
 const GRAPHQL_PERMISSION: Record<MediaPermission, IMediaPermission> = {
@@ -136,6 +146,8 @@ export const typeDefs = gql`
     description: String
     "Share page URL, the one to paste into a pull request"
     url: String!
+    "The token the share URL carries — the handle that opens this media's page"
+    shareToken: String!
     """
     Ready-to-paste Markdown embed, always pointing at the newest version: the
     picture served from the CDN, linked to the share page. Never built from
@@ -177,6 +189,17 @@ export const typeDefs = gql`
     and the pull request's title, author and number are not part of that.
     """
     pullRequest: PullRequest
+    """
+    Every media published to the same pull request, this one included, oldest
+    first — the order the managed pull request comment lists them in, so the
+    share page's sidebar reads like the comment the reviewer arrived from.
+
+    Empty when this media is not published to a pull request. Filtered by what
+    the viewer may see: without membership on the project, only the public ones
+    — which is what lets a public share link offer the rest of the public set
+    without opening the team-only uploads beside it.
+    """
+    pullRequestMedias: [Media!]!
     visibility: MediaVisibility!
     project: Project
     permissions: [MediaPermission!]!
@@ -238,6 +261,7 @@ export const resolvers: IResolvers = {
   },
   Media: {
     url: (media) => media.url,
+    shareToken: (media) => media.shareToken,
     latestVersion: async (media, _args, ctx) => {
       const version = await ctx.loaders.LatestMediaVersion.load(media.id);
       // `mediaByShareToken` refuses a media with no uploaded version, and nothing
@@ -299,6 +323,34 @@ export const resolvers: IResolvers = {
         return null;
       }
       return ctx.loaders.GithubPullRequest.load(media.githubPullRequestId);
+    },
+    pullRequestMedias: async (media, _args, ctx) => {
+      if (!media.githubPullRequestId) {
+        return [];
+      }
+      const project = await ctx.loaders.Project.load(media.projectId);
+      invariant(project, "project not found");
+      const membershipPermissions = await project.$getMembershipPermissions(
+        ctx.auth?.user ?? null,
+      );
+      // Scoped to this media's own project: a pull request can carry media from
+      // several projects, and access is decided per project.
+      const query = queryProjectMedia({
+        projectIds: [media.projectId],
+        filters: { githubPullRequestId: media.githubPullRequestId },
+        order: "asc",
+      }).limit(MAX_PULL_REQUEST_MEDIAS);
+      if (!membershipPermissions.includes("view")) {
+        // The per-item form of `checkCanViewMedia`, for the same reason
+        // `resolveVisibleCounterpart` re-checks: the halves of a pair are
+        // separate uploads with their own visibility, so a public link must not
+        // list the team-only media published beside it.
+        query.where("media.visibility", "public");
+      }
+      // Expiry is not filtered here, matching the REST list: a version can
+      // expire between this query and the click, and the share page already has
+      // one state for a media that is no longer there.
+      return query;
     },
     markdown: async (media, _args, ctx) => {
       const version = await ctx.loaders.LatestMediaVersion.load(media.id);

--- a/apps/backend/src/graphql/definitions/Media.ts
+++ b/apps/backend/src/graphql/definitions/Media.ts
@@ -8,7 +8,6 @@ import {
   getMediaPermissions,
   type MediaPermission,
 } from "@/media/permissions";
-import { queryProjectMedia } from "@/media/query";
 import {
   getMediaDiffUrl,
   getMediaEmbedArgs,
@@ -27,15 +26,6 @@ import {
 import type { Context } from "../context";
 
 const { gql } = gqlTag;
-
-/**
- * How many of a pull request's media the share page's sidebar lists.
- *
- * The list is not paginated — it is a sidebar the reviewer scrolls — so the cap
- * is what keeps a pull request with hundreds of uploads from being one enormous
- * response. Well above what a pull request realistically carries.
- */
-const MAX_PULL_REQUEST_MEDIAS = 100;
 
 /** The service's permission names, as the schema's enum members. */
 const GRAPHQL_PERMISSION: Record<MediaPermission, IMediaPermission> = {
@@ -404,22 +394,20 @@ export const resolvers: IResolvers = {
         });
       // Scoped to this media's own project: a pull request can carry media from
       // several projects, and access is decided per project.
-      const query = queryProjectMedia({
-        projectIds: [media.projectId],
-        filters: { githubPullRequestId: media.githubPullRequestId },
-        order: "asc",
-      }).limit(MAX_PULL_REQUEST_MEDIAS);
-      if (!membershipPermissions.includes("view")) {
+      //
+      // Through a loader because every media this returns has the same project
+      // and the same pull request, so each of them answers this field with the
+      // identical list — asking again once per element is the same query over
+      // and over.
+      return ctx.loaders.PullRequestMedia.load({
+        projectId: media.projectId,
+        githubPullRequestId: media.githubPullRequestId,
         // The per-item form of `checkCanViewMedia`, for the same reason
         // `resolveVisibleCounterpart` re-checks: the halves of a pair are
         // separate uploads with their own visibility, so a public link must not
         // list the team-only media published beside it.
-        query.where("media.visibility", "public");
-      }
-      // Expiry is not filtered here, matching the REST list: a version can
-      // expire between this query and the click, and the share page already has
-      // one state for a media that is no longer there.
-      return query;
+        includeTeamOnly: membershipPermissions.includes("view"),
+      });
     },
     markdown: async (media, _args, ctx) => {
       const version = await ctx.loaders.LatestMediaVersion.load(media.id);

--- a/apps/backend/src/graphql/definitions/Media.ts
+++ b/apps/backend/src/graphql/definitions/Media.ts
@@ -105,6 +105,10 @@ export const typeDefs = gql`
     0 when the two halves are identical, and 1 when their layouts differ.
     """
     score: Float
+    "The version this was computed from on the \`before\` side"
+    beforeVersion: MediaVersion!
+    "The version this was computed from on the \`after\` side"
+    afterVersion: MediaVersion!
   }
 
   """
@@ -130,6 +134,21 @@ export const typeDefs = gql`
     expiresAt: DateTime
     "Screenshot units this upload charged"
     billedUnits: Int!
+    """
+    The comparison this version took part in — the changed pixels between it and
+    the other half of its pair.
+
+    On the version rather than on the media because that is what a comparison is
+    of: re-uploading either half makes a new pair and a new comparison, and the
+    old one still describes the two versions it was computed from. Looking back
+    at an older version therefore gets that version's own comparison, and
+    \`afterVersion\` / \`beforeVersion\` say which two images it describes — the
+    pair to put on screen beside it.
+
+    Null when the media is not half of a visible pair, when the two halves were
+    never compared, and when the pair is not two images.
+    """
+    diff: MediaDiff
   }
 
   type Media implements Node {
@@ -173,14 +192,6 @@ export const typeDefs = gql`
     what lets the share page show the two together and compare them.
     """
     counterpart: Media
-    """
-    The comparison between this media's newest version and its counterpart's,
-    which is what the viewer draws its changes overlay from.
-
-    Null when this media is not half of a visible pair, and when the pair is not
-    two images — Argos does not compare videos frame by frame.
-    """
-    diff: MediaDiff
     """
     The pull request this media is published to.
 
@@ -251,6 +262,22 @@ export const resolvers: IResolvers = {
       }
     },
     url: (diff) => (diff.key ? getMediaDiffUrl(diff.key) : null),
+    beforeVersion: async (diff, _args, ctx) => {
+      const version = await ctx.loaders.MediaVersion.load(
+        diff.beforeMediaVersionId,
+      );
+      // The columns are `notNullable` foreign keys that cascade on delete, so a
+      // diff whose versions are gone is a diff that is gone.
+      invariant(version, "diff has no before version");
+      return version;
+    },
+    afterVersion: async (diff, _args, ctx) => {
+      const version = await ctx.loaders.MediaVersion.load(
+        diff.afterMediaVersionId,
+      );
+      invariant(version, "diff has no after version");
+      return version;
+    },
   },
   MediaVersion: {
     fileUrl: (version) => getMediaFileUrl(version),
@@ -258,6 +285,72 @@ export const resolvers: IResolvers = {
     contentType: (version) => version.mimeType,
     sizeBytes: (version) => version.size,
     isVideo: (version) => version.isVideo(),
+    diff: async (version, _args, ctx) => {
+      const media = await ctx.loaders.Media.load(version.mediaId);
+      invariant(media, "version has no media");
+      if (!media.state) {
+        return null;
+      }
+      // Gated on the *visible* counterpart, like `markdownPair`: the mask marks
+      // pixels of the other half, and a viewer who may not see that half may not
+      // see where it changed either.
+      const counterpart = await resolveVisibleCounterpart(media, ctx);
+      if (!counterpart) {
+        return null;
+      }
+      // Newest first, which is the order this version's comparisons are
+      // preferred in below.
+      const counterpartVersions = await ctx.loaders.MediaVersions.load(
+        counterpart.id,
+      );
+      const newestCounterpartVersion = counterpartVersions[0];
+      if (!newestCounterpartVersion) {
+        return null;
+      }
+
+      const ownNewest = await ctx.loaders.LatestMediaVersion.load(media.id);
+      if (ownNewest?.id === version.id) {
+        const [beforeVersion, afterVersion] =
+          media.state === "before"
+            ? [version, newestCounterpartVersion]
+            : [newestCounterpartVersion, version];
+        // Scheduling here as well as on upload is what makes the overlay show up
+        // for a pair that came together some other way — one half adopted onto a
+        // pull request, or a pair that predates the feature. The insert is
+        // idempotent, so a pair already computed costs one lookup.
+        //
+        // Only for the newest version: an older one is history, and asking for
+        // a comparison that was never made would queue a job per version the
+        // reviewer clicks through.
+        return ensureMediaDiff({ beforeVersion, afterVersion });
+      }
+
+      const ownSide =
+        media.state === "before"
+          ? "beforeMediaVersionId"
+          : "afterMediaVersionId";
+      const counterpartSide =
+        media.state === "before"
+          ? "afterMediaVersionId"
+          : "beforeMediaVersionId";
+      const diffs = await ctx.loaders.MediaVersionDiffs.load(version.id);
+      const byCounterpartVersion = new Map(
+        diffs
+          .filter((diff) => diff[ownSide] === version.id)
+          .map((diff) => [diff[counterpartSide], diff]),
+      );
+      // While this version was the newest of its half, every re-upload of the
+      // other half made another comparison against it — so it can sit in
+      // several. The newest of them is the one to show, because it is the half
+      // the page puts beside it.
+      for (const counterpartVersion of counterpartVersions) {
+        const diff = byCounterpartVersion.get(counterpartVersion.id);
+        if (diff) {
+          return diff;
+        }
+      }
+      return null;
+    },
   },
   Media: {
     url: (media) => media.url,
@@ -277,34 +370,6 @@ export const resolvers: IResolvers = {
         return null;
       }
       return resolveVisibleCounterpart(media, ctx);
-    },
-    diff: async (media, _args, ctx) => {
-      if (!media.state) {
-        return null;
-      }
-      // Gated on the *visible* counterpart, like `markdownPair`: the mask marks
-      // pixels of the other half, and a viewer who may not see that half may not
-      // see where it changed either.
-      const counterpart = await resolveVisibleCounterpart(media, ctx);
-      if (!counterpart) {
-        return null;
-      }
-      const [ownVersion, counterpartVersion] = await Promise.all([
-        ctx.loaders.LatestMediaVersion.load(media.id),
-        ctx.loaders.LatestMediaVersion.load(counterpart.id),
-      ]);
-      if (!ownVersion || !counterpartVersion) {
-        return null;
-      }
-      const [beforeVersion, afterVersion] =
-        media.state === "before"
-          ? [ownVersion, counterpartVersion]
-          : [counterpartVersion, ownVersion];
-      // Scheduling here as well as on upload is what makes the overlay show up
-      // for a pair that came together some other way — one half adopted onto a
-      // pull request, or a pair that predates the feature. The insert is
-      // idempotent, so a pair already computed costs one lookup.
-      return ensureMediaDiff({ beforeVersion, afterVersion });
     },
     pullRequest: async (media, _args, ctx) => {
       if (!media.githubPullRequestId) {

--- a/apps/backend/src/graphql/definitions/Media.ts
+++ b/apps/backend/src/graphql/definitions/Media.ts
@@ -381,9 +381,11 @@ export const resolvers: IResolvers = {
       // it may be.
       const project = await ctx.loaders.Project.load(media.projectId);
       invariant(project, "project not found");
-      const membershipPermissions = await project.$getMembershipPermissions(
-        ctx.auth?.user ?? null,
-      );
+      const membershipPermissions =
+        await ctx.loaders.ProjectMembershipPermissions.load({
+          project,
+          user: ctx.auth?.user ?? null,
+        });
       if (!membershipPermissions.includes("view")) {
         return null;
       }
@@ -395,9 +397,11 @@ export const resolvers: IResolvers = {
       }
       const project = await ctx.loaders.Project.load(media.projectId);
       invariant(project, "project not found");
-      const membershipPermissions = await project.$getMembershipPermissions(
-        ctx.auth?.user ?? null,
-      );
+      const membershipPermissions =
+        await ctx.loaders.ProjectMembershipPermissions.load({
+          project,
+          user: ctx.auth?.user ?? null,
+        });
       // Scoped to this media's own project: a pull request can carry media from
       // several projects, and access is decided per project.
       const query = queryProjectMedia({
@@ -488,9 +492,11 @@ export const resolvers: IResolvers = {
       }
       const project = await ctx.loaders.Project.load(media.projectId);
       invariant(project, "project not found");
-      const membershipPermissions = await project.$getMembershipPermissions(
-        ctx.auth.user,
-      );
+      const membershipPermissions =
+        await ctx.loaders.ProjectMembershipPermissions.load({
+          project,
+          user: ctx.auth.user,
+        });
       const permissions = getMediaPermissions({
         visibility: media.visibility,
         membershipPermissions,
@@ -520,9 +526,11 @@ export const resolvers: IResolvers = {
     permissions: async (media, _args, ctx) => {
       const project = await ctx.loaders.Project.load(media.projectId);
       invariant(project, "project not found");
-      const membershipPermissions = await project.$getMembershipPermissions(
-        ctx.auth?.user ?? null,
-      );
+      const membershipPermissions =
+        await ctx.loaders.ProjectMembershipPermissions.load({
+          project,
+          user: ctx.auth?.user ?? null,
+        });
       return getMediaPermissions({
         visibility: media.visibility,
         membershipPermissions,
@@ -558,9 +566,11 @@ export const resolvers: IResolvers = {
       invariant(project, "project not found");
       // Membership permissions, not `$getPermissions`: a public project grants
       // anyone "view", which must not open its team-only media to the world.
-      const membershipPermissions = await project.$getMembershipPermissions(
-        ctx.auth?.user ?? null,
-      );
+      const membershipPermissions =
+        await ctx.loaders.ProjectMembershipPermissions.load({
+          project,
+          user: ctx.auth?.user ?? null,
+        });
 
       return checkCanViewMedia({
         visibility: media.visibility,
@@ -596,9 +606,13 @@ async function resolveVisibleCounterpart(
   }
   const project = await ctx.loaders.Project.load(counterpart.projectId);
   invariant(project, "project not found");
-  const membershipPermissions = await project.$getMembershipPermissions(
-    ctx.auth?.user ?? null,
-  );
+  // Through the loader because this is now reached once per version, and the
+  // answer cannot differ between the versions of one media.
+  const membershipPermissions =
+    await ctx.loaders.ProjectMembershipPermissions.load({
+      project,
+      user: ctx.auth?.user ?? null,
+    });
   return checkCanViewMedia({
     visibility: counterpart.visibility,
     membershipPermissions,

--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -71,6 +71,7 @@ import {
   GhApiInstallation,
 } from "@/github";
 import { getMediaPairKey, getOppositeMediaState } from "@/media/pair";
+import { MAX_PULL_REQUEST_MEDIAS, queryProjectMedia } from "@/media/query";
 import { getLatestMediaVersions } from "@/media/version";
 import { getTestAllMetrics } from "@/metrics/test";
 
@@ -1111,6 +1112,48 @@ function createProjectMembershipPermissionsLoader() {
 }
 
 /**
+ * Everything published to one pull request, as one media's sidebar sees it.
+ *
+ * Keyed on what decides the answer rather than on the media asking: every media
+ * in the list shares this project and this pull request, so each of them would
+ * otherwise re-run the same query and get the same rows back.
+ */
+function createPullRequestMediaLoader() {
+  return new DataLoader<
+    {
+      projectId: string;
+      githubPullRequestId: string;
+      /** False for a viewer without membership, who sees only public media. */
+      includeTeamOnly: boolean;
+    },
+    Media[],
+    string
+  >(
+    async (inputs) =>
+      Promise.all(
+        inputs.map((input) => {
+          const query = queryProjectMedia({
+            projectIds: [input.projectId],
+            filters: { githubPullRequestId: input.githubPullRequestId },
+            order: "asc",
+          }).limit(MAX_PULL_REQUEST_MEDIAS);
+          if (!input.includeTeamOnly) {
+            query.where("media.visibility", "public");
+          }
+          // Expiry is not filtered here, matching the REST list: a version can
+          // expire between this query and the click, and the share page already
+          // has one state for a media that is no longer there.
+          return query;
+        }),
+      ),
+    {
+      cacheKeyFn: (input) =>
+        `${input.projectId}:${input.githubPullRequestId}:${input.includeTeamOnly}`,
+    },
+  );
+}
+
+/**
  * Every comparison a version took part in, on either side of it.
  *
  * Keyed on the version rather than the media because that is how the rows are
@@ -1850,6 +1893,7 @@ export const createLoaders = () => ({
   MediaVersions: createMediaVersionsLoader(),
   MediaVersion: createModelLoader(MediaVersion),
   MediaVersionDiffs: createMediaVersionDiffsLoader(),
+  PullRequestMedia: createPullRequestMediaLoader(),
   ProjectMembershipPermissions: createProjectMembershipPermissionsLoader(),
   MediaCounterpart: createMediaCounterpartLoader(),
   Media: createModelLoader(Media),

--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -54,6 +54,7 @@ import {
   Test,
   User,
 } from "@/database/models";
+import type { ProjectPermission } from "@/database/models/Project";
 import {
   getAccountPeriodUsages,
   type AccountPeriodUsage,
@@ -1083,6 +1084,33 @@ function createMediaVersionsLoader() {
 }
 
 /**
+ * What a viewer's membership grants them on a project, once per request.
+ *
+ * The check is two queries and every media field that gates on "is this viewer
+ * a member" runs it — including one now reached per *version*, where the answer
+ * cannot differ between them. Caching is the whole point here; the calls are
+ * still made one by one, because the check reads a `Project` instance rather
+ * than an id.
+ */
+function createProjectMembershipPermissionsLoader() {
+  return new DataLoader<
+    { project: Project; user: User | null },
+    ProjectPermission[],
+    string
+  >(
+    async (inputs) =>
+      Promise.all(
+        inputs.map((input) =>
+          Project.getMembershipPermissions(input.project, input.user),
+        ),
+      ),
+    {
+      cacheKeyFn: (input) => `${input.project.id}:${input.user?.id ?? ""}`,
+    },
+  );
+}
+
+/**
  * Every comparison a version took part in, on either side of it.
  *
  * Keyed on the version rather than the media because that is how the rows are
@@ -1822,6 +1850,7 @@ export const createLoaders = () => ({
   MediaVersions: createMediaVersionsLoader(),
   MediaVersion: createModelLoader(MediaVersion),
   MediaVersionDiffs: createMediaVersionDiffsLoader(),
+  ProjectMembershipPermissions: createProjectMembershipPermissionsLoader(),
   MediaCounterpart: createMediaCounterpartLoader(),
   Media: createModelLoader(Media),
   TestComments: createTestCommentsLoader(),

--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -36,6 +36,7 @@ import {
   GithubRepository,
   GitlabProject,
   Media,
+  MediaDiff,
   MediaVersion,
   IgnoredChange,
   Model,
@@ -1082,6 +1083,31 @@ function createMediaVersionsLoader() {
 }
 
 /**
+ * Every comparison a version took part in, on either side of it.
+ *
+ * Keyed on the version rather than the media because that is how the rows are
+ * keyed: a version is compared against whatever the other half's newest was
+ * when it landed, and re-uploading either half writes another row rather than
+ * replacing this one. Batched because the share page asks for the comparison of
+ * every version it lists at once.
+ */
+function createMediaVersionDiffsLoader() {
+  return new DataLoader<string, MediaDiff[]>(async (versionIds) => {
+    const ids = [...versionIds];
+    const diffs = await MediaDiff.query()
+      .whereIn("beforeMediaVersionId", ids)
+      .orWhereIn("afterMediaVersionId", ids);
+    return ids.map((versionId) =>
+      diffs.filter(
+        (diff) =>
+          diff.beforeMediaVersionId === versionId ||
+          diff.afterMediaVersionId === versionId,
+      ),
+    );
+  });
+}
+
+/**
  * The other half of a media's before/after pair.
  *
  * The batched form of `findMediaCounterpart`: same pairing tuple, built once
@@ -1794,7 +1820,10 @@ export const createLoaders = () => ({
   MediaComments: createMediaCommentsLoader(),
   LatestMediaVersion: createLatestMediaVersionLoader(),
   MediaVersions: createMediaVersionsLoader(),
+  MediaVersion: createModelLoader(MediaVersion),
+  MediaVersionDiffs: createMediaVersionDiffsLoader(),
   MediaCounterpart: createMediaCounterpartLoader(),
+  Media: createModelLoader(Media),
   TestComments: createTestCommentsLoader(),
   CommentReactions: createCommentReactionsLoader(),
   CommentMentionedUserIds: createCommentMentionedUserIdsLoader(),

--- a/apps/backend/src/graphql/tests/mediaShare.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/mediaShare.e2e.test.ts
@@ -571,8 +571,19 @@ describe("MediaVersion.diff", () => {
       mimeType: "image/png",
       uploadedAt: new Date().toISOString(),
     });
+    // …and a second "after", so the version under test is not the newest of its
+    // own half. Without this the resolver answers from its newest-version
+    // branch, which pairs with the counterpart's newest directly and never
+    // reaches the preference this test is about.
+    const afterV2 = await factory.MediaVersion.create({
+      mediaId: after.media.id,
+      number: 2,
+      key: "dummy-375x720.png",
+      mimeType: "image/png",
+      uploadedAt: new Date().toISOString(),
+    });
 
-    const [stale, current] = await MediaDiff.query().insertAndFetch([
+    const [stale, current, newest] = await MediaDiff.query().insertAndFetch([
       {
         beforeMediaVersionId: before.version.id,
         afterMediaVersionId: after.version.id,
@@ -585,15 +596,27 @@ describe("MediaVersion.diff", () => {
         jobStatus: "complete",
         score: 0.2,
       },
+      // The newest pair, so reading it settles rather than queueing work.
+      {
+        beforeMediaVersionId: beforeV2.id,
+        afterMediaVersionId: afterV2.id,
+        jobStatus: "complete",
+        score: 0.1,
+      },
     ]);
-    invariant(stale && current, "both comparisons should be created");
+    invariant(stale && current && newest, "the comparisons should be created");
 
     const res = await query({ auth, shareToken: "many-after" });
 
     expectNoGraphQLError(res);
-    const [version] = res.body.data.mediaByShareToken.versions;
-    expect(version.diff.id).toBe(String(current.id));
-    expect(version.diff.beforeVersion.id).toBe(String(beforeV2.id));
+    // Newest first: v2 answers with the newest pair, and v1 — which sits in two
+    // comparisons — answers with the one against the newest "before", the half
+    // shown beside it.
+    const [second, first] = res.body.data.mediaByShareToken.versions;
+    expect(second.diff.id).toBe(String(newest.id));
+    expect(first.id).toBe(String(after.version.id));
+    expect(first.diff.id).toBe(String(current.id));
+    expect(first.diff.beforeVersion.id).toBe(String(beforeV2.id));
   });
 });
 

--- a/apps/backend/src/graphql/tests/mediaShare.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/mediaShare.e2e.test.ts
@@ -3,7 +3,7 @@ import request from "supertest";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import type { Account, User } from "@/database/models";
-import { Comment, Project } from "@/database/models";
+import { Comment, MediaDiff, Project } from "@/database/models";
 import { createMediaScenario } from "@/database/seeds";
 import { factory, setupDatabase } from "@/database/testing";
 
@@ -58,6 +58,20 @@ const MEDIA_SHARE_QUERY = `
       versions {
         id
         number
+        diff {
+          id
+          status
+          url
+          width
+          height
+          score
+          beforeVersion {
+            id
+          }
+          afterVersion {
+            id
+          }
+        }
       }
       pullRequest {
         id
@@ -72,14 +86,6 @@ const MEDIA_SHARE_QUERY = `
           id
           fileUrl
         }
-      }
-      diff {
-        id
-        status
-        url
-        width
-        height
-        score
       }
       project {
         id
@@ -203,13 +209,24 @@ describe("mediaByShareToken", () => {
     expect(result.markdownPair).toContain(result.url);
     expect(result.markdownPair).toContain(result.counterpart.url);
 
-    // The pair's comparison, which is what the viewer's changes overlay draws.
-    expect(result.diff).toMatchObject({
+    // The comparison the viewer's changes overlay draws, carried by the version
+    // it was computed from. `versions` is newest first.
+    const [newest, first] = result.versions;
+    expect(newest.diff).toMatchObject({
       status: "complete",
       width: 375,
       height: 1024,
     });
-    expect(result.diff.url).toContain("diff-1024-to-720.png");
+    expect(newest.diff.url).toContain("diff-1024-to-720.png");
+    expect(newest.diff.afterVersion.id).toBe(newest.id);
+
+    // The first upload kept its own comparison: the same "before", its own
+    // result. Identical bytes, so it is complete with nothing to mark — which is
+    // a different answer from the newest version's, not a missing one.
+    expect(first.diff).toMatchObject({ status: "complete", score: 0 });
+    expect(first.diff.url).toBeNull();
+    expect(first.diff.afterVersion.id).toBe(first.id);
+    expect(first.diff.beforeVersion.id).toBe(newest.diff.beforeVersion.id);
 
     const pinned = result.comments.find(
       (comment: { anchor: unknown }) => comment.anchor !== null,
@@ -369,7 +386,11 @@ describe("mediaByShareToken", () => {
     // and so does the diff, whose mask marks the counterpart's pixels and whose
     // dimensions are the two halves' union.
     expect(result.markdownPair).toBeNull();
-    expect(result.diff).toBeNull();
+    expect(
+      result.versions.every(
+        (version: { diff: unknown }) => version.diff === null,
+      ),
+    ).toBe(true);
   });
 
   it("still shows a counterpart the viewer may see", async () => {
@@ -491,6 +512,88 @@ describe("mediaByShareToken", () => {
 
     expectNoGraphQLError(res);
     expect(res.body.data.mediaByShareToken.unresolvedCommentCount).toBe(1);
+  });
+});
+
+describe("MediaVersion.diff", () => {
+  beforeAll(async () => {
+    await setupDatabase();
+  });
+
+  it("gives a version the comparison it took part in, not the newest", async () => {
+    const { auth, project } = await createTeamOwner();
+    const media = await createMediaScenario({ projectId: project.id });
+
+    const res = await query({ auth, shareToken: media.after.shareToken });
+
+    expectNoGraphQLError(res);
+    const versions = res.body.data.mediaByShareToken.versions;
+    // Two uploads, two comparisons — each naming its own version on the "after"
+    // side, and both against the same "before".
+    expect(
+      versions.map((version: { diff: { id: string } }) => version.diff.id),
+    ).toHaveLength(2);
+    expect(versions[0].diff.id).not.toBe(versions[1].diff.id);
+    expect(versions[0].diff.afterVersion.id).toBe(versions[0].id);
+    expect(versions[1].diff.afterVersion.id).toBe(versions[1].id);
+  });
+
+  it("prefers the newest counterpart a version was compared against", async () => {
+    // A version stays the newest of its half while the other half is uploaded
+    // again, so it can sit in several comparisons. The one to show is the one
+    // against the counterpart the page puts beside it — its newest.
+    const { auth, project } = await createTeamOwner();
+    const before = await factory.createMediaWithVersion({
+      media: {
+        projectId: project.id,
+        name: "checkout.png",
+        state: "before",
+        branch: "feat/a",
+        shareToken: "many-before",
+      },
+      version: { key: "dummy-375x720.png", mimeType: "image/png" },
+    });
+    const after = await factory.createMediaWithVersion({
+      media: {
+        projectId: project.id,
+        name: "checkout.png",
+        state: "after",
+        branch: "feat/a",
+        shareToken: "many-after",
+      },
+      version: { key: "dummy-375x1024.png", mimeType: "image/png" },
+    });
+    // A second "before", landed after the pair was first compared.
+    const beforeV2 = await factory.MediaVersion.create({
+      mediaId: before.media.id,
+      number: 2,
+      key: "dummy-375x1024.png",
+      mimeType: "image/png",
+      uploadedAt: new Date().toISOString(),
+    });
+
+    const [stale, current] = await MediaDiff.query().insertAndFetch([
+      {
+        beforeMediaVersionId: before.version.id,
+        afterMediaVersionId: after.version.id,
+        jobStatus: "complete",
+        score: 0.4,
+      },
+      {
+        beforeMediaVersionId: beforeV2.id,
+        afterMediaVersionId: after.version.id,
+        jobStatus: "complete",
+        score: 0.2,
+      },
+    ]);
+    invariant(stale && current, "both comparisons should be created");
+
+    const res = await query({ auth, shareToken: "many-after" });
+
+    expectNoGraphQLError(res);
+    const [version] = res.body.data.mediaByShareToken.versions;
+    expect(version.diff.id).toBe(String(current.id));
+    expect(version.diff.beforeVersion.id).toBe(String(beforeV2.id));
   });
 });
 

--- a/apps/backend/src/graphql/tests/mediaShare.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/mediaShare.e2e.test.ts
@@ -27,10 +27,22 @@ const MEDIA_SHARE_QUERY = `
       state
       description
       url
+      shareToken
       markdown
       markdownPair
       permissions
       unresolvedCommentCount
+      pullRequestMedias {
+        id
+        name
+        state
+        shareToken
+        latestVersion {
+          id
+          fileUrl
+          isVideo
+        }
+      }
       latestVersion {
         id
         number
@@ -479,5 +491,192 @@ describe("mediaByShareToken", () => {
 
     expectNoGraphQLError(res);
     expect(res.body.data.mediaByShareToken.unresolvedCommentCount).toBe(1);
+  });
+});
+
+describe("Media.pullRequestMedias", () => {
+  beforeAll(async () => {
+    await setupDatabase();
+  });
+
+  /**
+   * A pull request with media on it, in the shape the sidebar has to render: a
+   * before/after pair, a lone screenshot, and a video — with each half's
+   * visibility given separately, because that is what decides who sees what.
+   */
+  async function createPullRequestMedia(input: {
+    projectId: string;
+    pairVisibility: "public" | "team";
+    soloVisibility: "public" | "team";
+  }) {
+    const { projectId, pairVisibility, soloVisibility } = input;
+    const repository = await factory.GithubRepository.create();
+    await Project.query()
+      .findById(projectId)
+      .patch({ githubRepositoryId: repository.id });
+    const pullRequest = await factory.PullRequest.create({
+      githubRepositoryId: repository.id,
+    });
+
+    // Inserted out of order on purpose: the field promises upload order, and
+    // `createdAt` is what has to decide it rather than the insert sequence.
+    const solo = await factory.createMediaWithVersion({
+      media: {
+        projectId,
+        name: "dashboard.png",
+        visibility: soloVisibility,
+        githubPullRequestId: pullRequest.id,
+        shareToken: `prm-solo-${projectId}`,
+        createdAt: "2026-04-20T09:00:00.000Z",
+      },
+    });
+    const before = await factory.createMediaWithVersion({
+      media: {
+        projectId,
+        name: "checkout.png",
+        state: "before",
+        visibility: pairVisibility,
+        githubPullRequestId: pullRequest.id,
+        shareToken: `prm-before-${projectId}`,
+        createdAt: "2026-04-20T08:00:00.000Z",
+      },
+    });
+    const after = await factory.createMediaWithVersion({
+      media: {
+        projectId,
+        name: "checkout.png",
+        state: "after",
+        visibility: "public",
+        githubPullRequestId: pullRequest.id,
+        shareToken: `prm-after-${projectId}`,
+        createdAt: "2026-04-20T08:30:00.000Z",
+      },
+    });
+
+    return {
+      before: before.media,
+      after: after.media,
+      solo: solo.media,
+    };
+  }
+
+  it("lists the pull request's media to a member, oldest first", async () => {
+    const { auth, project } = await createTeamOwner();
+    const media = await createPullRequestMedia({
+      projectId: project.id,
+      pairVisibility: "team",
+      soloVisibility: "team",
+    });
+
+    const res = await query({ auth, shareToken: media.after.shareToken });
+
+    expectNoGraphQLError(res);
+    const result = res.body.data.mediaByShareToken;
+    // Upload order, both halves of the pair, and the media being looked at is
+    // one of them — the sidebar highlights a row rather than a nothing.
+    expect(
+      result.pullRequestMedias.map(
+        (item: { shareToken: string }) => item.shareToken,
+      ),
+    ).toEqual([
+      media.before.shareToken,
+      media.after.shareToken,
+      media.solo.shareToken,
+    ]);
+    // The token is what the sidebar navigates with.
+    expect(result.shareToken).toBe(media.after.shareToken);
+  });
+
+  it("lists only the public media to an anonymous visitor", async () => {
+    const account = await factory.TeamAccount.create();
+    const project = await factory.Project.create({ accountId: account.id });
+    const media = await createPullRequestMedia({
+      projectId: project.id,
+      pairVisibility: "team",
+      soloVisibility: "public",
+    });
+
+    const res = await query({ auth: null, shareToken: media.after.shareToken });
+
+    expectNoGraphQLError(res);
+    const result = res.body.data.mediaByShareToken;
+    // The team-only half of the pair is not in the list, and neither is
+    // anything else the visitor could not open by its own link.
+    expect(
+      result.pullRequestMedias.map(
+        (item: { shareToken: string }) => item.shareToken,
+      ),
+    ).toEqual([media.after.shareToken, media.solo.shareToken]);
+    // The list is not the pull request: a public link still says nothing about
+    // the work it belongs to.
+    expect(result.pullRequest).toBeNull();
+  });
+
+  it("lists only the public media to a signed-in outsider", async () => {
+    const outsider = await factory.User.create();
+    const outsiderAccount = await factory.UserAccount.create({
+      userId: outsider.id,
+    });
+    const account = await factory.TeamAccount.create();
+    // Public project, so `$getPermissions` would grant "view" to anyone — an
+    // account is not membership, and must not open the team-only uploads.
+    const project = await factory.Project.create({
+      accountId: account.id,
+      private: false,
+    });
+    const media = await createPullRequestMedia({
+      projectId: project.id,
+      pairVisibility: "team",
+      soloVisibility: "team",
+    });
+
+    const res = await query({
+      auth: { user: outsider, account: outsiderAccount },
+      shareToken: media.after.shareToken,
+    });
+
+    expectNoGraphQLError(res);
+    expect(
+      res.body.data.mediaByShareToken.pullRequestMedias.map(
+        (item: { shareToken: string }) => item.shareToken,
+      ),
+    ).toEqual([media.after.shareToken]);
+  });
+
+  it("is empty for a media that is not published to a pull request", async () => {
+    const { auth, project } = await createTeamOwner();
+    const scenario = await createMediaScenario({ projectId: project.id });
+
+    const res = await query({ auth, shareToken: scenario.after.shareToken });
+
+    expectNoGraphQLError(res);
+    expect(res.body.data.mediaByShareToken.pullRequestMedias).toEqual([]);
+  });
+
+  it("leaves out a media whose upload never landed", async () => {
+    // A media created to sign an upload that never completed is a step of the
+    // two-step flow, not something the sidebar should offer a link to.
+    const { auth, project } = await createTeamOwner();
+    const media = await createPullRequestMedia({
+      projectId: project.id,
+      pairVisibility: "team",
+      soloVisibility: "team",
+    });
+    await factory.Media.create({
+      projectId: project.id,
+      name: "never-uploaded.png",
+      visibility: "team",
+      githubPullRequestId: media.after.githubPullRequestId,
+      shareToken: `prm-pending-${project.id}`,
+    });
+
+    const res = await query({ auth, shareToken: media.after.shareToken });
+
+    expectNoGraphQLError(res);
+    expect(
+      res.body.data.mediaByShareToken.pullRequestMedias.map(
+        (item: { name: string }) => item.name,
+      ),
+    ).toEqual(["checkout.png", "checkout.png", "dashboard.png"]);
   });
 });

--- a/apps/backend/src/media/query.ts
+++ b/apps/backend/src/media/query.ts
@@ -35,11 +35,17 @@ export type MediaFilters = {
 export function queryProjectMedia(args: {
   projectIds: string[];
   filters: MediaFilters | null;
+  /**
+   * Newest first by default, which is what a list of recent uploads wants.
+   * "asc" is upload order — how the pull request comment reads, and how the
+   * share page's sidebar has to read to match it.
+   */
+  order?: "asc" | "desc";
 }): QueryBuilder<Media, Media[]> {
   const query = Media.query()
     .whereIn("media.projectId", args.projectIds)
     .whereExists(uploadedVersions())
-    .orderBy("media.createdAt", "desc");
+    .orderBy("media.createdAt", args.order ?? "desc");
 
   const { search, type, branch, githubPullRequestId, stage } =
     args.filters ?? {};

--- a/apps/backend/src/media/query.ts
+++ b/apps/backend/src/media/query.ts
@@ -3,6 +3,15 @@ import type { QueryBuilder } from "objection";
 
 import { Media, MediaVersion } from "@/database/models";
 
+/**
+ * How many of a pull request's media the share page's sidebar lists.
+ *
+ * The list is not paginated — it is a sidebar the reviewer scrolls — so the cap
+ * is what keeps a pull request with hundreds of uploads from being one enormous
+ * response. Well above what a pull request realistically carries.
+ */
+export const MAX_PULL_REQUEST_MEDIAS = 100;
+
 export type MediaFilters = {
   /** Match on the media's name or its description. */
   search?: string | null | undefined;

--- a/apps/backend/src/notification/handlers/commentTarget.test.ts
+++ b/apps/backend/src/notification/handlers/commentTarget.test.ts
@@ -13,6 +13,7 @@ const ctx = { user: { id: "user-1", name: "James" }, preferencesUrl: null };
 
 const BUILD_TARGET = { buildNumber: 42, buildName: "default" };
 const TEST_TARGET = { testName: "Header renders" };
+const MEDIA_TARGET = { mediaName: "checkout.png" };
 const NO_TARGET = {};
 
 /**
@@ -29,6 +30,7 @@ function withTarget(
     buildNumber: undefined,
     buildName: undefined,
     testName: undefined,
+    mediaName: undefined,
     ...target,
   };
 }
@@ -50,7 +52,12 @@ describe("getCommentTargetLabel", () => {
     expect(getCommentTargetLabel(TEST_TARGET)).toBe("test Header renders");
   });
 
-  it("throws when the payload names neither", () => {
+  it("names a media by its file name alone", () => {
+    // No noun in front: "media checkout.png" reads like a category nobody uses.
+    expect(getCommentTargetLabel(MEDIA_TARGET)).toBe("checkout.png");
+  });
+
+  it("throws when the payload names none of them", () => {
     expect(() => getCommentTargetLabel(NO_TARGET)).toThrow(
       "A comment notification must name its target",
     );
@@ -79,12 +86,25 @@ describe.each(handlers)("$name", ({ handler }) => {
     expect(html).not.toContain("build default");
   });
 
-  it("accepts either target and rejects a payload naming none", () => {
+  it("renders the media it was posted on", async () => {
+    const rendered = handler.email({
+      ...withTarget(handler, MEDIA_TARGET),
+      ctx,
+    });
+    const html = await emailToText(rendered);
+    expect(html).toContain("checkout.png");
+    expect(html).not.toContain("build default");
+  });
+
+  it("accepts any target and rejects a payload naming none", () => {
     expect(
       handler.schema.safeParse(withTarget(handler, BUILD_TARGET)).success,
     ).toBe(true);
     expect(
       handler.schema.safeParse(withTarget(handler, TEST_TARGET)).success,
+    ).toBe(true);
+    expect(
+      handler.schema.safeParse(withTarget(handler, MEDIA_TARGET)).success,
     ).toBe(true);
     expect(
       handler.schema.safeParse(withTarget(handler, NO_TARGET)).success,

--- a/apps/backend/src/notification/handlers/commentTarget.ts
+++ b/apps/backend/src/notification/handlers/commentTarget.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 
 /**
  * Fields describing what a comment was posted on, shared by every comment
- * notification. A comment lives either on a build (`buildNumber`, with an
- * optional `buildName`) or on a test (`testName`) — see
+ * notification. A comment lives on a build (`buildNumber`, with an optional
+ * `buildName`), on a test (`testName`) or on a media (`mediaName`) — see
  * `getCommentTargetNotificationFields`.
  *
  * Each field is individually optional so a workflow queued before tests could be
@@ -16,13 +16,18 @@ const commentTargetSchema = z.object({
   buildNumber: z.number().nullish(),
   buildName: z.string().nullish(),
   testName: z.string().nullish(),
+  mediaName: z.string().nullish(),
 });
 
 export type CommentTargetFields = z.infer<typeof commentTargetSchema>;
 
 /** Whether a payload names what the comment was posted on. */
 function namesTarget(fields: CommentTargetFields): boolean {
-  return fields.buildNumber != null || fields.testName != null;
+  return (
+    fields.buildNumber != null ||
+    fields.testName != null ||
+    fields.mediaName != null
+  );
 }
 
 /**
@@ -44,9 +49,9 @@ export function commentNotificationSchema<TShape extends z.ZodRawShape>(
 }
 
 /**
- * Human label for what a comment was posted on, e.g. `build default #42` or
- * `test Header renders`. Used in email subjects and copy, so the same sentence
- * reads correctly for both kinds of comment.
+ * Human label for what a comment was posted on, e.g. `build default #42`,
+ * `test Header renders` or `checkout.png`. Used in email subjects and copy, so
+ * the same sentence reads correctly for every kind of comment.
  */
 export function getCommentTargetLabel(fields: CommentTargetFields): string {
   if (fields.buildNumber != null) {
@@ -55,6 +60,11 @@ export function getCommentTargetLabel(fields: CommentTargetFields): string {
       : `#${fields.buildNumber}`;
     return `build ${build}`;
   }
-  invariant(fields.testName, "A comment notification must name its target");
-  return `test ${fields.testName}`;
+  if (fields.testName != null) {
+    return `test ${fields.testName}`;
+  }
+  // No noun in front of it: a media's name is a file name, and "media
+  // checkout.png" reads like a category nobody uses out loud.
+  invariant(fields.mediaName, "A comment notification must name its target");
+  return fields.mediaName;
 }

--- a/apps/frontend/src/containers/Build/BuildDiffListPrimitives.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffListPrimitives.tsx
@@ -244,6 +244,10 @@ export function ListItemButton(
       elementType: "div",
       onPress,
       isDisabled,
+      // Handed to `useButton` rather than left to the spread below: it returns
+      // an `aria-current` of its own, and being spread last it would overwrite
+      // the caller's with the undefined it read from props it was never given.
+      "aria-current": rest["aria-current"],
     },
     ref,
   );

--- a/apps/frontend/src/containers/Build/BuildHotkeys.tsx
+++ b/apps/frontend/src/containers/Build/BuildHotkeys.tsx
@@ -188,35 +188,39 @@ const hotkeyGroups = [
         description: "Go to previous changes",
         envs: ["test", "build", "media"],
       },
+      // A media pair is compared with the same controls as a build's snapshot,
+      // so it answers to the same keys. The wording is the build's because the
+      // two sides are the same two things: a media's "before" is the baseline
+      // it is compared against, and its "after" is what changed.
       showBaseline: {
         keys: ["ArrowLeft"],
         displayKeys: ["←"],
         description: "Show only baseline",
-        envs: ["test", "build"],
+        envs: ["test", "build", "media"],
       },
       showChanges: {
         keys: ["ArrowRight"],
         displayKeys: ["→"],
         description: "Show only changes",
-        envs: ["test", "build"],
+        envs: ["test", "build", "media"],
       },
       showOnion: {
         keys: ["KeyO"],
         displayKeys: ["O"],
         description: "Show onion skin view",
-        envs: ["test", "build"],
+        envs: ["test", "build", "media"],
       },
       showSwipe: {
         keys: ["KeyW"],
         displayKeys: ["W"],
         description: "Show swipe view",
-        envs: ["test", "build"],
+        envs: ["test", "build", "media"],
       },
       toggleSplitView: {
         keys: ["KeyS"],
         displayKeys: ["S"],
         description: "Toggle side by side mode",
-        envs: ["test", "build"],
+        envs: ["test", "build", "media"],
       },
       toggleDiffFit: {
         keys: ["Space"],

--- a/apps/frontend/src/containers/Build/BuildHotkeys.tsx
+++ b/apps/frontend/src/containers/Build/BuildHotkeys.tsx
@@ -78,6 +78,21 @@ const hotkeyGroups = [
         description: "Go to next snapshot",
         envs: ["test", "build"],
       },
+      // The same keys as the two above, named apart so the `?` dialog can say
+      // "media" where a media page is what the reader is looking at. Only one
+      // pair is ever mounted, so they never contend.
+      goToPreviousMedia: {
+        keys: ["ArrowUp"],
+        displayKeys: ["↑"],
+        description: "Go to previous media",
+        envs: ["media"],
+      },
+      goToNextMedia: {
+        keys: ["ArrowDown"],
+        displayKeys: ["↓"],
+        description: "Go to next media",
+        envs: ["media"],
+      },
       toggleDiffGroup: {
         keys: ["KeyG"],
         displayKeys: ["G"],

--- a/apps/frontend/src/containers/Build/toolbar/DetailToolbar.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/DetailToolbar.tsx
@@ -1,0 +1,67 @@
+import { clsx } from "clsx";
+
+/**
+ * The row over whatever is being looked at: where it goes back and forward, what
+ * it is, and what can be done to it.
+ *
+ * One component because it is one bar — a build's snapshot and a shared media
+ * are different subjects with the same handling, and a reviewer moving between
+ * them should not have to find the arrows twice. The slots below are the parts
+ * that have to line up; everything else is passed in.
+ */
+export function DetailToolbar(props: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-4">
+      {props.children}
+    </div>
+  );
+}
+
+/**
+ * The arrows, leftmost. `shrink-0` because they are the one thing in the row
+ * that must never be the part that wraps or collapses — a bar too narrow for
+ * everything still navigates.
+ */
+export function DetailToolbarNav(props: { children: React.ReactNode }) {
+  return <div className="flex shrink-0 gap-1">{props.children}</div>;
+}
+
+/**
+ * What is on screen, named. Takes the space the controls leave and gives it
+ * back — `min-w-0` so a long name truncates instead of pushing them off the row.
+ *
+ * `heading` rather than an `h1` element: the slot is used on pages that already
+ * have one, and the level is stated explicitly rather than inferred.
+ */
+export function DetailToolbarTitle(props: {
+  children: React.ReactNode;
+  /** Wraps the title — a link to wherever the subject came from. */
+  render?: (title: React.ReactNode) => React.ReactNode;
+  className?: string;
+  /**
+   * Terse facts about what is on screen, set beside its name and reading as an
+   * extension of it — a file listing's second column, not a field.
+   */
+  meta?: React.ReactNode;
+}) {
+  const { children, render, className, meta } = props;
+  const title = (
+    <span
+      role="heading"
+      aria-level={1}
+      className={clsx("line-clamp-2 text-sm font-medium", className)}
+    >
+      {children}
+    </span>
+  );
+  return (
+    <div
+      className={clsx("flex min-w-0 flex-1", meta && "items-baseline gap-2")}
+    >
+      {render ? render(title) : title}
+      {meta ? (
+        <span className="text-low shrink-0 font-mono text-xs">{meta}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/frontend/src/containers/Build/toolbar/NavButtons.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/NavButtons.tsx
@@ -1,15 +1,23 @@
 import { ArrowDownIcon, ArrowUpIcon } from "lucide-react";
 
-import { useBuildHotkey } from "@/containers/Build/BuildHotkeys";
+import {
+  type HotkeyName,
+  useBuildHotkey,
+} from "@/containers/Build/BuildHotkeys";
 import { Button } from "@/ui/Button";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 
 export function NextButton(props: {
   onPress: () => void;
   isDisabled: boolean;
+  /**
+   * The shortcut this button owns. Same arrow key either way — what differs is
+   * how the `?` dialog words it, which depends on what is being navigated.
+   */
+  hotkeyName?: HotkeyName;
 }) {
-  const { onPress, isDisabled } = props;
-  const hotkey = useBuildHotkey("goToNextDiff", onPress, {
+  const { onPress, isDisabled, hotkeyName = "goToNextDiff" } = props;
+  const hotkey = useBuildHotkey(hotkeyName, onPress, {
     preventDefault: true,
     enabled: !isDisabled,
     allowInInput: true,
@@ -37,9 +45,16 @@ export function PreviousButton(props: {
    * a second one here read as a different destination.
    */
   toOverview?: boolean;
+  /** See {@link NextButton}. */
+  hotkeyName?: HotkeyName;
 }) {
-  const { onPress, isDisabled = false, toOverview = false } = props;
-  const hotkey = useBuildHotkey("goToPreviousDiff", onPress, {
+  const {
+    onPress,
+    isDisabled = false,
+    toOverview = false,
+    hotkeyName = "goToPreviousDiff",
+  } = props;
+  const hotkey = useBuildHotkey(hotkeyName, onPress, {
     preventDefault: true,
     enabled: !isDisabled,
     allowInInput: true,

--- a/apps/frontend/src/containers/Build/toolbar/ViewToggle.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/ViewToggle.tsx
@@ -10,71 +10,85 @@ import { Hotkey, useBuildHotkey } from "../BuildHotkeys";
 import { buildViewModeAtom, type ViewMode } from "../BuildViewMode";
 import { useZoomerSyncContext } from "../Zoomer";
 
-export const ViewToggle = memo((props: { blendEnabled: boolean }) => {
-  const { blendEnabled } = props;
-  const [viewMode, setViewMode] = useAtom(buildViewModeAtom);
-  const showBaselineHotkey = useBuildHotkey(
-    "showBaseline",
-    () => {
-      startTransition(() => {
-        setViewMode("baseline");
-      });
-    },
-    { preventDefault: true },
-  );
-  const showChangesHotkey = useBuildHotkey(
-    "showChanges",
-    () => {
-      startTransition(() => {
-        setViewMode("changes");
-      });
-    },
-    { preventDefault: true },
-  );
-  const showOnionHotkey = useBuildHotkey(
-    "showOnion",
-    () => {
-      startTransition(() => {
-        setViewMode("onion");
-      });
-    },
-    { preventDefault: true, enabled: blendEnabled },
-  );
-  const showSwipeHotkey = useBuildHotkey(
-    "showSwipe",
-    () => {
-      startTransition(() => {
-        setViewMode("swipe");
-      });
-    },
-    { preventDefault: true, enabled: blendEnabled },
-  );
+/**
+ * What the two sides of the comparison are called. A build compares a baseline
+ * against its changes; a media pair compares a "before" against an "after" —
+ * the same two things under different names.
+ */
+type ViewToggleLabels = { baseline: string; changes: string };
 
-  if (viewMode === "split") {
-    return null;
-  }
+const DEFAULT_LABELS: ViewToggleLabels = {
+  baseline: "Baseline",
+  changes: "Changes",
+};
 
-  return (
-    <ButtonGroup>
-      <ViewButton viewMode="baseline" hotkey={showBaselineHotkey}>
-        Baseline
-      </ViewButton>
-      <ViewButton viewMode="changes" hotkey={showChangesHotkey}>
-        Changes
-      </ViewButton>
-      {blendEnabled && (
-        <>
-          <ViewButton viewMode="onion" hotkey={showOnionHotkey}>
-            Onion
-          </ViewButton>
-          <ViewButton viewMode="swipe" hotkey={showSwipeHotkey}>
-            Swipe
-          </ViewButton>
-        </>
-      )}
-    </ButtonGroup>
-  );
-});
+export const ViewToggle = memo(
+  (props: { blendEnabled: boolean; labels?: ViewToggleLabels }) => {
+    const { blendEnabled, labels = DEFAULT_LABELS } = props;
+    const [viewMode, setViewMode] = useAtom(buildViewModeAtom);
+    const showBaselineHotkey = useBuildHotkey(
+      "showBaseline",
+      () => {
+        startTransition(() => {
+          setViewMode("baseline");
+        });
+      },
+      { preventDefault: true },
+    );
+    const showChangesHotkey = useBuildHotkey(
+      "showChanges",
+      () => {
+        startTransition(() => {
+          setViewMode("changes");
+        });
+      },
+      { preventDefault: true },
+    );
+    const showOnionHotkey = useBuildHotkey(
+      "showOnion",
+      () => {
+        startTransition(() => {
+          setViewMode("onion");
+        });
+      },
+      { preventDefault: true, enabled: blendEnabled },
+    );
+    const showSwipeHotkey = useBuildHotkey(
+      "showSwipe",
+      () => {
+        startTransition(() => {
+          setViewMode("swipe");
+        });
+      },
+      { preventDefault: true, enabled: blendEnabled },
+    );
+
+    if (viewMode === "split") {
+      return null;
+    }
+
+    return (
+      <ButtonGroup>
+        <ViewButton viewMode="baseline" hotkey={showBaselineHotkey}>
+          {labels.baseline}
+        </ViewButton>
+        <ViewButton viewMode="changes" hotkey={showChangesHotkey}>
+          {labels.changes}
+        </ViewButton>
+        {blendEnabled && (
+          <>
+            <ViewButton viewMode="onion" hotkey={showOnionHotkey}>
+              Onion
+            </ViewButton>
+            <ViewButton viewMode="swipe" hotkey={showSwipeHotkey}>
+              Swipe
+            </ViewButton>
+          </>
+        )}
+      </ButtonGroup>
+    );
+  },
+);
 
 function ViewButton(props: {
   viewMode: Exclude<ViewMode, "split">;

--- a/apps/frontend/src/containers/Media/MediaPullRequestList.tsx
+++ b/apps/frontend/src/containers/Media/MediaPullRequestList.tsx
@@ -1,0 +1,216 @@
+import { useEffect, useRef } from "react";
+import { FilmIcon } from "lucide-react";
+
+import {
+  constraintSize,
+  DiffCard,
+  DiffCardFooter,
+  DiffCardFooterText,
+  ListItemButton,
+} from "@/containers/Build/BuildDiffListPrimitives";
+import { type DocumentType, graphql } from "@/gql";
+import { ImageKitPicture } from "@/ui/ImageKitPicture";
+
+const _MediaFragment = graphql(`
+  fragment MediaPullRequestList_Media on Media {
+    id
+    name
+    state
+    shareToken
+    latestVersion {
+      id
+      fileUrl
+      posterUrl
+      width
+      height
+      isVideo
+    }
+  }
+`);
+
+type ListMedia = DocumentType<typeof _MediaFragment>;
+
+/**
+ * One row of the sidebar: a standalone media, or a before/after pair.
+ *
+ * A pair is one row because both halves open the same screen — the share page
+ * shows them side by side whichever one is asked for — so listing them twice
+ * would be two entries pointing at one destination.
+ */
+export type MediaListEntry = {
+  key: string;
+  name: string;
+  /** The half a click opens: the "after", which is what the reviewer came for. */
+  target: ListMedia;
+  /** Every half the viewer can see, which is what tells the row it is active. */
+  medias: ListMedia[];
+};
+
+/**
+ * Group a pull request's media so the two halves of a pair land in one row —
+ * the same grouping, keyed the same way, that the managed pull request comment
+ * uses to put a pair on one line.
+ *
+ * A media with no state is its own row, keyed by id so a standalone
+ * `checkout.png` never absorbs a `checkout.png` that is half of a pair. Order is
+ * first-seen, which is upload order: the server sends them oldest first.
+ */
+export function groupMediaByPair(
+  medias: readonly ListMedia[],
+): MediaListEntry[] {
+  const groups = new Map<string, MediaListEntry>();
+  for (const media of medias) {
+    const key = media.state ? `pair:${media.name}` : `solo:${media.id}`;
+    const group = groups.get(key);
+    if (!group) {
+      groups.set(key, {
+        key,
+        name: media.name,
+        target: media,
+        medias: [media],
+      });
+      continue;
+    }
+    group.medias.push(media);
+    // The "after" wins the row: it is the state of the work being reviewed, and
+    // landing on the "before" would open the same comparison the long way round.
+    // A mixed-visibility pair can leave a viewer with only the "before" — then
+    // it stays the target, because it is the only half there is.
+    if (media.state === "after") {
+      group.target = media;
+    }
+  }
+  return [...groups.values()];
+}
+
+/** How big a thumbnail gets. Narrower than the build's, for a narrower sidebar. */
+const THUMBNAIL_CONSTRAINTS = { maxWidth: 208, maxHeight: 280 };
+
+/** What a media with no recorded dimensions falls back to. */
+const THUMBNAIL_DEFAULT_HEIGHT = 160;
+
+/**
+ * Everything uploaded to the pull request, in one scrollable column.
+ *
+ * Deliberately not the build's list: there is no virtualizing, no grouping and
+ * no filtering here, because a pull request carries a handful of screenshots and
+ * a build carries thousands. What it does share is the build's cards, its arrow
+ * keys and its two arrow buttons — the reviewer moves through a pull request's
+ * media the way they move through a build's snapshots.
+ */
+export function MediaPullRequestList(props: {
+  entries: MediaListEntry[];
+  activeEntryKey: string | null;
+  onSelect: (entry: MediaListEntry) => void;
+}) {
+  const { entries, activeEntryKey, onSelect } = props;
+  return (
+    <div
+      role="region"
+      aria-label="Pull request media"
+      className="group/sidebar flex min-h-0 flex-col gap-4 lg:overflow-y-auto lg:pb-6"
+    >
+      {entries.map((entry) => (
+        <MediaListItem
+          key={entry.key}
+          entry={entry}
+          isActive={entry.key === activeEntryKey}
+          onSelect={onSelect}
+        />
+      ))}
+    </div>
+  );
+}
+
+function MediaListItem(props: {
+  entry: MediaListEntry;
+  isActive: boolean;
+  onSelect: (entry: MediaListEntry) => void;
+}) {
+  const { entry, isActive, onSelect } = props;
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Arrow keys move the active row without touching the scroll position, so a
+  // row navigated to from the keyboard can be off screen. `nearest` scrolls only
+  // when it has to, which leaves clicks alone.
+  useEffect(() => {
+    if (isActive) {
+      ref.current?.scrollIntoView({ block: "nearest" });
+    }
+  }, [isActive]);
+
+  const { latestVersion } = entry.target;
+  const dimensions =
+    latestVersion.width && latestVersion.height
+      ? constraintSize(
+          { width: latestVersion.width, height: latestVersion.height },
+          THUMBNAIL_CONSTRAINTS,
+        )
+      : {
+          width: THUMBNAIL_CONSTRAINTS.maxWidth,
+          height: THUMBNAIL_DEFAULT_HEIGHT,
+        };
+
+  return (
+    <ListItemButton
+      ref={ref}
+      onPress={() => {
+        // The row already on screen: navigating to it would reload the page it
+        // is showing.
+        if (!isActive) {
+          onSelect(entry);
+        }
+      }}
+      aria-current={isActive ? "true" : undefined}
+      className="shrink-0"
+    >
+      <DiffCard isActive={isActive} variant="primary" className="p-2">
+        <MediaThumbnail version={latestVersion} dimensions={dimensions} />
+        <DiffCardFooter alwaysVisible>
+          {latestVersion.isVideo ? (
+            <FilmIcon className="text-low size-3 shrink-0" />
+          ) : null}
+          <DiffCardFooterText>{entry.name}</DiffCardFooterText>
+        </DiffCardFooter>
+      </DiffCard>
+    </ListItemButton>
+  );
+}
+
+function MediaThumbnail(props: {
+  version: ListMedia["latestVersion"];
+  dimensions: { width: number; height: number };
+}) {
+  const { version, dimensions } = props;
+  // Decorative: the name is spelled out in the footer right under it, and a
+  // poster that fails to load should leave a gap rather than print the file
+  // name a second time.
+  const imgProps = {
+    alt: "",
+    className: "max-h-full max-w-full object-contain",
+  };
+
+  if (version.isVideo) {
+    // The poster comes out of the CDN already transformed — it is a frame taken
+    // from the video — so it is used as it is. Handing it to `ImageKitPicture`
+    // would append a second set of transformations to a URL that has one.
+    return version.posterUrl ? (
+      <img src={version.posterUrl} {...dimensions} {...imgProps} />
+    ) : null;
+  }
+
+  return (
+    <ImageKitPicture
+      key={version.fileUrl}
+      src={version.fileUrl}
+      {...dimensions}
+      transformations={[
+        `w-${dimensions.width}`,
+        `h-${dimensions.height}`,
+        "c-at_max",
+        "dpr-2",
+      ]}
+      {...imgProps}
+    />
+  );
+}

--- a/apps/frontend/src/containers/Media/MediaPullRequestList.tsx
+++ b/apps/frontend/src/containers/Media/MediaPullRequestList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { FilmIcon } from "lucide-react";
 
 import {
@@ -182,21 +182,32 @@ function MediaThumbnail(props: {
   dimensions: { width: number; height: number };
 }) {
   const { version, dimensions } = props;
-  // Decorative: the name is spelled out in the footer right under it, and a
-  // poster that fails to load should leave a gap rather than print the file
-  // name a second time.
+  const [posterFailed, setPosterFailed] = useState(false);
+  // Decorative: the name is spelled out in the footer right under it, so the
+  // image says nothing the row does not already say.
   const imgProps = {
     alt: "",
     className: "max-h-full max-w-full object-contain",
   };
 
   if (version.isVideo) {
+    // A recording that has no frame to show yet, or whose frame did not load:
+    // the film icon says what it is, where a broken image would only say that
+    // something went wrong with a thumbnail nobody asked about.
+    if (!version.posterUrl || posterFailed) {
+      return <FilmIcon className="text-low size-8" />;
+    }
     // The poster comes out of the CDN already transformed — it is a frame taken
     // from the video — so it is used as it is. Handing it to `ImageKitPicture`
     // would append a second set of transformations to a URL that has one.
-    return version.posterUrl ? (
-      <img src={version.posterUrl} {...dimensions} {...imgProps} />
-    ) : null;
+    return (
+      <img
+        src={version.posterUrl}
+        onError={() => setPosterFailed(true)}
+        {...dimensions}
+        {...imgProps}
+      />
+    );
   }
 
   return (

--- a/apps/frontend/src/containers/Media/MediaViewer.tsx
+++ b/apps/frontend/src/containers/Media/MediaViewer.tsx
@@ -233,9 +233,23 @@ export function MediaViewer(props: {
     );
   }
 
+  // Blending lays one half over the other as an image, so it needs two images.
+  // A pair is two uploads under one name and nothing stops one of them being a
+  // recording.
+  const blendEnabled = Boolean(counterpart && !counterpart.version.isVideo);
+
   // Every mode but one needs the other half; without it the media stands alone,
-  // which is what "changes" means here — this media, on its own.
-  const mode: ViewMode = counterpart ? storedMode : "changes";
+  // which is what "changes" means here — this media, on its own. A stored blend
+  // mode that this pair cannot do falls back to side by side rather than
+  // rendering a video where an image should be.
+  const mode: ViewMode = (() => {
+    if (!counterpart) {
+      return "changes";
+    }
+    return checkIsBlendViewMode(storedMode) && !blendEnabled
+      ? "split"
+      : storedMode;
+  })();
 
   // Which half is which, whichever one this page is for. A pair is ordered so
   // the "before" is always on the left: one that read right-to-left depending on
@@ -306,6 +320,11 @@ export function MediaViewer(props: {
     }
   })();
 
+  // Looking at the "before" alone puts the commentable half off screen, so
+  // there is nowhere for a pin to land — the tool has to come back down rather
+  // than leave the reviewer clicking at an image that cannot take it.
+  const commentable = panes.some((pane) => pane.interactive);
+
   // Where the page stacks (below `lg`), the viewer sizes itself from the
   // media's own shape instead of claiming a fixed slice of the viewport: a
   // wide screenshot on a phone would otherwise sit in a mostly-empty well.
@@ -323,15 +342,18 @@ export function MediaViewer(props: {
           pane registered itself as the highlighter, so both have to be under
           one provider. */}
       <BuildDiffHighlighterProvider>
+        <DisarmCommentTool
+          enabled={commentable}
+          placing={comments.placing}
+          onPlacingChange={comments.onPlacingChange}
+        />
         <div className="flex h-full min-h-0 flex-col gap-2">
           <MediaViewToolbar
             title={media.name}
             facts={getMediaFacts(media, counterpart !== null)}
             nav={nav}
             compare={
-              counterpart
-                ? { blendEnabled: true, hasChanges: diff !== null }
-                : null
+              counterpart ? { blendEnabled, hasChanges: diff !== null } : null
             }
           />
 
@@ -351,11 +373,17 @@ export function MediaViewer(props: {
               <MediaPane
                 key={pane.media.state ?? "solo"}
                 media={pane.media}
-                // A pair's half also names itself when shown alone — "single"
-                // is still one side of a comparison. Blended panes show both
-                // halves, and their controls already name the two layers.
+                // A pair's half names itself beside the other, and still does
+                // when shown alone — it is one side of a comparison either way.
+                // Not when blended: that pane is both halves at once, and its
+                // own controls already name the two layers.
                 labelled={
-                  panes.length > 1 || Boolean(pane.media.state && counterpart)
+                  panes.length > 1 ||
+                  Boolean(
+                    pane.media.state &&
+                    counterpart &&
+                    !checkIsBlendViewMode(mode),
+                  )
                 }
                 blend={pane.changes ? blend : null}
                 // Comments and the version picker belong to the media whose page
@@ -381,6 +409,28 @@ export function MediaViewer(props: {
       </BuildDiffHighlighterProvider>
     </ZoomerSyncProvider>
   );
+}
+
+/**
+ * Puts the comment tool away when the view has nothing that can take a pin —
+ * switching to the "before" alone, whose comments belong to the other half.
+ *
+ * Its own component so the effect can sit under the early return a recording
+ * takes, and rendering nothing because there is nothing to say: the tool simply
+ * stops being armed, the same as pressing Escape.
+ */
+function DisarmCommentTool(props: {
+  enabled: boolean;
+  placing: boolean;
+  onPlacingChange: (placing: boolean) => void;
+}) {
+  const { enabled, placing, onPlacingChange } = props;
+  useEffect(() => {
+    if (!enabled && placing) {
+      onPlacingChange(false);
+    }
+  }, [enabled, placing, onPlacingChange]);
+  return null;
 }
 
 /**

--- a/apps/frontend/src/containers/Media/MediaViewer.tsx
+++ b/apps/frontend/src/containers/Media/MediaViewer.tsx
@@ -7,7 +7,6 @@ import {
 } from "react";
 import { clsx } from "clsx";
 import { useAtom, useAtomValue } from "jotai/react";
-import { atomWithStorage } from "jotai/utils";
 import { DownloadIcon } from "lucide-react";
 
 import {
@@ -15,6 +14,14 @@ import {
   SwipeDivider,
 } from "@/containers/Build/BlendControls";
 import { BuildDiffHighlighterProvider } from "@/containers/Build/BuildDiffHighlighterContext";
+import {
+  buildViewModeAtom,
+  checkIsBlendViewMode,
+  onionOpacityAtom,
+  swipeHandleYAtom,
+  swipePositionAtom,
+  type ViewMode,
+} from "@/containers/Build/BuildViewMode";
 import {
   ChangesHighlights,
   ChangesMask,
@@ -42,9 +49,11 @@ import {
   NextButton,
   PreviousButton,
 } from "@/containers/Build/toolbar/NavButtons";
+import {
+  SplitViewToggle,
+  ViewToggle,
+} from "@/containers/Build/toolbar/ViewToggle";
 import { ZoomerSyncProvider, ZoomPane } from "@/containers/Build/Zoomer";
-import { Button } from "@/ui/Button";
-import { ButtonGroup } from "@/ui/ButtonGroup";
 import { MediaVideo, MediaWell } from "@/ui/MediaFrame";
 import { MenuItem, MenuItemIcon } from "@/ui/Menu";
 import { Separator } from "@/ui/Separator";
@@ -93,16 +102,14 @@ export type ViewerDiff = {
 };
 
 /**
- * How a before/after pair is looked at. `split` and `single` mirror the build's
- * side-by-side and one-image views; `onion` and `swipe` blend the two halves
- * into one pane, exactly like the build's diff viewer.
+ * How a pair is looked at — the build's own modes, on the build's own atom.
+ *
+ * A pair of media and a build's baseline against its changes are the same
+ * question, so they are looked at with the same controls and the same
+ * preference: someone who works side by side on builds gets side by side here
+ * without having to say so twice. `baseline` is the "before" and `changes` is
+ * the "after".
  */
-type MediaViewMode = "single" | "split" | "onion" | "swipe";
-
-const mediaViewModeAtom = atomWithStorage<MediaViewMode>(
-  "preferences.mediaViewMode",
-  "split",
-);
 
 /** Wiring for the comment layer drawn over the media's own pane. */
 type ViewerComments = Omit<
@@ -194,10 +201,10 @@ export function MediaViewer(props: {
 }) {
   const { media, counterpart, comments, diff, nav } = props;
   const version = media.version;
-  const [storedMode, setMode] = useAtom(mediaViewModeAtom);
-  const [onionOpacity, setOnionOpacity] = useState(0.5);
-  const [swipePosition, setSwipePosition] = useState(0.5);
-  const [swipeHandleY, setSwipeHandleY] = useState(0.5);
+  const storedMode = useAtomValue(buildViewModeAtom);
+  const [onionOpacity, setOnionOpacity] = useAtom(onionOpacityAtom);
+  const [swipePosition, setSwipePosition] = useAtom(swipePositionAtom);
+  const [swipeHandleY, setSwipeHandleY] = useAtom(swipeHandleYAtom);
 
   if (version.isVideo) {
     return (
@@ -226,15 +233,24 @@ export function MediaViewer(props: {
     );
   }
 
-  // The compare modes need the other half; without one the media stands alone.
-  const mode: MediaViewMode = counterpart ? storedMode : "single";
+  // Every mode but one needs the other half; without it the media stands alone,
+  // which is what "changes" means here — this media, on its own.
+  const mode: ViewMode = counterpart ? storedMode : "changes";
 
+  // Which half is which, whichever one this page is for. A pair is ordered so
+  // the "before" is always on the left: one that read right-to-left depending on
+  // which link the reviewer clicked would be actively misleading.
+  const beforeMedia = media.state === "before" ? media : (counterpart ?? media);
+  const afterMedia = media.state === "before" ? counterpart : media;
+
+  // Blended, the pane shows the "after" with the "before" laid over it — the
+  // same base the mask goes on, so the two describe the same image.
   const blend: BlendState | null =
-    counterpart && (mode === "onion" || mode === "swipe")
+    counterpart && checkIsBlendViewMode(mode)
       ? {
           mode,
-          counterpart: counterpart.version,
-          counterpartIsAfter: counterpart.state === "after",
+          counterpart: beforeMedia.version,
+          counterpartIsAfter: beforeMedia.state === "after",
           onionOpacity,
           onOnionOpacityChange: setOnionOpacity,
           swipe: {
@@ -246,27 +262,49 @@ export function MediaViewer(props: {
         }
       : null;
 
-  // Ordered so "before" is always on the left, whichever half was opened. A pair
-  // that read right-to-left depending on which link the reviewer clicked would be
-  // actively misleading.
-  //
-  // `changes` marks the pane the mask belongs on. Side by side, that is the
-  // "after" — the build's rule, and the one that reads right: the overlay says
-  // "here is what this half changed". Everywhere else there is a single pane,
-  // showing the after alone or both halves blended into it, and the mask goes
-  // there.
-  const panes =
-    counterpart && mode === "split"
-      ? media.state === "before"
-        ? [
-            { media, interactive: true, changes: false },
-            { media: counterpart, interactive: false, changes: true },
-          ]
-        : [
-            { media: counterpart, interactive: false, changes: false },
-            { media, interactive: true, changes: true },
-          ]
-      : [{ media, interactive: true, changes: true }];
+  // `changes` marks the pane the mask belongs on: the "after", the build's rule
+  // and the one that reads right — the overlay says "here is what this half
+  // changed". `interactive` marks the pane this page's comments belong to;
+  // drawing them on the counterpart would attach feedback to the wrong image.
+  const panes = (() => {
+    if (!counterpart || !afterMedia) {
+      return [{ media, interactive: true, changes: true }];
+    }
+    switch (mode) {
+      case "split":
+        return [
+          {
+            media: beforeMedia,
+            interactive: beforeMedia === media,
+            changes: false,
+          },
+          {
+            media: afterMedia,
+            interactive: afterMedia === media,
+            changes: true,
+          },
+        ];
+      case "baseline":
+        // The "before" on its own — nothing changed *it*, so no mask.
+        return [
+          {
+            media: beforeMedia,
+            interactive: beforeMedia === media,
+            changes: false,
+          },
+        ];
+      // The "after" alone, or both halves blended into one pane. Either way the
+      // mask describes what is under it.
+      default:
+        return [
+          {
+            media: afterMedia,
+            interactive: afterMedia === media,
+            changes: true,
+          },
+        ];
+    }
+  })();
 
   // Where the page stacks (below `lg`), the viewer sizes itself from the
   // media's own shape instead of claiming a fixed slice of the viewport: a
@@ -292,11 +330,7 @@ export function MediaViewer(props: {
             nav={nav}
             compare={
               counterpart
-                ? {
-                    mode,
-                    onModeChange: setMode,
-                    hasChanges: diff !== null,
-                  }
+                ? { blendEnabled: true, hasChanges: diff !== null }
                 : null
             }
           />
@@ -321,10 +355,9 @@ export function MediaViewer(props: {
                 // is still one side of a comparison. Blended panes show both
                 // halves, and their controls already name the two layers.
                 labelled={
-                  panes.length > 1 ||
-                  Boolean(mode === "single" && pane.media.state && counterpart)
+                  panes.length > 1 || Boolean(pane.media.state && counterpart)
                 }
-                blend={pane.interactive ? blend : null}
+                blend={pane.changes ? blend : null}
                 // Comments and the version picker belong to the media whose page
                 // this is. Drawing them on the counterpart would attach feedback
                 // to the wrong image.
@@ -368,14 +401,13 @@ function MediaViewToolbar(props: {
   nav: MediaViewerNav | null;
   /** The pair's controls, absent when the media stands alone or is a video. */
   compare: {
-    mode: MediaViewMode;
-    onModeChange: (mode: MediaViewMode) => void;
+    /** Whether the two halves can be blended into one pane. */
+    blendEnabled: boolean;
     /** Whether there is a mask to draw — the overlay controls act on nothing without one. */
     hasChanges: boolean;
   } | null;
 }) {
   const { title, facts, nav, compare } = props;
-  const comparing = compare !== null && compare.mode !== "single";
   return (
     // `mb-4` + the viewer column's `gap-2` puts 24px between the toolbar and
     // the panes, level with the sidebar's action strip.
@@ -406,54 +438,25 @@ function MediaViewToolbar(props: {
             narrow to hold them and they wrap under the title. */}
         <div className="ml-auto flex flex-wrap items-center gap-3">
           {compare ? (
-            <>
-              <ButtonGroup>
-                <Button
-                  variant="secondary"
-                  aria-pressed={!comparing}
-                  onPress={() => compare.onModeChange("single")}
-                >
-                  Single
-                </Button>
-                <Button
-                  variant="secondary"
-                  aria-pressed={comparing}
-                  onPress={() => compare.onModeChange("split")}
-                >
-                  Compare
-                </Button>
-              </ButtonGroup>
-              {comparing ? (
-                <ButtonGroup>
-                  {(
-                    [
-                      ["split", "Side by side"],
-                      ["onion", "Onion"],
-                      ["swipe", "Swipe"],
-                    ] as const
-                  ).map(([value, label]) => (
-                    <Button
-                      key={value}
-                      variant="secondary"
-                      aria-pressed={compare.mode === value}
-                      onPress={() => compare.onModeChange(value)}
-                    >
-                      {label}
-                    </Button>
-                  ))}
-                </ButtonGroup>
-              ) : null}
+            <div className="flex shrink-0 items-center gap-1.5">
+              {/* The build's own controls, on the build's own state: which half
+                  to look at, or both at once, with the same shortcuts. Only the
+                  two words change, because here the baseline is the "before"
+                  and the changes are the "after". */}
+              <ViewToggle
+                blendEnabled={compare.blendEnabled}
+                labels={{ baseline: "Before", changes: "After" }}
+              />
+              <SplitViewToggle />
               {compare.hasChanges ? (
                 <>
-                  <Separator orientation="vertical" className="h-6" />
-                  {/* The build's own cluster, unchanged: the same buttons, the
-                      same tooltips, the same D / H / J / K shortcuts. */}
-                  <div className="flex items-center gap-1.5">
-                    <ChangesOverlayControls />
-                  </div>
+                  <Separator orientation="vertical" className="mx-1 h-6" />
+                  {/* Same again: the same buttons, the same tooltips, the same
+                      D / H / J / K shortcuts. */}
+                  <ChangesOverlayControls />
                 </>
               ) : null}
-            </>
+            </div>
           ) : null}
         </div>
       </DetailToolbar>

--- a/apps/frontend/src/containers/Media/MediaViewer.tsx
+++ b/apps/frontend/src/containers/Media/MediaViewer.tsx
@@ -33,6 +33,15 @@ import {
   fetchBlob,
   ImageActionsMenu,
 } from "@/containers/Build/ScreenshotActions";
+import {
+  DetailToolbar,
+  DetailToolbarNav,
+  DetailToolbarTitle,
+} from "@/containers/Build/toolbar/DetailToolbar";
+import {
+  NextButton,
+  PreviousButton,
+} from "@/containers/Build/toolbar/NavButtons";
 import { ZoomerSyncProvider, ZoomPane } from "@/containers/Build/Zoomer";
 import { Button } from "@/ui/Button";
 import { ButtonGroup } from "@/ui/ButtonGroup";
@@ -40,6 +49,7 @@ import { MediaVideo, MediaWell } from "@/ui/MediaFrame";
 import { MenuItem, MenuItemIcon } from "@/ui/Menu";
 import { Separator } from "@/ui/Separator";
 import { useResizeObserver } from "@/ui/useResizeObserver";
+import { formatBytes, formatDimensions } from "@/util/media";
 
 import { MediaCommentLayer } from "./MediaCommentLayer";
 
@@ -52,7 +62,6 @@ type ViewerVersion = {
   isVideo: boolean;
   sizeBytes: number;
   createdAt: string;
-  expiresAt: string | null;
 };
 
 /**
@@ -101,6 +110,42 @@ type ViewerComments = Omit<
   "paneSize" | "imgSize"
 >;
 
+/**
+ * Moving between the media of one pull request. Null when there is nothing to
+ * move between — a media shared on its own has no arrows rather than two dead
+ * ones.
+ */
+export type MediaViewerNav = {
+  hasPrevious: boolean;
+  hasNext: boolean;
+  onPrevious: () => void;
+  onNext: () => void;
+};
+
+/**
+ * The shape and weight of what is on screen, for the line beside its name.
+ *
+ * The version's, not the media's: looking back at an older upload has to say
+ * that upload's numbers.
+ */
+function getMediaFacts(media: ViewerMedia, hasCounterpart: boolean): string[] {
+  const facts: string[] = [];
+  if (media.state && !hasCounterpart) {
+    // Which half of a pair this is. With both halves on screen the panes label
+    // themselves; alone, the fact lives here.
+    facts.push(media.state);
+  }
+  const dimensions = formatDimensions(
+    media.version.width,
+    media.version.height,
+  );
+  if (dimensions) {
+    facts.push(dimensions);
+  }
+  facts.push(formatBytes(media.version.sizeBytes));
+  return facts;
+}
+
 /** Everything a blended (onion/swipe) pane needs beyond its base media. */
 type BlendState = {
   mode: "onion" | "swipe";
@@ -144,8 +189,10 @@ export function MediaViewer(props: {
   comments: ViewerComments;
   /** The pair's computed comparison, once there is a mask to draw. */
   diff: ViewerDiff | null;
+  /** Moving through the pull request's media. */
+  nav: MediaViewerNav | null;
 }) {
-  const { media, counterpart, comments, diff } = props;
+  const { media, counterpart, comments, diff, nav } = props;
   const version = media.version;
   const [storedMode, setMode] = useAtom(mediaViewModeAtom);
   const [onionOpacity, setOnionOpacity] = useState(0.5);
@@ -154,17 +201,27 @@ export function MediaViewer(props: {
 
   if (version.isVideo) {
     return (
-      <div className="flex h-full min-h-0 flex-col items-center justify-center gap-1.5">
-        <MediaWell
-          aspectRatio={
-            version.width && version.height
-              ? { width: version.width, height: version.height }
-              : null
-          }
-          className="flex max-h-[70dvh] min-h-64 w-auto max-w-full items-center justify-center lg:max-h-full lg:min-h-0"
-        >
-          <MediaVideo src={version.fileUrl} poster={version.posterUrl} />
-        </MediaWell>
+      <div className="flex h-full min-h-0 flex-col">
+        {/* A recording gets the same bar as a screenshot — nothing to compare,
+            but the same name in the same place and the same way out of it. */}
+        <MediaViewToolbar
+          title={media.name}
+          facts={getMediaFacts(media, false)}
+          nav={nav}
+          compare={null}
+        />
+        <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-1.5">
+          <MediaWell
+            aspectRatio={
+              version.width && version.height
+                ? { width: version.width, height: version.height }
+                : null
+            }
+            className="flex max-h-[70dvh] min-h-64 w-auto max-w-full items-center justify-center lg:max-h-full lg:min-h-0"
+          >
+            <MediaVideo src={version.fileUrl} poster={version.posterUrl} />
+          </MediaWell>
+        </div>
       </div>
     );
   }
@@ -229,13 +286,21 @@ export function MediaViewer(props: {
           one provider. */}
       <BuildDiffHighlighterProvider>
         <div className="flex h-full min-h-0 flex-col gap-2">
-          {counterpart ? (
-            <MediaViewToolbar
-              mode={mode}
-              onModeChange={setMode}
-              hasChanges={diff !== null}
-            />
-          ) : null}
+          <MediaViewToolbar
+            title={media.name}
+            facts={getMediaFacts(media, counterpart !== null)}
+            nav={nav}
+            compare={
+              counterpart
+                ? {
+                    mode,
+                    onModeChange: setMode,
+                    hasChanges: diff !== null,
+                  }
+                : null
+            }
+          />
+
           <div
             className={clsx(
               "flex max-h-[70dvh] min-h-72 w-full gap-3 lg:h-auto lg:max-h-none lg:min-h-0 lg:flex-1",
@@ -286,69 +351,112 @@ export function MediaViewer(props: {
 }
 
 /**
- * The compare toolbar over a pair, in the build toolbar's grammar: whether to
- * compare at all, when comparing — the build's own three ways to do it — and,
- * once Argos has found changes, the build's own controls over the overlay
- * marking them.
+ * The bar over the media, in the build's own layout and built from the build's
+ * own components: where to go next on the left, what is on screen in the middle,
+ * what can be done to it on the right.
+ *
+ * The compare controls only exist for a pair — whether to compare at all, and
+ * the build's three ways to do it — and the overlay controls only once Argos has
+ * found changes to mark. The rest of the bar is there either way, which is what
+ * makes a video's page and a screenshot's page the same page.
  */
 function MediaViewToolbar(props: {
-  mode: MediaViewMode;
-  onModeChange: (mode: MediaViewMode) => void;
-  /** Whether there is a mask to draw — the overlay controls act on nothing without one. */
-  hasChanges: boolean;
+  title: string;
+  /** The version's plain facts, beside the name. */
+  facts: string[];
+  /** Moving through the pull request's media, when there is more than one. */
+  nav: MediaViewerNav | null;
+  /** The pair's controls, absent when the media stands alone or is a video. */
+  compare: {
+    mode: MediaViewMode;
+    onModeChange: (mode: MediaViewMode) => void;
+    /** Whether there is a mask to draw — the overlay controls act on nothing without one. */
+    hasChanges: boolean;
+  } | null;
 }) {
-  const { mode, onModeChange, hasChanges } = props;
-  const comparing = mode !== "single";
+  const { title, facts, nav, compare } = props;
+  const comparing = compare !== null && compare.mode !== "single";
   return (
     // `mb-4` + the viewer column's `gap-2` puts 24px between the toolbar and
     // the panes, level with the sidebar's action strip.
-    <div className="mb-4 flex shrink-0 flex-wrap items-center gap-3">
-      <ButtonGroup>
-        <Button
-          variant="secondary"
-          aria-pressed={!comparing}
-          onPress={() => onModeChange("single")}
+    <div className="mb-4 shrink-0">
+      <DetailToolbar>
+        {nav ? (
+          <DetailToolbarNav>
+            <PreviousButton
+              hotkeyName="goToPreviousMedia"
+              onPress={nav.onPrevious}
+              isDisabled={!nav.hasPrevious}
+            />
+            <NextButton
+              hotkeyName="goToNextMedia"
+              onPress={nav.onNext}
+              isDisabled={!nav.hasNext}
+            />
+          </DetailToolbarNav>
+        ) : null}
+        {/* Monospace, unlike a snapshot's name: this one is a file name. */}
+        <DetailToolbarTitle
+          className="font-mono"
+          meta={facts.length > 0 ? facts.join(" · ") : null}
         >
-          Single
-        </Button>
-        <Button
-          variant="secondary"
-          aria-pressed={comparing}
-          onPress={() => onModeChange("split")}
-        >
-          Compare
-        </Button>
-      </ButtonGroup>
-      {comparing ? (
-        <ButtonGroup>
-          {(
-            [
-              ["split", "Side by side"],
-              ["onion", "Onion"],
-              ["swipe", "Swipe"],
-            ] as const
-          ).map(([value, label]) => (
-            <Button
-              key={value}
-              variant="secondary"
-              aria-pressed={mode === value}
-              onPress={() => onModeChange(value)}
-            >
-              {label}
-            </Button>
-          ))}
-        </ButtonGroup>
-      ) : null}
-      {hasChanges ? (
-        <>
-          <Separator orientation="vertical" className="h-6" />
-          {/* The build's own cluster, unchanged: the same buttons, the same
-              tooltips, the same D / H / J / K shortcuts. */}
-          <div className="flex items-center gap-1.5">
-            <ChangesOverlayControls />
-          </div>
-        </>
-      ) : null}
+          {title}
+        </DetailToolbarTitle>
+        {/* `ml-auto` so the controls stay on the right even when the row is too
+            narrow to hold them and they wrap under the title. */}
+        <div className="ml-auto flex flex-wrap items-center gap-3">
+          {compare ? (
+            <>
+              <ButtonGroup>
+                <Button
+                  variant="secondary"
+                  aria-pressed={!comparing}
+                  onPress={() => compare.onModeChange("single")}
+                >
+                  Single
+                </Button>
+                <Button
+                  variant="secondary"
+                  aria-pressed={comparing}
+                  onPress={() => compare.onModeChange("split")}
+                >
+                  Compare
+                </Button>
+              </ButtonGroup>
+              {comparing ? (
+                <ButtonGroup>
+                  {(
+                    [
+                      ["split", "Side by side"],
+                      ["onion", "Onion"],
+                      ["swipe", "Swipe"],
+                    ] as const
+                  ).map(([value, label]) => (
+                    <Button
+                      key={value}
+                      variant="secondary"
+                      aria-pressed={compare.mode === value}
+                      onPress={() => compare.onModeChange(value)}
+                    >
+                      {label}
+                    </Button>
+                  ))}
+                </ButtonGroup>
+              ) : null}
+              {compare.hasChanges ? (
+                <>
+                  <Separator orientation="vertical" className="h-6" />
+                  {/* The build's own cluster, unchanged: the same buttons, the
+                      same tooltips, the same D / H / J / K shortcuts. */}
+                  <div className="flex items-center gap-1.5">
+                    <ChangesOverlayControls />
+                  </div>
+                </>
+              ) : null}
+            </>
+          ) : null}
+        </div>
+      </DetailToolbar>
     </div>
   );
 }

--- a/apps/frontend/src/pages/Build/BuildDetailHeader.tsx
+++ b/apps/frontend/src/pages/Build/BuildDetailHeader.tsx
@@ -4,6 +4,11 @@ import { Link } from "react-router";
 
 import { BuildDiffDetailToolbar } from "@/containers/Build/BuildDiffDetailToolbar";
 import { AriaSnapshotToggle } from "@/containers/Build/toolbar/AriaSnapshotToggle";
+import {
+  DetailToolbar,
+  DetailToolbarNav,
+  DetailToolbarTitle,
+} from "@/containers/Build/toolbar/DetailToolbar";
 import { IgnoreButton } from "@/containers/Build/toolbar/IgnoreButton";
 import {
   NextButton,
@@ -46,41 +51,41 @@ export const BuildDetailHeader = memo(function BuildDetailHeader(props: {
   const params = useProjectParams();
   invariant(params, "can't be used outside of a project route");
 
+  const testId = diff.test?.id;
+
   return (
-    <div className="flex flex-wrap items-center justify-between gap-4">
-      <BuildNavButtons />
-      <div className="flex min-w-0 flex-1">
-        {diff.test ? (
-          <Tooltip content="View test details">
-            <Link
-              to={getTestURL(
-                { ...params, testId: diff.test.id },
-                { change: diff.change?.id },
-              )}
-              className="group hover:underline-link"
-            >
-              <span
-                role="heading"
-                aria-level={1}
-                className="line-clamp-2 text-sm font-medium"
-              >
-                {diff.name}
-              </span>
-            </Link>
-          </Tooltip>
-        ) : (
-          <div role="heading" className="line-clamp-2 text-sm font-medium">
-            {diff.name}
-          </div>
-        )}
-      </div>
+    <DetailToolbar>
+      <DetailToolbarNav>
+        <BuildNavButtons />
+      </DetailToolbarNav>
+      <DetailToolbarTitle
+        render={
+          testId
+            ? (title) => (
+                <Tooltip content="View test details">
+                  <Link
+                    to={getTestURL(
+                      { ...params, testId },
+                      { change: diff.change?.id },
+                    )}
+                    className="group hover:underline-link"
+                  >
+                    {title}
+                  </Link>
+                </Tooltip>
+              )
+            : undefined
+        }
+      >
+        {diff.name}
+      </DetailToolbarTitle>
       <BuildDiffDetailToolbar diff={diff} fitControls={<AriaSnapshotToggle />}>
         <BuildDetailIgnoreButton diff={diff} />
         <TrackButtons diff={diff} disabled={!canBeReviewed} />
         <Separator orientation="vertical" className="mx-1 h-6" />
         <RightSidebarToggle />
       </BuildDiffDetailToolbar>
-    </div>
+    </DetailToolbar>
   );
 });
 
@@ -114,7 +119,7 @@ const BuildNavButtons = memo(function BuildNavButtons() {
   const hasPreviousDiff = useHasPreviousDiff();
   const goToBuildOverview = useGoToBuildOverview();
   return (
-    <div className="flex shrink-0 gap-1">
+    <>
       <PreviousButton
         toOverview={!hasPreviousDiff}
         onPress={() =>
@@ -122,6 +127,6 @@ const BuildNavButtons = memo(function BuildNavButtons() {
         }
       />
       <NextButton onPress={goToNextDiff} isDisabled={!hasNextDiff} />
-    </div>
+    </>
   );
 });

--- a/apps/frontend/src/pages/MediaShare.tsx
+++ b/apps/frontend/src/pages/MediaShare.tsx
@@ -74,6 +74,20 @@ import { toast } from "@/ui/Toaster";
 import { Tooltip } from "@/ui/Tooltip";
 import { getMentionUser } from "@/ui/UserCard";
 
+/** What the viewer needs to draw one version of a media. */
+const _ViewerVersionFragment = graphql(`
+  fragment MediaShare_ViewerVersion on MediaVersion {
+    id
+    createdAt
+    fileUrl
+    posterUrl
+    sizeBytes
+    width
+    height
+    isVideo
+  }
+`);
+
 const MediaShareQuery = graphql(`
   query MediaShare_media(
     $shareToken: String!
@@ -119,6 +133,23 @@ const MediaShareQuery = graphql(`
         width
         height
         isVideo
+        # Per version, not per media: an older version has its own comparison,
+        # and it names the two images to put on screen.
+        diff {
+          id
+          status
+          url
+          width
+          height
+          beforeVersion {
+            id
+            ...MediaShare_ViewerVersion
+          }
+          afterVersion {
+            id
+            ...MediaShare_ViewerVersion
+          }
+        }
       }
       counterpart {
         id
@@ -127,21 +158,8 @@ const MediaShareQuery = graphql(`
         url
         latestVersion {
           id
-          createdAt
-          fileUrl
-          posterUrl
-          sizeBytes
-          width
-          height
-          isVideo
+          ...MediaShare_ViewerVersion
         }
-      }
-      diff {
-        id
-        status
-        url
-        width
-        height
       }
       project {
         id
@@ -180,7 +198,12 @@ export function Component() {
   const media = data.mediaByShareToken;
 
   useAwaitPendingDiff({
-    pending: media?.diff?.status === MediaDiffStatus.Pending,
+    // The newest version's, which is the only comparison that can still be
+    // queued: an older one was settled back when it was the newest.
+    pending:
+      media?.versions.find(
+        (candidate) => candidate.id === media.latestVersion.id,
+      )?.diff?.status === MediaDiffStatus.Pending,
     refetch,
   });
 
@@ -210,22 +233,44 @@ export function Component() {
  * them is an error, and the page says the same thing about all of them — it
  * shows the pair without an overlay.
  *
- * Also null while the reviewer is looking back at an older version. The mask was
- * computed from the newest bytes of each half; drawing it over a version it did
- * not come from would mark pixels nothing said had changed.
+ * The comparison comes from the version on screen, so looking back at an older
+ * upload draws the mask that was computed from *it* — together with
+ * {@link getCounterpartVersion}, which puts the half it was computed against
+ * beside it. A mask only describes the two images it came from.
  */
-function getViewerDiff(
-  media: Media,
-  version: Media["versions"][number],
-): ViewerDiff | null {
-  const { diff } = media;
+function getViewerDiff(version: Media["versions"][number]): ViewerDiff | null {
+  const { diff } = version;
   if (!diff?.url || !diff.width || !diff.height) {
     return null;
   }
-  if (version.id !== media.latestVersion.id) {
+  return { url: diff.url, width: diff.width, height: diff.height };
+}
+
+/**
+ * The other half to show beside this version: the one its comparison was
+ * computed against.
+ *
+ * Falls back to the counterpart's newest when the two were never compared —
+ * that is the pair the reviewer would otherwise expect, and there is no mask to
+ * contradict it.
+ */
+function getCounterpartVersion(
+  media: Media,
+  version: Media["versions"][number],
+): DocumentType<typeof _ViewerVersionFragment> | null {
+  const { counterpart } = media;
+  if (!counterpart) {
     return null;
   }
-  return { url: diff.url, width: diff.width, height: diff.height };
+  const { diff } = version;
+  if (!diff) {
+    return counterpart.latestVersion;
+  }
+  // The sides are named after the pair, not after this media: whichever one is
+  // not this version is the other half.
+  return diff.beforeVersion.id === version.id
+    ? diff.afterVersion
+    : diff.beforeVersion;
 }
 
 /** How often the page asks whether the pair's comparison has landed. */
@@ -287,9 +332,15 @@ function SharePage(props: { media: Media }) {
 
   // Falls back to the latest if the selected version went away under us — a
   // retention purge can take an old one while the page is open.
+  // The newest is the fallback, and `versions` is newest first. Read from that
+  // list rather than from `latestVersion` because only these carry the
+  // comparison the viewer draws.
+  const newestVersion = media.versions[0];
+  invariant(newestVersion, "a listed media has an uploaded version");
   const version =
     media.versions.find((candidate) => candidate.id === versionId) ??
-    media.latestVersion;
+    newestVersion;
+  const counterpartVersion = getCounterpartVersion(media, version);
 
   const mentionUsers = useMemo(
     () => media.mentionableUsers.map(getMentionUser),
@@ -373,17 +424,18 @@ function SharePage(props: { media: Media }) {
                   nav={nav}
                   media={{ ...media, version }}
                   counterpart={
-                    media.counterpart
+                    media.counterpart && counterpartVersion
                       ? {
                           ...media.counterpart,
-                          // Its own newest, not the selected version number: the two
-                          // media have independent histories, and "v2 of the after" has
-                          // no counterpart "v2 of the before" to line up with.
-                          version: media.counterpart.latestVersion,
+                          // The half the selected version was compared against,
+                          // not simply the counterpart's newest: the two media
+                          // have independent histories, and the pair on screen
+                          // has to be the pair the mask describes.
+                          version: counterpartVersion,
                         }
                       : null
                   }
-                  diff={getViewerDiff(media, version)}
+                  diff={getViewerDiff(version)}
                   comments={{
                     media,
                     viewedVersionId: version.id,

--- a/apps/frontend/src/pages/MediaShare.tsx
+++ b/apps/frontend/src/pages/MediaShare.tsx
@@ -709,6 +709,29 @@ function VisibilityChip(props: { visibility: MediaVisibility }) {
 }
 
 /**
+ * Whose infrastructure served this page, for a visitor who has never seen Argos
+ * — the only branding either state of a share URL carries, now that the name is
+ * over the media and the footer is gone.
+ */
+function BrandLink() {
+  return (
+    <Tooltip content="Visual testing for your pull requests">
+      <HeadlessLink
+        href="https://argos-ci.com"
+        target="_blank"
+        // The mark is the link; the usual arrow beside it would hang off a logo
+        // rather than off a phrase.
+        external={false}
+        aria-label="Argos"
+        className="shrink-0 transition hover:brightness-125"
+      >
+        <BrandShield height={32} />
+      </HeadlessLink>
+    </Tooltip>
+  );
+}
+
+/**
  * The bar over the page: whose infrastructure served it on the left, and on the
  * right where the media came from, who can open it, and the same
  * login-or-avatar control as the app's.
@@ -722,19 +745,7 @@ function PageHeader(props: { media: Media }) {
   return (
     <header className="border-b-thin flex shrink-0 items-center justify-between gap-4 px-4 py-2">
       <div className="flex min-w-0 items-center gap-3">
-        <Tooltip content="Visual testing for your pull requests">
-          <HeadlessLink
-            href="https://argos-ci.com"
-            target="_blank"
-            // The mark is the link; the usual arrow beside it would hang off a
-            // logo rather than off a phrase.
-            external={false}
-            aria-label="Argos"
-            className="shrink-0 transition hover:brightness-125"
-          >
-            <BrandShield height={32} />
-          </HeadlessLink>
-        </Tooltip>
+        <BrandLink />
         {/* Null unless the viewer can reach the project — the resolver decides,
             so nothing here has to remember not to leak it. Reads as the build
             header's breadcrumb does: whose infrastructure, then whose work. */}
@@ -803,6 +814,12 @@ function UnavailableState() {
         <title>Media unavailable</title>
         <meta name="robots" content="noindex, nofollow" />
       </Helmet>
+      {/* The same corner as a working share page's, so a dead link still says
+          whose page it was — the empty state sells Argos in words, and this is
+          the one thing that shows it. */}
+      <header className="border-b-thin flex shrink-0 items-center px-4 py-2">
+        <BrandLink />
+      </header>
       <div className="bg-subtle flex flex-1 flex-col justify-center py-8">
         <EmptyState>
           <EmptyStateIllustration>

--- a/apps/frontend/src/pages/MediaShare.tsx
+++ b/apps/frontend/src/pages/MediaShare.tsx
@@ -20,7 +20,7 @@ import {
 } from "lucide-react";
 import { Heading, MenuTrigger, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
-import { useLocation, useNavigate, useParams } from "react-router";
+import { Navigate, useLocation, useNavigate, useParams } from "react-router";
 import { useClipboard } from "use-clipboard-copy";
 
 import {
@@ -52,7 +52,7 @@ import { NavUserControl } from "@/containers/NavUserControl";
 import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
 import { PullRequestButton } from "@/containers/PullRequestButton";
 import { DocumentType, graphql } from "@/gql";
-import { MediaDiffStatus, MediaVisibility } from "@/gql/graphql";
+import { MediaDiffStatus, MediaState, MediaVisibility } from "@/gql/graphql";
 import { BrandShield } from "@/ui/BrandShield";
 import { Button, LinkButton } from "@/ui/Button";
 import { ButtonGroup } from "@/ui/ButtonGroup";
@@ -156,6 +156,7 @@ const MediaShareQuery = graphql(`
         name
         state
         url
+        shareToken
         latestVersion {
           id
           ...MediaShare_ViewerVersion
@@ -209,6 +210,22 @@ export function Component() {
 
   if (!media) {
     return <UnavailableState />;
+  }
+
+  // A pair has one page, and it is the "after".
+  //
+  // Both halves show the same two images side by side, so two pages meant one
+  // subject with two comment threads on it, split by which link the reviewer
+  // happened to click — a remark about the change landing where whoever came
+  // the other way would never see it. The "after" is the state being reviewed,
+  // so it is the one that keeps the conversation, and the "before" sends its
+  // visitors there.
+  //
+  // Only when the counterpart is actually visible: the field is filtered by
+  // what the viewer may see, so a public "before" whose "after" is team-only
+  // stays where it is rather than bouncing someone into a dead end.
+  if (media.state === MediaState.Before && media.counterpart) {
+    return <Navigate replace to={`/m/${media.counterpart.shareToken}`} />;
   }
 
   return (

--- a/apps/frontend/src/pages/MediaShare.tsx
+++ b/apps/frontend/src/pages/MediaShare.tsx
@@ -375,7 +375,11 @@ function SharePage(props: { media: Media }) {
   );
   // One entry is this media itself, and a list of one is a list of where you
   // already are.
-  const showList = entries.length > 1;
+  //
+  // And nothing at all if this media is not among them: the list is capped, so
+  // a pull request with more media than the cap can leave the one being viewed
+  // out of it — a hundred rows, none of them this page, with both arrows dead.
+  const showList = entries.length > 1 && activeIndex !== -1;
   const navigate = useNavigate();
   // The next media has to be fetched, and until it is, the page still shows the
   // current one. Marking that wait as a transition keeps the media on screen

--- a/apps/frontend/src/pages/MediaShare.tsx
+++ b/apps/frontend/src/pages/MediaShare.tsx
@@ -1,4 +1,10 @@
-import { startTransition, useEffect, useMemo, useState } from "react";
+import {
+  startTransition,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from "react";
 import { useSuspenseQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import {
@@ -14,7 +20,7 @@ import {
 } from "lucide-react";
 import { Heading, MenuTrigger, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
-import { useLocation, useParams } from "react-router";
+import { useLocation, useNavigate, useParams } from "react-router";
 import { useClipboard } from "use-clipboard-copy";
 
 import {
@@ -31,6 +37,11 @@ import { MentionableUsersProvider } from "@/containers/Comment/MentionableUsersC
 import { useCommentRoleScope } from "@/containers/Comment/useCommentRoleScope";
 import { MediaSharingIllustration } from "@/containers/EmptyStateIllustrations";
 import { MediaComments } from "@/containers/Media/MediaComments";
+import {
+  groupMediaByPair,
+  type MediaListEntry,
+  MediaPullRequestList,
+} from "@/containers/Media/MediaPullRequestList";
 import { MediaVersions } from "@/containers/Media/MediaVersions";
 import {
   getMediaDownloadName,
@@ -56,14 +67,12 @@ import {
   EmptyStateStep,
   EmptyStateSteps,
 } from "@/ui/Layout";
-import { Link } from "@/ui/Link";
+import { HeadlessLink } from "@/ui/Link";
 import { Menu, MenuItem } from "@/ui/Menu";
 import { Popover } from "@/ui/Popover";
 import { toast } from "@/ui/Toaster";
 import { Tooltip } from "@/ui/Tooltip";
-import { Truncable } from "@/ui/Truncable";
 import { getMentionUser } from "@/ui/UserCard";
-import { formatBytes, formatDimensions, formatExpiry } from "@/util/media";
 
 const MediaShareQuery = graphql(`
   query MediaShare_media(
@@ -85,6 +94,10 @@ const MediaShareQuery = graphql(`
         id
         ...PullRequestButton_PullRequest
       }
+      pullRequestMedias {
+        id
+        ...MediaPullRequestList_Media
+      }
       latestVersion {
         id
         number
@@ -95,7 +108,6 @@ const MediaShareQuery = graphql(`
         width
         height
         isVideo
-        expiresAt
       }
       versions {
         id
@@ -107,7 +119,6 @@ const MediaShareQuery = graphql(`
         width
         height
         isVideo
-        expiresAt
       }
       counterpart {
         id
@@ -123,7 +134,6 @@ const MediaShareQuery = graphql(`
           width
           height
           isVideo
-          expiresAt
         }
       }
       diff {
@@ -286,6 +296,54 @@ function SharePage(props: { media: Media }) {
     [media.mentionableUsers],
   );
 
+  const entries = useMemo(
+    () => groupMediaByPair(media.pullRequestMedias),
+    [media.pullRequestMedias],
+  );
+  // The row this page is showing — matched against both halves, because a pair
+  // is one row and either half can be the one that was opened.
+  const activeIndex = entries.findIndex((entry) =>
+    entry.medias.some((candidate) => candidate.id === media.id),
+  );
+  // One entry is this media itself, and a list of one is a list of where you
+  // already are.
+  const showList = entries.length > 1;
+  const navigate = useNavigate();
+  // The next media has to be fetched, and until it is, the page still shows the
+  // current one. Marking that wait as a transition keeps the media on screen
+  // instead of flashing a fallback, and `isNavigating` closes the door behind
+  // it: a second press while the first is in flight would step from the media
+  // being replaced, landing somewhere nobody asked for.
+  const [isNavigating, startNavigating] = useTransition();
+  const goToEntry = (entry: MediaListEntry) => {
+    // Same route, so the page stays mounted and the query refetches under it
+    // rather than the whole share page unmounting and suspending.
+    startNavigating(() => {
+      navigate(`/m/${entry.target.shareToken}`);
+    });
+  };
+  const nav = showList
+    ? {
+        hasPrevious: activeIndex > 0 && !isNavigating,
+        hasNext:
+          activeIndex !== -1 &&
+          activeIndex < entries.length - 1 &&
+          !isNavigating,
+        onPrevious: () => {
+          const previous = entries[activeIndex - 1];
+          if (previous) {
+            goToEntry(previous);
+          }
+        },
+        onNext: () => {
+          const next = entries[activeIndex + 1];
+          if (next) {
+            goToEntry(next);
+          }
+        },
+      }
+    : null;
+
   // The comment components ask the project what the viewer may do — reacting is a
   // `review`, same as commenting. An anonymous visitor on a public link is not
   // shown the project at all, so they get no permissions, which is exactly right:
@@ -296,10 +354,23 @@ function SharePage(props: { media: Media }) {
         <BuildHotkeysDialogStateProvider>
           <BuildHotkeysDialog env="media" />
           <div className="flex min-h-dvh flex-col lg:h-dvh">
-            <PageHeader media={media} version={version} />
+            <PageHeader media={media} />
             <div className="bg-subtle flex flex-1 flex-col gap-4 p-4 lg:min-h-0 lg:flex-row">
+              {showList ? (
+                // Below `lg` the page stacks, and the list goes last: every
+                // pixel above the media is a pixel of it the visitor cannot
+                // see. Beside it, the list is where a build puts its own.
+                <aside className="flex w-full flex-col max-lg:order-last lg:min-h-0 lg:w-56 lg:shrink-0">
+                  <MediaPullRequestList
+                    entries={entries}
+                    activeEntryKey={entries[activeIndex]?.key ?? null}
+                    onSelect={goToEntry}
+                  />
+                </aside>
+              ) : null}
               <main className="flex min-w-0 flex-col justify-center lg:min-h-0 lg:flex-1">
                 <MediaViewer
+                  nav={nav}
                   media={{ ...media, version }}
                   counterpart={
                     media.counterpart
@@ -331,6 +402,7 @@ function SharePage(props: { media: Media }) {
                     is the build sidebar's: without it the scroll container
                     crops the last panel's shadow. */}
                 <div className="flex min-h-0 flex-col gap-4 lg:overflow-y-auto lg:pb-6">
+                  <MediaDescription media={media} />
                   <MediaVersions
                     versions={media.versions}
                     selectedId={version.id}
@@ -353,7 +425,6 @@ function SharePage(props: { media: Media }) {
                 </div>
               </aside>
             </div>
-            <PageFooter />
           </div>
         </BuildHotkeysDialogStateProvider>
       </MentionableUsersProvider>
@@ -569,77 +640,51 @@ function VisibilityChip(props: { visibility: MediaVisibility }) {
 }
 
 /**
- * The bar over the media, two lines and done: what the file is (name and the
- * prose that shipped with it), then the version's numbers — dimensions, size,
- * time left — with who may open it and the same login-or-avatar control as
- * the app's on the right. Every value reads without a label, the way a file
- * listing does. Versions have their own panel in the sidebar.
+ * The bar over the page: whose infrastructure served it on the left, and on the
+ * right where the media came from, who can open it, and the same
+ * login-or-avatar control as the app's.
+ *
+ * The name is not here — it sits over the media itself, where a build puts its
+ * snapshot's, so the two pages read the same way. That leaves the corner for the
+ * logo, which is what a visitor who has never seen Argos needs from this page.
  */
-function PageHeader(props: {
-  media: Media;
-  version: Media["versions"][number];
-}) {
-  const { media, version } = props;
-  const facts: React.ReactNode[] = [];
-  if (media.state && !media.counterpart) {
-    // Which half of a pair this is. With both halves on the page the panes
-    // label themselves; alone, the fact lives here.
-    facts.push(media.state);
-  }
-  const dimensions = formatDimensions(version.width, version.height);
-  if (dimensions) {
-    facts.push(dimensions);
-  }
-  facts.push(formatBytes(version.sizeBytes));
-  const expiry = formatExpiry(version.expiresAt);
-  if (expiry) {
-    facts.push(
-      <Tooltip content="Time left before this version is deleted">
-        {/* A live countdown: neutralized in visual tests so the baseline
-            doesn't change every day, the same way `<Time>` is. */}
-        <span data-visual-test="transparent">{expiry}</span>
-      </Tooltip>,
-    );
-  }
-
+function PageHeader(props: { media: Media }) {
+  const { media } = props;
   return (
     <header className="border-b-thin flex shrink-0 items-center justify-between gap-4 px-4 py-2">
-      <div className="flex min-w-0 flex-col gap-1">
-        <div className="flex min-w-0 items-baseline gap-1.5">
-          {/* The file name is the page's title, in monospace because it is a
-              value, not a sentence. */}
-          <h1 className="shrink-0 font-mono text-sm leading-tight font-medium">
-            {media.name}
-          </h1>
-          {media.description ? (
-            // Truncated with its full text on hover: the prose that shipped
-            // with the upload is often a sentence, and the header is one line.
-            <Truncable className="text-low min-w-0 text-xs leading-tight">
-              <span aria-hidden="true" className="mr-1.5 opacity-60">
-                ·
-              </span>
-              {media.description}
-            </Truncable>
-          ) : null}
-        </div>
-        <div className="text-default flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5 font-mono text-xs leading-tight">
-          {facts.map((fact, index) => (
-            // Order is fixed and the parts are static per render.
-            // oxlint-disable-next-line react/no-array-index-key
-            <span key={index} className="flex items-baseline gap-x-2">
-              {index > 0 ? (
-                <span aria-hidden="true" className="text-low opacity-60">
-                  ·
-                </span>
-              ) : null}
-              {fact}
-            </span>
-          ))}
-        </div>
+      <div className="flex min-w-0 items-center gap-3">
+        <Tooltip content="Visual testing for your pull requests">
+          <HeadlessLink
+            href="https://argos-ci.com"
+            target="_blank"
+            // The mark is the link; the usual arrow beside it would hang off a
+            // logo rather than off a phrase.
+            external={false}
+            aria-label="Argos"
+            className="shrink-0 transition hover:brightness-125"
+          >
+            <BrandShield height={32} />
+          </HeadlessLink>
+        </Tooltip>
+        {/* Null unless the viewer can reach the project — the resolver decides,
+            so nothing here has to remember not to leak it. Reads as the build
+            header's breadcrumb does: whose infrastructure, then whose work. */}
+        {media.project ? (
+          <Tooltip content="See all builds">
+            <HeadlessLink
+              href={`/${media.project.slug}/builds`}
+              className="text-low data-hovered:text-default rac-focus min-w-0 truncate text-xs leading-none transition"
+            >
+              {media.project.slug}
+            </HeadlessLink>
+          </Tooltip>
+        ) : null}
+        {/* With the project, not with the actions: both answer "whose is this
+            and who can open it", and the answer matters most at the moment of
+            forwarding the link. */}
+        <VisibilityChip visibility={media.visibility} />
       </div>
       <div className="flex shrink-0 items-center gap-3">
-        {/* Null unless the viewer has access to the project — the resolver
-            decides, so nothing here has to remember not to leak it. */}
         {media.pullRequest ? (
           <PullRequestButton
             pullRequest={media.pullRequest}
@@ -647,7 +692,6 @@ function PageHeader(props: {
             target="_blank"
           />
         ) : null}
-        <VisibilityChip visibility={media.visibility} />
         <NavUserControl />
       </div>
     </header>
@@ -655,30 +699,20 @@ function PageHeader(props: {
 }
 
 /**
- * The tiny footer: one line saying whose infrastructure served the page — the
- * name spelled out for a visitor who has never seen it.
+ * The prose that shipped with the upload, in full — the sidebar has the room
+ * for a sentence the old one-line header did not.
+ *
+ * Deliberately not a panel, and deliberately alone: the version's numbers read
+ * beside the file name over the media itself, where the name they describe is,
+ * and a titled card around one paragraph is a title saying what the paragraph
+ * says. Nothing at all when the upload shipped without a description.
  */
-function PageFooter() {
-  return (
-    <footer className="border-t-thin text-low flex shrink-0 items-center gap-2 px-4 py-2.5 text-xs">
-      <BrandShield className="size-4 shrink-0" />
-      <span className="min-w-0 truncate">
-        Hosted by{" "}
-        <Link
-          href="https://argos-ci.com"
-          target="_blank"
-          external={false}
-          className="font-medium"
-        >
-          Argos
-        </Link>
-        <span aria-hidden="true" className="mx-1.5 opacity-60">
-          ·
-        </span>
-        Visual testing for your pull requests
-      </span>
-    </footer>
-  );
+function MediaDescription(props: { media: Media }) {
+  const { media } = props;
+  if (!media.description) {
+    return null;
+  }
+  return <p className="text-low px-1 text-sm">{media.description}</p>;
 }
 
 /**
@@ -753,7 +787,6 @@ function UnavailableState() {
           </EmptyStateSteps>
         </EmptyState>
       </div>
-      <PageFooter />
     </div>
   );
 }

--- a/apps/frontend/src/util/media.ts
+++ b/apps/frontend/src/util/media.ts
@@ -15,29 +15,6 @@ export function formatBytes(bytes: number): string {
   return mb < 10 ? `${mb.toFixed(1)} MB` : `${Math.round(mb)} MB`;
 }
 
-/**
- * How long a media has left, as a coarse countdown.
- *
- * Coarse on purpose: what a reader needs to know is whether the link they are
- * about to paste somewhere will outlive the review, and "29 days left" answers
- * that where a timestamp makes them do arithmetic.
- */
-export function formatExpiry(expiresAt: string | null): string | null {
-  if (!expiresAt) {
-    return null;
-  }
-  const remainingMs = new Date(expiresAt).getTime() - Date.now();
-  if (remainingMs <= 0) {
-    return "expired";
-  }
-  const days = Math.floor(remainingMs / (24 * 60 * 60 * 1000));
-  if (days >= 1) {
-    return `${days}d left`;
-  }
-  const hours = Math.max(1, Math.floor(remainingMs / (60 * 60 * 1000)));
-  return `${hours}h left`;
-}
-
 /** Compact dimensions, e.g. `1440×900`. Null when they aren't known yet. */
 export function formatDimensions(
   width: number | null,

--- a/tests/media.spec.ts
+++ b/tests/media.spec.ts
@@ -309,6 +309,50 @@ loggedTest(
 );
 
 loggedTest(
+  "switches between the two halves with the build's own controls",
+  async ({ page, project }) => {
+    // A pair and a build's baseline-against-changes are the same question, so
+    // they are looked at with the same controls and the same shortcuts — only
+    // the two words differ.
+    const media = await createMediaScenario({ projectId: project.id });
+
+    await page.goto(`/m/${media.after.shareToken}`);
+
+    const panes = page.locator("[data-media-pane]");
+    await expect(panes).toHaveCount(2);
+
+    // `S` leaves side by side for one image at a time, and the toggle appears.
+    await page.keyboard.press("s");
+    await expect(panes).toHaveCount(1);
+    const after = page.getByRole("button", { name: "After", exact: true });
+    const before = page.getByRole("button", { name: "Before", exact: true });
+    await expect(after).toHaveAttribute("aria-pressed", "true");
+    await expect(
+      page.getByRole("img", { name: "checkout.png (after)" }),
+    ).toBeVisible();
+
+    // `←` shows the other half alone, `→` comes back — the build's keys.
+    await page.keyboard.press("ArrowLeft");
+    await expect(before).toHaveAttribute("aria-pressed", "true");
+    await expect(
+      page.getByRole("img", { name: "checkout.png (before)" }),
+    ).toBeVisible();
+    await expect(panes).toHaveCount(1);
+
+    await page.keyboard.press("ArrowRight");
+    await expect(after).toHaveAttribute("aria-pressed", "true");
+
+    // And the buttons do what the keys do.
+    await before.click();
+    await expect(
+      page.getByRole("img", { name: "checkout.png (before)" }),
+    ).toBeVisible();
+
+    await screenshot(page, "media-share-single-half");
+  },
+);
+
+loggedTest(
   "rings the half a pin would land on, in compare mode",
   async ({ page, auth, project }) => {
     // Side by side puts two images on screen and only one of them takes
@@ -320,9 +364,8 @@ loggedTest(
     });
 
     await page.goto(`/m/${media.after.shareToken}`);
-    await page.getByRole("button", { name: "Compare" }).click();
-    await page.getByRole("button", { name: "Side by side" }).click();
 
+    // Side by side is the default, the same one a build opens with.
     const panes = page.locator("[data-media-pane]");
     await expect(panes).toHaveCount(2);
     // Nothing is singled out until the tool is armed: a ring that is always on

--- a/tests/media.spec.ts
+++ b/tests/media.spec.ts
@@ -268,6 +268,35 @@ loggedTest(
 );
 
 loggedTest(
+  "shows each version its own comparison",
+  async ({ page, project }) => {
+    // Two uploads of the "after", each compared against the "before" when it
+    // landed. Picking an older one used to hide the overlay entirely, because
+    // the only comparison the page could reach was the newest pair's.
+    const media = await createMediaScenario({ projectId: project.id });
+
+    await page.goto(`/m/${media.after.shareToken}`);
+
+    const mask = page.locator(
+      '[data-media-pane] span[style*="diff-1024-to-720.png"]',
+    );
+    await expect(mask).toHaveCount(1);
+
+    // v1 is the same file as the "before", so its comparison found nothing to
+    // mark — a real answer, and a different one from v2's.
+    await page.getByRole("button", { name: /^v1/ }).click();
+    await expect(mask).toHaveCount(0);
+    await expect(
+      page.getByRole("img", { name: "checkout.png (before)" }),
+    ).toBeVisible();
+
+    // And back: the newest version's mask returns.
+    await page.getByRole("button", { name: /^v2/ }).click();
+    await expect(mask).toHaveCount(1);
+  },
+);
+
+loggedTest(
   "rings the half a pin would land on, in compare mode",
   async ({ page, auth, project }) => {
     // Side by side puts two images on screen and only one of them takes

--- a/tests/media.spec.ts
+++ b/tests/media.spec.ts
@@ -130,15 +130,27 @@ loggedTest(
 );
 
 loggedTest(
-  "keeps a pair on one row whichever half is opened",
-  async ({ page, project }) => {
+  "sends the before half to the after, so a pair has one page",
+  async ({ page, auth, project }) => {
+    // Both halves show the same two images, so two pages meant one subject with
+    // two comment threads on it, split by which link was clicked.
     const media = await createMediaScenario({
       projectId: project.id,
+      commentAuthorId: auth.user.id,
       withPullRequest: true,
     });
 
-    // Landing on the "before" shows the same comparison and marks the same row.
     await page.goto(`/m/${media.before.shareToken}`);
+
+    await expect(page).toHaveURL(`/m/${media.after.shareToken}`);
+    // Arriving from the "before" link and reading the conversation that was
+    // left on the "after" — the point of the redirect.
+    await expect(
+      page.getByText("The primary button is misaligned here."),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("img", { name: "checkout.png (before)" }),
+    ).toBeVisible();
 
     const sidebar = page.getByRole("region", { name: "Pull request media" });
     const active = sidebar.locator("[aria-current]");

--- a/tests/media.spec.ts
+++ b/tests/media.spec.ts
@@ -44,6 +44,14 @@ loggedTest("media share page", async ({ page, auth, project }) => {
     page.getByRole("link", { name: /Tighten the checkout spacing/ }),
   ).toBeVisible();
 
+  // Everything else uploaded to the same pull request, in a sidebar: three
+  // rows, because the pair counts once.
+  const sidebar = page.getByRole("region", { name: "Pull request media" });
+  await expect(sidebar.locator("[aria-current]")).toHaveCount(1);
+  await expect(sidebar.getByText("checkout.png")).toBeVisible();
+  await expect(sidebar.getByText("dashboard.png")).toBeVisible();
+  await expect(sidebar.getByText("checkout-flow.mp4")).toBeVisible();
+
   // Two threads, one of them pinned to a point on the image — the pin is a
   // floating marker on the image itself, and the panel tells the media's
   // whole story.
@@ -60,6 +68,88 @@ loggedTest("media share page", async ({ page, auth, project }) => {
 
   await screenshot(page, "media-share-page");
 });
+
+loggedTest(
+  "navigates the pull request's media with the sidebar and the keyboard",
+  async ({ page, project }) => {
+    // Uploaded oldest first: dashboard.png (07:00), the checkout.png pair
+    // (08:00), then checkout-flow.mp4 (09:30).
+    const media = await createMediaScenario({
+      projectId: project.id,
+      withPullRequest: true,
+    });
+
+    await page.goto(`/m/${media.after.shareToken}`);
+
+    const sidebar = page.getByRole("region", { name: "Pull request media" });
+    const previous = page
+      .getByRole("main")
+      .locator("button:has(.lucide-arrow-up)");
+    const next = page
+      .getByRole("main")
+      .locator("button:has(.lucide-arrow-down)");
+    await expect(previous).toBeVisible();
+    await expect(next).toBeVisible();
+
+    // Up from the pair reaches the lone screenshot, which is the first upload —
+    // so there is nothing before it.
+    await page.keyboard.press("ArrowUp");
+    await expect(page).toHaveURL(`/m/${media.solo.shareToken}`);
+    await expect(
+      page.getByRole("heading", { name: "dashboard.png" }),
+    ).toBeVisible();
+    await expect(previous).toBeDisabled();
+
+    // Down twice: back through the pair and on to the recording. A video used
+    // to render no toolbar at all, which took the arrows and the name with it.
+    //
+    // Waiting for the name between the two presses, not just the URL: the next
+    // media is still being fetched when the URL changes, and the arrows are
+    // deliberately shut while it is.
+    await page.keyboard.press("ArrowDown");
+    await expect(page).toHaveURL(`/m/${media.after.shareToken}`);
+    await expect(
+      page.getByRole("heading", { name: "checkout.png" }),
+    ).toBeVisible();
+    await expect(next).toBeEnabled();
+    await page.keyboard.press("ArrowDown");
+    await expect(page).toHaveURL(`/m/${media.video.shareToken}`);
+    await expect(
+      page.getByRole("heading", { name: "checkout-flow.mp4" }),
+    ).toBeVisible();
+    await expect(page.locator("video")).toBeVisible();
+    await expect(next).toBeDisabled();
+
+    // Clicking the pair opens the "after": both halves are one row, and the
+    // after is the state of the work being reviewed.
+    await sidebar.getByText("checkout.png").click();
+    await expect(page).toHaveURL(`/m/${media.after.shareToken}`);
+
+    await screenshot(page, "media-share-sidebar");
+  },
+);
+
+loggedTest(
+  "keeps a pair on one row whichever half is opened",
+  async ({ page, project }) => {
+    const media = await createMediaScenario({
+      projectId: project.id,
+      withPullRequest: true,
+    });
+
+    // Landing on the "before" shows the same comparison and marks the same row.
+    await page.goto(`/m/${media.before.shareToken}`);
+
+    const sidebar = page.getByRole("region", { name: "Pull request media" });
+    const active = sidebar.locator("[aria-current]");
+    await expect(active).toHaveCount(1);
+    await expect(active).toContainText("checkout.png");
+
+    // And navigating on from it moves relative to the row, not to the half.
+    await page.keyboard.press("ArrowUp");
+    await expect(page).toHaveURL(`/m/${media.solo.shareToken}`);
+  },
+);
 
 loggedTest(
   "pins a comment to a point on the image",

--- a/tests/media.spec.ts
+++ b/tests/media.spec.ts
@@ -349,6 +349,19 @@ loggedTest(
     ).toBeVisible();
 
     await screenshot(page, "media-share-single-half");
+
+    // Comments belong to the "after", so with only the "before" on screen there
+    // is nowhere for a pin to land — the tool puts itself away rather than
+    // leaving the reviewer clicking at an image that cannot take one.
+    await after.click();
+    await page.getByRole("button", { name: "Pin a comment" }).click();
+    await expect(
+      page.getByText("Click the spot on the image you want to comment on."),
+    ).toBeVisible();
+    await page.keyboard.press("ArrowLeft");
+    await expect(
+      page.getByText("Click the spot on the image you want to comment on."),
+    ).toBeHidden();
   },
 );
 


### PR DESCRIPTION
Closes ARG-491.

A share link opened one media and stopped there. Reviewing a pull request that uploaded five of them meant going back to the GitHub comment between each one.

## What changes

The share page now carries the pull request's whole set in a sidebar, with the build's own navigation: `↑` and `↓` move through it, two arrow buttons sit at the left of the bar over the media, and the controls that act on what is on screen sit at its right. A before/after pair is **one row** — both halves open the same comparison — and lands on the "after".

`Media.pullRequestMedias` is that list, filtered by what the viewer may see: members get everything published to the pull request, and a public link gets the public media beside it, never the team-only uploads. It reuses `queryProjectMedia`, whose docstring has promised this consumer since the REST list shipped.

The page is rearranged to match the build's, which is what makes one set of shortcuts serve both:

- the file name moves out of the header and over the media where the build puts its snapshot's, with the version's shape and weight beside it;
- the header takes the Argos mark, the project and who can open the link;
- the description moves to the sidebar, on its own;
- the footer goes, its branding being the mark's job now;
- videos gain the bar they never had — they were the one page with no name and nowhere to go.

## Shared, not copied

`DetailToolbar` is the row itself, now built once and rendered by both the build page and the media page. The nav buttons and the hotkey registry take a name, so each page words its own shortcuts (`↑` reads "Go to previous snapshot" on a build and "Go to previous media" here).

## Two fixes that fell out

- `ListItemButton` dropped any `aria-current` it was given: react-aria's own undefined one won the spread.
- Stepping twice before the next media arrived moved from the media being replaced. Navigation is a transition now, and the arrows are shut while one is in flight.

## Verification

- Backend integration 1178/1178, unit 600/600, `static-checks` 18/18.
- Playwright chromium 91/92 — the one failure, `passkeys - register then sign in with it`, was confirmed failing identically on an unmodified frontend.
- New coverage: five resolver tests (member ordering, anonymous and signed-in-outsider filtering, media with no pull request, upload that never landed) and two Playwright specs for keyboard navigation, disabled ends, the video toolbar and pair-row behaviour from either half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)