### PR TITLE
feat(assets): serve hashed frontend assets from a CDN origin

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,0 +1,104 @@
+name: Infra
+
+permissions: {}
+
+# Path-filtered at the workflow level, which is the only place GitHub supports
+# it, and kept out of `release.yml` deliberately: these are the slow-moving
+# stacks. An app release must not be able to drag an unreviewed infrastructure
+# change along with it, and an infrastructure change must not have to wait for
+# an app release.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "infra/**"
+      - ".github/workflows/infra.yml"
+  push:
+    branches: [main]
+    paths:
+      - "infra/**"
+      - ".github/workflows/infra.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  AWS_REGION: us-east-1
+  CDK_STAGE: production
+
+jobs:
+  # Renders the change against the live stacks so it can be read in review,
+  # rather than discovered at deploy time.
+  diff:
+    # Same-repo pull requests only: a fork PR is issued no OIDC token, so this
+    # would fail on credentials rather than on anything about the change. Argos
+    # is public, so that is a normal case, not an edge one.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js & install dependencies
+        uses: ./.github/actions/setup-deps
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.CDK_AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: cdk diff
+        run: |
+          pnpm --filter @argos/infra exec cdk diff \
+            -c stage="$CDK_STAGE" \
+            -c source=ssm
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js & install dependencies
+        uses: ./.github/actions/setup-deps
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.CDK_AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # `--require-approval never`: these stacks contain IAM and would otherwise
+      # block on an interactive prompt. The `diff` job above is the review gate.
+      - name: cdk deploy
+        run: |
+          pnpm --filter @argos/infra exec cdk deploy --all \
+            --require-approval never \
+            -c stage="$CDK_STAGE" \
+            -c source=ssm
+
+      - name: Notify infra deployment failure
+        if: failure()
+        uses: ./.github/actions/notify-discord
+        continue-on-error: true
+        with:
+          webhook-url: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          title: "Infra deployment failed"
+          description: "cdk deploy failed - [GitHub Actions logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          color: "15548997"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,13 @@ env:
   ECR_CACHE_TAG: buildcache
   ECS_TASK_ROLE_ARN: ${{ secrets.ECS_TASK_ROLE_ARN }}
   ECS_TASK_EXECUTION_ROLE_ARN: ${{ secrets.ECS_TASK_EXECUTION_ROLE_ARN }}
+  # Assets are served from their own origin, which retains every recent build.
+  # A task only ever holds the build baked into its image, so serving hashed
+  # assets from the app itself 404s them mid-rollout and for every tab still
+  # holding an older shell. Baked into the image at build time and read again by
+  # the running container, which has to authorise the origin in its CSP.
+  ASSETS_BASE_URL: https://assets.argos-ci.com
+  ASSETS_BUCKET: argos-assets-production
 
 jobs:
   build:
@@ -74,6 +81,10 @@ jobs:
         with:
           context: .
           push: true
+          # The Dockerfile's last stage is `dist`, a scratch image holding only
+          # the frontend build output. Without this the default target applies
+          # and the pushed "app" image is that empty scratch image.
+          target: build
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ env.ECR_CACHE_TAG }}
@@ -82,10 +93,90 @@ jobs:
             TURBO_TOKEN=${{ secrets.TURBO_TOKEN }}
           build-args: |
             TURBO_TEAM=${{ vars.TURBO_TEAM }}
+            ASSETS_BASE_URL=${{ env.ASSETS_BASE_URL }}
+
+      # Lifts the frontend build out of the image that was just built. Every
+      # layer is already in this job's buildx cache, so this resolves without
+      # rebuilding anything.
+      - name: Export frontend assets
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          target: dist
+          outputs: type=local,dest=frontend-dist
+          cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ env.ECR_CACHE_TAG }}
+          secrets: |
+            TURBO_TOKEN=${{ secrets.TURBO_TOKEN }}
+          build-args: |
+            TURBO_TEAM=${{ vars.TURBO_TEAM }}
+            ASSETS_BASE_URL=${{ env.ASSETS_BASE_URL }}
+
+      # Only `assets/` — the content-hashed output. Public-directory files keep
+      # their stable names and stay on the app origin (see `renderBuiltUrl` in
+      # apps/frontend/vite.config.mts), so they are deliberately not here.
+      - name: Upload built assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: frontend-assets
+          path: frontend-dist/assets
+          retention-days: 1
+          if-no-files-found: error
 
       - name: Export image reference
         id: image
         run: echo "value=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
+  # Publishes the build's hashed assets to the CDN *before* anything serves HTML
+  # that names them. `deploy` waits on this job for exactly that reason.
+  #
+  # Nothing here ever deletes: the bucket is append-only, so the assets of every
+  # recent build stay reachable and a rollback to an older image keeps working.
+  # Retention is handled out of band by the purge Lambda in infra/.
+  assets:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: build
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Download built assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: frontend-assets
+          path: assets
+
+      # `--no-delete` is the default and is relied on: an object already present
+      # is the *same* object, since the name is a hash of the content. Repeat
+      # deploys of an unchanged chunk are a no-op.
+      - name: Sync assets to S3
+        run: |
+          set -euo pipefail
+          aws s3 sync assets "s3://$ASSETS_BUCKET/assets/" \
+            --cache-control "public, max-age=31536000, immutable" \
+            --no-progress
+
+      # The retention job reads these. It keeps every key named by a manifest
+      # younger than its window and deletes the rest, which is what makes it
+      # safe: an unchanged chunk keeps its hash across builds and is skipped by
+      # `s3 sync`, so its S3 creation date goes stale while it is still
+      # referenced. Age of the *manifest*, never age of the object.
+      - name: Write build manifest
+        run: |
+          set -euo pipefail
+          find assets -type f -printf 'assets/%P\n' | jq -R . | jq -s \
+            --arg sha "$GITHUB_SHA" \
+            '{sha: $sha, keys: .}' > manifest.json
+          aws s3 cp manifest.json "s3://$ASSETS_BUCKET/manifests/$GITHUB_SHA.json" \
+            --cache-control "no-cache" \
+            --no-progress
 
   migrate:
     runs-on: ubuntu-latest
@@ -183,7 +274,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [build, migrate]
+    # `assets` gates this: the CDN must already hold the chunks the shell this
+    # image serves will name.
+    needs: [build, migrate, assets]
     permissions:
       id-token: write
       contents: read
@@ -232,6 +325,7 @@ jobs:
             MCP_BASE_URL=https://mcp.argos-ci.com
             SERVER_URL=https://app.argos-ci.com
             SENTRY_RELEASE_VERSION=${{ github.sha }}
+            ASSETS_BASE_URL=${{ env.ASSETS_BASE_URL }}
           secrets: |
             AMQP_URL=/production/amqp_url
             AWS_ACCESS_KEY_ID=/production/aws_access_key_id

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1.7
 ARG TURBO_TEAM
+ARG ASSETS_BASE_URL
 
 FROM node:26-bookworm-slim AS base
 ENV PNPM_HOME="/pnpm"
@@ -9,6 +10,11 @@ RUN npm install -g corepack@latest --force && corepack enable
 FROM base AS build
 ARG TURBO_TEAM
 ENV TURBO_TEAM=$TURBO_TEAM
+# Origin the built frontend points at for its hashed assets. Baked in here
+# because Vite resolves `base` at build time; the running container reads the
+# same value from its own `ASSETS_BASE_URL` so the CSP can authorise it.
+ARG ASSETS_BASE_URL
+ENV ASSETS_BASE_URL=$ASSETS_BASE_URL
 WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /app
 RUN pnpm fetch
@@ -19,3 +25,15 @@ RUN --mount=type=secret,id=TURBO_TOKEN \
   TURBO_TOKEN="$(cat /run/secrets/TURBO_TOKEN)" BUILD_MODE=production pnpm run build
 RUN pnpm run clean-deps
 RUN pnpm install --prod
+
+# Frontend build output on its own, so CI can lift it out of the same cached
+# build and upload it to the asset CDN:
+#
+#   docker buildx build --target dist --output type=local,dest=<dir> .
+#
+# CAUTION: this is the last stage, which makes it the *default* build target.
+# The image build has to pass `--target build` explicitly or it will produce
+# this empty scratch image instead of the app. See `target: build` in
+# .github/workflows/release.yml.
+FROM scratch AS dist
+COPY --from=build /app/apps/frontend/dist /

--- a/apps/backend/src/config/index.ts
+++ b/apps/backend/src/config/index.ts
@@ -150,6 +150,14 @@ export function createConfig() {
         env: "ENCRYPTION_KEY",
       },
     },
+    assets: {
+      baseUrl: {
+        doc: "Origin the content-hashed frontend assets are served from, e.g. `https://assets.argos-ci.com`. Empty serves them from the app origin itself, which is what development and the E2E build do. Set it here *and* as the `ASSETS_BASE_URL` build arg — the value is baked into the built HTML by Vite, and repeated here so the CSP can authorise it.",
+        format: String,
+        default: "",
+        env: "ASSETS_BASE_URL",
+      },
+    },
     csp: {
       scriptSrc: {
         doc: "Content Security Policy script-src",

--- a/apps/backend/src/web/app-router.ts
+++ b/apps/backend/src/web/app-router.ts
@@ -247,6 +247,16 @@ export const installAppRouter = async (app: express.Application) => {
     }),
   );
 
