### PR TITLE
fix(comment): keep threads in the same order between loads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,31 @@ users) — re-parse the stored JSON server-side and check permissions (see
 `src/comment/mentions.ts`). A `mention` node persists **only the account id**,
 never the label; labels are resolved at render time on both sides.
 
+## What to test
+
+Coverage is not the goal. Every test is code someone has to keep working, so it
+has to earn its place by protecting something the project actually depends on.
+
+- **Test what matters to the whole project, not edge cases.** Billing,
+  permissions and auth, the build lifecycle, review and comment flows,
+  notifications — the paths where a regression reaches users or corrupts data.
+  A test that pins one component's internal state buys little and costs
+  maintenance forever.
+- **The more end-to-end, the better.** A Playwright spec exercises the real
+  server, the real database and the real client together, which is where bugs
+  actually live; the same assertion one layer down proves much less. When a
+  behavior can be reached from the UI, test it there and skip the unit test.
+- **Avoid mocking.** A mock asserts what you assumed the collaborator does, so
+  the test passes while production breaks. If a behavior can only be reached by
+  mocking, move the test further out — or accept that it does not need one.
+- **Low-level utilities are the exception worth being exhaustive about.** Pure
+  helpers with many input shapes — parsers, validators, comparators, formatters
+  — are cheap to cover case by case, and that is exactly where a table-driven
+  `*.test.ts` pays off.
+- **Not every fix needs a test.** A flake, a one-off rendering detail or an
+  ordering tweak is usually fixed and left at that. Add a guard only when the
+  behavior is worth defending on its own.
+
 ## Testing (Vitest)
 
 - Tests live next to the code. `*.e2e.test.ts` requires Redis/Postgres,
@@ -157,8 +182,7 @@ never the label; labels are resolved at render time on both sides.
 - Use `apps/backend/src/database/testing/factory.ts` for fixtures, and
   `test.extend` (prefer one per file, creating models inside fixtures).
 - Keep fixtures small, reusable, independent, and split by concern so tests run
-  in parallel. Avoid large shared setups and avoid mocking unless the behavior
-  can't be tested realistically.
+  in parallel. Avoid large shared setups.
 - Test API endpoints with `createTestHandlerApp` + `supertest`.
 - `test:integration` runs in parallel, and every test truncates the whole
   database, so each worker owns a `test_<workerId>` database, a Redis database
@@ -195,8 +219,9 @@ Specs live in `tests/*.spec.ts` and run against the **built** app.
   depend on. Use a unique `keyPrefix` (e.g. the project id) for `File` keys, and
   reuse existing image keys (`dummy-*`, `diff-*`) so images load from
   `files.argos-ci.com/test/<s3Id>`.
-- A guard test should fail without the fix — verify by temporarily reverting the
-  fix, rebuilding, and re-running before trusting it.
+- A guard test — when the behavior warrants one, see [What to test](#what-to-test)
+  — should fail without the fix. Verify by temporarily reverting the fix,
+  rebuilding, and re-running before trusting it.
 
 ### Seeding gotchas
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,17 @@ is oxlint's `correctness` category across the `typescript`, `unicorn`, `oxc`,
 Suppress with `// oxlint-disable-next-line <rule>`. Oxlint still honours
 `eslint-disable` comments, but do not write new ones.
 
+## Commits
+
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), with one
+rule that decides the type: **`feat` and `fix` are for what a user would
+notice** — a capability they gain, a bug they hit. Judge it from their side of
+the screen, not from how much code moved or how hard it was to find. Everything
+else is `chore`, however substantial: refactors, tests, tooling, docs,
+dependency bumps, and internal fixes no user could ever observe. Do not use
+`style` — the formatter owns formatting, so the type has nothing left to
+describe.
+
 ## TypeScript
 
 - Never use `!` (non-null assertion). Use `invariant` for required values.

