### PR TITLE
feat(build): merge the view-mode controls into one icon group

### DIFF
--- a/.agents/skills/lucide-style-icons/SKILL.md
+++ b/.agents/skills/lucide-style-icons/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: lucide-style-icons
+description: Design original SVG icons that match the Lucide icon set used across the Argos frontend — grid, stroke and corner conventions, createLucideIcon wiring, Storybook documentation, 16px verification. Use when a concept has no fitting Lucide icon and needs a custom one, or when reviewing/adjusting the existing custom icons.
+---
+
+# Lucide-style custom icons
+
+Custom icons live in `apps/frontend/src/ui/Icons.tsx` and are documented in
+`apps/frontend/src/ui/Icons.stories.tsx`. Read both before adding one — new
+icons should extend the metaphors already there, not invent parallel ones.
+
+## First: prove Lucide doesn't have it
+
+Search https://lucide.dev/icons/ (or grep the export list in
+`node_modules/lucide-react/dist/lucide-react.d.ts`) for the concept **and its
+synonyms**. Only draw a custom icon when nothing fits, and say in the icon's
+JSDoc which Lucide icons it borrows from. A custom icon that duplicates a
+Lucide drawing is a bug: it will drift from upstream refinements.
+
+## Lucide's design language
+
+- **Grid**: 24×24 viewBox. Keep strokes inside the 20×20 live area
+  (coordinates 2–22); primary square shapes usually sit in 3–21. Center the
+  composition optically — the bounding box of all strokes should be roughly
+  centered.
+- **Stroke only**: 2px stroke, round caps and joins, no fill. Color is
+  `currentColor`. `createLucideIcon` applies all of this — never restate it.
+- **Corners**: 2px radius. `rx="2"` on rects; mid-path either the arc
+  `a2 2 0 0 1 -2 2` or the cubic `c-1 0-2-1-2-2` official icons use — both
+  draw the same corner.
+- **Coordinates**: snap to whole pixels. Sub-pixel values only when optical
+  centering demands it (official icons use `.1`/`.9` in cubics, nothing
+  finer).
+- **Spacing**: keep ≥2px of clearance between separate elements so they don't
+  fuse at small sizes. Strokes may touch or cross **only when the drawing
+  means it** (a handle sitting on its line, two layers blending — see
+  Lucide's `blend`).
+- **Density**: at most ~5 elements. The app renders icons at 16px inside
+  buttons (`*:size-4`); a detail thinner than ~2px of gap disappears there.
+- **Metaphor before geometry**: decide what the icon *says* first, reusing
+  Lucide's vocabulary — a rounded rect is a document/image, stacked offset
+  frames are layers (front = bottom-right, back = top-left, as in `copy`),
+  a dashed stroke is a ghost/absence.
+
+## Icons that belong to one control
+
+When several icons sit in the same button group, they are one drawing in
+several states, not several drawings. Build them from **shared geometry
+constants** and change only the ink — the set then reads as a single control,
+and the eye compares the difference instead of re-reading each icon. The
+comparison set in `Icons.tsx` does this: the same two panels every time, solid
+for the side on screen and ghosted for the side held back.
+
+## Ghosting a shape
+
+To say "this part is not here", dash its outline with `strokeDasharray` rather
+than drawing dash segments by hand. Lucide's own `*-dashed` icons place each
+dash as its own path, which suits a full-size square but leaves a small shape
+looking like scattered ticks with open corners.
+
+Round caps eat the gaps: with the standard 2px stroke, a dash of `d` renders as
+`d + 2` of ink and a gap of `g` as `g - 2` of space, so `"2 4"` reads as 4 units
+of ink and 2 of gap. Pick the pattern **at 16px, not at 24px** — too fine a dash
+closes up at button size and the ghosted shape becomes indistinguishable from a
+solid one, which is the whole distinction the icon exists to make. Render the
+candidates side by side at 48/24/16px and choose from that, rather than from the
+numbers.
+
+## Reusing official fragments
+
+The fastest way to stay on-style is to build from official path data. Each
+icon's source is readable at
+`node_modules/lucide-react/dist/esm/icons/<kebab-name>.mjs` — copy fragments
+from there (a half-frame from `square-split-horizontal`, the corner peek from
+`copy`, the handle-on-line from `git-commit-vertical`, …) and recombine them.
+
+## Implementation
+
+```tsx
+import { createLucideIcon } from "lucide-react";
+
+/** What the drawing says, and which Lucide icons it borrows from. */
+export const MyThingIcon = createLucideIcon("my-thing", [
+  ["rect", { x: "3", y: "3", width: "12", height: "12", rx: "2", key: "back" }],
+  ["path", { d: "M21 12v7a2 2 0 0 1-2 2h-7", key: "front-peek" }],
+]);
+```
+
+- Name the icon after the **app concept** (`baseline-view`), kebab-case. The
+  name becomes the `lucide-<name>` class on the `<svg>` — that class is how
+  Playwright locates icon-only buttons (see CLAUDE.md), so treat it as API
+  and don't rename casually.
+- Every element needs a unique `key` (they render as a React list).
+- The component accepts all Lucide props (`size`, `strokeWidth`,
+  `className`, aria attributes) — no wrapper needed, it drops into `Button`
+  like any Lucide icon.
+
+## Document and validate
+
+1. Add the icon to `Icons.stories.tsx`: at 24px with its name, at 16px, and
+   inside a secondary `iconOnly` `Button` (with `aria-label`) next to the
+   Lucide icons it will sit beside in the real toolbar.
+2. Run Storybook (`pnpm run --filter @argos/frontend storybook`) and check:
+   - legibility at 16px — squint test: is it still distinct from its
+     neighbors in the set?
+   - stroke weight looks identical to the adjacent Lucide originals;
+   - nothing clips the viewBox edge; the icon doesn't look off-center;
+   - both light and dark color schemes.
+3. `pnpm run static-checks` before finishing, like any change.

--- a/.claude/skills/lucide-style-icons
+++ b/.claude/skills/lucide-style-icons
@@ -1,0 +1,1 @@
+../../.agents/skills/lucide-style-icons

--- a/apps/frontend/src/containers/Build/BuildDiffDetailToolbar.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetailToolbar.tsx
@@ -14,7 +14,7 @@ import { CommentsEnabledContext } from "./CommentsContext";
 import { CommentsVisibilityToggle } from "./toolbar/CommentsVisibilityToggle";
 import { CommentToolToggle } from "./toolbar/CommentToolToggle";
 import { FitToggle } from "./toolbar/FitToggle";
-import { SplitViewToggle, ViewToggle } from "./toolbar/ViewToggle";
+import { ViewToggle } from "./toolbar/ViewToggle";
 
 interface BuildDiffDetailToolbarProps {
   diff: BuildDiffDetailDocument;
@@ -74,7 +74,6 @@ export function BuildDiffDetailToolbar(props: BuildDiffDetailToolbarProps) {
   return (
     <div className="flex shrink-0 items-center gap-1.5">
       <ViewToggle blendEnabled={checkDiffCanBeBlended(diff)} />
-      <SplitViewToggle />
       <FitToggle />
       {fitControls}
       {shouldShowToolbarControls && (

--- a/apps/frontend/src/containers/Build/toolbar/ViewToggle.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/ViewToggle.tsx
@@ -1,10 +1,17 @@
 import { memo, startTransition } from "react";
 import { useAtom } from "jotai/react";
-import { ColumnsIcon, GalleryHorizontalIcon } from "lucide-react";
 
 import { Button } from "@/ui/Button";
 import { ButtonGroup } from "@/ui/ButtonGroup";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
+import {
+  BaselineViewIcon,
+  ChangesViewIcon,
+  OnionViewIcon,
+  SplitViewIcon,
+  SwipeViewIcon,
+} from "@/ui/Icons";
+import { useEventCallback } from "@/ui/useEventCallback";
 
 import { Hotkey, useBuildHotkey } from "../BuildHotkeys";
 import { buildViewModeAtom, type ViewMode } from "../BuildViewMode";
@@ -22,66 +29,121 @@ const DEFAULT_LABELS: ViewToggleLabels = {
   changes: "Changes",
 };
 
+/**
+ * Every way of looking at the comparison, in one control: one side alone, both
+ * sides apart, or both sides merged. Reading left to right, the two sides come
+ * together — which is also why side by side sits in the middle rather than
+ * beside the group as its own button.
+ *
+ * Icons rather than words because five words do not fit a toolbar that also
+ * carries the overlay, comment and fit controls, and because the drawings say
+ * what the words could not: which side is being held back.
+ */
 export const ViewToggle = memo(
   (props: { blendEnabled: boolean; labels?: ViewToggleLabels }) => {
     const { blendEnabled, labels = DEFAULT_LABELS } = props;
     const [viewMode, setViewMode] = useAtom(buildViewModeAtom);
+    const { reset } = useZoomerSyncContext();
+
+    const select = useEventCallback((next: ViewMode) => {
+      // Entering or leaving side by side changes how many panes the zoom is
+      // spread over, so the shared transform no longer means anything. Every
+      // other switch keeps one pane and keeps the reviewer where they were —
+      // resetting there would throw away the spot they are looking at.
+      if ((viewMode === "split") !== (next === "split")) {
+        reset();
+      }
+      startTransition(() => {
+        setViewMode(next);
+      });
+    });
+
     const showBaselineHotkey = useBuildHotkey(
       "showBaseline",
       () => {
-        startTransition(() => {
-          setViewMode("baseline");
-        });
+        select("baseline");
       },
       { preventDefault: true },
     );
     const showChangesHotkey = useBuildHotkey(
       "showChanges",
       () => {
-        startTransition(() => {
-          setViewMode("changes");
-        });
+        select("changes");
+      },
+      { preventDefault: true },
+    );
+    // The key stays a toggle even though the button is a plain selection: it is
+    // the way back out of side by side, and there is no second key for that.
+    const toggleSplitViewHotkey = useBuildHotkey(
+      "toggleSplitView",
+      () => {
+        select(viewMode === "split" ? "changes" : "split");
       },
       { preventDefault: true },
     );
     const showOnionHotkey = useBuildHotkey(
       "showOnion",
       () => {
-        startTransition(() => {
-          setViewMode("onion");
-        });
+        select("onion");
       },
       { preventDefault: true, enabled: blendEnabled },
     );
     const showSwipeHotkey = useBuildHotkey(
       "showSwipe",
       () => {
-        startTransition(() => {
-          setViewMode("swipe");
-        });
+        select("swipe");
       },
       { preventDefault: true, enabled: blendEnabled },
     );
 
-    if (viewMode === "split") {
-      return null;
-    }
-
     return (
       <ButtonGroup>
-        <ViewButton viewMode="baseline" hotkey={showBaselineHotkey}>
-          {labels.baseline}
+        <ViewButton
+          viewMode="baseline"
+          currentViewMode={viewMode}
+          label={labels.baseline}
+          hotkey={showBaselineHotkey}
+          onSelect={select}
+        >
+          <BaselineViewIcon />
         </ViewButton>
-        <ViewButton viewMode="changes" hotkey={showChangesHotkey}>
-          {labels.changes}
+        <ViewButton
+          viewMode="changes"
+          currentViewMode={viewMode}
+          label={labels.changes}
+          hotkey={showChangesHotkey}
+          onSelect={select}
+        >
+          <ChangesViewIcon />
+        </ViewButton>
+        <ViewButton
+          viewMode="split"
+          currentViewMode={viewMode}
+          label="Side by side"
+          hotkey={toggleSplitViewHotkey}
+          onSelect={select}
+        >
+          <SplitViewIcon />
         </ViewButton>
         {blendEnabled && (
           <>
-            <ViewButton viewMode="onion" hotkey={showOnionHotkey}>
-              Onion
+            <ViewButton
+              viewMode="onion"
+              currentViewMode={viewMode}
+              label="Onion skin"
+              hotkey={showOnionHotkey}
+              onSelect={select}
+            >
+              <OnionViewIcon />
             </ViewButton>
-            <ViewButton viewMode="swipe" hotkey={showSwipeHotkey}>
-              Swipe
+            <ViewButton
+              viewMode="swipe"
+              currentViewMode={viewMode}
+              label="Swipe"
+              hotkey={showSwipeHotkey}
+              onSelect={select}
+            >
+              <SwipeViewIcon />
             </ViewButton>
           </>
         )}
@@ -91,57 +153,34 @@ export const ViewToggle = memo(
 );
 
 function ViewButton(props: {
-  viewMode: Exclude<ViewMode, "split">;
+  viewMode: ViewMode;
+  currentViewMode: ViewMode;
+  /** Names the button, and names it the same way to a screen reader. */
+  label: string;
   hotkey: Hotkey;
+  onSelect: (viewMode: ViewMode) => void;
   children: React.ReactNode;
 }) {
-  const [viewMode, setViewMode] = useAtom(buildViewModeAtom);
-  const activate = () => {
-    startTransition(() => {
-      setViewMode(props.viewMode);
-    });
-  };
+  const { viewMode, currentViewMode, label, hotkey, onSelect, children } =
+    props;
+  const isCurrent = currentViewMode === viewMode;
   return (
     <HotkeyTooltip
-      description={props.hotkey.description}
-      keys={props.hotkey.displayKeys}
-      keysEnabled={viewMode !== props.viewMode}
+      description={label}
+      keys={hotkey.displayKeys}
+      keysEnabled={!isCurrent}
     >
       <Button
         variant="secondary"
-        aria-pressed={viewMode === props.viewMode}
-        onPress={activate}
+        iconOnly
+        aria-pressed={isCurrent}
+        aria-label={label}
+        onPress={() => {
+          onSelect(viewMode);
+        }}
       >
-        {props.children}
+        {children}
       </Button>
     </HotkeyTooltip>
   );
 }
-
-export const SplitViewToggle = memo(() => {
-  const [viewMode, setViewMode] = useAtom(buildViewModeAtom);
-  const { reset } = useZoomerSyncContext();
-  const toggleSplitView = () => {
-    setViewMode((viewMode) => (viewMode === "split" ? "changes" : "split"));
-    reset();
-  };
-  const hotkey = useBuildHotkey("toggleSplitView", toggleSplitView, {
-    preventDefault: true,
-  });
-  return (
-    <HotkeyTooltip
-      description={
-        viewMode === "split"
-          ? "Show only one image at a time"
-          : "Show baseline and changes side by side"
-      }
-      keys={hotkey.displayKeys}
-    >
-      {/* Two panes or one: the icon is the state, so there is no pressed
-          state on top of it. */}
-      <Button variant="secondary" iconOnly onPress={toggleSplitView}>
-        {viewMode === "split" ? <GalleryHorizontalIcon /> : <ColumnsIcon />}
-      </Button>
-    </HotkeyTooltip>
-  );
-});

--- a/apps/frontend/src/containers/Media/MediaViewer.tsx
+++ b/apps/frontend/src/containers/Media/MediaViewer.tsx
@@ -49,10 +49,7 @@ import {
   NextButton,
   PreviousButton,
 } from "@/containers/Build/toolbar/NavButtons";
-import {
-  SplitViewToggle,
-  ViewToggle,
-} from "@/containers/Build/toolbar/ViewToggle";
+import { ViewToggle } from "@/containers/Build/toolbar/ViewToggle";
 import { ZoomerSyncProvider, ZoomPane } from "@/containers/Build/Zoomer";
 import { MediaVideo, MediaWell } from "@/ui/MediaFrame";
 import { MenuItem, MenuItemIcon } from "@/ui/Menu";
@@ -491,13 +488,12 @@ function MediaViewToolbar(props: {
             <div className="flex shrink-0 items-center gap-1.5">
               {/* The build's own controls, on the build's own state: which half
                   to look at, or both at once, with the same shortcuts. Only the
-                  two words change, because here the baseline is the "before"
+                  two names change, because here the baseline is the "before"
                   and the changes are the "after". */}
               <ViewToggle
                 blendEnabled={compare.blendEnabled}
                 labels={{ baseline: "Before", changes: "After" }}
               />
-              <SplitViewToggle />
               {compare.hasChanges ? (
                 <>
                   <Separator orientation="vertical" className="mx-1 h-6" />

--- a/apps/frontend/src/pages/Test/index.tsx
+++ b/apps/frontend/src/pages/Test/index.tsx
@@ -467,7 +467,13 @@ function BuildHeader(props: {
         />
         <NextButton onPress={goToNextDiff} isDisabled={!nextChange} />
       </div>
-      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-3 max-2xl:-order-1 max-2xl:basis-full max-2xl:border-b max-2xl:pb-4 xl:gap-4">
+      <BuildDiffDetailToolbar diff={change.stats.lastSeenDiff}>
+        <IgnoreButton diff={change.stats.lastSeenDiff} />
+      </BuildDiffDetailToolbar>
+      {/* A line of its own, under the controls: these are facts about the
+          change, and squeezing them onto the row that also carries the
+          arrows and the toolbar left them wrapping mid-phrase. */}
+      <div className="flex min-w-0 basis-full flex-wrap items-center gap-3 xl:gap-4">
         <Counter>
           <Tooltip
             content={
@@ -509,9 +515,6 @@ function BuildHeader(props: {
           />
         </div>
       </div>
-      <BuildDiffDetailToolbar diff={change.stats.lastSeenDiff}>
-        <IgnoreButton diff={change.stats.lastSeenDiff} />
-      </BuildDiffDetailToolbar>
     </div>
   );
 }

--- a/apps/frontend/src/ui/Icons.stories.tsx
+++ b/apps/frontend/src/ui/Icons.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  BlendIcon,
+  ColumnsIcon,
+  CopyIcon,
+  HandIcon,
+  MessageSquarePlusIcon,
+} from "lucide-react";
+
+import { Button } from "./Button";
+import { ButtonGroup } from "./ButtonGroup";
+import {
+  BaselineViewIcon,
+  ChangesViewIcon,
+  OnionViewIcon,
+  SplitViewIcon,
+  SwipeViewIcon,
+} from "./Icons";
+import { StoryTitle } from "./StoryTitle";
+import { Tooltip } from "./Tooltip";
+
+const meta = {
+  title: "UI/Icons",
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The comparison viewer's control, in the order it is laid out there. */
+const viewModeIcons = [
+  { label: "Baseline", Icon: BaselineViewIcon },
+  { label: "Changes", Icon: ChangesViewIcon },
+  { label: "Side by side", Icon: SplitViewIcon },
+  { label: "Onion skin", Icon: OnionViewIcon },
+  { label: "Swipe", Icon: SwipeViewIcon },
+];
+
+export const ViewModes: Story = {
+  render: () => (
+    <div className="flex flex-col">
+      <StoryTitle>View-mode icons</StoryTitle>
+      <div className="flex gap-6">
+        {viewModeIcons.map(({ label, Icon }) => (
+          <div key={label} className="flex flex-col items-center gap-2">
+            <Icon size={24} />
+            <span className="text-low font-mono text-xs">{label}</span>
+          </div>
+        ))}
+      </div>
+
+      <StoryTitle>At button size (16px)</StoryTitle>
+      <div className="flex items-center gap-4">
+        {viewModeIcons.map(({ label, Icon }) => (
+          <Icon key={label} size={16} />
+        ))}
+      </div>
+
+      <StoryTitle>Alongside Lucide originals</StoryTitle>
+      <div className="flex items-center gap-4">
+        {viewModeIcons.map(({ label, Icon }) => (
+          <Icon key={label} size={24} />
+        ))}
+        <span className="text-low font-mono text-xs">/ lucide:</span>
+        <CopyIcon size={24} />
+        <BlendIcon size={24} />
+        <ColumnsIcon size={24} />
+        <HandIcon size={24} />
+        <MessageSquarePlusIcon size={24} />
+      </div>
+
+      <StoryTitle>In context</StoryTitle>
+      <ButtonGroup>
+        {viewModeIcons.map(({ label, Icon }, index) => (
+          <Tooltip key={label} content={label}>
+            <Button
+              variant="secondary"
+              iconOnly
+              aria-pressed={index === 1}
+              aria-label={label}
+            >
+              <Icon />
+            </Button>
+          </Tooltip>
+        ))}
+      </ButtonGroup>
+    </div>
+  ),
+};

--- a/apps/frontend/src/ui/Icons.tsx
+++ b/apps/frontend/src/ui/Icons.tsx
@@ -1,0 +1,78 @@
+import { createLucideIcon } from "lucide-react";
+
+/**
+ * Original icons for concepts Lucide has no drawing for, built from Lucide's
+ * own vocabulary (24px grid, 2px stroke, 2px corner radius) so they sit next
+ * to Lucide icons without looking foreign. The design rules and recipes live
+ * in the `lucide-style-icons` skill; the icons are documented in
+ * `Icons.stories.tsx`.
+ *
+ * The comparison viewer's icons share one metaphor: a screenshot is a rounded
+ * frame, and a comparison is two of them — the baseline on the left, the
+ * changes on the right, the way the `←` / `→` keys reach for them.
+ *
+ * `SplitViewIcon`, `BaselineViewIcon` and `ChangesViewIcon` are the same two
+ * panels every time; only the ink changes. Solid is the side on screen, dashed
+ * is the side held back, so the three read as one control rather than three
+ * drawings.
+ */
+
+/** The two panels the comparison icons are built from. */
+const PANEL = { y: "5", width: "8", height: "14", rx: "2" } as const;
+const LEFT_PANEL = { ...PANEL, x: "2" };
+const RIGHT_PANEL = { ...PANEL, x: "14" };
+
+/**
+ * Ghosts a panel: the side that is not on screen. Coarse enough that the gaps
+ * survive at the 16px the toolbar renders at — a finer dash closes up and the
+ * icon becomes indistinguishable from the side-by-side one.
+ */
+const HELD_BACK = { strokeDasharray: "2 4" } as const;
+
+/** The left panel solid, the right one ghosted: show the baseline alone. */
+export const BaselineViewIcon = createLucideIcon("baseline-view", [
+  ["rect", { ...LEFT_PANEL, key: "shown" }],
+  ["rect", { ...RIGHT_PANEL, ...HELD_BACK, key: "held-back" }],
+]);
+
+/** The right panel solid, the left one ghosted: show the changes alone. */
+export const ChangesViewIcon = createLucideIcon("changes-view", [
+  ["rect", { ...LEFT_PANEL, ...HELD_BACK, key: "held-back" }],
+  ["rect", { ...RIGHT_PANEL, key: "shown" }],
+]);
+
+/**
+ * Both frames full, blended into each other: the onion view lays the changes
+ * over the baseline with an opacity slider. Same statement as Lucide's
+ * `blend`, made with our frames instead of circles.
+ */
+export const OnionViewIcon = createLucideIcon("onion-view", [
+  ["rect", { x: "3", y: "3", width: "12", height: "12", rx: "2", key: "back" }],
+  [
+    "rect",
+    { x: "9", y: "9", width: "12", height: "12", rx: "2", key: "front" },
+  ],
+]);
+
+/**
+ * One frame cut by a divider with a round drag handle: the swipe view scrubs
+ * a divider across the image to reveal one layer over the other. The frame
+ * halves are Lucide's `square-split-horizontal`; the handle on the line is
+ * `git-commit-vertical`.
+ */
+export const SwipeViewIcon = createLucideIcon("swipe-view", [
+  ["path", { d: "M8 19H5c-1 0-2-1-2-2V7c0-1 1-2 2-2h3", key: "left" }],
+  ["path", { d: "M16 5h3c1 0 2 1 2 2v10c0 1-1 2-2 2h-3", key: "right" }],
+  ["path", { d: "M12 3v6", key: "divider-top" }],
+  ["path", { d: "M12 15v6", key: "divider-bottom" }],
+  ["circle", { cx: "12", cy: "12", r: "3", key: "handle" }],
+]);
+
+/**
+ * Both panels solid: the split view shows baseline and changes as two separate
+ * panes, not one image divided (which is the swipe).
+ */
+export const SplitViewIcon = createLucideIcon("split-view", [
+  ["rect", { ...LEFT_PANEL, key: "left" }],
+  ["rect", { ...RIGHT_PANEL, key: "right" }],
+]);

--- a/tests/media.spec.ts
+++ b/tests/media.spec.ts
@@ -321,7 +321,7 @@ loggedTest(
     const panes = page.locator("[data-media-pane]");
     await expect(panes).toHaveCount(2);
 
-    // `S` leaves side by side for one image at a time, and the toggle appears.
+    // `S` leaves side by side for one image at a time.
     await page.keyboard.press("s");
     await expect(panes).toHaveCount(1);
     const after = page.getByRole("button", { name: "After", exact: true });


### PR DESCRIPTION
The comparison viewer carried two controls for one question: a group of four text buttons (Baseline / Changes / Onion / Swipe) that hid itself in side-by-side mode, plus a separate icon button that toggled side by side. Five words and a stray button crowded a bar that also carries the overlay, comment and fit controls, and the split state lived apart from the states it belongs with.

## What changed

**One control instead of two.** `ViewToggle` is now a single `ButtonGroup` of icon buttons — baseline, changes, side by side, onion skin, swipe — and `SplitViewToggle` is gone. Reading left to right, the two sides come together, which is why side by side sits in the middle rather than off on its own. It is a pressed state like any other now, so the group no longer disappears when it is active.

**Five original icons**, in `ui/Icons.tsx` and documented in Storybook (`UI/Icons`). Lucide has no drawing for "the baseline alone", so these are built from Lucide's own vocabulary — 24px grid, 2px stroke, 2px corners — via `createLucideIcon`. The three that answer *which side* share their geometry and differ only in ink: solid is the side on screen, a dashed outline the side held back, left and right the way the `←` / `→` keys reach for them.

**A skill, `lucide-style-icons`**, writing down how to draw more of them: prove Lucide lacks it first, the grid and spacing rules, how to reuse fragments from `lucide-react`'s own icon sources, and the ghosting technique below.

## Notes for the reviewer

- **The dash pattern is chosen at 16px, not 24px.** That is the size the toolbar renders at, and a finer dash closes up there until the ghosted panel is indistinguishable from the solid side-by-side icon — the one distinction these icons exist to make. I rendered five candidates at 48/24/16px and picked `"2 4"`. Round caps matter: a dash of `d` renders as `d + 2` of ink and a gap of `g` as `g - 2` of space.
- **`S` stays a toggle** even though its button is now a plain selection, because it is the only way back out of side by side.
- **A latent zoom bug is fixed in passing.** Leaving side by side with `←` changed how many panes the shared zoom transform was spread over without resetting it — only the old split button reset. The reset now keys off crossing that boundary, whichever control does it.
- **Accessible names are unchanged**, which is what keeps the existing Playwright locators (`getByRole("button", { name: "After" })`) working untouched.
- **Argos baselines for the build and media pages will change**, which is the point of the change.

## Verification

- `pnpm run static-checks` clean.
- Full chromium e2e suite: 92/94. The two failures (`auth-guard`, `passkeys`) were artifacts of my local setup, not this change — port 3000 was in use so I ran on 3011, and the test env pins `config.server.url` to `:3000`, sending redirects and WebAuthn origins to the wrong server. Re-run with a matching `SERVER_URL`: 9/9.
- Checked the merged control in the running app, and the icon set in Storybook at 24px, at 16px, and beside the Lucide icons it sits next to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)