### PR TITLE
feat(comment): bring a resolved thread's pin back with the thread

### DIFF
--- a/apps/frontend/src/containers/Comment/CommentMarker.tsx
+++ b/apps/frontend/src/containers/Comment/CommentMarker.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { clsx } from "clsx";
-import { MessageSquareIcon } from "lucide-react";
+import { CheckIcon, MessageSquareIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { createPortal } from "react-dom";
 
@@ -30,6 +30,8 @@ type Comment = {
   date: string;
   content: React.ComponentProps<typeof ReadOnlyEditor>["content"];
   mentionedUsers: Parameters<typeof getMentionUser>[0][];
+  /** Set on a thread that is done: the pin then wears a check. */
+  resolvedAt: string | null;
 };
 
 /** Pin badge size: a size-7 (28px) avatar with 4px (`p-1`) padding all around. */
@@ -45,6 +47,11 @@ const TRANSITION = { duration: 0.18, ease: [0.4, 0, 0.2, 1] } as const;
  * in beside it and the comment appears below. Clicking opens the full thread,
  * shown as a separate popover beside the pin (see {@link CommentThreadPopover}),
  * so while open the pin stays put as a selected marker.
+ *
+ * A resolved thread's pin is only on the image because the reviewer expanded the
+ * thread (see `useIsThreadAnchorShown`), so it wears a check: an expansion
+ * outlives the session it was made in, and a pin that still looked open would
+ * hand back work that is already done.
  */
 export function CommentMarker(props: {
   /** Anchor point (the pin's bottom-left tip) in viewport coordinates. */
@@ -57,6 +64,7 @@ export function CommentMarker(props: {
   const [hovered, setHovered] = useState(false);
   const mentionedUsers = comment.mentionedUsers.map(getMentionUser);
   const name = comment.user?.name || comment.user?.slug || "Unknown user";
+  const resolved = Boolean(comment.resolvedAt);
   // The preview only shows on hover while the thread popover is closed; once
   // open the pin is just a selected marker beside the popover.
   const expanded = hovered && !open;
@@ -81,7 +89,11 @@ export function CommentMarker(props: {
       <motion.div
         role="button"
         tabIndex={0}
-        aria-label={`Open comment from ${name}`}
+        aria-label={
+          resolved
+            ? `Open resolved comment from ${name}`
+            : `Open comment from ${name}`
+        }
         onHoverStart={() => setHovered(true)}
         onHoverEnd={() => setHovered(false)}
         onClick={onOpen}
@@ -102,7 +114,7 @@ export function CommentMarker(props: {
         {/* Top row, laid out at the full preview width so the avatar stays put
             while the author/time are revealed as the card widens. */}
         <div className="flex w-72 items-center">
-          <div className="shrink-0 p-1">
+          <div className="relative shrink-0 p-1">
             {comment.user ? (
               <AccountAvatar
                 avatar={comment.user.avatar}
@@ -113,6 +125,17 @@ export function CommentMarker(props: {
                 <MessageSquareIcon className="size-4" />
               </div>
             )}
+            {/* On the avatar rather than on the pin's corner: the corner is
+                rounded and the card clips its overflow, and the badge has to
+                hold the same spot once the card grows into the preview. */}
+            {resolved ? (
+              <div
+                aria-hidden
+                className="bg-app border-thin text-low absolute right-1 bottom-1 flex size-3.5 items-center justify-center rounded-full"
+              >
+                <CheckIcon className="size-2.5" />
+              </div>
+            ) : null}
           </div>
           <div className="flex min-w-0 items-baseline gap-1.5 pr-3 pl-1">
             <span className="text-default min-w-0 truncate text-xs font-medium">

--- a/apps/frontend/src/containers/Comment/PointCommentLayer.tsx
+++ b/apps/frontend/src/containers/Comment/PointCommentLayer.tsx
@@ -145,6 +145,14 @@ export function PointCommentLayer<TComment extends LayerComment>(props: {
   const openThread =
     threads.find((thread) => thread.root.id === openThreadId) ?? null;
 
+  // A thread that leaves the layer — resolved, deleted, filtered out — closes
+  // with its marker instead of lingering as a stale id that would reopen the
+  // popover if the thread ever came back (a resolved thread the reviewer
+  // expands again does). Adjusted during render, like `placing` below.
+  if (openThreadId !== null && !openThread) {
+    setOpenThreadId(null);
+  }
+
   // Honor a request to open a specific thread, set when jumping to a comment
   // from outside the viewer. Once the requested comment is one of this image's
   // threads, open it and report the request consumed. Any in-progress draft is

--- a/apps/frontend/src/containers/Comment/useCollapsedThread.ts
+++ b/apps/frontend/src/containers/Comment/useCollapsedThread.ts
@@ -1,4 +1,5 @@
-import { atom, useAtom } from "jotai";
+import { useCallback } from "react";
+import { atom, useAtom, useAtomValue } from "jotai";
 import { atomFamily } from "jotai-family";
 import { atomWithStorage, RESET } from "jotai/utils";
 
@@ -50,4 +51,32 @@ export function useCollapsedThread(
     collapsedThreadAtomFamily(commentId),
   );
   return [resolved && collapsed, setCollapsed] as const;
+}
+
+/**
+ * The expanded ids as a set, derived once so membership tests share an identity
+ * that only changes when the preference does — unlike the per-thread family,
+ * this one re-renders its readers on every toggle, which is the point.
+ */
+const expandedThreadIdsAtom = atom((get) => new Set(get(expandedThreadsAtom)));
+
+/**
+ * Whether a thread is drawn where it is anchored — its pin on a screenshot, its
+ * inline card on a diff. An unresolved thread always is; a resolved one only
+ * while the user keeps it expanded, so the anchor comes back with the thread it
+ * explains. "The primary button is misaligned here" needs the pin to say where
+ * *here* is, and a resolved thread whose pin is gone for good reads as a riddle.
+ *
+ * A predicate rather than the set itself, so the rule lives next to the collapse
+ * state it reads and the three anchored surfaces cannot drift apart.
+ */
+export function useIsThreadAnchorShown(): (root: {
+  id: string;
+  resolvedAt: string | null;
+}) => boolean {
+  const expandedThreadIds = useAtomValue(expandedThreadIdsAtom);
+  return useCallback(
+    (root) => !root.resolvedAt || expandedThreadIds.has(root.id),
+    [expandedThreadIds],
+  );
 }

--- a/apps/frontend/src/containers/Media/MediaCommentLayer.tsx
+++ b/apps/frontend/src/containers/Media/MediaCommentLayer.tsx
@@ -10,6 +10,7 @@ import {
   PointCommentLayer,
   type PointCommentThread,
 } from "@/containers/Comment/PointCommentLayer";
+import { useIsThreadAnchorShown } from "@/containers/Comment/useCollapsedThread";
 import { useCommentRoleScope } from "@/containers/Comment/useCommentRoleScope";
 import { DocumentType, graphql } from "@/gql";
 import { MediaPermission } from "@/gql/graphql";
@@ -112,6 +113,9 @@ export function MediaCommentLayer(props: {
 
   const canComment = media.permissions.includes(MediaPermission.Comment);
 
+  // A resolved thread's pin drops off the image until the reviewer expands the
+  // thread again; the panel keeps the thread either way.
+  const isAnchorShown = useIsThreadAnchorShown();
   const threads = useMemo(
     () =>
       getCommentThreads(media.comments).flatMap(
@@ -120,14 +124,14 @@ export function MediaCommentLayer(props: {
           if (
             root.anchor?.__typename !== "CommentPointAnchor" ||
             root.mediaVersionId !== viewedVersionId ||
-            root.resolvedAt
+            !isAnchorShown(root)
           ) {
             return [];
           }
           return [{ ...thread, point: { x: root.anchor.x, y: root.anchor.y } }];
         },
       ),
-    [media.comments, viewedVersionId],
+    [media.comments, viewedVersionId, isAnchorShown],
   );
 
   const currentAvatar = useMemo(() => {

--- a/apps/frontend/src/pages/Build/diffComments/DiffCommentLayer.tsx
+++ b/apps/frontend/src/pages/Build/diffComments/DiffCommentLayer.tsx
@@ -16,6 +16,7 @@ import {
   type CommentThread,
 } from "@/containers/Comment/commentThreads";
 import { MentionableUsersProvider } from "@/containers/Comment/MentionableUsersContext";
+import { useIsThreadAnchorShown } from "@/containers/Comment/useCollapsedThread";
 import { useProjectPermission } from "@/containers/Project/PermissionsContext";
 import { DocumentType, graphql } from "@/gql";
 import { ProjectPermission } from "@/gql/graphql";
@@ -148,17 +149,19 @@ export function DiffCommentLayer(props: {
     [accountId, build.members],
   );
 
-  // Threads anchored to a line range on this diff. Resolved threads drop off the
-  // diff (they remain in the sidebar).
+  // Threads anchored to a line range on this diff. A resolved thread drops off
+  // the diff until the reviewer expands it again (it remains in the sidebar),
+  // the same rule the pinned threads follow on an image diff.
+  const isAnchorShown = useIsThreadAnchorShown();
   const threads = useMemo(
     () =>
       getCommentThreads(build.comments).filter(
         (thread) =>
           thread.root.screenshotDiff?.id === screenshotDiffId &&
           thread.root.anchor?.__typename === "CommentLinesAnchor" &&
-          !thread.root.resolvedAt,
+          isAnchorShown(thread.root),
       ),
-    [build.comments, screenshotDiffId],
+    [build.comments, screenshotDiffId, isAnchorShown],
   );
 
   // The hovered thread's line range, derived from the live list so it resolves

--- a/apps/frontend/src/pages/Build/screenshotComments/ScreenshotCommentLayer.tsx
+++ b/apps/frontend/src/pages/Build/screenshotComments/ScreenshotCommentLayer.tsx
@@ -18,6 +18,7 @@ import {
   PointCommentLayer,
   type PointCommentThread,
 } from "@/containers/Comment/PointCommentLayer";
+import { useIsThreadAnchorShown } from "@/containers/Comment/useCollapsedThread";
 import { useProjectPermission } from "@/containers/Project/PermissionsContext";
 import { DocumentType, graphql } from "@/gql";
 import { ProjectPermission } from "@/gql/graphql";
@@ -87,8 +88,10 @@ export function ScreenshotCommentLayer(props: {
     auth.status === "authenticated" ? auth.account?.id : undefined;
   const client = useApolloClient();
 
-  // Threads anchored to a point on this diff. Resolved threads drop off the
-  // image (they remain in the sidebar), and hiding comments drops them all.
+  // Threads anchored to a point on this diff. A resolved thread's pin drops off
+  // the image until the reviewer expands the thread again (the thread itself
+  // remains in the sidebar), and hiding comments drops them all.
+  const isAnchorShown = useIsThreadAnchorShown();
   const threads = useMemo(
     () =>
       visible
@@ -98,7 +101,7 @@ export function ScreenshotCommentLayer(props: {
               if (
                 root.screenshotDiff?.id !== screenshotDiffId ||
                 root.anchor?.__typename !== "CommentPointAnchor" ||
-                root.resolvedAt
+                !isAnchorShown(root)
               ) {
                 return [];
               }
@@ -108,7 +111,7 @@ export function ScreenshotCommentLayer(props: {
             },
           )
         : [],
-    [visible, build.comments, screenshotDiffId],
+    [visible, build.comments, screenshotDiffId, isAnchorShown],
   );
 
   // Honor a request to open a specific thread, set when jumping to a comment

--- a/tests/media.spec.ts
+++ b/tests/media.spec.ts
@@ -212,6 +212,48 @@ loggedTest(
 );
 
 loggedTest(
+  "brings a resolved thread's pin back with the thread",
+  async ({ page, auth, project }) => {
+    // "The primary button is misaligned here" only says something next to its
+    // pin, so a resolved thread the reviewer expands gets its pin back — wearing
+    // a check, since the expansion outlives the session that made it.
+    const media = await createMediaScenario({
+      projectId: project.id,
+      commentAuthorId: auth.user.id,
+    });
+
+    await page.goto(`/m/${media.after.shareToken}`);
+
+    const openPin = page.getByRole("button", { name: /^Open comment from/ });
+    const resolvedPin = page.getByRole("button", {
+      name: /^Open resolved comment from/,
+    });
+    await openPin.click();
+
+    // Resolve from the pin's own popover: the thread is done, so the marker
+    // leaves the image with it.
+    const thread = page.getByRole("dialog", { name: /^Comment from/ });
+    await thread.getByText("The primary button is misaligned here.").hover();
+    await thread
+      .getByRole("button", { name: "Comment actions" })
+      .first()
+      .click();
+    await page.getByRole("menuitem", { name: "Resolve thread" }).click();
+    await expect(openPin).toBeHidden();
+    await expect(resolvedPin).toBeHidden();
+
+    // Expanding the thread in the panel puts the pin back on the image.
+    await page.getByRole("button", { name: "Expand thread" }).click();
+    await expect(resolvedPin).toBeVisible();
+    await screenshot(page, "media-resolved-pin-expanded");
+
+    // And collapsing it takes the pin away again.
+    await page.getByRole("button", { name: "Collapse thread" }).click();
+    await expect(resolvedPin).toBeHidden();
+  },
+);
+
+loggedTest(
   "pins a comment on a media that stands alone",
   async ({ page, auth, project }) => {
     // A lone media has no counterpart, so no compare toolbar and a single pane —


### PR DESCRIPTION
Closes ARG-497.

Resolving a thread takes its pin off the image, which is right — the work is done and the marker would still read as open. But it also takes away the only thing that made the thread readable: "The primary button is misaligned here" needs the pin to say where *here* is, so a reviewer expanding a resolved thread in the panel was left with a sentence pointing at nothing.

The collapse preference now decides whether a thread is drawn where it is anchored, not just whether its card is open. `useIsThreadAnchorShown` lives next to that state and answers for the three anchored surfaces at once, replacing the three separate `resolvedAt` checks that would otherwise drift:

- a build's pins on an image diff (`ScreenshotCommentLayer`)
- a shared media's pins (`MediaCommentLayer`)
- the line-anchored threads inline on a text diff (`DiffCommentLayer`)

Line comments are in for the same reason the pins are: the sidebar's "go to snapshot" would work for a resolved pin and stay a dead end for a resolved line comment.

A resolved marker wears a check on its avatar and announces itself as "Open resolved comment from …". An expansion is persisted in local storage, so it outlives the session that made it, and an unmarked pin would hand back finished work weeks later. The badge sits on the avatar rather than the pin's corner because the card clips its overflow as it grows into the hover preview.

One bug found on the way: `openThreadId` survived its thread leaving the layer, so expanding a resolved thread in the panel popped its popover open over the image. The id is now cleared when its thread goes — resolved, deleted or filtered out.

## Verification

- New guard test `brings a resolved thread's pin back with the thread` resolves the seeded pinned thread from its own popover, expands it, collapses it. It fails at the expand step with the fix reverted.
- Full chromium e2e suite: 95 passed. `pnpm run static-checks`: 18/18.
- Adds one baseline, `media-resolved-pin-expanded` — the check on the pin is the visual part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)