### PR TITLE
fix(csp): allow source-map fetches from the asset CDN

### DIFF
--- a/apps/backend/src/web/security-headers.test.ts
+++ b/apps/backend/src/web/security-headers.test.ts
@@ -171,11 +171,13 @@ describe("app security headers", () => {
       const csp = await getCsp();
       // Scripts and styles are the build output; fonts ship inside it via
       // `@fontsource-variable/inter`; images cover anything Vite emits to
-      // `assets/`. Miss one and that resource type breaks on deploy.
+      // `assets/`; `connect-src` is how DevTools fetches the source maps the
+      // chunks point at. Miss one and that resource type breaks on deploy.
       expect(csp["script-src"]).toContain("https://assets.argos-ci.com");
       expect(csp["style-src"]).toContain("https://assets.argos-ci.com");
       expect(csp["font-src"]).toContain("https://assets.argos-ci.com");
       expect(csp["img-src"]).toContain("https://assets.argos-ci.com");
+      expect(csp["connect-src"]).toContain("https://assets.argos-ci.com");
     });
 
     it("does not authorise the CDN for workers", async () => {

--- a/apps/backend/src/web/security-headers.ts
+++ b/apps/backend/src/web/security-headers.ts
@@ -180,5 +180,15 @@ export function getConnectSrc(): string[] {
   // Sentry posts envelopes to its DSN's ingest host.
   addOrigin(origins, config.get("sentry.clientDsn"));
 
+  // The build ships a `//# sourceMappingURL` next to every chunk, and DevTools
+  // fetches those `.js.map` files through the page's own `connect-src`. They were
+  // same-origin until the assets moved to the CDN, so `'self'` covered them;
+  // without the CDN here, opening DevTools logs one blocked-connection error per
+  // chunk. Nothing else in the app connects to this origin — code, styles and
+  // fonts load through their own directives.
+  for (const origin of getAssetsOrigin()) {
+    origins.add(origin);
+  }
+
   return Array.from(origins);
 }


### PR DESCRIPTION
## What

Adds the asset CDN origin to the app's `connect-src` directive, alongside the `script-src` / `style-src` / `font-src` / `img-src` entries it already appears in.

## Why

Opening DevTools on production logged 155 CSP errors — one per chunk:

> Connecting to `https://assets.argos-ci.com/assets/frontend-DBHL8YEh.js.map` violates the following Content Security Policy directive: `connect-src 'self' …`. The request has been blocked.

The production build ships a `//# sourceMappingURL` next to every chunk, and DevTools fetches those `.js.map` files through the page's own `connect-src`. They were same-origin — so covered by `'self'` — until hashed assets moved to the CDN in #2467; that change named the new origin in every other asset directive but not this one.

## Notes for the reviewer

- Nothing else in the app connects to the asset origin: code, styles and fonts load through their own directives, and the colour-detection worker stays inlined as a blob (`worker-src` is deliberately untouched). So this only widens `connect-src` to a read-only origin the app already loads all of its code from.
- The `asset origin` test that checks "every directive that can name an asset" now asserts `connect-src` too, so the next directive-by-directive omission fails instead of shipping.
- Alternative considered and not taken: stop publishing the maps (`sourcemaps.filesToDeleteAfterUpload` in the Sentry Vite plugin) and keep `connect-src` narrow. The maps were already publicly readable from the app origin before the CDN move, so this keeps that behaviour rather than changing it in a CSP fix — happy to do it separately if we'd rather not publish them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)