--- a/apps/backend/src/comment/getVisibleComments.ts
+++ b/apps/backend/src/comment/getVisibleComments.ts
@@ -37,6 +37,22 @@ export function filterVisibleComments<QB extends QueryBuilder<Comment, any>>(
 }
 
 /**
+ * Order comments oldest first, breaking ties on `id`.
+ *
+ * `createdAt` alone is not a total order: comments written in the same
+ * transaction share it to the millisecond, and Postgres is then free to return
+ * them in any order it likes. Without the tiebreaker a thread list reshuffles
+ * between two loads of the same data — which is also what made the media
+ * activity panel's visual test flaky. `id` is a sequence, so ordering on it is
+ * insertion order.
+ */
+function orderOldestFirst<QB extends QueryBuilder<Comment, any>>(
+  query: QB,
+): QB {
+  return query.orderBy("createdAt", "asc").orderBy("id", "asc");
+}
+
+/**
  * Load the comments visible to a given viewer on a single build, oldest first.
  */
 async function getVisibleBuildComments(input: {
@@ -44,10 +60,12 @@ async function getVisibleBuildComments(input: {
   viewerUserId: string | null;
 }): Promise<Comment[]> {
   const { buildId, viewerUserId } = input;
-  return filterVisibleComments(
-    Comment.query().where("buildId", buildId),
-    viewerUserId,
-  ).orderBy("createdAt", "asc");
+  return orderOldestFirst(
+    filterVisibleComments(
+      Comment.query().where("buildId", buildId),
+      viewerUserId,
+    ),
+  );
 }
 
 /**
@@ -78,7 +96,7 @@ export function getVisibleTestCommentsQuery(input: {
   viewerUserId: string | null;
 }): QueryBuilder<Comment, Comment[]> {
   const { testIds, viewerUserId } = input;
-  return Comment.query()
+  const query = Comment.query()
     .with(
       "ranked",
       filterVisibleComments(
@@ -94,8 +112,8 @@ export function getVisibleTestCommentsQuery(input: {
     .whereIn(
       "id",
       knex.select("id").from("ranked").where("rank", "<=", TEST_COMMENTS_LIMIT),
-    )
-    .orderBy("createdAt", "asc");
+    );
+  return orderOldestFirst(query);
 }
 
 /**
@@ -119,7 +137,7 @@ export function getVisibleMediaCommentsQuery(input: {
   viewerUserId: string | null;
 }): QueryBuilder<Comment, Comment[]> {
   const { mediaIds, viewerUserId } = input;
-  return Comment.query()
+  const query = Comment.query()
     .with(
       "ranked",
       filterVisibleComments(
@@ -138,8 +156,8 @@ export function getVisibleMediaCommentsQuery(input: {
         .select("id")
         .from("ranked")
         .where("rank", "<=", MEDIA_COMMENTS_LIMIT),
-    )
-    .orderBy("createdAt", "asc");
+    );
+  return orderOldestFirst(query);
 }
 
 /**

--- a/apps/frontend/src/containers/Build/BuildDiffHighlighterContext.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffHighlighterContext.tsx
@@ -14,7 +14,15 @@ export type Highlighter = {
 
 type BuildDiffHighlighterContextValue = {
   highlighter: Highlighter | null;
+  /**
+   * Whether the changed areas are still being detected. A `null` highlighter
+   * then means "the answer is not in yet" rather than "there is nothing to step
+   * through", which is the difference between a control that is about to work
+   * and one that never will.
+   */
+  loading: boolean;
   registerHighlighter: (highlighter: Highlighter) => () => void;
+  setLoading: (loading: boolean) => void;
 };
 
 const BuildDiffHighlighterContext =
@@ -24,13 +32,14 @@ export function BuildDiffHighlighterProvider(props: {
   children: React.ReactNode;
 }) {
   const [highlighter, setHighlighter] = useState<Highlighter | null>(null);
+  const [loading, setLoading] = useState(false);
   const registerHighlighter = useCallback((highlighter: Highlighter) => {
     setHighlighter(highlighter);
     return () => setHighlighter(null);
   }, []);
   const value = useMemo(
-    () => ({ registerHighlighter, highlighter }),
-    [registerHighlighter, highlighter],
+    () => ({ registerHighlighter, highlighter, loading, setLoading }),
+    [registerHighlighter, highlighter, loading],
   );
   return (
     <BuildDiffHighlighterContext value={value}>

--- a/apps/frontend/src/containers/Build/ChangesOverlay.tsx
+++ b/apps/frontend/src/containers/Build/ChangesOverlay.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { invariant } from "@argos/util/invariant";
 import { useAtomValue } from "jotai/react";
 
@@ -42,10 +42,20 @@ type Dimensions = { width: number; height: number };
  * and spacing.
  */
 export const ChangesOverlayControls = memo(function ChangesOverlayControls() {
+  const { loading } = useBuildDiffHighlighterContext();
   return (
     <>
       <OverlayToggle />
-      <ButtonGroup>
+      {/*
+       * All three enable together, once the changed areas have been detected —
+       * so the group is what is busy until then, not any one button. It also has
+       * to be the group because React Aria drops unknown ARIA props off the DOM
+       * node, `aria-busy` among them, and `ButtonGroup` is a plain div.
+       *
+       * Beyond announcing the wait, this is what makes Argos hold the screenshot
+       * until the answer is in, instead of catching the buttons disabled.
+       */}
+      <ButtonGroup aria-busy={loading}>
         <GoToPreviousChangesButton />
         <HighlightButton />
         <GoToNextChangesButton />
@@ -117,7 +127,7 @@ export function ChangesHighlights(props: {
   const containerRef = useRef<HTMLDivElement>(null);
   const transform = useZoomTransform();
   const jpgUrl = useMemo(() => getChangesDetectionUrl(url), [url]);
-  const { rects } = useColoredRects({ url: jpgUrl, blockSize: 24 });
+  const { rects, loading } = useColoredRects({ url: jpgUrl, blockSize: 24 });
   const [imgScale] = useScaleContext();
   const realScale = imgScale ? imgScale * transform.scale : null;
   // Convert image coordinates to pane coordinates.
@@ -131,7 +141,14 @@ export function ChangesHighlights(props: {
         : 0;
     return [x * imgScale + x1, y * imgScale + y1];
   };
-  const { registerHighlighter } = useBuildDiffHighlighterContext();
+  const { registerHighlighter, setLoading } = useBuildDiffHighlighterContext();
+  // Nothing registers until the detector answers, so on its own the toolbar
+  // cannot tell "still counting" from "nothing to step through". Reporting it is
+  // what lets the toolbar mark those controls busy while they wait.
+  useEffect(() => {
+    setLoading(loading);
+    return () => setLoading(false);
+  }, [loading, setLoading]);
   const highlight: Highlighter["highlight"] = useEventCallback(() => {
     const container = containerRef.current;
     if (!container) {

--- a/tests/media.spec.ts
+++ b/tests/media.spec.ts
@@ -245,6 +245,14 @@ loggedTest(
     // Expanding the thread in the panel puts the pin back on the image.
     await page.getByRole("button", { name: "Expand thread" }).click();
     await expect(resolvedPin).toBeVisible();
+
+    // Resolving popped a toast over the panel, and it slides in and out on its
+    // own timeline — left alone it lands in the screenshot mid-animation, at a
+    // different offset every run. Dismissing it is the only way to be sure which
+    // frame is captured.
+    await page.getByRole("button", { name: "Close toast" }).click();
+    await expect(page.getByText("Thread resolved.")).toBeHidden();
+
     await screenshot(page, "media-resolved-pin-expanded");
 
     // And collapsing it takes the pin away again.


### PR DESCRIPTION
Fixes the two flaky baselines reported from builds [5515](https://app.argos-ci.com/argos-ci/argos/builds/5515/405714977) and [5518](https://app.argos-ci.com/argos-ci/argos/builds/5518/405753192). Both were real product defects rather than test noise, so the fixes are in the app.

## `media-share-changes-overlay` — controls captured mid-detection

The diff was only the three change-navigation buttons (previous / highlight / next): enabled in the baseline, disabled in the head. They enable once `useColoredRects` — a web worker reading the mask — answers, and nothing told Argos to wait, so the capture landed on whichever state the worker happened to be in.

`BuildDiffHighlighterContext` now carries a `loading` flag next to the highlighter, so a `null` highlighter can mean "the answer is not in yet" rather than "there is nothing to step through", and `ChangesOverlayControls` marks the group `aria-busy` until it settles.

**Why the group and not each button:** React Aria's `filterDOMProps` allow-list is `id`, four labelable `aria-*`, link props, `dir/lang/hidden/inert/translate`, events and `data-*` — it silently strips `aria-busy` off the DOM node. Verified empirically: on the `Button` the attribute never reached the DOM (`getAttribute("aria-busy") → null`); on the `ButtonGroup` div it renders `"true"`. All three buttons enable together anyway, so the group is the honest anchor.

## `media-resolved-pin-expanded` — two causes

1. **Comment order was non-deterministic.** `orderBy("createdAt", "asc")` is not a total order, and the seed gives all three comments one identical timestamp, so Postgres returned the two threads in either order. Added an `id` tiebreaker via a shared `orderOldestFirst` helper, applied to the media, build **and** test queries — all three had the same defect and all three document themselves as "oldest first".
2. **A toast was captured mid-animation.** Not visible in the reported diff, but three runs after the ordering fix still differed in that region: resolving a thread pops a toast that slides in and out on its own timeline. The test now dismisses it before capturing.

## Reviewer notes

- **One baseline needs approval:** `media-resolved-pin-expanded`. Comment order is now deterministic insertion order (pinned thread first, the opposite of the current baseline) and the toast is gone. `media-share-changes-overlay` should match its existing baseline, since the buttons now settle into the enabled state it already has.
- The comment-ordering change is global (build and test comments too), so the full e2e suite was run: **190 passed**. Backend integration suite: **1184 passed**. `pnpm run static-checks`: 18/18.
- Both directions of the `aria-busy` fix were verified by holding the mask's JPEG with a route block: busy while detecting, settled after — and absent when the attribute is removed.
- `AGENTS.md` gains a **What to test** section (requested separately): cover what matters project-wide over edge cases, prefer end-to-end, avoid mocking, be exhaustive only for pure low-level utilities, and accept that not every fix needs a test. I had written a guard spec for the `aria-busy` behaviour and removed it under exactly that rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)