### PR TITLE
fix(frontend): balance the edges of a chip button group

### DIFF
--- a/apps/frontend/src/ui/Chip.stories.tsx
+++ b/apps/frontend/src/ui/Chip.stories.tsx
@@ -1,6 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { CircleIcon, FlameIcon, ZapIcon } from "lucide-react";
+import {
+  CircleIcon,
+  FlameIcon,
+  SunIcon,
+  SunMoonIcon,
+  XIcon,
+  ZapIcon,
+} from "lucide-react";
 
+import { ButtonGroup } from "./ButtonGroup";
 import { Chip, ChipButton, ChipLink } from "./Chip";
 import type { ChipColor } from "./Chip";
 import { StoryTitle } from "./StoryTitle";
@@ -76,6 +84,27 @@ export const Default: Story = {
         <ChipLink color="info" href="#">
           Link Chip
         </ChipLink>
+      </div>
+
+      <StoryTitle>Filter group</StoryTitle>
+      <div className="flex flex-col items-start gap-3">
+        {(["xs", "sm", "md"] as const).map((scale) => (
+          <ButtonGroup key={scale}>
+            <Chip scale={scale} icon={SunMoonIcon}>
+              Color scheme
+            </Chip>
+            <Chip scale={scale}>is</Chip>
+            <ChipButton scale={scale} icon={SunIcon} onPress={() => {}}>
+              light
+            </ChipButton>
+            <ChipButton
+              scale={scale}
+              icon={XIcon}
+              onPress={() => {}}
+              aria-label="Remove Color scheme filter"
+            />
+          </ButtonGroup>
+        ))}
       </div>
     </div>
   ),