+  // A hashed asset `serveStatic` did not find belongs to a build this task does
+  // not have, and no later handler can produce it. Without this it falls through
+  // to the SPA catch-all and comes back as index.html with a 200, which the
+  // browser reports as an opaque MIME type error rather than a missing file —
+  // the single most confusing symptom of the deploy race this whole change
+  // exists to remove.
+  router.use("/assets", (_req, res) => {
+    res.status(404).type("txt").send("Not Found");
+  });
+
   router.use(
     createAppSecurityHeaders({
       configScriptCspHash: shell?.configScriptCspHash ?? null,

--- a/apps/backend/src/web/security-headers.test.ts
+++ b/apps/backend/src/web/security-headers.test.ts
@@ -1,5 +1,7 @@
 import request from "supertest";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+
+import config from "@/config";
 
 import { createAppSecurityHeaders, getConnectSrc } from "./security-headers";
 import { createTestApp } from "./test-util";
@@ -150,8 +152,55 @@ describe("app security headers", () => {
     });
 
     it("serves fonts from this origin only", async () => {
-      // Inter is self-hosted, so no third-party font origin is needed.
+      // Inter is self-hosted, and with no asset CDN configured it is served
+      // from this origin like everything else.
       const csp = await getCsp();
+      expect(csp["font-src"]).toEqual(["'self'", "data:"]);
+    });
+  });
+
+  describe("asset origin", () => {
+    const originalBaseUrl = config.get("assets.baseUrl");
+
+    afterEach(() => {
+      config.set("assets.baseUrl", originalBaseUrl);
+    });
+
+    it("authorises the CDN for every directive that can name an asset", async () => {
+      config.set("assets.baseUrl", "https://assets.argos-ci.com");
+      const csp = await getCsp();
+      // Scripts and styles are the build output; fonts ship inside it via
+      // `@fontsource-variable/inter`; images cover anything Vite emits to
+      // `assets/`. Miss one and that resource type breaks on deploy.
+      expect(csp["script-src"]).toContain("https://assets.argos-ci.com");
+      expect(csp["style-src"]).toContain("https://assets.argos-ci.com");
+      expect(csp["font-src"]).toContain("https://assets.argos-ci.com");
+      expect(csp["img-src"]).toContain("https://assets.argos-ci.com");
+    });
+
+    it("does not authorise the CDN for workers", async () => {
+      // A worker's top-level script has to be same-origin no matter what CORS
+      // says, so the colour-detection worker is inlined as a blob instead of
+      // loaded from the CDN. Widening this directive would not make a
+      // cross-origin worker load — it would just hide why.
+      config.set("assets.baseUrl", "https://assets.argos-ci.com");
+      const csp = await getCsp();
+      expect(csp["worker-src"]).toEqual(["'self'", "blob:"]);
+    });
+
+    it("authorises the origin, not the path", async () => {
+      // CSP source expressions match on origin; a path here would either be
+      // ignored or narrow the directive in ways nobody intended.
+      config.set("assets.baseUrl", "https://assets.argos-ci.com/build/");
+      const csp = await getCsp();
+      expect(csp["script-src"]).toContain("https://assets.argos-ci.com");
+      expect(csp["script-src"]?.join(" ")).not.toContain("/build");
+    });
+
+    it("adds nothing when no CDN is configured", async () => {
+      config.set("assets.baseUrl", "");
+      const csp = await getCsp();
+      expect(csp["style-src"]).toEqual(["'self'", "'unsafe-inline'"]);
       expect(csp["font-src"]).toEqual(["'self'", "data:"]);
     });
   });

--- a/apps/backend/src/web/security-headers.ts
+++ b/apps/backend/src/web/security-headers.ts
@@ -20,6 +20,7 @@ export function createAppSecurityHeaders(options: {
   cspReportUri: string | null;
 }): RequestHandler[] {
   const { configScriptCspHash, cspReportUri } = options;
+  const assetsOrigin = getAssetsOrigin();
   return [
     helmet({
       // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
@@ -44,22 +45,30 @@ export function createAppSecurityHeaders(options: {
             "https://avatars.githubusercontent.com",
             "https://gitlab.com",
             "https://secure.gravatar.com",
+            ...assetsOrigin,
           ],
+          // The one directive the asset origin is deliberately absent from: a
+          // worker's top-level script has to be same-origin whatever CORS says,
+          // so the colour-detection worker is inlined as a blob instead of
+          // being loaded from the CDN. See `util/color-detection/hook.ts`.
           "worker-src": ["'self'", "blob:"],
           "script-src": [
             "'self'",
             // Script to update color classes
             "'sha256-3eiqAvd5lbIOVQdobPBczwuRAhAf7/oxg3HH2aFmp8Y='",
             ...(configScriptCspHash ? [configScriptCspHash] : []),
+            ...assetsOrigin,
             ...config.get("csp.scriptSrc"),
           ],
           "connect-src": getConnectSrc(),
           // Narrower than helmet's defaults, which allow all of `https:`.
           // `unsafe-inline` stays: React and react-aria both set style
           // attributes, and there is no way to hash those.
-          "style-src": ["'self'", "'unsafe-inline'"],
-          // Fonts are self-hosted, so no third-party origin is needed.
-          "font-src": ["'self'", "data:"],
+          "style-src": ["'self'", "'unsafe-inline'", ...assetsOrigin],
+          // Fonts are self-hosted, but `@fontsource-variable/inter` emits its
+          // woff2 into the build output, so they move with everything else when
+          // assets are served from the CDN.
+          "font-src": ["'self'", "data:", ...assetsOrigin],
           ...(cspReportUri
             ? { "report-to": ["csp-endpoint"], "report-uri": [cspReportUri] }
             : {}),
@@ -110,6 +119,25 @@ function addOrigin(origins: Set<string>, value: string): void {
   } catch {
     // Not a URL (or a bare path): nothing to authorise.
   }
+}
+
+/**
+ * Origin the content-hashed frontend assets are served from, as a list to splice
+ * into a directive — empty when they are served from the app origin, where
+ * `'self'` already covers them.
+ *
+ * Assets live on their own origin in production so that a rolling deploy cannot
+ * 404 a chunk the shell references: the CDN keeps every recent build, while an
+ * ECS task only ever holds its own. That puts scripts, styles and fonts
+ * off-origin, so every directive that can name one has to name the CDN too.
+ *
+ * Derived from config for the same reason as `getConnectSrc()` below: the value
+ * is set once and cannot drift from where the app actually loads its code.
+ */
+function getAssetsOrigin(): string[] {
+  const origins = new Set<string>();
+  addOrigin(origins, config.get("assets.baseUrl"));
+  return Array.from(origins);
 }
 
 /**

--- a/apps/frontend/src/util/color-detection/hook.ts
+++ b/apps/frontend/src/util/color-detection/hook.ts
@@ -1,6 +1,12 @@
 import { useEffect, useState } from "react";
 
 import type { MessageData, Rect } from "./types";
+// Inlined rather than emitted as its own chunk: a worker's top-level script has
+// to be same-origin, whatever CORS allows, and in production the rest of the
+// build is served from the asset CDN. `?worker&inline` bundles the worker with
+// its imports and constructs it from a blob URL, which is same-origin by
+// construction — so this keeps working wherever the assets live.
+import ColorDetectionWorker from "./worker?worker&inline";
 
 /**
  * State of the colored rects detection.
@@ -28,9 +34,7 @@ export function useColoredRects(input: {
   useEffect(() => {
     setState(LOADING_STATE);
 
-    const worker = new Worker(new URL("./worker.ts", import.meta.url), {
-      type: "module",
-    });
+    const worker = new ColorDetectionWorker();
     worker.addEventListener("message", (event: MessageEvent<MessageData>) => {
       setState({ loading: false, rects: event.data });
     });

--- a/apps/frontend/turbo.json
+++ b/apps/frontend/turbo.json
@@ -6,7 +6,7 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"],
       "inputs": ["src/**", "index.html", "vite.config.mts"],
-      "env": ["BUILD_MODE", "SENTRY_AUTH_TOKEN"]
+      "env": ["ASSETS_BASE_URL", "BUILD_MODE", "SENTRY_AUTH_TOKEN"]
     },
     "watch-build": {
       "dependsOn": ["^build"],

--- a/apps/frontend/typings/assets.d.ts
+++ b/apps/frontend/typings/assets.d.ts
@@ -7,3 +7,13 @@ declare module "*.png" {
   const url: string;
   export default url;
 }
+
+/**
+ * Vite's inline-worker import: the worker and everything it pulls in are bundled
+ * into one file, base64'd into the importing chunk, and constructed from a blob
+ * URL. Declared by hand because the project does not pull in `vite/client`.
+ */
+declare module "*?worker&inline" {
+  const WorkerConstructor: new () => Worker;
+  export default WorkerConstructor;
+}

--- a/apps/frontend/vite.config.mts
+++ b/apps/frontend/vite.config.mts
@@ -170,11 +170,49 @@ function getPackageName(id: string): string | null {
   return first.startsWith("@") && second ? `${first}/${second}` : first;
 }
 
+/**
+ * Public base path for built assets.
+ *
+ * In production this is the asset CDN, which retains every recent build. An ECS
+ * task only ever holds the build baked into its own image, so while a rolling
+ * deploy is in flight the shell from a new task names chunks the old tasks
+ * cannot serve — and once the old tasks are gone, any tab still holding the old
+ * shell can never load another lazy route. Pointing the build at an origin whose
+ * contents outlive the containers is what removes both.
+ *
+ * Unset everywhere else — dev, Storybook, and the Playwright build all serve
+ * assets from the app origin — so `/` stays the default.
+ *
+ * Vite expects a trailing slash and silently mis-joins URLs without one, so
+ * normalise rather than trusting whoever set the variable.
+ */
+function getBase(): string {
+  const baseUrl = process.env.ASSETS_BASE_URL;
+  if (!baseUrl) {
+    return "/";
+  }
+  return `${baseUrl.replace(/\/+$/, "")}/`;
+}
+
 // https://vitejs.dev/config/
 export default defineConfig((args) => {
   const mode = process.env.BUILD_MODE || args.mode;
   return {
     mode,
+    base: getBase(),
+    experimental: {
+      // `base` would send *everything* to the CDN, including the public
+      // directory. Keep those on the app origin: their names are not
+      // content-hashed, so they gain nothing from an origin that retains old
+      // builds — they are identical in every build and never part of the deploy
+      // race. Moving them would cost a second cache-control class in the upload
+      // (`immutable` is wrong for a stable name) and a `manifest-src` CSP
+      // directive, since `manifest.json` falls back to `default-src 'self'` and
+      // would otherwise be blocked.
+      renderBuiltUrl(filename, { type }) {
+        return type === "public" ? `/${filename}` : undefined;
+      },
+    },
     plugins: [
       graphqlDocuments({
         generatedDir: fileURLToPath(new URL("./src/gql", import.meta.url)),

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,1 +1,3 @@
 /cdk.out
+# Secrets written at synth time for esbuild to --inject into the edge bundle.
+/.generated

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,328 @@
+# Argos infrastructure (CDK)
+
+## Stacks
+
+| Stack                                 | Region      | What it is                                                                  |
+| ------------------------------------- | ----------- | --------------------------------------------------------------------------- |
+| `argos-deployment-<stage>`            | `us-east-1` | Customer deployment hosting — `argos-ci.live`. S3 + DynamoDB + Lambda@Edge. |
+| `argos-deployment-production-replica` | `eu-west-1` | Cross-region replica bucket for the above.                                  |
+| `argos-assets-<stage>`                | `us-east-1` | Argos's **own** frontend assets — `assets.argos-ci.com`. S3 + CloudFront.   |
+
+The two domains are unrelated and easy to confuse. `argos-ci.live` is a Route 53
+zone in this account, so the deployment stack creates its own certificate and
+DNS records. `argos-ci.com` is **not** in Route 53 — its DNS lives with an
+external provider — so the assets stack creates neither, and both records are
+made by hand once (see the runbook below).
+
+## Why the assets stack exists
+
+The app runs as several ECS tasks behind an ALB, and each task can only serve
+the frontend build baked into its own image. During a rolling deploy the shell
+served by a new task names content-hashed chunks the old tasks do not have, so
+whichever task answers the asset request may 404 it. Worse, once the old tasks
+are gone, any browser tab still holding the old shell can never load another
+lazy route — and there are ~40 of them behind `lazy: () => import(...)`.
+
+Both are the same bug: asset lifetime was tied to container lifetime. The assets
+stack unties them. Its bucket is **append-only across deploys** — every recent
+build's chunks stay reachable no matter which task answers, and rolling back to
+an older image keeps working. Space is reclaimed out of band by a daily Lambda,
+never by a deploy.
+
+## Where configuration comes from
+
+`scripts/app.ts` takes stack props from one of three sources, chosen with
+`-c source=...`:
+
+| `source` | Reads from                               | Used by           |
+| -------- | ---------------------------------------- | ----------------- |
+| `1P`     | `op://argos-{prod,dev}/cdk/config.json`  | Local, historical |
+| `ssm`    | SSM parameter `/<stage>/cdk/config.json` | CI, and local     |
+| _unset_  | Individual `-c` context flags            | Throwaway synths  |
+
+The document is the same in all cases:
+
+```jsonc
+{
+  "stage": "production",
+  // argos-ci.live — the customer deployment zone, in Route 53
+  "hostedZoneId": "Z0123456789ABCDEFGHIJ",
+  "apiBaseUrl": "https://api.argos-ci.com",
+  "appUrl": "https://app.argos-ci.com",
+  "accessTokenSecret": "…",
+  "appUserArns": ["arn:aws:iam::<ACCOUNT_ID>:user/greg"],
+
+  "assets": {
+    "domainName": "assets.argos-ci.com",
+    // Issued by hand in us-east-1 — see step 2 below
+    "certificateArn": "arn:aws:acm:us-east-1:<ACCOUNT_ID>:certificate/…",
+    // Every origin the SPA is served from. Module scripts are always fetched
+    // in CORS mode, so an origin missing here cannot boot the app at all.
+    "allowedOrigins": ["https://app.argos-ci.com"],
+    // The role release.yml assumes to sync assets — the existing AWS_ROLE_ARN
+    // secret, NOT the new CDK role. Today that is GitHubActionsECRPush; to
+    // confirm, list the roles trusting GitHub OIDC and pick the one that is
+    // not argos-github-actions-cdk:
+    //   aws iam list-roles --query \
+    //     'Roles[?contains(to_string(AssumeRolePolicyDocument), `githubusercontent`)].RoleName'
+    "uploaderRoleArns": ["arn:aws:iam::<ACCOUNT_ID>:role/GitHubActionsECRPush"],
+  },
+}
+```
+
+> Keeping the 1Password item and the SSM parameter in sync by hand is a
+> standing trap. You already need AWS credentials to run `cdk deploy` locally,
+> so the simplest fix is to use `-c source=ssm` locally too and let the
+> 1Password copy go. The `1P` branch is kept only so nothing breaks mid-migration.
+
+---
+
+## One-time setup runbook
+
+Everything below is done once. Steps 1–6 touch only new resources and change
+nothing that is currently serving traffic. **Step 7 is the only irreversible-ish
+one**, and it is explained there.
+
+Have `aws` authenticated against the production account first:
+
+```sh
+aws sts get-caller-identity
+```
+
+Note the `Account` value — it is `<ACCOUNT_ID>` throughout.
+
+### 1. Confirm the account is CDK-bootstrapped
+
+The CDK role created in step 3 has no permissions of its own; it works by
+assuming the bootstrap roles. If bootstrap is missing or old, nothing else
+works.
+
+```sh
+aws ssm get-parameter --name /cdk-bootstrap/hnb659fds/version --region us-east-1 --query Parameter.Value --output text
+aws ssm get-parameter --name /cdk-bootstrap/hnb659fds/version --region eu-west-1 --query Parameter.Value --output text
+```
+
+Both should print a version number (≥ 21). `us-east-1` carries the deployment
+and assets stacks; `eu-west-1` carries the replica stack. A `ParameterNotFound`
+means that region was never bootstrapped — run `pnpm --filter @argos/infra exec
+cdk bootstrap aws://<ACCOUNT_ID>/<region>` before continuing.
+
+### 2. Issue the certificate for `assets.argos-ci.com`
+
+It **must** be in `us-east-1`: CloudFront only accepts certificates from that
+region, whatever region the distribution actually serves from.
+
+```sh
+aws acm request-certificate \
+  --domain-name assets.argos-ci.com \
+  --validation-method DNS \
+  --region us-east-1 \
+  --query CertificateArn --output text
+```
+
+That prints the ARN. Now ask ACM which CNAME proves you own the name:
+
+```sh
+aws acm describe-certificate \
+  --certificate-arn <CERT_ARN> \
+  --region us-east-1 \
+  --query 'Certificate.DomainValidationOptions[0].ResourceRecord'
+```
+
+Create that `Name` → `Value` CNAME at whoever hosts `argos-ci.com` DNS. If that
+is Cloudflare, set it to **DNS only** (grey cloud) — a proxied validation record
+is rewritten and ACM never sees it.
+
+Then block until it is issued (minutes, occasionally longer):
+
+```sh
+aws acm wait certificate-validated --certificate-arn <CERT_ARN> --region us-east-1
+```
+
+The certificate is created here rather than by CDK for a specific reason: a
+DNS-validated certificate with no Route 53 zone makes CloudFormation sit and
+wait for a human to add a record, and eventually time out. Issuing it once out
+of band keeps every future `cdk deploy` non-interactive.
+
+### 3. Create the GitHub OIDC role
+
+First check whether the account already trusts GitHub's OIDC provider. It almost
+certainly does — `release.yml` already authenticates this way — and creating a
+second provider for the same URL fails the stack:
+
+```sh
+aws iam list-open-id-connect-providers
+```
+
+If `token.actions.githubusercontent.com` appears, leave `CreateOidcProvider` at
+its `false` default:
+
+```sh
+aws cloudformation deploy \
+  --stack-name argos-github-oidc-cdk-role \
+  --template-file infra/bootstrap/github-oidc-cdk-role.yml \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --region us-east-1
+```
+
+If it does **not** appear, add
+`--parameter-overrides CreateOidcProvider=true` to that command.
+
+Read the ARN back out:
+
+```sh
+aws cloudformation describe-stacks \
+  --stack-name argos-github-oidc-cdk-role \
+  --region us-east-1 \
+  --query 'Stacks[0].Outputs[?OutputKey==`RoleArn`].OutputValue' --output text
+```
+
+Store it as the **`CDK_AWS_ROLE_ARN`** repository secret in GitHub
+(Settings → Secrets and variables → Actions).
+
+**What this role can do.** Almost nothing directly. It holds `sts:AssumeRole` on
+`cdk-hnb659fds-*` — the bootstrap roles that already carry deploy rights — plus
+`ssm:GetParameter` on `*/cdk/config.json` and read-only CloudFormation for
+`cdk diff`. So the blast radius is whatever `cdk bootstrap` provisioned, and
+revoking CI's access later is deleting this one stack. Trust is scoped to
+`refs/heads/main` and same-repo pull requests; fork PRs receive no token at all,
+which is why `infra.yml` also gates the diff job on the head repository.
+
+### 4. Publish the config parameter
+
+Write the JSON from [Where configuration comes from](#where-configuration-comes-from)
+to a local file — starting from the current 1Password item and adding the
+`assets` block — then:
+
+```sh
+aws ssm put-parameter \
+  --name /production/cdk/config.json \
+  --type SecureString \
+  --value file://config.json \
+  --region us-east-1 \
+  --overwrite
+```
+
+`SecureString` because the document carries `accessTokenSecret`. The default
+`alias/aws/ssm` key is used when `--key-id` is omitted, and its key policy
+already allows any principal in the account to decrypt via SSM — so the CDK role
+needs no extra `kms:Decrypt`. If you point it at a customer-managed key instead,
+you must add that permission to the role.
+
+Delete the local file afterwards.
+
+Verify `app.ts` can read it — this synthesizes without deploying anything:
+
+```sh
+pnpm --filter @argos/infra exec cdk synth argos-assets-production -c stage=production -c source=ssm
+```
+
+### 5. Deploy the assets stack
+
+Deploy **only** this stack. `--all` would also push any drift in the deployment
+stack, which is not what you want on the first CI-adjacent deploy:
+
+```sh
+pnpm --filter @argos/infra exec cdk deploy argos-assets-production -c stage=production -c source=ssm
+```
+
+Nothing serves yet — the distribution exists but no DNS points at it. Note the
+`DistributionDomainName` output (`dxxxxxxxxxxxxx.cloudfront.net`).
+
+### 6. Point DNS at the distribution, and verify
+
+Create `assets.argos-ci.com` → `<DistributionDomainName>` as a CNAME at the
+external DNS provider. On Cloudflare, **DNS only** again — proxying would stack a
+second CDN in front of CloudFront.
+
+Once it propagates, upload a probe file and fetch it the way a browser will:
+
+```sh
+echo 'ok' | aws s3 cp - s3://argos-assets-production/assets/_probe.txt --cache-control "public, max-age=60"
+```
+
+```sh
+curl -sSI -H 'Origin: https://app.argos-ci.com' https://assets.argos-ci.com/assets/_probe.txt
+```
+
+You are looking for three things:
+
+- `HTTP/2 200` — DNS, the certificate and the origin access control all work.
+- `access-control-allow-origin: https://app.argos-ci.com` — without this, module
+  scripts fail to load even though the file is reachable.
+- `cache-control: public, max-age=60` — proves object metadata is passed through.
+
+Then clean up: `aws s3 rm s3://argos-assets-production/assets/_probe.txt`
+
+### 7. Ship the app change
+
+Only now merge the application PR.
+
+This is the step to be careful with, because it is all-or-nothing:
+`release.yml` sets `ASSETS_BASE_URL`, so from the first release after merge the
+built HTML names `https://assets.argos-ci.com/...` for **every** script and
+stylesheet. If the CDN were not live, that is a blank page, not a slow one —
+which is exactly why steps 1–6 come first and end in a verification.
+
+Watch the first release: the `assets` job must succeed **before** `deploy`
+starts. That ordering is enforced by `needs: [build, migrate, assets]`, and it
+is the guarantee that the CDN already holds the chunks the new shell names.
+
+**Backing out** does not require undoing any of the above. Remove
+`ASSETS_BASE_URL` from `release.yml` and release again: assets go back to being
+served from the app origin, because the container never stopped serving
+`apps/frontend/dist`. The bucket and distribution can stay up, unused.
+
+---
+
+## Day to day
+
+- **Changing infra:** open a PR touching `infra/**`. `infra.yml` runs `cdk diff`
+  against the live stacks and prints it in the job log. Merging to `main` runs
+  `cdk deploy --all`.
+- **Deploying by hand:** `pnpm --filter @argos/infra exec cdk deploy <stack> -c stage=production -c source=ssm`
+- **Changing config:** update the SSM parameter (step 4), then redeploy. Config
+  is read at synth time, so a parameter change alone does nothing.
+
+## Asset retention
+
+Each release writes `manifests/<sha>.json` listing the keys it published. A
+daily Lambda keeps the union of every manifest newer than 30 days and deletes
+the rest.
+
+It is deliberately **not** an S3 lifecycle rule. A chunk whose content is
+unchanged keeps the same hash across builds, so `aws s3 sync` skips re-uploading
+it and its S3 creation date never moves — a lifecycle rule would expire files
+that today's HTML still references. Retention has to follow the age of the build
+that last named a key, not the age of the object.
+
+Two guards make it safe to run unattended, both covered by tests in
+`lambda/purge-assets.test.ts`:
+
+- If no manifest falls inside the window, it deletes nothing. An empty keep-set
+  means "delete everything", and a listing failure is likelier than a genuinely
+  idle month.
+- It never deletes an object younger than a day. A release uploads its assets
+  and _then_ writes its manifest; in that window the new chunks are referenced
+  by nothing.
+
+## Troubleshooting
+
+**`cdk diff` fails on credentials in a PR.** Expected for fork PRs — they get no
+OIDC token. The job is gated to same-repo PRs; a fork's infra change has to be
+diffed by a maintainer.
+
+**`Need to perform AWS calls but no credentials configured`.** The
+`CDK_AWS_ROLE_ARN` secret is missing or the trust policy does not match. The
+`sub` claim must be `repo:argos-ci/argos:ref:refs/heads/main` or
+`repo:argos-ci/argos:pull_request`.
+
+**Assets 404 from the CDN but exist in the bucket.** Under origin access control
+the bucket grants only `s3:GetObject`, so S3 answers a _missing_ key with 403
+rather than 404. A 403 here means the key is absent, not that permissions are
+wrong.
+
+**Browser reports a MIME type error for a script.** The app origin returns
+`index.html` for unmatched paths. `app-router.ts` now 404s `/assets/*`
+explicitly, so this should mean the CDN is not being used at all — check that
+`ASSETS_BASE_URL` was set at image build time, not just at runtime.

--- a/infra/README.md
+++ b/infra/README.md
@@ -308,6 +308,14 @@ Two guards make it safe to run unattended, both covered by tests in
 
 ## Troubleshooting
 
+**`Command "esbuild" not found` during synth or diff.** `NodejsFunction`
+bundles by shelling out to `pnpm exec -- esbuild`, and it does so from the
+**repository root**, because that is where the lockfile is. So `esbuild` is a
+root `devDependency` even though only `infra/` uses it — declaring it in
+`infra/package.json` would not put it on the path where CDK actually invokes it,
+since `pnpm exec` searches upward, not downward. It is in knip's
+`ignoreDependencies` for the same reason: nothing imports it, CDK spawns it.
+
 **`cdk diff` fails on credentials in a PR.** Expected for fork PRs — they get no
 OIDC token. The job is gated to same-repo PRs; a fork's infra change has to be
 diffed by a maintainer.

--- a/infra/bootstrap/github-oidc-cdk-role.yml
+++ b/infra/bootstrap/github-oidc-cdk-role.yml
@@ -1,0 +1,141 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >-
+  Role assumed by GitHub Actions to run `cdk diff` and `cdk deploy`
+  (.github/workflows/infra.yml). Deployed once, by hand, with local admin
+  credentials; it is the thing CI needs before CI can deploy anything.
+
+# Deploy:
+#
+#   aws cloudformation deploy \
+#     --stack-name argos-github-oidc-cdk-role \
+#     --template-file infra/bootstrap/github-oidc-cdk-role.yml \
+#     --capabilities CAPABILITY_NAMED_IAM \
+#     --region us-east-1
+#
+# Then read the role ARN back out and store it as the CDK_AWS_ROLE_ARN repo
+# secret:
+#
+#   aws cloudformation describe-stacks \
+#     --stack-name argos-github-oidc-cdk-role \
+#     --query 'Stacks[0].Outputs[?OutputKey==`RoleArn`].OutputValue' \
+#     --output text
+#
+# This grants no AWS permissions directly. It only lets GitHub assume the CDK
+# bootstrap roles, which are what actually hold deploy rights, so the blast
+# radius is whatever `cdk bootstrap` already provisioned, and revoking CI access
+# is a matter of deleting this one stack.
+
+Parameters:
+  GitHubRepo:
+    Type: String
+    Default: argos-ci/argos
+    Description: owner/repo allowed to assume this role.
+
+  CreateOidcProvider:
+    Type: String
+    Default: "false"
+    AllowedValues: ["true", "false"]
+    Description: >-
+      Leave "false" if the account already has the GitHub OIDC provider; it
+      does if any workflow already uses aws-actions/configure-aws-credentials
+      with id-token: write, which release.yml does. Check with:
+      aws iam list-open-id-connect-providers
+      Creating a second one for the same URL fails the stack.
+
+  BootstrapQualifier:
+    Type: String
+    Default: hnb659fds
+    Description: >-
+      CDK bootstrap qualifier. The default is CDK's own default; change it only
+      if `cdk bootstrap` was run with --qualifier.
+
+Conditions:
+  ShouldCreateOidcProvider: !Equals [!Ref CreateOidcProvider, "true"]
+
+Resources:
+  GitHubOidcProvider:
+    Type: AWS::IAM::OIDCProvider
+    Condition: ShouldCreateOidcProvider
+    Properties:
+      Url: https://token.actions.githubusercontent.com
+      ClientIdList:
+        - sts.amazonaws.com
+      ThumbprintList:
+        - 6938fd4d98bab03faadb97b34396831e3780aea1
+        - 1c58a3a8518e8759bf075b76b750d4f2df264fcd
+
+  CdkDeployRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: argos-github-actions-cdk
+      # Keep this ASCII. IAM rejects any character above U+00FF here, and an
+      # em dash costs you a CREATE_FAILED whose only clue is a validation
+      # error naming the description field, with no hint as to which byte.
+      Description: GitHub Actions - cdk diff and cdk deploy for the Argos infra stacks.
+      MaxSessionDuration: 3600
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                token.actions.githubusercontent.com:aud: sts.amazonaws.com
+              # Scoped to main and to same-repo pull requests. Note that a fork
+              # PR gets no token at all, so the diff job is gated on the head
+              # repo in the workflow as well.
+              StringLike:
+                token.actions.githubusercontent.com:sub:
+                  - !Sub repo:${GitHubRepo}:ref:refs/heads/main
+                  - !Sub repo:${GitHubRepo}:pull_request
+      Policies:
+        - PolicyName: assume-cdk-bootstrap-roles
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              # Where the real permissions live. The CDK CLI assumes these per
+              # region (deploy, file-publishing, image-publishing, lookup), so
+              # this role needs no S3, ECS, CloudFront or IAM rights of its own.
+              - Effect: Allow
+                Action: sts:AssumeRole
+                Resource:
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-${BootstrapQualifier}-*-${AWS::AccountId}-*
+
+        - PolicyName: read-cdk-config
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              # infra/scripts/app.ts reads its stack props from here when
+              # invoked with `-c source=ssm`, which is how CI runs it.
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                Resource:
+                  - !Sub arn:${AWS::Partition}:ssm:*:${AWS::AccountId}:parameter/*/cdk/config.json
+                  - !Sub arn:${AWS::Partition}:ssm:*:${AWS::AccountId}:parameter/cdk-bootstrap/*
+
+        - PolicyName: read-stack-state
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              # `cdk diff` compares against the deployed template before it
+              # assumes anything.
+              - Effect: Allow
+                Action:
+                  - cloudformation:DescribeStacks
+                  - cloudformation:DescribeStackEvents
+                  - cloudformation:GetTemplate
+                Resource:
+                  - !Sub arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/*
+              - Effect: Allow
+                Action:
+                  - cloudformation:ListStacks
+                Resource: "*"
+
+Outputs:
+  RoleArn:
+    Description: Store as the CDK_AWS_ROLE_ARN repository secret.
+    Value: !GetAtt CdkDeployRole.Arn

--- a/infra/lambda/purge-assets.test.ts
+++ b/infra/lambda/purge-assets.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { send } = vi.hoisted(() => ({ send: vi.fn() }));
+
+vi.mock("@aws-sdk/client-s3", () => {
+  class FakeCommand {
+    constructor(public input: Record<string, unknown>) {}
+  }
+  return {
+    S3Client: class {
+      send = send;
+    },
+    ListObjectsV2Command: class extends FakeCommand {
+      readonly kind = "list";
+    },
+    GetObjectCommand: class extends FakeCommand {
+      readonly kind = "get";
+    },
+    DeleteObjectsCommand: class extends FakeCommand {
+      readonly kind = "delete";
+    },
+  };
+});
+
+const NOW = new Date("2026-08-12T00:00:00Z");
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function daysAgo(days: number): Date {
+  return new Date(NOW.getTime() - days * DAY_MS);
+}
+
+type S3Object = { Key: string; LastModified: Date };
+
+/**
+ * Wires `send` to a bucket described as a listing per prefix plus the body of
+ * each manifest, and records everything the handler asks to delete.
+ */
+function givenBucket(options: {
+  assets: S3Object[];
+  manifests: S3Object[];
+  manifestBodies: Record<string, string>;
+}) {
+  const deleted: string[] = [];
+  send.mockImplementation((command: { kind: string; input: any }) => {
+    switch (command.kind) {
+      case "list": {
+        const prefix = command.input.Prefix;
+        const contents =
+          prefix === "assets/" ? options.assets : options.manifests;
+        return Promise.resolve({ Contents: contents });
+      }
+      case "get": {
+        const body = options.manifestBodies[command.input.Key];
+        if (body === undefined) {
+          return Promise.reject(new Error("NoSuchKey"));
+        }
+        return Promise.resolve({
+          Body: { transformToString: () => Promise.resolve(body) },
+        });
+      }
+      case "delete": {
+        for (const { Key } of command.input.Delete.Objects) {
+          deleted.push(Key);
+        }
+        return Promise.resolve({ Errors: [] });
+      }
+      default:
+        throw new Error(`Unexpected command: ${command.kind}`);
+    }
+  });
+  return { deleted };
+}
+
+async function runHandler(): Promise<void> {
+  const { handler } = await import("./purge-assets.ts");
+  await handler();
+}
+
+describe("purge-assets", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    vi.resetModules();
+    vi.stubEnv("BUCKET", "argos-assets-test");
+    vi.stubEnv("RETENTION_DAYS", "30");
+    send.mockReset();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("deletes an asset no manifest in the window still references", async () => {
+    const { deleted } = givenBucket({
+      assets: [
+        { Key: "assets/live-aaa.js", LastModified: daysAgo(10) },
+        { Key: "assets/orphan-bbb.js", LastModified: daysAgo(10) },
+      ],
+      manifests: [{ Key: "manifests/sha1.json", LastModified: daysAgo(5) }],
+      manifestBodies: {
+        "manifests/sha1.json": JSON.stringify({ keys: ["assets/live-aaa.js"] }),
+      },
+    });
+
+    await runHandler();
+
+    expect(deleted).toEqual(["assets/orphan-bbb.js"]);
+  });
+
+  it("keeps an asset that only an older build in the window references", async () => {
+    // The whole point of the window: a tab opened days ago still loads lazy
+    // chunks from the build it booted on.
+    const { deleted } = givenBucket({
+      assets: [{ Key: "assets/old-aaa.js", LastModified: daysAgo(25) }],
+      manifests: [
+        { Key: "manifests/old.json", LastModified: daysAgo(25) },
+        { Key: "manifests/new.json", LastModified: daysAgo(1) },
+      ],
+      manifestBodies: {
+        "manifests/old.json": JSON.stringify({ keys: ["assets/old-aaa.js"] }),
+        "manifests/new.json": JSON.stringify({ keys: ["assets/new-bbb.js"] }),
+      },
+    });
+
+    await runHandler();
+
+    expect(deleted).toEqual([]);
+  });
+
+  it("never deletes an asset younger than the manifest-write gap", async () => {
+    // A deploy uploads assets and *then* writes its manifest. Between the two
+    // the new chunks are referenced by nothing, and deleting them would break
+    // the release that is about to go live.
+    const { deleted } = givenBucket({
+      assets: [{ Key: "assets/just-uploaded.js", LastModified: daysAgo(0.02) }],
+      manifests: [{ Key: "manifests/sha1.json", LastModified: daysAgo(5) }],
+      manifestBodies: {
+        "manifests/sha1.json": JSON.stringify({ keys: [] }),
+      },
+    });
+
+    await runHandler();
+
+    expect(deleted).toEqual([]);
+  });
+
+  it("refuses to purge when no manifest falls inside the window", async () => {
+    // An empty keep-set means "delete everything". A listing failure or a
+    // renamed prefix is far likelier than a genuinely idle month.
+    const { deleted } = givenBucket({
+      assets: [{ Key: "assets/live-aaa.js", LastModified: daysAgo(10) }],
+      manifests: [{ Key: "manifests/ancient.json", LastModified: daysAgo(90) }],
+      manifestBodies: {
+        "manifests/ancient.json": JSON.stringify({ keys: [] }),
+      },
+    });
+
+    await runHandler();
+
+    expect(deleted).toEqual([]);
+  });
+
+  it("refuses to purge when a manifest in the window cannot be read", async () => {
+    // Treating an unreadable manifest as "references nothing" would delete
+    // live assets on the strength of a corrupt file.
+    const { deleted } = givenBucket({
+      assets: [{ Key: "assets/live-aaa.js", LastModified: daysAgo(10) }],
+      manifests: [
+        { Key: "manifests/good.json", LastModified: daysAgo(2) },
+        { Key: "manifests/corrupt.json", LastModified: daysAgo(3) },
+      ],
+      manifestBodies: {
+        "manifests/good.json": JSON.stringify({ keys: [] }),
+        "manifests/corrupt.json": "{ this is not json",
+      },
+    });
+
+    await runHandler();
+
+    expect(deleted).toEqual([]);
+  });
+
+  it("drops manifests that have aged out", async () => {
+    const { deleted } = givenBucket({
+      assets: [],
+      manifests: [
+        { Key: "manifests/fresh.json", LastModified: daysAgo(2) },
+        { Key: "manifests/stale.json", LastModified: daysAgo(40) },
+      ],
+      manifestBodies: {
+        "manifests/fresh.json": JSON.stringify({ keys: [] }),
+        "manifests/stale.json": JSON.stringify({ keys: [] }),
+      },
+    });
+
+    await runHandler();
+
+    expect(deleted).toEqual(["manifests/stale.json"]);
+  });
+});

--- a/infra/lambda/purge-assets.ts
+++ b/infra/lambda/purge-assets.ts
@@ -1,0 +1,191 @@
+import {
+  DeleteObjectsCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+  type _Object,
+  S3Client,
+} from "@aws-sdk/client-s3";
+
+/**
+ * Retention for the frontend asset bucket.
+ *
+ * The bucket is append-only during a deploy: assets are uploaded before
+ * anything serves HTML naming them, and nothing is ever removed as part of a
+ * release. That is what lets a rolling deploy — and a rollback to an older
+ * image — keep working, since every recent build's chunks stay reachable no
+ * matter which ECS task answers.
+ *
+ * Something still has to reclaim the space, and the rule matters. A chunk whose
+ * content is unchanged keeps its hash across builds, so `aws s3 sync` skips
+ * re-uploading it and its S3 creation date never moves. An S3 lifecycle rule —
+ * the obvious choice — would therefore expire files that today's HTML still
+ * references. Retention has to be driven by the age of the *build* that last
+ * named a key, not the age of the object.
+ *
+ * So each deploy writes `manifests/<sha>.json` listing the keys it published.
+ * This job keeps the union of every manifest inside the window and deletes the
+ * rest.
+ */
+
+const BUCKET = requireEnv("BUCKET");
+const ASSET_PREFIX = "assets/";
+const MANIFEST_PREFIX = "manifests/";
+const RETENTION_DAYS = Number(process.env["RETENTION_DAYS"] ?? "30");
+
+/**
+ * Floor on how new an object can be and still be considered for deletion.
+ *
+ * A deploy uploads its assets and *then* writes its manifest. In that window
+ * the new chunks are named by no manifest at all, so a purge running at the
+ * wrong moment would delete the build that is about to go live. Nothing this
+ * young is ever touched, whatever the manifests say.
+ */
+const MIN_AGE_DAYS = 1;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const s3 = new S3Client({});
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+/** Every object under a prefix, following pagination to the end. */
+async function listObjects(prefix: string): Promise<_Object[]> {
+  const objects: _Object[] = [];
+  let continuationToken: string | undefined;
+  do {
+    const response = await s3.send(
+      new ListObjectsV2Command({
+        Bucket: BUCKET,
+        Prefix: prefix,
+        ContinuationToken: continuationToken,
+      }),
+    );
+    objects.push(...(response.Contents ?? []));
+    continuationToken = response.NextContinuationToken;
+  } while (continuationToken);
+  return objects;
+}
+
+/**
+ * Keys named by a manifest, or null when it cannot be read or parsed.
+ *
+ * A manifest that fails to parse must not narrow the keep-set — that would
+ * delete live assets on the strength of a corrupt file — so the caller treats
+ * null as a reason to abort rather than as an empty list.
+ */
+async function readManifestKeys(key: string): Promise<string[] | null> {
+  try {
+    const response = await s3.send(
+      new GetObjectCommand({ Bucket: BUCKET, Key: key }),
+    );
+    const body = await response.Body?.transformToString();
+    if (!body) {
+      return null;
+    }
+    const parsed: unknown = JSON.parse(body);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      !("keys" in parsed) ||
+      !Array.isArray(parsed.keys)
+    ) {
+      return null;
+    }
+    return parsed.keys.filter((key): key is string => typeof key === "string");
+  } catch (error) {
+    console.error(`Failed to read manifest ${key}`, error);
+    return null;
+  }
+}
+
+async function deleteKeys(keys: string[]): Promise<void> {
+  // DeleteObjects takes at most 1000 keys per call.
+  for (let index = 0; index < keys.length; index += 1000) {
+    const batch = keys.slice(index, index + 1000);
+    const response = await s3.send(
+      new DeleteObjectsCommand({
+        Bucket: BUCKET,
+        Delete: { Objects: batch.map((Key) => ({ Key })), Quiet: true },
+      }),
+    );
+    for (const error of response.Errors ?? []) {
+      console.error(`Failed to delete ${error.Key}: ${error.Message}`);
+    }
+  }
+}
+
+export async function handler(): Promise<void> {
+  const now = Date.now();
+  const retentionCutoff = now - RETENTION_DAYS * DAY_MS;
+  const minAgeCutoff = now - MIN_AGE_DAYS * DAY_MS;
+
+  const manifests = await listObjects(MANIFEST_PREFIX);
+  const freshManifests = manifests.filter(
+    (object) => (object.LastModified?.getTime() ?? 0) >= retentionCutoff,
+  );
+
+  // An empty keep-set would mean "delete everything". Far more likely than a
+  // genuinely idle month is that listing failed, the prefix moved, or the
+  // deploy stopped writing manifests — none of which should empty the bucket.
+  if (freshManifests.length === 0) {
+    console.warn(
+      `No manifest newer than ${RETENTION_DAYS} days under ${MANIFEST_PREFIX}; refusing to purge.`,
+    );
+    return;
+  }
+
+  const keep = new Set<string>();
+  for (const manifest of freshManifests) {
+    if (!manifest.Key) {
+      continue;
+    }
+    const keys = await readManifestKeys(manifest.Key);
+    if (keys === null) {
+      console.error(
+        `Manifest ${manifest.Key} is unreadable; refusing to purge on an incomplete keep-set.`,
+      );
+      return;
+    }
+    for (const key of keys) {
+      keep.add(key);
+    }
+  }
+
+  const assets = await listObjects(ASSET_PREFIX);
+  const expired = assets.filter((object) => {
+    if (!object.Key || keep.has(object.Key)) {
+      return false;
+    }
+    return (object.LastModified?.getTime() ?? now) < minAgeCutoff;
+  });
+
+  console.log(
+    `${assets.length} assets, ${keep.size} referenced by ${freshManifests.length} manifests within ${RETENTION_DAYS} days, ${expired.length} to delete.`,
+  );
+
+  if (expired.length > 0) {
+    await deleteKeys(expired.map((object) => object.Key).filter(isString));
+  }
+
+  // Manifests outside the window no longer contribute to the keep-set, and
+  // dropping them keeps the listing above from growing without bound. Done last
+  // so a failure here can never shrink the keep-set used above.
+  const staleManifests = manifests
+    .filter((object) => (object.LastModified?.getTime() ?? 0) < retentionCutoff)
+    .map((object) => object.Key)
+    .filter(isString);
+
+  if (staleManifests.length > 0) {
+    await deleteKeys(staleManifests);
+  }
+}
+
+function isString(value: string | undefined): value is string {
+  return value !== undefined;
+}

--- a/infra/lambda/resolve-alias-viewer-request.ts
+++ b/infra/lambda/resolve-alias-viewer-request.ts
@@ -9,7 +9,25 @@ import type {
 const API_BASEURL = process.env.API_BASEURL ?? "";
 const APP_URL = process.env.APP_URL ?? "";
 const BASE_DOMAIN = process.env.BASE_DOMAIN ?? "";
-const ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET ?? "";
+
+/**
+ * Substituted at bundle time by an esbuild `--inject` file that
+ * `ArgosDeploymentStack` writes, rather than by a `--define` like the constants
+ * above.
+ *
+ * The difference is only where the value travels. A `define` becomes
+ * `--define:process.env.ACCESS_TOKEN_SECRET="..."` on esbuild's command line,
+ * and CDK prints that whole command line whenever bundling fails -- which, in a
+ * public repository with `cdk diff` running in CI, publishes the secret to
+ * anyone reading a failed build log. An inject puts only a file path there.
+ *
+ * Lambda@Edge cannot read environment variables at runtime, so baking the value
+ * into the bundle is the only option; this keeps it out of argv while doing so.
+ *
+ * Declared, never defined: a real `const` here would shadow the global and
+ * esbuild would have nothing to substitute.
+ */
+declare const ACCESS_TOKEN_SECRET: string;
 const COOKIE_MAX_AGE_SECONDS = 60 * 60;
 const AUTH_CALLBACK_PATH = "/__argos/auth";
 

--- a/infra/lib/assets-stack.ts
+++ b/infra/lib/assets-stack.ts
@@ -1,0 +1,241 @@
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import * as cdk from "aws-cdk-lib";
+import * as acm from "aws-cdk-lib/aws-certificatemanager";
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
+import * as events from "aws-cdk-lib/aws-events";
+import * as targets from "aws-cdk-lib/aws-events-targets";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as nodejs from "aws-cdk-lib/aws-lambda-nodejs";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import type { Construct } from "constructs";
+import { z } from "zod";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const ArgosAssetsStackPropsSchema = z.object({
+  stage: z.enum(["development", "production"]),
+  /** Host the assets are served from, e.g. `assets.argos-ci.com`. */
+  domainName: z.string(),
+  /**
+   * ACM certificate for `domainName`, issued in us-east-1 and validated once by
+   * hand.
+   *
+   * `argos-ci.com` is not a Route 53 zone, so CDK can neither look the zone up
+   * nor write the alias record — unlike `argos-ci.live` in the deployment
+   * stack. Creating the certificate here instead would make every deploy of
+   * this stack sit and wait while someone adds a validation CNAME at the
+   * external DNS provider, and time out if they don't. Issuing it once out of
+   * band and importing the ARN keeps `cdk deploy` non-interactive.
+   */
+  certificateArn: z.string(),
+  /**
+   * Origins allowed to load these assets. Module scripts are always fetched in
+   * CORS mode, so an origin missing here cannot boot the app at all — list every
+   * host the SPA is served from.
+   */
+  allowedOrigins: z.array(z.string()).min(1),
+  /**
+   * Roles the release pipeline assumes to upload. Granted through the bucket
+   * policy rather than by mutating a role this stack does not own.
+   */
+  uploaderRoleArns: z.array(z.string()).default([]),
+  /** How long an asset outlives the last build that referenced it. */
+  retentionDays: z.number().int().positive().default(30),
+});
+
+type ArgosAssetsStackOwnProps = z.infer<typeof ArgosAssetsStackPropsSchema>;
+
+interface ArgosAssetsStackProps
+  extends cdk.StackProps, ArgosAssetsStackOwnProps {}
+
+/**
+ * Origin for the frontend's content-hashed assets.
+ *
+ * The app runs as several ECS tasks behind an ALB, and each task can only serve
+ * the build baked into its own image. While a rolling deploy is in flight, a
+ * shell served by a new task names chunks the old tasks do not have, and once
+ * the old tasks are gone any tab still holding an older shell can never load
+ * another lazy route. Both are the same bug: asset lifetime was tied to
+ * container lifetime.
+ *
+ * This bucket unties them. It is append-only across deploys — every recent
+ * build's chunks stay reachable, so it does not matter which task answered, and
+ * rolling back to an older image keeps working. Space is reclaimed out of band
+ * by the purge function below, never by a deploy.
+ */
+export class ArgosAssetsStack extends cdk.Stack {
+  public readonly bucket: s3.Bucket;
+  public readonly distribution: cloudfront.Distribution;
+
+  constructor(scope: Construct, id: string, props: ArgosAssetsStackProps) {
+    super(scope, id, props);
+
+    const {
+      stage,
+      domainName,
+      certificateArn,
+      allowedOrigins,
+      uploaderRoleArns,
+      retentionDays,
+    } = props;
+    const isProduction = stage === "production";
+
+    // ----------------------------------------------------------------
+    // S3 Bucket — append-only store of every recent build's assets
+    // ----------------------------------------------------------------
+    // Not versioned: object names are content hashes, so a key's contents can
+    // never change and there is no prior version to keep.
+    this.bucket = new s3.Bucket(this, "AssetsBucket", {
+      bucketName: `argos-assets-${stage}`,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      removalPolicy: isProduction
+        ? cdk.RemovalPolicy.RETAIN
+        : cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: !isProduction,
+    });
+
+    if (uploaderRoleArns.length > 0) {
+      const uploaders = uploaderRoleArns.map(
+        (arn) => new iam.ArnPrincipal(arn),
+      );
+      // `aws s3 sync` reads before it writes, to skip objects already present.
+      this.bucket.addToResourcePolicy(
+        new iam.PolicyStatement({
+          principals: uploaders,
+          actions: ["s3:GetObject", "s3:PutObject"],
+          resources: [`${this.bucket.bucketArn}/*`],
+        }),
+      );
+      this.bucket.addToResourcePolicy(
+        new iam.PolicyStatement({
+          principals: uploaders,
+          actions: ["s3:ListBucket"],
+          resources: [this.bucket.bucketArn],
+        }),
+      );
+    }
+
+    // ----------------------------------------------------------------
+    // ACM Certificate — imported, see `certificateArn` on the props
+    // ----------------------------------------------------------------
+    const certificate = acm.Certificate.fromCertificateArn(
+      this,
+      "Certificate",
+      certificateArn,
+    );
+
+    // ----------------------------------------------------------------
+    // CloudFront — path-only cache key, everything immutable
+    // ----------------------------------------------------------------
+    const cachePolicy = new cloudfront.CachePolicy(this, "CachePolicy", {
+      headerBehavior: cloudfront.CacheHeaderBehavior.none(),
+      queryStringBehavior: cloudfront.CacheQueryStringBehavior.none(),
+      cookieBehavior: cloudfront.CacheCookieBehavior.none(),
+      minTtl: cdk.Duration.days(1),
+      defaultTtl: cdk.Duration.days(365),
+      maxTtl: cdk.Duration.days(365),
+    });
+
+    // The upload stamps `Cache-Control: public, max-age=31536000, immutable` on
+    // the objects themselves, so only CORS is added here. Response headers
+    // policies are evaluated per request rather than stored with the cached
+    // object, which is why the cache key above can stay path-only even though
+    // the allowed origin is echoed back.
+    const responseHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
+      this,
+      "ResponseHeadersPolicy",
+      {
+        corsBehavior: {
+          accessControlAllowCredentials: false,
+          accessControlAllowHeaders: ["*"],
+          accessControlAllowMethods: ["GET", "HEAD", "OPTIONS"],
+          accessControlAllowOrigins: allowedOrigins,
+          originOverride: true,
+        },
+        customHeadersBehavior: {
+          customHeaders: [
+            {
+              // Not required today — the app leaves COEP off — but it costs
+              // nothing and keeps these assets loadable if it is ever turned on.
+              header: "Cross-Origin-Resource-Policy",
+              value: "cross-origin",
+              override: true,
+            },
+          ],
+        },
+      },
+    );
+
+    // Note: with origin access control the bucket grants only `s3:GetObject`,
+    // so S3 answers a missing key with 403 rather than 404. That is expected,
+    // not a permissions fault.
+    this.distribution = new cloudfront.Distribution(this, "Distribution", {
+      defaultBehavior: {
+        origin: origins.S3BucketOrigin.withOriginAccessControl(this.bucket),
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+        cachePolicy,
+        responseHeadersPolicy,
+        compress: true,
+      },
+      domainNames: [domainName],
+      certificate,
+      httpVersion: cloudfront.HttpVersion.HTTP2_AND_3,
+    });
+
+    // No Route 53 records here: `argos-ci.com` is not hosted in this account.
+    // `domainName` has to be pointed at `DistributionDomainName` (below) with a
+    // CNAME at whoever runs that zone, once, by hand.
+
+    // ----------------------------------------------------------------
+    // Retention — daily, driven by build manifests rather than object age
+    // ----------------------------------------------------------------
+    const purgeFn = new nodejs.NodejsFunction(this, "PurgeFn", {
+      entry: path.join(__dirname, "../lambda/purge-assets.ts"),
+      handler: "handler",
+      runtime: lambda.Runtime.NODEJS_24_X,
+      memorySize: 512,
+      // Listing and deleting tens of thousands of keys is paginated, and this
+      // runs once a day with nothing waiting on it.
+      timeout: cdk.Duration.minutes(15),
+      logGroup: new cdk.aws_logs.LogGroup(this, "PurgeFnLogGroup", {
+        retention: cdk.aws_logs.RetentionDays.ONE_MONTH,
+      }),
+      environment: {
+        BUCKET: this.bucket.bucketName,
+        RETENTION_DAYS: String(retentionDays),
+      },
+      bundling: {
+        minify: true,
+        sourceMap: false,
+        target: "es2022",
+      },
+    });
+
+    this.bucket.grantReadWrite(purgeFn);
+
+    new events.Rule(this, "PurgeSchedule", {
+      schedule: events.Schedule.rate(cdk.Duration.days(1)),
+      targets: [new targets.LambdaFunction(purgeFn)],
+    });
+
+    // ----------------------------------------------------------------
+    // Outputs
+    // ----------------------------------------------------------------
+    new cdk.CfnOutput(this, "BucketName", { value: this.bucket.bucketName });
+    new cdk.CfnOutput(this, "AssetsBaseUrl", {
+      value: `https://${domainName}`,
+    });
+    new cdk.CfnOutput(this, "DistributionId", {
+      value: this.distribution.distributionId,
+    });
+    new cdk.CfnOutput(this, "DistributionDomainName", {
+      value: this.distribution.distributionDomainName,
+      description: `CNAME target for ${domainName}. Create this record at the external DNS provider for the zone; nothing serves until it exists.`,
+    });
+  }
+}

--- a/infra/lib/deployment-stack.ts
+++ b/infra/lib/deployment-stack.ts
@@ -213,8 +213,11 @@ export class ArgosDeploymentStack extends cdk.Stack {
           "process.env.API_BASEURL": JSON.stringify(apiBaseUrl),
           "process.env.APP_URL": JSON.stringify(appUrl),
           "process.env.BASE_DOMAIN": JSON.stringify(baseDomain),
-          "process.env.ACCESS_TOKEN_SECRET": JSON.stringify(accessTokenSecret),
         },
+        // The secret is injected from a file instead of defined inline. See
+        // `writeInjectedSecret` and the `ACCESS_TOKEN_SECRET` declaration in
+        // the lambda for why.
+        inject: [writeInjectedSecret(accessTokenSecret)],
       },
     });
 
@@ -426,4 +429,32 @@ export class ArgosDeploymentStack extends cdk.Stack {
       value: apiBaseUrl,
     });
   }
+}
+
+/**
+ * Writes the edge function's access-token secret to a file for esbuild to
+ * `--inject`, returning its path.
+ *
+ * Lambda@Edge cannot read environment variables at runtime, so the secret has
+ * to be compiled into the bundle either way. What changed is how it gets there:
+ * as a `--define` it sat on esbuild's command line, and CDK reproduces that
+ * command line verbatim in its error whenever bundling fails. In a public
+ * repository running `cdk diff` in CI, one failed build publishes the secret.
+ * With an inject, only this path appears.
+ *
+ * Written inside the package rather than `os.tmpdir()` so it stays visible if
+ * bundling ever falls back to running in Docker, which mounts the project but
+ * not the host's temp directory. The directory is gitignored, and the file is
+ * owner-only.
+ */
+function writeInjectedSecret(secret: string): string {
+  const directory = path.join(__dirname, "../.generated");
+  fs.mkdirSync(directory, { recursive: true });
+  const file = path.join(directory, "edge-access-token-secret.js");
+  fs.writeFileSync(
+    file,
+    `export const ACCESS_TOKEN_SECRET = ${JSON.stringify(secret)};\n`,
+    { mode: 0o600 },
+  );
+  return file;
 }

--- a/infra/package.json
+++ b/infra/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.1105.0",
+    "@aws-sdk/client-s3": "^3.1105.0",
     "@aws-sdk/lib-dynamodb": "^3.1105.0",
     "aws-cdk-lib": "^2.263.0",
     "constructs": "^10.8.1"

--- a/infra/scripts/app.ts
+++ b/infra/scripts/app.ts
@@ -2,6 +2,10 @@ import { execFileSync } from "node:child_process";
 import * as cdk from "aws-cdk-lib";
 
 import {
+  ArgosAssetsStack,
+  ArgosAssetsStackPropsSchema,
+} from "../lib/assets-stack.ts";
+import {
   ArgosDeploymentStack,
   ArgosDeploymentStackPropsSchema,
 } from "../lib/deployment-stack.ts";
@@ -35,6 +39,14 @@ function get1PasswordItemName(stage: string) {
   return item;
 }
 
+function assertStageMatches(config: { stage?: string }, stage: string) {
+  if (config.stage !== stage) {
+    throw new Error(
+      `Stage mismatch: context stage is "${stage}" but the loaded config stage is "${config.stage}"`,
+    );
+  }
+}
+
 function read1PasswordConfig(stage: string) {
   const item = get1PasswordItemName(stage);
 
@@ -44,29 +56,72 @@ function read1PasswordConfig(stage: string) {
 
   const config = JSON.parse(json);
 
-  if (config.stage !== stage) {
-    throw new Error(
-      `Stage mismatch: context stage is "${stage}" but 1Password config stage is "${config.stage}"`,
-    );
-  }
+  assertStageMatches(config, stage);
 
   return config;
+}
+
+/**
+ * The same config document, read from SSM Parameter Store instead of 1Password.
+ *
+ * CI has no `op` binary and no way to authenticate one, so the parameter is the
+ * automation-facing copy of the 1Password item. `release.yml` already reads
+ * `/production/*` parameters for the ECS task definitions, so the mechanism and
+ * the role's permissions are established.
+ */
+function readSsmConfig(stage: string) {
+  const json = execFileSync(
+    "aws",
+    [
+      "ssm",
+      "get-parameter",
+      "--name",
+      `/${stage}/cdk/config.json`,
+      "--with-decryption",
+      "--query",
+      "Parameter.Value",
+      "--output",
+      "text",
+    ],
+    { encoding: "utf8" },
+  );
+
+  const config = JSON.parse(json);
+
+  assertStageMatches(config, stage);
+
+  return config;
+}
+
+/** Reads a comma-separated context value as a list. */
+function getContextList(name: string): string[] {
+  return (app.node.tryGetContext(name) ?? "")
+    .split(",")
+    .map((value: string) => value.trim())
+    .filter(Boolean);
 }
 
 const rawProps =
   source === "1P"
     ? read1PasswordConfig(stage)
-    : {
-        stage,
-        apiBaseUrl: app.node.tryGetContext("apiBaseUrl"),
-        appUrl: app.node.tryGetContext("appUrl"),
-        hostedZoneId: app.node.tryGetContext("hostedZoneId"),
-        accessTokenSecret: app.node.tryGetContext("accessTokenSecret"),
-        appUserArns: (app.node.tryGetContext("appUserArns") ?? "")
-          .split(",")
-          .map((s: string) => s.trim())
-          .filter(Boolean),
-      };
+    : source === "ssm"
+      ? readSsmConfig(stage)
+      : {
+          stage,
+          apiBaseUrl: app.node.tryGetContext("apiBaseUrl"),
+          appUrl: app.node.tryGetContext("appUrl"),
+          hostedZoneId: app.node.tryGetContext("hostedZoneId"),
+          accessTokenSecret: app.node.tryGetContext("accessTokenSecret"),
+          appUserArns: getContextList("appUserArns"),
+          assets: {
+            domainName: app.node.tryGetContext("assetsDomainName"),
+            // Imported, not created: unlike `argos-ci.live` above, the app's
+            // own domain is not a Route 53 zone in this account.
+            certificateArn: app.node.tryGetContext("assetsCertificateArn"),
+            allowedOrigins: getContextList("assetsAllowedOrigins"),
+            uploaderRoleArns: getContextList("assetsUploaderRoleArns"),
+          },
+        };
 
 const props = ArgosDeploymentStackPropsSchema.parse(rawProps);
 
@@ -81,6 +136,24 @@ const deploymentStack = new ArgosDeploymentStack(
     },
   },
 );
+
+// Independent of the deployment stack: this one serves Argos's own frontend,
+// that one serves customer deployments. Kept separate so a release, which
+// touches only the asset bucket, never has to update the deployment stack.
+const assetsProps = ArgosAssetsStackPropsSchema.parse({
+  stage: props.stage,
+  ...rawProps.assets,
+});
+
+new ArgosAssetsStack(app, `argos-assets-${props.stage}`, {
+  ...assetsProps,
+  env: {
+    account: process.env["CDK_DEFAULT_ACCOUNT"],
+    // Must be us-east-1: CloudFront only accepts an ACM certificate issued
+    // there, whatever region the distribution serves from.
+    region: "us-east-1",
+  },
+});
 
 if (props.stage === "production") {
   const replicaStack = new ArgosReplicaStack(

--- a/knip.json
+++ b/knip.json
@@ -31,5 +31,5 @@
     "vitest/vitest.unit.config.mts"
   ],
   "ignoreBinaries": ["stripe", "ngrok", "op"],
-  "ignoreDependencies": ["@graphql-codegen/add"]
+  "ignoreDependencies": ["@graphql-codegen/add", "esbuild"]
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@parcel/watcher": "^2.6.0",
     "@playwright/test": "1.62.1",
     "@types/node": "^26.1.2",
+    "esbuild": "^0.28.1",
     "knip": "^6.32.0",
     "oxfmt": "^0.62.0",
     "oxlint": "^1.77.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@types/node':
         specifier: ^26.1.2
         version: 26.1.2
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
       knip:
         specifier: ^6.32.0
         version: 6.32.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -689,6 +689,9 @@ importers:
       '@aws-sdk/client-dynamodb':
         specifier: ^3.1105.0
         version: 3.1105.0
+      '@aws-sdk/client-s3':
+        specifier: ^3.1105.0
+        version: 3.1105.0
       '@aws-sdk/lib-dynamodb':
         specifier: ^3.1105.0
         version: 3.1105.0(@aws-sdk/client-dynamodb@3.1105.0)


### PR DESCRIPTION
## Problem

The app runs as several ECS tasks behind an ALB, and each task can only serve the frontend build baked into its own image. During a rolling deploy, a shell served by a new task names content-hashed chunks the old tasks do not have, so whichever task answers the asset request may 404 it.

The deploy window is only half of it. `router.tsx` splits ~40 routes behind `lazy: () => import(...)`, and the old build ceases to exist the moment the last old task stops — so a tab open across a deploy breaks on the *next* chunk it needs, permanently. Rollbacks have the same shape: redeploying an older image breaks everyone who loaded the newer one.

The existing `DYNAMIC_IMPORT_MODULE_FAILED_TO_LOAD` recovery is why this is survivable today, but it only fires once. If the reload's HTML comes from a new task and its assets land on an old one, the second failure has no reload budget left and the user gets the error boundary plus a Sentry event.

## Approach

Decouple asset lifetime from container lifetime. Filenames are content-hashed, so the asset store is **append-only**: every deploy adds files, no deploy removes any. Assets move to `assets.argos-ci.com` (S3 + CloudFront), retained 30 days, purged out of band by manifest age.

Retention is deliberately **not** an S3 lifecycle rule. An unchanged chunk keeps its hash across builds, so `s3 sync` skips re-uploading it and its creation date never moves — a lifecycle rule would expire files today's HTML still references. Each release writes `manifests/<sha>.json`; a daily Lambda keeps the union of every manifest inside the window.

## Things worth a reviewer's attention

- **`target: build` on the image build is load-bearing.** The Dockerfile's new last stage exports the frontend output, which makes it the default build target. Without the explicit target, the pushed app image becomes an empty scratch image.
- **The colour-detection worker is now inlined.** A worker's top-level script must be same-origin whatever CORS allows, so building it from `import.meta.url` throws a `SecurityError` once that URL is cross-origin. `worker-src` is deliberately *not* widened to the CDN — that would hide the reason, not fix it.
- **Public-directory files stay on the app origin** via `renderBuiltUrl`. They are not content-hashed, so they gain nothing from the CDN and would need a second cache-control class plus a `manifest-src` CSP directive.
- **`/assets/*` now 404s.** Misses previously fell through to the SPA catch-all and returned index.html with a 200, which the browser reports as an opaque MIME type error.
- **`deploy` gains `needs: assets`** so the CDN holds the chunks before anything serves HTML naming them.

## Deploy state

The AWS side is already done and verified: certificate issued, `argos-assets-production` deployed, DNS pointed at the distribution (DNS-only, not proxied), CORS and cache headers confirmed with a probe fetch. Runbook is in `infra/README.md`.

## Rollback

Remove `ASSETS_BASE_URL` from `release.yml` and release again — assets return to the app origin, because the container never stopped serving `apps/frontend/dist`.

## Tests

`pnpm run static-checks` (18/18) and 27 unit tests pass. The two retention guards have tests that were verified to fail when the guard is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)