### PR TITLE
feat(comment): autolink commit shas to the project's repository

### DIFF
--- a/apps/backend/src/build/createBuildReview.ts
+++ b/apps/backend/src/build/createBuildReview.ts
@@ -255,7 +255,9 @@ async function notifyBuildSubscribers(input: {
       buildUrl,
       reviewerName,
       state,
-      bodyHtml: comment ? await renderCommentHtmlWithMentions(comment) : null,
+      bodyHtml: comment
+        ? await renderCommentHtmlWithMentions(comment, { project })
+        : null,
     },
     recipients,
   });

--- a/apps/backend/src/build/repository-url.ts
+++ b/apps/backend/src/build/repository-url.ts
@@ -41,18 +41,45 @@ export function getRepositoryUrl(project: Project): string | null {
   return null;
 }
 
+/** The relations {@link getRepositoryUrl} reads. */
+const REPOSITORY_GRAPH = "[githubRepository.githubAccount, gitlabProject]";
+
+/** Whether a project carries the *whole* graph {@link getRepositoryUrl} needs. */
+function hasRepositoryGraph(project: Project): boolean {
+  if (project.githubRepositoryId) {
+    // The nested account, not just the repository: a project that has been
+    // through a permission check carries `githubRepository` alone —
+    // `$checkIsPublic` fetches it for its `private` flag — and reading that as
+    // "loaded" is what makes `getRepositoryUrl` throw.
+    return Boolean(project.githubRepository?.githubAccount);
+  }
+  return Boolean(project.gitlabProject);
+}
+
+/**
+ * Load the graph {@link getRepositoryUrl} needs onto a project.
+ *
+ * Call this once before a batch of renders that share a project (see
+ * `notifyReviewCommentsWentLive`), so {@link fetchRepositoryUrl} answers each of
+ * them from the instance instead of querying per render. Loads the complete
+ * graph, so it can only ever improve what is on the project.
+ */
+export async function loadRepositoryGraph(project: Project): Promise<void> {
+  if (!project.githubRepositoryId && !project.gitlabProjectId) {
+    return;
+  }
+  await project.$fetchGraph(REPOSITORY_GRAPH);
+}
+
 /**
  * Same as {@link getRepositoryUrl}, for callers holding a project whose
  * repository relations aren't loaded.
  *
- * Fetches into a clone rather than into the caller's instance, and without
- * consulting what is already on it. A project that has been through a permission
- * check carries a *partially* loaded graph — `$checkIsPublic` fetches
- * `githubRepository` alone, for its `private` flag — so "the relation is already
- * there" says nothing about `githubAccount` being there with it, and skipping the
- * fetch on that basis throws. Loading unconditionally into a copy keeps this
- * independent of whatever the caller happened to load, and leaves that graph
- * alone for whoever else reads it.
+ * Fetches into a clone, so this neither depends on nor disturbs the graph the
+ * caller happened to load — a half-loaded one is the norm rather than the
+ * exception (see {@link hasRepositoryGraph}). The only state it trusts is a
+ * *complete* graph, which is what lets {@link loadRepositoryGraph} spare a batch
+ * of renders a query each.
  */
 export async function fetchRepositoryUrl(
   project: Project,
@@ -60,8 +87,9 @@ export async function fetchRepositoryUrl(
   if (!project.githubRepositoryId && !project.gitlabProjectId) {
     return null;
   }
-  const richProject = await project
-    .$clone()
-    .$fetchGraph("[githubRepository.githubAccount, gitlabProject]");
+  if (hasRepositoryGraph(project)) {
+    return getRepositoryUrl(project);
+  }
+  const richProject = await project.$clone().$fetchGraph(REPOSITORY_GRAPH);
   return getRepositoryUrl(richProject);
 }

--- a/apps/backend/src/build/repository-url.ts
+++ b/apps/backend/src/build/repository-url.ts
@@ -40,3 +40,22 @@ export function getRepositoryUrl(project: Project): string | null {
 
   return null;
 }
+
+/**
+ * Same as {@link getRepositoryUrl}, for callers holding a project whose
+ * repository relations aren't loaded. Loads them into the given instance, so
+ * asking a second time (e.g. once per comment of a review) costs no query.
+ */
+export async function fetchRepositoryUrl(
+  project: Project,
+): Promise<string | null> {
+  if (!project.githubRepositoryId && !project.gitlabProjectId) {
+    return null;
+  }
+  if (!project.githubRepository && !project.gitlabProject) {
+    await project.$fetchGraph(
+      "[githubRepository.githubAccount, gitlabProject]",
+    );
+  }
+  return getRepositoryUrl(project);
+}

--- a/apps/backend/src/build/repository-url.ts
+++ b/apps/backend/src/build/repository-url.ts
@@ -43,8 +43,16 @@ export function getRepositoryUrl(project: Project): string | null {
 
 /**
  * Same as {@link getRepositoryUrl}, for callers holding a project whose
- * repository relations aren't loaded. Loads them into the given instance, so
- * asking a second time (e.g. once per comment of a review) costs no query.
+ * repository relations aren't loaded.
+ *
+ * Fetches into a clone rather than into the caller's instance, and without
+ * consulting what is already on it. A project that has been through a permission
+ * check carries a *partially* loaded graph — `$checkIsPublic` fetches
+ * `githubRepository` alone, for its `private` flag — so "the relation is already
+ * there" says nothing about `githubAccount` being there with it, and skipping the
+ * fetch on that basis throws. Loading unconditionally into a copy keeps this
+ * independent of whatever the caller happened to load, and leaves that graph
+ * alone for whoever else reads it.
  */
 export async function fetchRepositoryUrl(
   project: Project,
@@ -52,10 +60,8 @@ export async function fetchRepositoryUrl(
   if (!project.githubRepositoryId && !project.gitlabProjectId) {
     return null;
   }
-  if (!project.githubRepository && !project.gitlabProject) {
-    await project.$fetchGraph(
-      "[githubRepository.githubAccount, gitlabProject]",
-    );
-  }
-  return getRepositoryUrl(project);
+  const richProject = await project
+    .$clone()
+    .$fetchGraph("[githubRepository.githubAccount, gitlabProject]");
+  return getRepositoryUrl(richProject);
 }

--- a/apps/backend/src/comment/addCommentReaction.ts
+++ b/apps/backend/src/comment/addCommentReaction.ts
@@ -109,7 +109,7 @@ async function notifyCommentThreadSubscribers(input: {
       commentAuthorId: comment.userId,
       reactorName,
       emoji,
-      bodyHtml: await renderCommentHtmlWithMentions(comment),
+      bodyHtml: await renderCommentHtmlWithMentions(comment, { project }),
     },
     recipients,
   });

--- a/apps/backend/src/comment/autolink.ts
+++ b/apps/backend/src/comment/autolink.ts
@@ -1,0 +1,88 @@
+import { findCommitShas } from "@argos/util/git";
+import type { JSONContent } from "@tiptap/core";
+
+/**
+ * Marks that mean a piece of text must be left exactly as written: `code` is an
+ * explicit "render this literally", and `link` already points somewhere. Kept in
+ * sync with the frontend's decoration-based autolink
+ * (`apps/frontend/src/ui/Editor/commitAutolink.ts`) so a comment reads the same
+ * in an email as it does in the app.
+ */
+const OPAQUE_MARKS = new Set(["code", "link"]);
+
+function hasOpaqueMark(node: JSONContent): boolean {
+  return Boolean(node.marks?.some((mark) => OPAQUE_MARKS.has(mark.type)));
+}
+
+/**
+ * Split a text node around the commit shas it contains, linking each one. The
+ * pieces keep the node's original marks, so a sha inside bold text stays bold.
+ */
+function linkTextNode(node: JSONContent, repositoryUrl: string): JSONContent[] {
+  const { text } = node;
+  if (!text || hasOpaqueMark(node)) {
+    return [node];
+  }
+  const matches = findCommitShas(text);
+  if (matches.length === 0) {
+    return [node];
+  }
+  const marks = node.marks ?? [];
+  const nodes: JSONContent[] = [];
+  let cursor = 0;
+  for (const { sha, index } of matches) {
+    if (index > cursor) {
+      nodes.push({ ...node, text: text.slice(cursor, index) });
+    }
+    nodes.push({
+      ...node,
+      text: sha,
+      marks: [
+        ...marks,
+        { type: "link", attrs: { href: `${repositoryUrl}/commit/${sha}` } },
+      ],
+    });
+    cursor = index + sha.length;
+  }
+  if (cursor < text.length) {
+    nodes.push({ ...node, text: text.slice(cursor) });
+  }
+  return nodes;
+}
+
+function transformNode(
+  node: JSONContent,
+  repositoryUrl: string,
+): JSONContent[] {
+  if (node.type === "text") {
+    return linkTextNode(node, repositoryUrl);
+  }
+  // A code block is verbatim by definition — don't look inside it.
+  if (node.type === "codeBlock" || !Array.isArray(node.content)) {
+    return [node];
+  }
+  return [
+    {
+      ...node,
+      content: node.content.flatMap((child) =>
+        transformNode(child, repositoryUrl),
+      ),
+    },
+  ];
+}
+
+/**
+ * Return a copy of a comment document with every commit sha turned into a link
+ * to its commit on the repository host.
+ *
+ * The stored document is never touched: the link belongs to the repository the
+ * project points at *now*, so it is added at render time — the same reason the
+ * app renders these as decorations rather than persisting marks.
+ */
+export function autolinkCommitShas(
+  content: JSONContent,
+  repositoryUrl: string,
+): JSONContent {
+  const [transformed] = transformNode(content, repositoryUrl);
+  return transformed ?? content;
+}

--- a/apps/backend/src/comment/commentNotifications.ts
+++ b/apps/backend/src/comment/commentNotifications.ts
@@ -60,7 +60,7 @@ export async function getCommentNotificationData(input: {
   const [author, commentUrl, bodyHtml] = await Promise.all([
     User.query().findById(userId).withGraphFetched("account"),
     getCommentUrl({ target, comment }),
-    renderCommentHtmlWithMentions(comment),
+    renderCommentHtmlWithMentions(comment, { project }),
   ]);
   return {
     accountSlug: project.account.slug,

--- a/apps/backend/src/comment/commentNotifications.ts
+++ b/apps/backend/src/comment/commentNotifications.ts
@@ -1,5 +1,6 @@
 import { invariant } from "@argos/util/invariant";
 
+import { loadRepositoryGraph } from "@/build/repository-url";
 import { Build, BuildReview, Comment, Project, User } from "@/database/models";
 import { subscribeUserToCommentThread } from "@/database/services/comment-notification-subscription";
 import { sendNotification } from "@/notification";
@@ -136,6 +137,10 @@ export async function notifyReviewCommentsWentLive(input: {
   if (comments.length === 0) {
     return;
   }
+  // Every comment below renders against this one project, and rendering resolves
+  // its repository to link the commit shas — load that graph once here rather
+  // than once per comment.
+  await loadRepositoryGraph(project);
   const target: CommentTarget = { type: "build", build };
   await Promise.all(
     comments.map(async (comment) => {

--- a/apps/backend/src/comment/html.test.ts
+++ b/apps/backend/src/comment/html.test.ts
@@ -153,3 +153,108 @@ describe("renderCommentHtml", () => {
     );
   });
 });
+
+describe("renderCommentHtml commit autolinking", () => {
+  const REPOSITORY_URL = "https://github.com/argos-ci/argos";
+
+  /** Render a one-paragraph document made of the given inline nodes. */
+  function render(
+    content: JSONContent[],
+    options?: { repositoryUrl?: string | null },
+  ): string {
+    return renderCommentHtml(
+      { type: "doc", content: [{ type: "paragraph", content }] },
+      { mentionLabels: new Map(), ...options },
+    );
+  }
+
+  it("links a commit sha to the repository", () => {
+    expect(
+      render([{ type: "text", text: "Pushed to the PR in d15cba5." }], {
+        repositoryUrl: REPOSITORY_URL,
+      }),
+    ).toBe(
+      "<p>Pushed to the PR in " +
+        '<a target="_blank" rel="noopener noreferrer nofollow" ' +
+        `href="${REPOSITORY_URL}/commit/d15cba5">d15cba5</a>.</p>`,
+    );
+  });
+
+  it("links every sha in the text", () => {
+    const html = render(
+      [{ type: "text", text: "Squashed abc1234 and 7fed210" }],
+      {
+        repositoryUrl: REPOSITORY_URL,
+      },
+    );
+    expect(html).toContain(
+      `href="${REPOSITORY_URL}/commit/abc1234">abc1234</a>`,
+    );
+    expect(html).toContain(
+      `href="${REPOSITORY_URL}/commit/7fed210">7fed210</a>`,
+    );
+  });
+
+  it("leaves shas as plain text without a repository", () => {
+    const text = "Pushed to the PR in d15cba5.";
+    expect(render([{ type: "text", text }])).toBe(`<p>${text}</p>`);
+    expect(render([{ type: "text", text }], { repositoryUrl: null })).toBe(
+      `<p>${text}</p>`,
+    );
+  });
+
+  it("keeps the marks of the text it splits", () => {
+    expect(
+      render(
+        [{ type: "text", text: "see d15cba5", marks: [{ type: "bold" }] }],
+        {
+          repositoryUrl: REPOSITORY_URL,
+        },
+      ),
+    ).toBe(
+      "<p><strong>see </strong>" +
+        '<a target="_blank" rel="noopener noreferrer nofollow" ' +
+        `href="${REPOSITORY_URL}/commit/d15cba5"><strong>d15cba5</strong></a></p>`,
+    );
+  });
+
+  it("leaves a sha written as code alone", () => {
+    expect(
+      render([{ type: "text", text: "d15cba5", marks: [{ type: "code" }] }], {
+        repositoryUrl: REPOSITORY_URL,
+      }),
+    ).toBe("<p><code>d15cba5</code></p>");
+  });
+
+  it("leaves a code block alone", () => {
+    expect(
+      renderCommentHtml(
+        {
+          type: "doc",
+          content: [
+            {
+              type: "codeBlock",
+              content: [{ type: "text", text: "git show d15cba5" }],
+            },
+          ],
+        },
+        { mentionLabels: new Map(), repositoryUrl: REPOSITORY_URL },
+      ),
+    ).toBe("<pre><code>git show d15cba5</code></pre>");
+  });
+
+  it("leaves an existing link alone", () => {
+    expect(
+      render(
+        [
+          {
+            type: "text",
+            text: "d15cba5",
+            marks: [{ type: "link", attrs: { href: "https://argos-ci.com" } }],
+          },
+        ],
+        { repositoryUrl: REPOSITORY_URL },
+      ),
+    ).toContain('href="https://argos-ci.com"');
+  });
+});

--- a/apps/backend/src/comment/html.ts
+++ b/apps/backend/src/comment/html.ts
@@ -1,18 +1,28 @@
 import type { JSONContent } from "@tiptap/core";
 import { generateHTML } from "@tiptap/html/server";
 
+import { autolinkCommitShas } from "./autolink";
 import { getExtensions } from "./schema";
 
 /**
  * Render a TipTap rich-text comment as an HTML string. Mentions store only an
  * id, so `mentionLabels` (keyed by the mentioned account id) provides the label
  * to render after `@`; unresolved mentions fall back to "@unknown".
+ *
+ * `repositoryUrl` is the web URL of the repository the comment is about, which
+ * turns the commit shas in it into links — the same thing the app does when it
+ * renders the comment. Without it they stay plain text.
  */
 export function renderCommentHtml(
   content: JSONContent,
   config: {
     mentionLabels: Map<string, string>;
+    repositoryUrl?: string | null;
   },
 ): string {
-  return generateHTML(content, getExtensions(config));
+  const { repositoryUrl } = config;
+  const doc = repositoryUrl
+    ? autolinkCommitShas(content, repositoryUrl)
+    : content;
+  return generateHTML(doc, getExtensions(config));
 }

--- a/apps/backend/src/comment/mentions.e2e.test.ts
+++ b/apps/backend/src/comment/mentions.e2e.test.ts
@@ -1,6 +1,7 @@
 import { invariant } from "@argos/util/invariant";
 import { beforeEach, describe, expect, it } from "vitest";
 
+import { loadRepositoryGraph } from "@/build/repository-url";
 import { Account, Comment, CommentMention } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
 
@@ -220,6 +221,21 @@ describe("renderCommentHtmlWithMentions", () => {
     await project.$getPermissions(null);
     expect(project.githubRepository).toBeTruthy();
     expect(project.githubRepository?.githubAccount).toBeUndefined();
+
+    await expect(
+      renderCommentHtmlWithMentions(comment, { project }),
+    ).resolves.toContain(
+      'href="https://github.com/argos-ci/argos/commit/d15cba5"',
+    );
+  });
+
+  it("links the sha from a graph loaded once for a batch", async () => {
+    const project = await createProjectOnARepository();
+    const comment = await createCommentAboutACommit();
+    // What `notifyReviewCommentsWentLive` does before rendering a review's
+    // comments: load the graph once so the renders don't query for it each.
+    await loadRepositoryGraph(project);
+    expect(project.githubRepository?.githubAccount).toBeTruthy();
 
     await expect(
       renderCommentHtmlWithMentions(comment, { project }),

--- a/apps/backend/src/comment/mentions.e2e.test.ts
+++ b/apps/backend/src/comment/mentions.e2e.test.ts
@@ -4,7 +4,11 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { Account, Comment, CommentMention } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
 
-import { getCommentMentionLabels, syncCommentMentions } from "./mentions";
+import {
+  getCommentMentionLabels,
+  renderCommentHtmlWithMentions,
+  syncCommentMentions,
+} from "./mentions";
 
 function mentionDoc(accountIds: string[]) {
   return {
@@ -154,5 +158,61 @@ describe("getCommentMentionLabels", () => {
     const comment = await factory.Comment.create({ buildId: build.id });
     const labels = await getCommentMentionLabels(comment.id);
     expect(labels.size).toBe(0);
+  });
+});
+
+describe("renderCommentHtmlWithMentions", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  /** A one-paragraph comment mentioning a commit sha. */
+  async function createCommentAboutACommit() {
+    const build = await factory.Build.create();
+    return factory.Comment.create({
+      buildId: build.id,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Pushed to the PR in d15cba5." }],
+          },
+        ],
+      },
+    });
+  }
+
+  it("links a commit sha to the project's repository", async () => {
+    const githubAccount = await factory.GithubAccount.create({
+      login: "argos-ci",
+    });
+    const githubRepository = await factory.GithubRepository.create({
+      name: "argos",
+      githubAccountId: githubAccount.id,
+    });
+    // The project comes with none of its repository relations loaded, which is
+    // the state every notification job hands over.
+    const project = await factory.Project.create({
+      githubRepositoryId: githubRepository.id,
+    });
+    const comment = await createCommentAboutACommit();
+
+    await expect(
+      renderCommentHtmlWithMentions(comment, { project }),
+    ).resolves.toContain(
+      'href="https://github.com/argos-ci/argos/commit/d15cba5"',
+    );
+  });
+
+  it("leaves the sha alone for a project with no repository", async () => {
+    const project = await factory.Project.create({
+      githubRepositoryId: null,
+    });
+    const comment = await createCommentAboutACommit();
+
+    await expect(
+      renderCommentHtmlWithMentions(comment, { project }),
+    ).resolves.toBe("<p>Pushed to the PR in d15cba5.</p>");
   });
 });

--- a/apps/backend/src/comment/mentions.e2e.test.ts
+++ b/apps/backend/src/comment/mentions.e2e.test.ts
@@ -183,7 +183,8 @@ describe("renderCommentHtmlWithMentions", () => {
     });
   }
 
-  it("links a commit sha to the project's repository", async () => {
+  /** A project on `argos-ci/argos`, so the expected commit URL is readable. */
+  async function createProjectOnARepository() {
     const githubAccount = await factory.GithubAccount.create({
       login: "argos-ci",
     });
@@ -191,12 +192,34 @@ describe("renderCommentHtmlWithMentions", () => {
       name: "argos",
       githubAccountId: githubAccount.id,
     });
-    // The project comes with none of its repository relations loaded, which is
-    // the state every notification job hands over.
-    const project = await factory.Project.create({
+    return factory.Project.create({
       githubRepositoryId: githubRepository.id,
     });
+  }
+
+  it("links a commit sha to the project's repository", async () => {
+    // The project comes with none of its repository relations loaded, which is
+    // the state every notification job hands over.
+    const project = await createProjectOnARepository();
     const comment = await createCommentAboutACommit();
+
+    await expect(
+      renderCommentHtmlWithMentions(comment, { project }),
+    ).resolves.toContain(
+      'href="https://github.com/argos-ci/argos/commit/d15cba5"',
+    );
+  });
+
+  it("links the sha on a project that has been through a permission check", async () => {
+    const project = await createProjectOnARepository();
+    const comment = await createCommentAboutACommit();
+    // Every mutation authorizes before it notifies, and `$checkIsPublic` caches
+    // `githubRepository` on the project *without* its account to read the
+    // `private` flag. Treating that half-loaded graph as good enough is how the
+    // render used to throw "githubAccount relation not found".
+    await project.$getPermissions(null);
+    expect(project.githubRepository).toBeTruthy();
+    expect(project.githubRepository?.githubAccount).toBeUndefined();
 
     await expect(
       renderCommentHtmlWithMentions(comment, { project }),

--- a/apps/backend/src/comment/mentions.ts
+++ b/apps/backend/src/comment/mentions.ts
@@ -1,5 +1,6 @@
 import type { JSONContent } from "@tiptap/core";
 
+import { fetchRepositoryUrl } from "@/build/repository-url";
 import { Account, Comment, CommentMention, Project } from "@/database/models";
 import { getProjectMemberIds } from "@/project/members";
 
@@ -111,15 +112,22 @@ export async function getCommentMentionLabels(
 
 /**
  * Render a stored comment to HTML with its persisted mentions resolved to their
- * current display labels. Combines the mention-label lookup and the HTML
- * rendering that every comment notification needs, so callers don't have to
- * repeat the two-step dance (or forget to pass the labels).
+ * current display labels, and its commit shas linked to the project's
+ * repository. Combines the lookups and the HTML rendering that every comment
+ * notification needs, so callers don't have to repeat the dance (or forget one).
  */
 export async function renderCommentHtmlWithMentions(
   comment: Comment,
+  options: { project: Project },
 ): Promise<string> {
-  const mentionLabels = await getCommentMentionLabels(comment.id);
-  return renderCommentHtml(comment.content as JSONContent, { mentionLabels });
+  const [mentionLabels, repositoryUrl] = await Promise.all([
+    getCommentMentionLabels(comment.id),
+    fetchRepositoryUrl(options.project),
+  ]);
+  return renderCommentHtml(comment.content as JSONContent, {
+    mentionLabels,
+    repositoryUrl,
+  });
 }
 
 /**

--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -1954,7 +1954,12 @@ export async function createMediaScenario(input: {
         mediaId: after.id,
         mediaVersionId: afterV2.id,
         userId: commentAuthorId,
-        content: commentDoc("Otherwise this looks good to ship."),
+        // Mentions a commit sha, which the page autolinks to the repository the
+        // project is connected to — only seeded with `withPullRequest`, so a
+        // scenario without one is also the "nothing to link to" case.
+        content: commentDoc(
+          "Otherwise this looks good to ship. Pushed to the PR in d15cba5.",
+        ),
         createdAt: commentTs,
         updatedAt: commentTs,
       },

--- a/apps/frontend/src/containers/Comment/CommentCard.tsx
+++ b/apps/frontend/src/containers/Comment/CommentCard.tsx
@@ -14,6 +14,7 @@ import { useClipboard } from "use-clipboard-copy";
 
 import { AccountAvatar } from "@/containers/AccountAvatar";
 import { useCommentRoleScope } from "@/containers/Comment/useCommentRoleScope";
+import { useProjectRepositoryUrl } from "@/containers/Project/RepositoryContext";
 import { DocumentType, graphql } from "@/gql";
 import { CommentPermission } from "@/gql/graphql";
 import { Button } from "@/ui/Button";
@@ -520,6 +521,7 @@ function CommentMessage(props: {
   // Resolve the comment's own mentions (which persist only an id) to render
   // their name/avatar/role — these may include users no longer mentionable.
   const mentionedUsers = comment.mentionedUsers.map(getMentionUser);
+  const repositoryUrl = useProjectRepositoryUrl();
   const [isEditing, setIsEditing] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const client = useApolloClient();
@@ -683,6 +685,7 @@ function CommentMessage(props: {
               content={comment.content}
               className={contentClassName}
               mentionedUsers={mentionedUsers}
+              repositoryUrl={repositoryUrl}
             />
           )}
         </div>

--- a/apps/frontend/src/containers/Comment/CommentMarker.tsx
+++ b/apps/frontend/src/containers/Comment/CommentMarker.tsx
@@ -136,6 +136,10 @@ export function CommentMarker(props: {
               transition={TRANSITION}
               className="w-72 overflow-hidden"
             >
+              {/* No `repositoryUrl`: the preview is a clamped teaser whose only
+                  click opens the thread, and a commit link inside it would take
+                  that click to the code host instead. Shas are linked in the
+                  card the pin opens. */}
               <div className="text-default line-clamp-4 px-2 pb-2 text-sm">
                 <ReadOnlyEditor
                   content={comment.content}

--- a/apps/frontend/src/containers/Project/RepositoryContext.tsx
+++ b/apps/frontend/src/containers/Project/RepositoryContext.tsx
@@ -1,0 +1,20 @@
+import { createContext, use } from "react";
+
+/**
+ * Web URL of the Git repository backing the current project (e.g.
+ * `https://github.com/argos-ci/argos`), or null when the project has none — or
+ * when the viewer isn't allowed to know of it, which is the case on a public
+ * share link opened by someone with no access to the project.
+ *
+ * Provided once per project route and consumed wherever content authored about
+ * that repository is rendered, so a comment's commit shas link to the commits
+ * they name.
+ */
+const ProjectRepositoryUrlContext = createContext<string | null>(null);
+
+export const ProjectRepositoryUrlProvider =
+  ProjectRepositoryUrlContext.Provider;
+
+export function useProjectRepositoryUrl(): string | null {
+  return use(ProjectRepositoryUrlContext);
+}

--- a/apps/frontend/src/containers/Project/RepositoryContext.tsx
+++ b/apps/frontend/src/containers/Project/RepositoryContext.tsx
@@ -1,20 +1,49 @@
-import { createContext, use } from "react";
+import { createContext, useMemo, type ReactNode } from "react";
+
+import { useNonNullable } from "@/util/useNonNullable";
 
 /**
- * Web URL of the Git repository backing the current project (e.g.
- * `https://github.com/argos-ci/argos`), or null when the project has none — or
- * when the viewer isn't allowed to know of it, which is the case on a public
- * share link opened by someone with no access to the project.
+ * The Git repository backing the current project. `url` is its web URL (e.g.
+ * `https://github.com/argos-ci/argos`), and is null when the project has no
+ * repository — or when the viewer isn't allowed to know of it, which is the case
+ * on a public share link opened by someone with no access to the project.
  *
- * Provided once per project route and consumed wherever content authored about
+ * Wrapped in an object rather than exposed as a bare `string | null` so a
+ * missing provider is distinguishable from a project with no repository: both
+ * would otherwise read as null, and a comment surface mounted outside a project
+ * route would silently stop linking its commit shas instead of saying so.
+ */
+interface ProjectRepository {
+  url: string | null;
+}
+
+const ProjectRepositoryContext = createContext<ProjectRepository | null>(null);
+
+/**
+ * Provided once per project route, and consumed wherever content authored about
  * that repository is rendered, so a comment's commit shas link to the commits
  * they name.
  */
-const ProjectRepositoryUrlContext = createContext<string | null>(null);
+export function ProjectRepositoryProvider(props: {
+  url: string | null;
+  children: ReactNode;
+}) {
+  const { url, children } = props;
+  const value = useMemo(() => ({ url }), [url]);
+  return (
+    <ProjectRepositoryContext value={value}>
+      {children}
+    </ProjectRepositoryContext>
+  );
+}
 
-export const ProjectRepositoryUrlProvider =
-  ProjectRepositoryUrlContext.Provider;
-
+/**
+ * Web URL of the current project's repository, or null when it has none. Use
+ * within a project route, where {@link ProjectRepositoryProvider} is always set.
+ */
 export function useProjectRepositoryUrl(): string | null {
-  return use(ProjectRepositoryUrlContext);
+  return useNonNullable(
+    ProjectRepositoryContext,
+    "Project repository must be provided",
+  ).url;
 }

--- a/apps/frontend/src/pages/Build/BuildWorkspace.tsx
+++ b/apps/frontend/src/pages/Build/BuildWorkspace.tsx
@@ -6,6 +6,7 @@ import { BuildDiffHighlighterProvider } from "@/containers/Build/BuildDiffHighli
 import { snapshotTypeAtom } from "@/containers/Build/SnapshotType";
 import { ZoomerSyncProvider } from "@/containers/Build/Zoomer";
 import { BuildStatusDescription } from "@/containers/BuildStatusDescription";
+import { ProjectRepositoryUrlProvider } from "@/containers/Project/RepositoryContext";
 import { DocumentType, graphql } from "@/gql";
 import { BuildStatus, BuildType } from "@/gql/graphql";
 import { Alert, AlertText, AlertTitle } from "@/ui/Alert";
@@ -110,65 +111,69 @@ export function BuildWorkspace(props: {
   const repoUrl = project.repository?.url ?? null;
 
   return (
-    <div className="flex min-h-0 flex-1">
-      <BuildLeftSidebar build={build} repoUrl={repoUrl} params={params} />
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-        <BuildDetailProviders>
-          <Toolbar build={build} />
-          <div className="bg-subtle flex min-h-0 flex-1">
-            {(() => {
-              switch (build.status) {
-                case BuildStatus.Aborted:
-                case BuildStatus.Error:
-                case BuildStatus.Expired:
-                  return (
-                    <div className="min-h-0 flex-1 p-6 text-xl">
-                      <Alert className="mx-auto max-w-xl rounded-sm border p-4">
-                        <AlertTitle>
-                          {
+    // Every comment surface of the build page hangs below here (the activity
+    // sidebar, the screenshot and diff pins), so one provider covers them all.
+    <ProjectRepositoryUrlProvider value={repoUrl}>
+      <div className="flex min-h-0 flex-1">
+        <BuildLeftSidebar build={build} repoUrl={repoUrl} params={params} />
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <BuildDetailProviders>
+            <Toolbar build={build} />
+            <div className="bg-subtle flex min-h-0 flex-1">
+              {(() => {
+                switch (build.status) {
+                  case BuildStatus.Aborted:
+                  case BuildStatus.Error:
+                  case BuildStatus.Expired:
+                    return (
+                      <div className="min-h-0 flex-1 p-6 text-xl">
+                        <Alert className="mx-auto max-w-xl rounded-sm border p-4">
+                          <AlertTitle>
                             {
-                              [BuildStatus.Error]: "Build failed",
-                              [BuildStatus.Expired]: "Build expired",
-                              [BuildStatus.Aborted]: "Build aborted",
-                            }[build.status]
-                          }
-                        </AlertTitle>
-                        <AlertText>
-                          <BuildStatusDescription build={build} />
-                        </AlertText>
-                      </Alert>
-                    </div>
-                  );
-                case BuildStatus.Pending:
-                case BuildStatus.Progress:
-                  return <BuildProgress parallel={build.parallel} />;
-                default:
-                  if (
-                    !params.diffId &&
-                    build.type !== BuildType.Skipped &&
-                    ((build.stats?.total ?? 0) > 0 ||
-                      build.type === BuildType.Orphan)
-                  ) {
-                    return <BuildOverview build={build} repoUrl={repoUrl} />;
-                  }
+                              {
+                                [BuildStatus.Error]: "Build failed",
+                                [BuildStatus.Expired]: "Build expired",
+                                [BuildStatus.Aborted]: "Build aborted",
+                              }[build.status]
+                            }
+                          </AlertTitle>
+                          <AlertText>
+                            <BuildStatusDescription build={build} />
+                          </AlertText>
+                        </Alert>
+                      </div>
+                    );
+                  case BuildStatus.Pending:
+                  case BuildStatus.Progress:
+                    return <BuildProgress parallel={build.parallel} />;
+                  default:
+                    if (
+                      !params.diffId &&
+                      build.type !== BuildType.Skipped &&
+                      ((build.stats?.total ?? 0) > 0 ||
+                        build.type === BuildType.Orphan)
+                    ) {
+                      return <BuildOverview build={build} repoUrl={repoUrl} />;
+                    }
 
-                  return (
-                    build && <BuildDetail build={build} repoUrl={repoUrl} />
-                  );
-              }
-            })()}
-            <RightSidebar
-              build={build}
-              repoUrl={repoUrl}
-              baseBranch={build.baseBranch ?? null}
-              compareBranch={build.branch}
-              deploymentUrl={build.deployment?.url ?? null}
-              prMerged={build.pullRequest?.merged ?? false}
-            />
-          </div>
-        </BuildDetailProviders>
+                    return (
+                      build && <BuildDetail build={build} repoUrl={repoUrl} />
+                    );
+                }
+              })()}
+              <RightSidebar
+                build={build}
+                repoUrl={repoUrl}
+                baseBranch={build.baseBranch ?? null}
+                compareBranch={build.branch}
+                deploymentUrl={build.deployment?.url ?? null}
+                prMerged={build.pullRequest?.merged ?? false}
+              />
+            </div>
+          </BuildDetailProviders>
+        </div>
       </div>
-    </div>
+    </ProjectRepositoryUrlProvider>
   );
 }
 

--- a/apps/frontend/src/pages/Build/BuildWorkspace.tsx
+++ b/apps/frontend/src/pages/Build/BuildWorkspace.tsx
@@ -6,7 +6,7 @@ import { BuildDiffHighlighterProvider } from "@/containers/Build/BuildDiffHighli
 import { snapshotTypeAtom } from "@/containers/Build/SnapshotType";
 import { ZoomerSyncProvider } from "@/containers/Build/Zoomer";
 import { BuildStatusDescription } from "@/containers/BuildStatusDescription";
-import { ProjectRepositoryUrlProvider } from "@/containers/Project/RepositoryContext";
+import { ProjectRepositoryProvider } from "@/containers/Project/RepositoryContext";
 import { DocumentType, graphql } from "@/gql";
 import { BuildStatus, BuildType } from "@/gql/graphql";
 import { Alert, AlertText, AlertTitle } from "@/ui/Alert";
@@ -113,7 +113,7 @@ export function BuildWorkspace(props: {
   return (
     // Every comment surface of the build page hangs below here (the activity
     // sidebar, the screenshot and diff pins), so one provider covers them all.
-    <ProjectRepositoryUrlProvider value={repoUrl}>
+    <ProjectRepositoryProvider url={repoUrl}>
       <div className="flex min-h-0 flex-1">
         <BuildLeftSidebar build={build} repoUrl={repoUrl} params={params} />
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
@@ -173,7 +173,7 @@ export function BuildWorkspace(props: {
           </BuildDetailProviders>
         </div>
       </div>
-    </ProjectRepositoryUrlProvider>
+    </ProjectRepositoryProvider>
   );
 }
 

--- a/apps/frontend/src/pages/MediaShare.tsx
+++ b/apps/frontend/src/pages/MediaShare.tsx
@@ -50,7 +50,7 @@ import {
 } from "@/containers/Media/MediaViewer";
 import { NavUserControl } from "@/containers/NavUserControl";
 import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
-import { ProjectRepositoryUrlProvider } from "@/containers/Project/RepositoryContext";
+import { ProjectRepositoryProvider } from "@/containers/Project/RepositoryContext";
 import { PullRequestButton } from "@/containers/PullRequestButton";
 import { DocumentType, graphql } from "@/gql";
 import { MediaDiffStatus, MediaState, MediaVisibility } from "@/gql/graphql";
@@ -429,9 +429,7 @@ function SharePage(props: { media: Media }) {
   // repository's name is not part of what a share link hands out.
   return (
     <ProjectPermissionsContext value={media.project?.permissions ?? []}>
-      <ProjectRepositoryUrlProvider
-        value={media.project?.repository?.url ?? null}
-      >
+      <ProjectRepositoryProvider url={media.project?.repository?.url ?? null}>
         <MentionableUsersProvider value={mentionUsers}>
           <BuildHotkeysDialogStateProvider>
             <BuildHotkeysDialog env="media" />
@@ -512,7 +510,7 @@ function SharePage(props: { media: Media }) {
             </div>
           </BuildHotkeysDialogStateProvider>
         </MentionableUsersProvider>
-      </ProjectRepositoryUrlProvider>
+      </ProjectRepositoryProvider>
     </ProjectPermissionsContext>
   );
 }

--- a/apps/frontend/src/pages/MediaShare.tsx
+++ b/apps/frontend/src/pages/MediaShare.tsx
@@ -50,6 +50,7 @@ import {
 } from "@/containers/Media/MediaViewer";
 import { NavUserControl } from "@/containers/NavUserControl";
 import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
+import { ProjectRepositoryUrlProvider } from "@/containers/Project/RepositoryContext";
 import { PullRequestButton } from "@/containers/PullRequestButton";
 import { DocumentType, graphql } from "@/gql";
 import { MediaDiffStatus, MediaState, MediaVisibility } from "@/gql/graphql";
@@ -166,6 +167,10 @@ const MediaShareQuery = graphql(`
         id
         slug
         permissions
+        repository {
+          id
+          url
+        }
       }
       ...MediaComments_Media
       ...MediaCommentLayer_Media
@@ -419,88 +424,95 @@ function SharePage(props: { media: Media }) {
   // The comment components ask the project what the viewer may do — reacting is a
   // `review`, same as commenting. An anonymous visitor on a public link is not
   // shown the project at all, so they get no permissions, which is exactly right:
-  // they can read the discussion and change nothing.
+  // they can read the discussion and change nothing. Same reason the commit shas
+  // in those comments only link for someone who can see the project: the
+  // repository's name is not part of what a share link hands out.
   return (
     <ProjectPermissionsContext value={media.project?.permissions ?? []}>
-      <MentionableUsersProvider value={mentionUsers}>
-        <BuildHotkeysDialogStateProvider>
-          <BuildHotkeysDialog env="media" />
-          <div className="flex min-h-dvh flex-col lg:h-dvh">
-            <PageHeader media={media} />
-            <div className="bg-subtle flex flex-1 flex-col gap-4 p-4 lg:min-h-0 lg:flex-row">
-              {showList ? (
-                // Below `lg` the page stacks, and the list goes last: every
-                // pixel above the media is a pixel of it the visitor cannot
-                // see. Beside it, the list is where a build puts its own.
-                <aside className="flex w-full flex-col max-lg:order-last lg:min-h-0 lg:w-56 lg:shrink-0">
-                  <MediaPullRequestList
-                    entries={entries}
-                    activeEntryKey={entries[activeIndex]?.key ?? null}
-                    onSelect={goToEntry}
+      <ProjectRepositoryUrlProvider
+        value={media.project?.repository?.url ?? null}
+      >
+        <MentionableUsersProvider value={mentionUsers}>
+          <BuildHotkeysDialogStateProvider>
+            <BuildHotkeysDialog env="media" />
+            <div className="flex min-h-dvh flex-col lg:h-dvh">
+              <PageHeader media={media} />
+              <div className="bg-subtle flex flex-1 flex-col gap-4 p-4 lg:min-h-0 lg:flex-row">
+                {showList ? (
+                  // Below `lg` the page stacks, and the list goes last: every
+                  // pixel above the media is a pixel of it the visitor cannot
+                  // see. Beside it, the list is where a build puts its own.
+                  <aside className="flex w-full flex-col max-lg:order-last lg:min-h-0 lg:w-56 lg:shrink-0">
+                    <MediaPullRequestList
+                      entries={entries}
+                      activeEntryKey={entries[activeIndex]?.key ?? null}
+                      onSelect={goToEntry}
+                    />
+                  </aside>
+                ) : null}
+                <main className="flex min-w-0 flex-col justify-center lg:min-h-0 lg:flex-1">
+                  <MediaViewer
+                    nav={nav}
+                    media={{ ...media, version }}
+                    counterpart={
+                      media.counterpart && counterpartVersion
+                        ? {
+                            ...media.counterpart,
+                            // The half the selected version was compared against,
+                            // not simply the counterpart's newest: the two media
+                            // have independent histories, and the pair on screen
+                            // has to be the pair the mask describes.
+                            version: counterpartVersion,
+                          }
+                        : null
+                    }
+                    diff={getViewerDiff(version)}
+                    comments={{
+                      media,
+                      viewedVersionId: version.id,
+                      placing,
+                      onPlacingChange: setPlacing,
+                      requestedThreadId,
+                      onRequestedThreadConsumed: () =>
+                        setRequestedThreadId(null),
+                    }}
                   />
-                </aside>
-              ) : null}
-              <main className="flex min-w-0 flex-col justify-center lg:min-h-0 lg:flex-1">
-                <MediaViewer
-                  nav={nav}
-                  media={{ ...media, version }}
-                  counterpart={
-                    media.counterpart && counterpartVersion
-                      ? {
-                          ...media.counterpart,
-                          // The half the selected version was compared against,
-                          // not simply the counterpart's newest: the two media
-                          // have independent histories, and the pair on screen
-                          // has to be the pair the mask describes.
-                          version: counterpartVersion,
-                        }
-                      : null
-                  }
-                  diff={getViewerDiff(version)}
-                  comments={{
-                    media,
-                    viewedVersionId: version.id,
-                    placing,
-                    onPlacingChange: setPlacing,
-                    requestedThreadId,
-                    onRequestedThreadConsumed: () => setRequestedThreadId(null),
-                  }}
-                />
-              </main>
+                </main>
 
-              <aside className="flex w-full flex-col lg:min-h-0 lg:w-80 lg:shrink-0">
-                <MediaActions media={media} version={version} />
-                {/* Only the panels scroll: the action strip is page chrome and
+                <aside className="flex w-full flex-col lg:min-h-0 lg:w-80 lg:shrink-0">
+                  <MediaActions media={media} version={version} />
+                  {/* Only the panels scroll: the action strip is page chrome and
                     stays put, instead of getting clipped at the fold. `pb-6`
                     is the build sidebar's: without it the scroll container
                     crops the last panel's shadow. */}
-                <div className="flex min-h-0 flex-col gap-4 lg:overflow-y-auto lg:pb-6">
-                  <MediaDescription media={media} />
-                  <MediaVersions
-                    versions={media.versions}
-                    selectedId={version.id}
-                    onSelect={setVersionId}
-                  />
-                  <MediaComments
-                    media={media}
-                    viewedVersionId={version.id}
-                    placing={placing}
-                    onPlacingChange={setPlacing}
-                    onOpenPinned={(comment) => {
-                      // The marker only exists on the version the pin was dropped
-                      // on, so showing the thread may mean switching to it first.
-                      if (comment.mediaVersionId) {
-                        setVersionId(comment.mediaVersionId);
-                      }
-                      setRequestedThreadId(comment.id);
-                    }}
-                  />
-                </div>
-              </aside>
+                  <div className="flex min-h-0 flex-col gap-4 lg:overflow-y-auto lg:pb-6">
+                    <MediaDescription media={media} />
+                    <MediaVersions
+                      versions={media.versions}
+                      selectedId={version.id}
+                      onSelect={setVersionId}
+                    />
+                    <MediaComments
+                      media={media}
+                      viewedVersionId={version.id}
+                      placing={placing}
+                      onPlacingChange={setPlacing}
+                      onOpenPinned={(comment) => {
+                        // The marker only exists on the version the pin was dropped
+                        // on, so showing the thread may mean switching to it first.
+                        if (comment.mediaVersionId) {
+                          setVersionId(comment.mediaVersionId);
+                        }
+                        setRequestedThreadId(comment.id);
+                      }}
+                    />
+                  </div>
+                </aside>
+              </div>
             </div>
-          </div>
-        </BuildHotkeysDialogStateProvider>
-      </MentionableUsersProvider>
+          </BuildHotkeysDialogStateProvider>
+        </MentionableUsersProvider>
+      </ProjectRepositoryUrlProvider>
     </ProjectPermissionsContext>
   );
 }

--- a/apps/frontend/src/pages/Test/index.tsx
+++ b/apps/frontend/src/pages/Test/index.tsx
@@ -33,7 +33,7 @@ import { ZoomerSyncProvider } from "@/containers/Build/Zoomer";
 import { PeriodSelect } from "@/containers/PeriodSelect";
 import { ProjectIgnoreEnabledProvider } from "@/containers/Project/IgnoreContext";
 import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
-import { ProjectRepositoryUrlProvider } from "@/containers/Project/RepositoryContext";
+import { ProjectRepositoryProvider } from "@/containers/Project/RepositoryContext";
 import {
   useTestPeriodState,
   type TestMetricPeriodState,
@@ -184,7 +184,7 @@ export function Component() {
           </PageHeaderContent>
         </PageHeader>
         <ProjectPermissionsContext value={project.permissions}>
-          <ProjectRepositoryUrlProvider value={project.repository?.url ?? null}>
+          <ProjectRepositoryProvider url={project.repository?.url ?? null}>
             <div className="flex flex-col gap-4 xl:flex-row xl:items-start">
               <div className="flex min-w-0 flex-1 flex-col gap-10">
                 <div className="flex flex-col items-start gap-4 self-stretch">
@@ -272,7 +272,7 @@ export function Component() {
                 <ActivitySection test={test} />
               </div>
             </div>
-          </ProjectRepositoryUrlProvider>
+          </ProjectRepositoryProvider>
         </ProjectPermissionsContext>
       </PageContainer>
     </Page>

--- a/apps/frontend/src/pages/Test/index.tsx
+++ b/apps/frontend/src/pages/Test/index.tsx
@@ -33,6 +33,7 @@ import { ZoomerSyncProvider } from "@/containers/Build/Zoomer";
 import { PeriodSelect } from "@/containers/PeriodSelect";
 import { ProjectIgnoreEnabledProvider } from "@/containers/Project/IgnoreContext";
 import { ProjectPermissionsContext } from "@/containers/Project/PermissionsContext";
+import { ProjectRepositoryUrlProvider } from "@/containers/Project/RepositoryContext";
 import {
   useTestPeriodState,
   type TestMetricPeriodState,
@@ -88,6 +89,10 @@ const TestQuery = graphql(`
     project(accountSlug: $accountSlug, projectName: $projectName) {
       id
       permissions
+      repository {
+        id
+        url
+      }
       ignoreConfig {
         enabled
       }
@@ -179,91 +184,95 @@ export function Component() {
           </PageHeaderContent>
         </PageHeader>
         <ProjectPermissionsContext value={project.permissions}>
-          <div className="flex flex-col gap-4 xl:flex-row xl:items-start">
-            <div className="flex min-w-0 flex-1 flex-col gap-10">
-              <div className="flex flex-col items-start gap-4 self-stretch">
-                <PeriodSelect state={periodState} />
-                {/* The counters size to their content and the chart takes the
+          <ProjectRepositoryUrlProvider value={project.repository?.url ?? null}>
+            <div className="flex flex-col gap-4 xl:flex-row xl:items-start">
+              <div className="flex min-w-0 flex-1 flex-col gap-10">
+                <div className="flex flex-col items-start gap-4 self-stretch">
+                  <PeriodSelect state={periodState} />
+                  {/* The counters size to their content and the chart takes the
                     rest, so the chart keeps as much width as the column has to
                     spare. */}
+                  <div
+                    className={clsx(
+                      "flex flex-col gap-4 self-stretch lg:flex-row",
+                      isPeriodPending && "animate-pulse",
+                    )}
+                  >
+                    <Panel>
+                      <div className="flex flex-wrap items-center gap-3 gap-y-6 px-4">
+                        <FlakinessGauge value={test.metrics.all.flakiness} />
+                        <div className="flex flex-col justify-between self-stretch">
+                          <BuildsCounter
+                            value={test.metrics.all.total}
+                            periodLabel={periodLabel}
+                          />
+                          <ChangesCounter
+                            value={test.metrics.all.changes}
+                            periodLabel={periodLabel}
+                          />
+                        </div>
+                        <div className="flex flex-col justify-between self-stretch">
+                          <StabilityCounter
+                            value={test.metrics.all.stability}
+                          />
+                          <ConsistencyCounter
+                            value={test.metrics.all.consistency}
+                          />
+                        </div>
+                      </div>
+                    </Panel>
+                    <Panel className="flex min-w-0 flex-1 items-center">
+                      <ChangesChart
+                        className="h-22 min-w-0 flex-1 px-4"
+                        series={test.metrics.series}
+                        from={period.from}
+                      />
+                    </Panel>
+                  </div>
+                </div>
+                {/* The title and the filter label the card rather than sit in it,
+                  so `px-4` keeps both ends aligned with its content. */}
                 <div
                   className={clsx(
-                    "flex flex-col gap-4 self-stretch lg:flex-row",
-                    isPeriodPending && "animate-pulse",
+                    "flex flex-col gap-2",
+                    areChangesPending && "animate-pulse",
                   )}
                 >
-                  <Panel>
-                    <div className="flex flex-wrap items-center gap-3 gap-y-6 px-4">
-                      <FlakinessGauge value={test.metrics.all.flakiness} />
-                      <div className="flex flex-col justify-between self-stretch">
-                        <BuildsCounter
-                          value={test.metrics.all.total}
-                          periodLabel={periodLabel}
-                        />
-                        <ChangesCounter
-                          value={test.metrics.all.changes}
-                          periodLabel={periodLabel}
-                        />
-                      </div>
-                      <div className="flex flex-col justify-between self-stretch">
-                        <StabilityCounter value={test.metrics.all.stability} />
-                        <ConsistencyCounter
-                          value={test.metrics.all.consistency}
-                        />
-                      </div>
-                    </div>
-                  </Panel>
-                  <Panel className="flex min-w-0 flex-1 items-center">
-                    <ChangesChart
-                      className="h-22 min-w-0 flex-1 px-4"
-                      series={test.metrics.series}
-                      from={period.from}
-                    />
+                  <div className="flex flex-wrap items-center justify-between gap-2 pl-4">
+                    <Heading level={2} className="font-medium">
+                      {filterState.value === "ignored"
+                        ? "Ignored changes"
+                        : "Changes"}{" "}
+                      <span className="text-low">over the {periodLabel}</span>
+                    </Heading>
+                    <ChangesFilterToggle state={filterState} />
+                  </div>
+                  <Panel spacing={false}>
+                    <ProjectIgnoreEnabledProvider
+                      enabled={project.ignoreConfig.enabled}
+                    >
+                      <ChangesExplorer
+                        test={test}
+                        periodState={periodState}
+                        filterState={filterState}
+                      />
+                    </ProjectIgnoreEnabledProvider>
                   </Panel>
                 </div>
               </div>
-              {/* The title and the filter label the card rather than sit in it,
-                  so `px-4` keeps both ends aligned with its content. */}
-              <div
-                className={clsx(
-                  "flex flex-col gap-2",
-                  areChangesPending && "animate-pulse",
-                )}
-              >
-                <div className="flex flex-wrap items-center justify-between gap-2 pl-4">
-                  <Heading level={2} className="font-medium">
-                    {filterState.value === "ignored"
-                      ? "Ignored changes"
-                      : "Changes"}{" "}
-                    <span className="text-low">over the {periodLabel}</span>
-                  </Heading>
-                  <ChangesFilterToggle state={filterState} />
-                </div>
-                <Panel spacing={false}>
-                  <ProjectIgnoreEnabledProvider
-                    enabled={project.ignoreConfig.enabled}
-                  >
-                    <ChangesExplorer
-                      test={test}
-                      periodState={periodState}
-                      filterState={filterState}
-                    />
-                  </ProjectIgnoreEnabledProvider>
-                </Panel>
-              </div>
-            </div>
-            <div className="flex w-full shrink-0 flex-col gap-4 xl:w-80">
-              <ChangeHistorySection test={test} params={params} />
-              {/* The prompt quotes the metrics, so it labels itself with the
+              <div className="flex w-full shrink-0 flex-col gap-4 xl:w-80">
+                <ChangeHistorySection test={test} params={params} />
+                {/* The prompt quotes the metrics, so it labels itself with the
                   period they were fetched for, not the one being switched to. */}
-              <FixFlakinessSection
-                test={test}
-                period={deferredPeriodValue}
-                periodLabel={period.label.toLowerCase()}
-              />
-              <ActivitySection test={test} />
+                <FixFlakinessSection
+                  test={test}
+                  period={deferredPeriodValue}
+                  periodLabel={period.label.toLowerCase()}
+                />
+                <ActivitySection test={test} />
+              </div>
             </div>
-          </div>
+          </ProjectRepositoryUrlProvider>
         </ProjectPermissionsContext>
       </PageContainer>
     </Page>

--- a/apps/frontend/src/ui/Editor/Editor.stories.tsx
+++ b/apps/frontend/src/ui/Editor/Editor.stories.tsx
@@ -40,6 +40,78 @@ function ControlledEditor(props: { initialValue?: EditorValue }) {
   );
 }
 
+/** A paragraph of plain text, the shape stored content takes. */
+function paragraph(text: string): EditorValue {
+  return {
+    type: "doc",
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  };
+}
+
+export const CommitAutolink: Story = {
+  name: "Commit autolink",
+  render: () => (
+    <div className="flex max-w-xl flex-col">
+      <StoryTitle>Linked</StoryTitle>
+      <Editor
+        variant="plain"
+        readOnly
+        repositoryUrl="https://github.com/argos-ci/argos"
+        value={paragraph("Pushed to the PR in d15cba5.")}
+      />
+      <Editor
+        variant="plain"
+        readOnly
+        repositoryUrl="https://github.com/argos-ci/argos"
+        value={paragraph(
+          "Reverted 9f2c1a7b3e4d5c6a8b0f1e2d3c4b5a6978d0e1f2, then squashed abc1234 and 7fed210.",
+        )}
+      />
+
+      <StoryTitle>Left alone</StoryTitle>
+      {/* Shape heuristics: a plain number, a hex-only word, an asset name, a
+          color, and a sha the author chose to write as code. */}
+      <Editor
+        variant="plain"
+        readOnly
+        repositoryUrl="https://github.com/argos-ci/argos"
+        value={paragraph(
+          "2000000 pixels, acceded, chunk-abc1234.js and #a1b2c3d4 are not commits.",
+        )}
+      />
+      <Editor
+        variant="plain"
+        readOnly
+        repositoryUrl="https://github.com/argos-ci/argos"
+        value={{
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                { type: "text", text: "Run " },
+                {
+                  type: "text",
+                  text: "git show d15cba5",
+                  marks: [{ type: "code" }],
+                },
+                { type: "text", text: " to see it." },
+              ],
+            },
+          ],
+        }}
+      />
+
+      <StoryTitle>No repository linked</StoryTitle>
+      <Editor
+        variant="plain"
+        readOnly
+        value={paragraph("Pushed to the PR in d15cba5.")}
+      />
+    </div>
+  ),
+};
+
 export const Default: Story = {
   render: () => (
     <div className="flex flex-col">

--- a/apps/frontend/src/ui/Editor/EditorImpl.tsx
+++ b/apps/frontend/src/ui/Editor/EditorImpl.tsx
@@ -10,6 +10,7 @@ import {
 import StarterKit from "@tiptap/starter-kit";
 import { clsx } from "clsx";
 
+import { createCommitAutolinkExtension } from "./commitAutolink";
 import {
   EDITOR_BOXED_CLASS,
   EDITOR_BOXED_CONTENT_PADDING_CLASS,
@@ -118,6 +119,13 @@ export interface EditorProps {
    * into "@name" + a hover card. Falls back to the `mentions` list.
    */
   mentionedUsers?: MentionUser[];
+  /**
+   * Web URL of the repository the content is about (e.g.
+   * `https://github.com/argos-ci/argos`). Commit shas in the content are linked
+   * to it when rendering read-only; without it they stay plain text. Read
+   * lazily, so it can change without recreating the editor.
+   */
+  repositoryUrl?: string | null;
 }
 
 /**
@@ -152,6 +160,7 @@ export default function Editor(props: EditorProps) {
     readOnly = false,
     mentions,
     mentionedUsers,
+    repositoryUrl,
   } = props;
 
   const isBoxed = variant === "boxed";
@@ -161,15 +170,18 @@ export default function Editor(props: EditorProps) {
   const onBlurRef = useRef(onBlur);
   const onSubmitRef = useRef(onSubmit);
   // Read lazily by the mention suggestion/resolution so the lists can update
-  // without recreating the editor.
+  // without recreating the editor. Same for the repository the commit autolink
+  // resolves shas against.
   const mentionsRef = useRef(mentions);
   const mentionedUsersRef = useRef(mentionedUsers);
+  const repositoryUrlRef = useRef(repositoryUrl);
   useEffect(() => {
     onChangeRef.current = onChange;
     onBlurRef.current = onBlur;
     onSubmitRef.current = onSubmit;
     mentionsRef.current = mentions;
     mentionedUsersRef.current = mentionedUsers;
+    repositoryUrlRef.current = repositoryUrl;
   });
 
   const editor = useEditor({
@@ -193,6 +205,9 @@ export default function Editor(props: EditorProps) {
         resolveUser: (id) =>
           mentionedUsersRef.current?.find((user) => user.id === id) ??
           mentionsRef.current?.find((user) => user.id === id),
+      }),
+      createCommitAutolinkExtension({
+        getRepositoryUrl: () => repositoryUrlRef.current,
       }),
       /* oxlint-enable react/react-compiler */
       SlashCommand,

--- a/apps/frontend/src/ui/Editor/ReadOnlyEditor.tsx
+++ b/apps/frontend/src/ui/Editor/ReadOnlyEditor.tsx
@@ -12,6 +12,11 @@ export interface ReadOnlyEditorProps {
    * hover card.
    */
   mentionedUsers?: MentionUser[];
+  /**
+   * Web URL of the repository the content is about. Commit shas in the content
+   * are linked to it; without it they stay plain text.
+   */
+  repositoryUrl?: string | null;
 }
 
 /**
@@ -22,7 +27,7 @@ export interface ReadOnlyEditorProps {
 export const ReadOnlyEditor = memo(function ReadOnlyEditor(
   props: ReadOnlyEditorProps,
 ) {
-  const { content, className, mentionedUsers } = props;
+  const { content, className, mentionedUsers, repositoryUrl } = props;
   if (!content) {
     return null;
   }
@@ -33,6 +38,7 @@ export const ReadOnlyEditor = memo(function ReadOnlyEditor(
       value={content}
       className={className}
       mentionedUsers={mentionedUsers}
+      repositoryUrl={repositoryUrl}
     />
   );
 });

--- a/apps/frontend/src/ui/Editor/commitAutolink.ts
+++ b/apps/frontend/src/ui/Editor/commitAutolink.ts
@@ -1,0 +1,96 @@
+import { findCommitShas } from "@argos/util/git";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { Plugin } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import { Extension } from "@tiptap/react";
+
+/**
+ * Marks that mean a piece of text must be left exactly as written: `code` is an
+ * explicit "render this literally", and `link` already points somewhere.
+ */
+const OPAQUE_MARKS = new Set(["code", "link"]);
+
+/**
+ * Wrap every commit sha in the document in a link to its commit on the
+ * repository host.
+ *
+ * Decorations, not marks: the stored document keeps the plain text its author
+ * typed, and the link is recomputed from the repository the project points at
+ * today — a project moved to another repository relinks its whole history of
+ * comments, and nothing has to be migrated.
+ */
+function buildDecorations(
+  doc: ProseMirrorNode,
+  repositoryUrl: string,
+): DecorationSet {
+  const decorations: Decoration[] = [];
+  doc.descendants((node, pos) => {
+    // A code block is verbatim by definition — don't look inside it.
+    if (node.type.spec.code) {
+      return false;
+    }
+    if (!node.isText || !node.text) {
+      return true;
+    }
+    if (node.marks.some((mark) => OPAQUE_MARKS.has(mark.type.name))) {
+      return true;
+    }
+    for (const { sha, index } of findCommitShas(node.text)) {
+      decorations.push(
+        Decoration.inline(pos + index, pos + index + sha.length, {
+          nodeName: "a",
+          href: `${repositoryUrl}/commit/${sha}`,
+          target: "_blank",
+          rel: "noopener noreferrer nofollow",
+        }),
+      );
+    }
+    return true;
+  });
+  return DecorationSet.create(doc, decorations);
+}
+
+export interface CommitAutolinkOptions {
+  /**
+   * Web URL of the repository the content is about (e.g.
+   * `https://github.com/argos-ci/argos`), or null when the project has none or
+   * the viewer may not know of it. Read lazily, so it can change without
+   * recreating the editor.
+   */
+  getRepositoryUrl: () => string | null | undefined;
+}
+
+/**
+ * Autolink commit shas found in the content, the way a code host does it.
+ *
+ * Only applies while the editor is **not** editable: an author typing a sha
+ * wants the characters, not a link they can't click — inside `contenteditable`
+ * a click on a link opens the link editor (`EditorLinkEdit`) instead of
+ * following it. The rendered comment is where the link earns its place.
+ * Detection is a shape heuristic — see `findCommitShas`.
+ */
+export function createCommitAutolinkExtension(options: CommitAutolinkOptions) {
+  const { getRepositoryUrl } = options;
+  return Extension.create({
+    name: "commitAutolink",
+    addProseMirrorPlugins() {
+      const { editor } = this;
+      return [
+        new Plugin({
+          props: {
+            decorations: (state) => {
+              if (editor.isEditable) {
+                return null;
+              }
+              const repositoryUrl = getRepositoryUrl();
+              if (!repositoryUrl) {
+                return null;
+              }
+              return buildDecorations(state.doc, repositoryUrl);
+            },
+          },
+        }),
+      ];
+    },
+  });
+}

--- a/packages/util/src/git.test.ts
+++ b/packages/util/src/git.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { findCommitShas } from "./git";
+
+/** The shas found in a text, as plain strings — most cases only need those. */
+function shas(text: string): string[] {
+  return findCommitShas(text).map((match) => match.sha);
+}
+
+describe("findCommitShas", () => {
+  it("finds an abbreviated sha in a sentence", () => {
+    expect(findCommitShas("Pushed to the PR in d15cba5.")).toEqual([
+      { sha: "d15cba5", index: 20 },
+    ]);
+  });
+
+  it("finds a full 40-character sha", () => {
+    const sha = "9f2c1a7b3e4d5c6a8b0f1e2d3c4b5a6978d0e1f2";
+    expect(shas(`Reverted ${sha} on main`)).toEqual([sha]);
+  });
+
+  it("finds several shas in one text", () => {
+    expect(shas("Squashed abc1234 and 7fed210 together")).toEqual([
+      "abc1234",
+      "7fed210",
+    ]);
+  });
+
+  it("matches at the very start and end of the text", () => {
+    expect(shas("d15cba5")).toEqual(["d15cba5"]);
+    expect(shas("d15cba5 fixed it, then f00ba12")).toEqual([
+      "d15cba5",
+      "f00ba12",
+    ]);
+  });
+
+  it("accepts surrounding punctuation and brackets", () => {
+    expect(shas("(d15cba5)")).toEqual(["d15cba5"]);
+    expect(shas("see d15cba5, then abc1234!")).toEqual(["d15cba5", "abc1234"]);
+    expect(shas("v2.d15cba5")).toEqual(["d15cba5"]);
+  });
+
+  it("ignores runs shorter than 7 or longer than 40 characters", () => {
+    expect(shas("abc123 is too short")).toEqual([]);
+    // A sha256 is 64 characters — not a commit sha, and not the first 40 of one.
+    expect(
+      shas("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+    ).toEqual([]);
+  });
+
+  it("ignores plain numbers", () => {
+    expect(shas("We now render 2000000 pixels")).toEqual([]);
+    expect(shas("Order 1234567 shipped")).toEqual([]);
+  });
+
+  it("ignores hex-only words", () => {
+    expect(shas("The team acceded and defaced the facade")).toEqual([]);
+  });
+
+  it("ignores a run glued to a word character", () => {
+    expect(shas("0xabc1234 and abc1234z and z1234abc")).toEqual([]);
+  });
+
+  it("ignores branch and asset names", () => {
+    expect(shas("Merged fix-abc1234 into main")).toEqual([]);
+    expect(shas("Loaded chunk-abc1234.js")).toEqual([]);
+  });
+
+  it("ignores a sha that is already part of a URL", () => {
+    expect(
+      shas("https://github.com/argos-ci/argos/commit/d15cba5 is the one"),
+    ).toEqual([]);
+  });
+
+  it("ignores CSS colors", () => {
+    expect(shas("The border should be #a1b2c3d4 instead")).toEqual([]);
+  });
+
+  it("ignores uppercase hex", () => {
+    expect(shas("Request AB12CD34 failed")).toEqual([]);
+  });
+
+  it("returns nothing for text without hex runs", () => {
+    expect(shas("")).toEqual([]);
+    expect(shas("Looks good to me!")).toEqual([]);
+  });
+});

--- a/packages/util/src/git.ts
+++ b/packages/util/src/git.ts
@@ -1,0 +1,95 @@
+/**
+ * Length bounds of a commit sha as people write one: `git log --abbrev-commit`
+ * prints seven characters, a full sha is forty.
+ */
+const MIN_SHA_LENGTH = 7;
+const MAX_SHA_LENGTH = 40;
+
+/**
+ * Characters that, sitting next to a hex run, mean it is not a standalone sha:
+ * word characters (`0xabc1234`, `abc1234z`), `-` (a branch or a hashed asset
+ * name like `chunk-abc1234`), `/` (a path, or a URL that already points at the
+ * commit) and `#` (a CSS color — `#a1b2c3d4` is eight hex characters).
+ */
+const BOUNDARY_EXCLUDED = /[0-9A-Za-z_\-/#]/;
+
+/** A commit sha found in a run of text, and where it starts. */
+export interface CommitShaMatch {
+  sha: string;
+  /** Index of the sha's first character in the scanned string. */
+  index: number;
+}
+
+/**
+ * Lowercase only: that is how git prints a sha, and accepting uppercase would
+ * widen the net to identifiers and codes ("AB12CD34") for nothing.
+ */
+function isHex(char: string): boolean {
+  return (char >= "0" && char <= "9") || (char >= "a" && char <= "f");
+}
+
+function isDigit(char: string): boolean {
+  return char >= "0" && char <= "9";
+}
+
+/**
+ * Whether the character on a side of a hex run allows it to be a sha. The empty
+ * string stands for the start or the end of the text, which both qualify.
+ */
+function isBoundary(char: string): boolean {
+  return char === "" || !BOUNDARY_EXCLUDED.test(char);
+}
+
+/**
+ * Find the commit shas written in a piece of prose, so they can be linked to the
+ * repository the text is about.
+ *
+ * Nothing here can confirm a sha names a real commit, so this is a heuristic on
+ * shape: a standalone run of 7–40 hex characters mixing digits and letters.
+ * Requiring both keeps out the two believable ways of being wrong — plain
+ * numbers ("2000000 users") and hex-only English words ("acceded", "defaced") —
+ * at the cost of the ~4% of shas that happen to be all digits. A sha left
+ * unlinked reads exactly as it does today; a linked number is a dead link in
+ * the middle of someone's sentence.
+ *
+ * Scanned character by character rather than with a regex: matching stays
+ * linear on untrusted input (CWE-1333), and the boundary rules are easier to
+ * read spelled out. `charAt` returns "" past either end of the string, which is
+ * what makes a sha at the very start or end of the text a boundary match.
+ */
+export function findCommitShas(text: string): CommitShaMatch[] {
+  const matches: CommitShaMatch[] = [];
+  let index = 0;
+  while (index < text.length) {
+    if (!isHex(text.charAt(index))) {
+      index += 1;
+      continue;
+    }
+    // Take the whole hex run: a longer one (a sha256, an id) is not a commit
+    // sha, so it has to be rejected as a whole rather than trimmed to 40.
+    let end = index;
+    let digits = 0;
+    let letters = 0;
+    while (end < text.length && isHex(text.charAt(end))) {
+      if (isDigit(text.charAt(end))) {
+        digits += 1;
+      } else {
+        letters += 1;
+      }
+      end += 1;
+    }
+    const length = end - index;
+    if (
+      length >= MIN_SHA_LENGTH &&
+      length <= MAX_SHA_LENGTH &&
+      digits > 0 &&
+      letters > 0 &&
+      isBoundary(index === 0 ? "" : text.charAt(index - 1)) &&
+      isBoundary(text.charAt(end))
+    ) {
+      matches.push({ sha: text.slice(index, end), index });
+    }
+    index = end;
+  }
+  return matches;
+}

--- a/tests/media.spec.ts
+++ b/tests/media.spec.ts
@@ -65,6 +65,12 @@ loggedTest("media share page", async ({ page, auth, project }) => {
   await expect(
     page.getByRole("button", { name: /^Open comment from/ }),
   ).toBeVisible();
+  // A commit sha written in a comment links to that commit on the repository the
+  // project is connected to — the seed's is `acme-<projectId>/sparkle`.
+  await expect(page.getByRole("link", { name: "d15cba5" })).toHaveAttribute(
+    "href",
+    `https://github.com/acme-${project.id}/sparkle/commit/d15cba5`,
+  );
 
   await screenshot(page, "media-share-page");
 });


### PR DESCRIPTION
Closes ARG-495.

A comment saying "Pushed to the PR in d15cba5" left the sha as dead text. It now links to that commit on the repository the project is connected to.

[![commit-autolink.png](https://files.argos-ci.com/media/9/75b99dd00634b3af88538e8ba409d77511ea14001da47684008d8ca7cb9cd27a.webp)](https://app.argos-ci.com/m/fn3dfsw7syqih9ea8loc)

## Detecting a sha

Nothing on our side can confirm a sha names a real commit, so detection is a heuristic on shape, in `@argos/util/git` and shared by both renderers: a standalone run of 7–40 hex characters that mixes digits and letters.

Requiring **both** digits and letters is the one judgement call worth flagging. It keeps out the two believable ways of being wrong — plain numbers ("2000000 users") and hex-only English words ("acceded", "defaced") — at the cost of the ~4% of shas that happen to be all digits. A sha left unlinked reads exactly as it does today; a linked number is a dead link in the middle of someone's sentence.

Boundary rules drop the rest: branch and asset names (`fix-abc1234`, `chunk-abc1234.js`), a URL that already points at the commit, and CSS colors — `#a1b2c3d4` is eight hex characters, and this is a product where people write about borders. Scanned character by character rather than with a regex, so matching stays linear on untrusted input, matching the convention in `util/url.ts`.

## Rendered, never stored

The app draws the links as **ProseMirror decorations**; the email renderer adds link marks to a *copy* of the document. Neither touches the stored comment, which means the text stays what its author typed, and a project moved to another repository relinks its whole history of comments with nothing to migrate — the same reasoning as mentions persisting only an account id.

Left verbatim on both sides: `code` marks, code blocks, and text that is already a link. The **editable** editor is left alone too — a sha being typed should stay characters, and inside `contenteditable` a click on a link opens the link editor rather than following it.

## Where the link appears

The URL comes from `Project.repository`, provided once per project route (`ProjectRepositoryUrlContext`, alongside `ProjectPermissionsContext`) and consumed by `CommentCard`. A public share link resolves `Media.project` to null for a visitor without access, so for them the sha stays plain text rather than leaking the repository's name — the same rule the pull request widget already follows.

The comment-pin hover preview deliberately does **not** link: its only click opens the thread, and a commit link there would take that click to GitHub instead.

Notification emails embed the comment body, so they get the same treatment — `renderCommentHtmlWithMentions` now takes the project and resolves the repository URL alongside the mention labels.

## Testing

- `packages/util/src/git.test.ts` — 14 cases pinning the heuristic, including everything it must *not* link.
- `apps/backend/src/comment/html.test.ts` — the email rendering, including mark preservation across the split, code marks, code blocks and existing links.
- `apps/backend/src/comment/mentions.e2e.test.ts` — the project → repository plumbing, from a project with no relations loaded (the state every notification job hands over).
- `tests/media.spec.ts` — asserts the rendered `href` on the share page. Verified it fails without the fix.
- A `Commit autolink` Storybook story covering the linked and left-alone cases, so it gets an Argos baseline.

Locally: `static-checks` 18/18, 626 unit, 1180 integration, 184 E2E.

## Reviewer notes

- **The `media-share-page` baseline changes.** The seeded comment now mentions a sha, which is how the feature shows up in the visual baseline.
- Three page files show large diffs that are almost entirely **reindentation** from the added provider nesting — reviewing with whitespace ignored leaves 3 real lines in each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