--- a/apps/frontend/src/ui/Chip.tsx
+++ b/apps/frontend/src/ui/Chip.tsx
@@ -109,13 +109,20 @@ function getChipClassName(props: {
     sm: "text-xs",
     md: "text-sm",
   };
-  // For an icon-only chip we mirror the non-empty vertical padding on every
-  // side so it ends up square (a circle) and the same height as a text chip of
-  // the same scale.
+  // Spacing tokens of a scale. `--chip-gap` is the internal rhythm: icon to
+  // label, and one segment of a button group to the next. `--chip-edge` is the
+  // padding at the two outer edges of a button group — tighter than a lone
+  // chip's, because there the pill is the whole group and a segment does not
+  // have to carry a full chip's worth of padding.
   const spacingClassName: Record<ChipScale, string> = {
-    xs: clsx(isEmpty ? "p-0" : "px-2.5", "[--chip-gap:--spacing(1)]"),
-    sm: clsx(isEmpty ? "p-1" : "px-2.5 py-1", "[--chip-gap:--spacing(1.5)]"),
-    md: clsx(isEmpty ? "p-2" : "px-4.5 py-2", "[--chip-gap:--spacing(2)]"),
+    xs: "[--chip-py:--spacing(0)] [--chip-gap:--spacing(1)] [--chip-edge:--spacing(2)]",
+    sm: "[--chip-py:--spacing(1)] [--chip-gap:--spacing(1.5)] [--chip-edge:--spacing(2)]",
+    md: "[--chip-py:--spacing(2)] [--chip-gap:--spacing(2)] [--chip-edge:--spacing(3.5)]",
+  };
+  const paddingXClassName: Record<ChipScale, string> = {
+    xs: "px-2.5",
+    sm: "px-2.5",
+    md: "px-4.5",
   };
   const colorClassNames: Record<ChipColor, string> = {
     primary: clsx(
@@ -149,7 +156,16 @@ function getChipClassName(props: {
     interactive && "rac-focus",
     textSizeClassName[scale],
     spacingClassName[scale],
-    "group-[*]/button-group:not-first:pl-(--chip-gap) group-[*]/button-group:not-last:pr-(--chip-gap)",
+    "py-(--chip-py)",
+    // An icon-only chip mirrors its vertical padding horizontally, so it ends
+    // up square — a circle the same height as a text chip of the same scale.
+    // The padding sits on the chip rather than on the icon so that a button
+    // group can override it at its edges.
+    isEmpty
+      ? "px-[calc(var(--chip-py)+(1lh-1em)/2)]"
+      : paddingXClassName[scale],
+    "group-[*]/button-group:first:pl-(--chip-edge) group-[*]/button-group:not-first:pl-(--chip-gap)",
+    "group-[*]/button-group:last:pr-(--chip-edge) group-[*]/button-group:not-last:pr-(--chip-gap)",
     "group-[*]/button-group:rounded-none",
     "group-[*]/button-group:first:rounded-l-chip group-[*]/button-group:not-first:border-l-0",
     "group-[*]/button-group:last:rounded-r-chip",
@@ -188,13 +204,8 @@ function useChip<
         <>
           {(() => {
             // The margin pads the 1em icon out to a full line box so it aligns
-            // with the text. With no text, applying it on every side keeps that
-            // box square, so the chip is a circle the same height as a text
-            // chip of the same scale.
-            const iconClassName = clsx(
-              "size-[1em] shrink-0",
-              isEmpty ? "m-[calc((1lh-1em)/2)]" : "my-[calc((1lh-1em)/2)]",
-            );
+            // with the text.
+            const iconClassName = "size-[1em] my-[calc((1lh-1em)/2)] shrink-0";
             if (isValidElement(icon)) {
               return cloneElement(icon, {
                 className: clsx(icon.props.className, iconClassName),

--- a/apps/frontend/src/ui/Chip.tsx
+++ b/apps/frontend/src/ui/Chip.tsx
@@ -109,15 +109,15 @@ function getChipClassName(props: {
     sm: "text-xs",
     md: "text-sm",
   };
-  // Spacing tokens of a scale. `--chip-gap` is the internal rhythm: icon to
-  // label, and one segment of a button group to the next. `--chip-edge` is the
-  // padding at the two outer edges of a button group — tighter than a lone
-  // chip's, because there the pill is the whole group and a segment does not
-  // have to carry a full chip's worth of padding.
+  // Spacing tokens of a scale. `--chip-gap` is the one horizontal unit a button
+  // group is built from: icon to label, one segment to the next, and each end
+  // of the group to its round cap. A lone chip is a pill and carries a pill's
+  // padding; in a group the pill is the whole group, so every gap in it — the
+  // outer two included — is the same.
   const spacingClassName: Record<ChipScale, string> = {
-    xs: "[--chip-py:--spacing(0)] [--chip-gap:--spacing(1)] [--chip-edge:--spacing(2)]",
-    sm: "[--chip-py:--spacing(1)] [--chip-gap:--spacing(1.5)] [--chip-edge:--spacing(2)]",
-    md: "[--chip-py:--spacing(2)] [--chip-gap:--spacing(2)] [--chip-edge:--spacing(3.5)]",
+    xs: "[--chip-py:--spacing(0)] [--chip-gap:--spacing(1)]",
+    sm: "[--chip-py:--spacing(1)] [--chip-gap:--spacing(1.5)]",
+    md: "[--chip-py:--spacing(2)] [--chip-gap:--spacing(2)]",
   };
   const paddingXClassName: Record<ChipScale, string> = {
     xs: "px-2.5",
@@ -160,12 +160,11 @@ function getChipClassName(props: {
     // An icon-only chip mirrors its vertical padding horizontally, so it ends
     // up square — a circle the same height as a text chip of the same scale.
     // The padding sits on the chip rather than on the icon so that a button
-    // group can override it at its edges.
+    // group can override it.
     isEmpty
       ? "px-[calc(var(--chip-py)+(1lh-1em)/2)]"
       : paddingXClassName[scale],
-    "group-[*]/button-group:first:pl-(--chip-edge) group-[*]/button-group:not-first:pl-(--chip-gap)",
-    "group-[*]/button-group:last:pr-(--chip-edge) group-[*]/button-group:not-last:pr-(--chip-gap)",
+    "group-[*]/button-group:px-(--chip-gap)",
     "group-[*]/button-group:rounded-none",
     "group-[*]/button-group:first:rounded-l-chip group-[*]/button-group:not-first:border-l-0",
     "group-[*]/button-group:last:rounded-r-chip",


### PR DESCRIPTION
Fixes ARG-494.

## The regression

The chip padding rework 7 weeks ago (f6707e4b / ac9f43fb) left a chip button group lopsided. Measured on the `xs` filter chip from the issue:

| edge | before | after |
| --- | --- | --- |
| left of the leading icon | 10px | 4px |
| left of the × | 6px | 4px |
| right of the × | 2px | 4px |

Two separate defects:

1. **The group's outer padding was a standalone chip's `px`** — 10px at `xs`, 18px at `md` — while every inner edge was `--chip-gap` (4px). The leading icon sat far off the cap and broke the group's rhythm.
2. **An icon-only chip collapsed the trailing edge.** `isEmpty` set `p-0` and moved the spacing onto the icon as `m-[calc((1lh-1em)/2)]`, so the group's `pl-(--chip-gap)` *added* to that margin (4+2=6) while the right side kept only the 2px margin. The × ended up shoved against the round cap.

## The fix

A lone chip is a pill and carries a pill's padding. Inside a button group the pill is the whole group, so **every gap in it is one unit** — `--chip-gap`, the same value already used between icon and label and between segments: 4px at `xs`, 6 at `sm`, 8 at `md`. That collapses the four first/last/not-first/not-last padding rules to a single `group-[*]/button-group:px-(--chip-gap)`, and the × is symmetric by construction rather than by tuning.

For that override to reach an icon-only chip, its square-making spacing had to move off the icon's margin and onto the chip's own padding (`px-[calc(var(--chip-py)+(1lh-1em)/2)]`). The icon is back to a plain `my-` margin.

## Verification

Verified in Storybook by measuring computed geometry, not just eyeballing:

- Standalone chips are byte-identical: `xs` 10/10/0/0, `sm` 10/10/4/4, `md` 18/18/8/8.
- Icon-only chips are still exact circles: 17×17, 25×25, 33×33.
- Every edge inside a group is uniform: 4/4, 6/6, 8/8.

Adds a **Filter group** story to `Chip.stories.tsx` covering all three scales. Nothing previously exercised an icon-only chip as the last segment of a group, which is why this slipped through.

## For the reviewer

This also touches the `sm` metadata rows in the build sidebar — `ColorSchemeRow`, `BrowserRow`, `ViewportRow`, `StoryModeRow` — whose outer padding goes 10px → 6px. Expect Argos diffs there alongside the `xs` filter chips.

`oxfmt`, `oxlint` and `knip` are clean. `tsc` reports 162 errors in 7 media-related files, identical on a stashed tree — pre-existing, that worktree needs `pnpm run codegen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
