### PR TITLE
feat(comment): show which agent posted a comment

### DIFF
--- a/apps/backend/db/migrations/20260813191611_comment-agent.js
+++ b/apps/backend/db/migrations/20260813191611_comment-agent.js
@@ -1,0 +1,29 @@
+/**
+ * Record which coding agent posted a comment, when one did.
+ *
+ * An agent acts with its user's own credentials, so a comment it writes is
+ * indistinguishable from one the person typed. This is what lets the UI say
+ * "posted through Claude Code" next to the author's avatar, rather than
+ * silently attributing the agent's words to them.
+ *
+ * A plain string, not a foreign key: the value is an id from the curated
+ * registry in `src/agent/registry.ts` (or `unknown` for an agent we can't put a
+ * name to), which lives in code because adding an agent is a display decision,
+ * not data anyone edits. `NULL` means a person acted directly.
+ *
+ * @param {import('knex').Knex} knex
+ */
+export const up = async (knex) => {
+  await knex.schema.alterTable("comments", (table) => {
+    table.string("agent");
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+export const down = async (knex) => {
+  await knex.schema.alterTable("comments", (table) => {
+    table.dropColumn("agent");
+  });
+};

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict SJMOjW7fwlbG5V9h9dOw91WWYjjnPhrNmOhMNNy0ftDq9k87kzZthcc2phDVXnb
+\restrict 8WS8KvWTX1NC5mccR9MIC9lXebzpzWv8u6YEgWIomHaGpKkaShrQhTYIWaa3QEM
 
 -- Dumped from database version 18.4
 -- Dumped by pg_dump version 18.4 (Homebrew)
@@ -701,6 +701,7 @@ CREATE TABLE public.comments (
     "testId" bigint,
     "mediaId" bigint,
     "mediaVersionId" bigint,
+    agent character varying(255),
     CONSTRAINT comments_anchor_requires_target CHECK (((anchor IS NULL) OR ("screenshotDiffId" IS NOT NULL) OR ("mediaId" IS NOT NULL))),
     CONSTRAINT comments_media_target_scope CHECK ((("mediaId" IS NULL) OR (("buildReviewId" IS NULL) AND ("screenshotDiffId" IS NULL)))),
     CONSTRAINT comments_media_version_requires_media CHECK ((("mediaVersionId" IS NULL) OR ("mediaId" IS NOT NULL))),
@@ -6234,7 +6235,7 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-\unrestrict SJMOjW7fwlbG5V9h9dOw91WWYjjnPhrNmOhMNNy0ftDq9k87kzZthcc2phDVXnb
+\unrestrict 8WS8KvWTX1NC5mccR9MIC9lXebzpzWv8u6YEgWIomHaGpKkaShrQhTYIWaa3QEM
 
 -- Knex migrations
 
@@ -6478,3 +6479,4 @@ INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('2026080
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260808140000_comment-media.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260809203017_media-branch.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260811133709_media-diffs.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260813191611_comment-agent.js', 1, NOW());

--- a/apps/backend/src/agent/registry.ts
+++ b/apps/backend/src/agent/registry.ts
@@ -1,0 +1,94 @@
+/**
+ * Curated registry of the coding agents that act on Argos through the CLI or
+ * the MCP server.
+ *
+ * An agent reaches the API with its user's own credentials, so the identity of
+ * the *tool* is self-asserted: the CLI forwards what `@vercel/detect-agent`
+ * found (ultimately the `AI_AGENT` environment variable, which anyone can set),
+ * and an MCP client picks its own OAuth registration metadata. Nothing here is
+ * a trust decision — it only decides which name and logo we show next to a
+ * comment. Anything unrecognized still counts as an agent and renders as a
+ * generic bot.
+ *
+ * Ids are shared with `oauth/known-apps.ts` where the same product appears in
+ * both, so the frontend keys a single logo map by them.
+ */
+
+type AgentDefinition = {
+  /** Stable id; also the key the frontend uses to pick the bundled logo. */
+  id: string;
+  displayName: string;
+};
+
+const AGENTS: AgentDefinition[] = [
+  { id: "claude-code", displayName: "Claude Code" },
+  { id: "claude", displayName: "Claude" },
+  { id: "openai-codex", displayName: "OpenAI Codex" },
+  { id: "cursor", displayName: "Cursor" },
+  { id: "vscode", displayName: "Visual Studio Code" },
+  { id: "windsurf", displayName: "Windsurf" },
+  { id: "zed", displayName: "Zed" },
+  { id: "gemini-cli", displayName: "Gemini CLI" },
+  { id: "github-copilot", displayName: "GitHub Copilot" },
+  { id: "devin", displayName: "Devin" },
+  { id: "replit", displayName: "Replit" },
+  { id: "antigravity", displayName: "Antigravity" },
+  { id: "augment-cli", displayName: "Augment CLI" },
+  { id: "opencode", displayName: "OpenCode" },
+  { id: "v0", displayName: "v0" },
+];
+
+/**
+ * Id stored for an agent we could not put a name to — an unrecognized MCP
+ * client, or a CLI run under a custom `AI_AGENT`. The action is still known to
+ * be agent-made, which is what the bot marker conveys; only the brand is
+ * missing. Self-asserted names are deliberately *not* stored under their own
+ * id: they would render as a name nobody vetted.
+ */
+export const UNKNOWN_AGENT_ID = "unknown";
+
+/**
+ * Names the CLI reports that differ from our id.
+ *
+ * These are the slugs `@vercel/detect-agent` returns, which are shorter than
+ * ours and, for `claude`, ambiguous: the CLI only ever runs under Claude *Code*
+ * — `claude` as a registry id is the desktop/web app, which reaches us over MCP
+ * instead. Keeping this map on the CLI side of the resolution is what lets the
+ * same word mean the right product on each side.
+ */
+const REPORTED_AGENT_ALIASES: Record<string, string> = {
+  claude: "claude-code",
+  claudecode: "claude-code",
+  cowork: "claude-code",
+  codex: "openai-codex",
+  "cursor-cli": "cursor",
+  gemini: "gemini-cli",
+  copilot: "github-copilot",
+  "github-copilot-cli": "github-copilot",
+};
+
+const AGENT_BY_ID = new Map(AGENTS.map((agent) => [agent.id, agent]));
+
+/**
+ * Resolve the name an agent reported for itself (the CLI's `agent/` token) to a
+ * registry id, falling back to {@link UNKNOWN_AGENT_ID}.
+ */
+export function resolveReportedAgentId(name: string): string {
+  const normalized = name.trim().toLowerCase();
+  const id = REPORTED_AGENT_ALIASES[normalized] ?? normalized;
+  return AGENT_BY_ID.has(id) ? id : UNKNOWN_AGENT_ID;
+}
+
+/**
+ * Whether an id names an agent in this registry — used to tell the well-known
+ * OAuth apps that are agents (Claude, Cursor, …) from the ones that are not
+ * (the Argos CLI itself).
+ */
+export function isAgentId(id: string): boolean {
+  return AGENT_BY_ID.has(id);
+}
+
+/** Display name of an agent id, `null` for an id outside the registry. */
+export function getAgentDisplayName(id: string): string | null {
+  return AGENT_BY_ID.get(id)?.displayName ?? null;
+}

--- a/apps/backend/src/agent/registry.ts
+++ b/apps/backend/src/agent/registry.ts
@@ -70,11 +70,23 @@ const REPORTED_AGENT_ALIASES: Record<string, string> = {
 const AGENT_BY_ID = new Map(AGENTS.map((agent) => [agent.id, agent]));
 
 /**
+ * Strip the version an agent may append to its name, leaving the product.
+ *
+ * Two shapes occur in the wild: the `@` separator the `AI_AGENT` convention
+ * documents (`devin@1`, `custom-agent@2.0`), and the `_` one Claude Code
+ * actually emits (`claude-code_2-1-227_agent`). A hyphen is *not* a separator —
+ * it is what the convention uses inside a name, as in `cursor-cli`.
+ */
+function stripAgentVersion(name: string): string {
+  return name.split("@")[0]!.split("_")[0]!;
+}
+
+/**
  * Resolve the name an agent reported for itself (the CLI's `agent/` token) to a
  * registry id, falling back to {@link UNKNOWN_AGENT_ID}.
  */
 export function resolveReportedAgentId(name: string): string {
-  const normalized = name.trim().toLowerCase();
+  const normalized = stripAgentVersion(name.trim().toLowerCase());
   const id = REPORTED_AGENT_ALIASES[normalized] ?? normalized;
   return AGENT_BY_ID.has(id) ? id : UNKNOWN_AGENT_ID;
 }

--- a/apps/backend/src/agent/request.test.ts
+++ b/apps/backend/src/agent/request.test.ts
@@ -50,13 +50,20 @@ describe("parseUserAgentAgentName", () => {
 });
 
 describe("resolveRequestAgentId", () => {
-  it("resolves the name the CLI reports to a registry id", () => {
+  it.each([
+    // The slugs `@vercel/detect-agent` returns for its own detections.
+    ["claude", "claude-code"],
+    ["codex", "openai-codex"],
+    ["cursor-cli", "cursor"],
+    ["gemini", "gemini-cli"],
+    // Versioned names: `_` is what Claude Code actually puts in `AI_AGENT`,
+    // `@` is what the convention documents.
+    ["claude-code_2-1-227_agent", "claude-code"],
+    ["devin@1", "devin"],
+  ])("resolves the reported name %j to %j", (reported, expected) => {
     expect(
-      resolveRequestAgentId(req("argos-cli/6.7.0 agent/claude"), PAT),
-    ).toBe("claude-code");
-    expect(resolveRequestAgentId(req("argos-cli/6.7.0 agent/codex"), PAT)).toBe(
-      "openai-codex",
-    );
+      resolveRequestAgentId(req(`argos-cli/6.7.0 agent/${reported}`), PAT),
+    ).toBe(expected);
   });
 
   it("keeps an unrecognized agent as an agent", () => {

--- a/apps/backend/src/agent/request.test.ts
+++ b/apps/backend/src/agent/request.test.ts
@@ -1,0 +1,111 @@
+import type { Request } from "express";
+import { describe, expect, it } from "vitest";
+
+import type {
+  AuthOAuthPayload,
+  AuthPATPayload,
+  AuthProjectPayload,
+} from "@/auth/payload";
+
+import { parseUserAgentAgentName, resolveRequestAgentId } from "./request";
+
+/** A request carrying just the header the resolver reads. */
+function req(userAgent?: string): Request {
+  return {
+    get: (name: string) =>
+      name.toLowerCase() === "user-agent" ? userAgent : undefined,
+  } as Request;
+}
+
+/** An OAuth payload with only the fields the resolver reads. */
+function oauth(input: {
+  clientId: string;
+  knownAppId: string | null;
+}): AuthOAuthPayload {
+  return { type: "oauth", ...input } as AuthOAuthPayload;
+}
+
+const PAT = { type: "pat" } as AuthPATPayload;
+const PROJECT = { type: "project" } as AuthProjectPayload;
+
+describe("parseUserAgentAgentName", () => {
+  it.each([
+    ["argos-cli/6.7.0 node/22.11.0 agent/claude", "claude"],
+    ["argos-cli/6.7.0 agent/custom-agent@2.0", "custom-agent@2.0"],
+    ["agent/devin", "devin"],
+    ["argos-cli/6.7.0 agent/cursor some-proxy/1.0", "cursor"],
+  ])("reads the agent token of %j", (userAgent, expected) => {
+    expect(parseUserAgentAgentName(userAgent)).toBe(expected);
+  });
+
+  it.each([
+    ["no header", undefined],
+    ["no agent token", "argos-cli/6.7.0 node/22.11.0"],
+    ["a token that only looks like one", "myagent/claude"],
+    ["an empty agent token", "argos-cli/6.7.0 agent/"],
+    ["a name outside the token grammar", "argos-cli/6.7.0 agent/(claude)"],
+  ])("returns null for %s", (_label, userAgent) => {
+    expect(parseUserAgentAgentName(userAgent)).toBeNull();
+  });
+});
+
+describe("resolveRequestAgentId", () => {
+  it("resolves the name the CLI reports to a registry id", () => {
+    expect(
+      resolveRequestAgentId(req("argos-cli/6.7.0 agent/claude"), PAT),
+    ).toBe("claude-code");
+    expect(resolveRequestAgentId(req("argos-cli/6.7.0 agent/codex"), PAT)).toBe(
+      "openai-codex",
+    );
+  });
+
+  it("keeps an unrecognized agent as an agent", () => {
+    expect(
+      resolveRequestAgentId(req("argos-cli/6.7.0 agent/homemade"), PAT),
+    ).toBe("unknown");
+  });
+
+  it("prefers the reported agent over the OAuth client", () => {
+    expect(
+      resolveRequestAgentId(
+        req("argos-cli/6.7.0 agent/cursor"),
+        oauth({ clientId: "argos-cli", knownAppId: "argos-cli" }),
+      ),
+    ).toBe("cursor");
+  });
+
+  it("resolves a well-known MCP client from its OAuth registration", () => {
+    expect(
+      resolveRequestAgentId(
+        req("node"),
+        oauth({ clientId: "oc_abc", knownAppId: "claude-code" }),
+      ),
+    ).toBe("claude-code");
+  });
+
+  it("treats an unrecognized OAuth client as an agent", () => {
+    expect(
+      resolveRequestAgentId(
+        req("node"),
+        oauth({ clientId: "oc_abc", knownAppId: null }),
+      ),
+    ).toBe("unknown");
+  });
+
+  it("does not take the CLI itself for an agent", () => {
+    expect(
+      resolveRequestAgentId(
+        req("argos-cli/6.7.0 node/22.11.0"),
+        oauth({ clientId: "argos-cli", knownAppId: "argos-cli" }),
+      ),
+    ).toBeNull();
+  });
+
+  it.each([
+    ["a personal access token", PAT],
+    ["a project token", PROJECT],
+    ["no authentication", null],
+  ])("resolves no agent for %s without an agent token", (_label, auth) => {
+    expect(resolveRequestAgentId(req("Mozilla/5.0"), auth)).toBeNull();
+  });
+});

--- a/apps/backend/src/agent/request.ts
+++ b/apps/backend/src/agent/request.ts
@@ -1,0 +1,81 @@
+/**
+ * Works out whether an API request was made by a coding agent, and which one.
+ *
+ * Agents never call the API directly — they drive the CLI or the MCP server —
+ * so each surface carries the identity differently:
+ *
+ * - **CLI**: an `agent/<name>` token in the `User-Agent`, from the agent
+ *   detection the CLI runs at startup.
+ * - **MCP**: the OAuth client holding the access token. OAuth exists here to
+ *   serve the CLI and MCP clients, and MCP is an agent protocol — so an OAuth
+ *   client that isn't the CLI is taken to be an agent even when the curated
+ *   known-apps registry doesn't recognize it.
+ *
+ * A request with neither is a person acting directly (the web app, a script, a
+ * personal access token) and resolves to `null`.
+ */
+import type { Request } from "express";
+
+import type {
+  AuthOAuthPayload,
+  AuthPATPayload,
+  AuthProjectPayload,
+} from "@/auth/payload";
+import { getKnownApp } from "@/oauth/known-apps";
+
+import {
+  isAgentId,
+  resolveReportedAgentId,
+  UNKNOWN_AGENT_ID,
+} from "./registry";
+
+/**
+ * The `agent/<name>` product token of a `User-Agent`. The CLI already
+ * sanitizes the name into an HTTP token, and this only accepts that shape, so a
+ * hand-crafted header can't smuggle anything else through.
+ */
+const AGENT_TOKEN_REGEX = /(?:^|\s)agent\/([\w.@-]{1,64})(?:\s|$)/i;
+
+/** The agent name a `User-Agent` reports, if it reports one. */
+export function parseUserAgentAgentName(
+  userAgent: string | undefined,
+): string | null {
+  const match = userAgent ? AGENT_TOKEN_REGEX.exec(userAgent) : null;
+  return match?.[1] ?? null;
+}
+
+type RequestAuth =
+  | AuthProjectPayload
+  | AuthPATPayload
+  | AuthOAuthPayload
+  | null;
+
+/**
+ * Resolve the agent behind a request to a registry id, or `null` when a person
+ * made it directly.
+ *
+ * The `User-Agent` wins over the OAuth client: an agent driving the CLI is more
+ * specific than "the CLI", which is the only thing the client id says.
+ */
+export function resolveRequestAgentId(
+  request: Request,
+  auth: RequestAuth,
+): string | null {
+  const reported = parseUserAgentAgentName(request.get("user-agent"));
+  if (reported) {
+    return resolveReportedAgentId(reported);
+  }
+
+  if (auth?.type !== "oauth") {
+    return null;
+  }
+
+  // A first-party client id we control (`argos-cli`) names the tool, not an
+  // agent — an agent driving it identifies itself in the `User-Agent` above.
+  const knownApp = getKnownApp(auth.knownAppId);
+  if (knownApp && !isAgentId(knownApp.id)) {
+    return null;
+  }
+
+  return knownApp?.id ?? UNKNOWN_AGENT_ID;
+}

--- a/apps/backend/src/api/handlers/comments.e2e.test.ts
+++ b/apps/backend/src/api/handlers/comments.e2e.test.ts
@@ -244,6 +244,54 @@ describe("createComment", () => {
       .expect(401);
     expect(res.body.error).toEqual(expect.any(String));
   });
+
+  test("records the agent the CLI reports", async ({
+    build,
+    scopedPatToken,
+  }) => {
+    const res = await request(app)
+      .post(`/projects/acme/web/builds/${build.number}/comments`)
+      .set(auth(scopedPatToken))
+      .set("user-agent", "argos-cli/6.7.0 node/22.11.0 agent/claude")
+      .send({ body: "Fixed the padding" })
+      .expect(201);
+
+    expect(res.body.agent).toEqual({ id: "claude-code", name: "Claude Code" });
+
+    const comment = await Comment.query().findById(parseCommentId(res.body.id));
+    expect(comment?.agent).toBe("claude-code");
+  });
+
+  test("records an unrecognized agent as one all the same", async ({
+    build,
+    scopedPatToken,
+  }) => {
+    const res = await request(app)
+      .post(`/projects/acme/web/builds/${build.number}/comments`)
+      .set(auth(scopedPatToken))
+      .set("user-agent", "argos-cli/6.7.0 agent/homemade")
+      .send({ body: "Fixed the padding" })
+      .expect(201);
+
+    expect(res.body.agent).toEqual({ id: "unknown", name: null });
+  });
+
+  test("records no agent when a person posts directly", async ({
+    build,
+    scopedPatToken,
+  }) => {
+    const res = await request(app)
+      .post(`/projects/acme/web/builds/${build.number}/comments`)
+      .set(auth(scopedPatToken))
+      .set("user-agent", "argos-cli/6.7.0 node/22.11.0")
+      .send({ body: "Looks good" })
+      .expect(201);
+
+    expect(res.body.agent).toBeNull();
+
+    const comment = await Comment.query().findById(parseCommentId(res.body.id));
+    expect(comment?.agent).toBeNull();
+  });
 });
 
 describe("listComments / getComment", () => {

--- a/apps/backend/src/api/handlers/comments.e2e.test.ts
+++ b/apps/backend/src/api/handlers/comments.e2e.test.ts
@@ -252,7 +252,11 @@ describe("createComment", () => {
     const res = await request(app)
       .post(`/projects/acme/web/builds/${build.number}/comments`)
       .set(auth(scopedPatToken))
-      .set("user-agent", "argos-cli/6.7.0 node/22.11.0 agent/claude")
+      // The header the CLI really sends under Claude Code, version tag and all.
+      .set(
+        "user-agent",
+        "argos-cli/6.7.0 node/22.11.0 agent/claude-code_2-1-227_agent",
+      )
       .send({ body: "Fixed the padding" })
       .expect(201);
 

--- a/apps/backend/src/api/handlers/createComment.ts
+++ b/apps/backend/src/api/handlers/createComment.ts
@@ -1,6 +1,8 @@
+import type { Request } from "express";
 import { z } from "zod";
 import { ZodOpenApiOperationObject } from "zod-openapi";
 
+import { resolveRequestAgentId } from "@/agent/request";
 import { getOrCreatePendingBuildReview } from "@/build/pendingReview";
 import { isReviewableBuildStatus } from "@/build/reviewableStatus";
 import { resolveCommentBody } from "@/comment/body";
@@ -272,6 +274,7 @@ function resolveMediaCommentOptions(input: {
  * don't accept them, so their comments are created without.
  */
 async function createTargetComment(input: {
+  request: Request;
   authPromise: Promise<CommentAuth>;
   params: CommentRouteParams;
   body: z.infer<typeof CreateCommentBodySchema>;
@@ -317,6 +320,7 @@ async function createTargetComment(input: {
     userId: auth.user.id,
     body: await resolveCommentBody(requestBody.body),
     threadId: thread?.id ?? null,
+    agent: resolveRequestAgentId(input.request, auth),
     ...targetOptions,
   });
 
@@ -329,6 +333,7 @@ export const createComment: CreateAPIHandler = ({ post }) => {
     async (req, res) => {
       res.status(201).send(
         await createTargetComment({
+          request: req,
           authPromise: req.ctx.auth(),
           params: req.ctx.params,
           body: req.ctx.body,
@@ -342,6 +347,7 @@ export const createComment: CreateAPIHandler = ({ post }) => {
     async (req, res) => {
       res.status(201).send(
         await createTargetComment({
+          request: req,
           authPromise: req.ctx.auth(),
           params: req.ctx.params,
           body: req.ctx.body,
@@ -353,6 +359,7 @@ export const createComment: CreateAPIHandler = ({ post }) => {
   post("/media/{mediaId}/comments", async (req, res) => {
     res.status(201).send(
       await createTargetComment({
+        request: req,
         authPromise: req.ctx.auth(),
         params: req.ctx.params,
         body: req.ctx.body,

--- a/apps/backend/src/api/schema/primitives/comment.ts
+++ b/apps/backend/src/api/schema/primitives/comment.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { getAgentDisplayName } from "@/agent/registry";
 import { formatCommentId } from "@/comment/id";
 import { schema as proseMirrorSchema } from "@/comment/schema";
 import { BuildReview, Comment, CommentReaction } from "@/database/models";
@@ -60,6 +61,23 @@ export const CommentAnchorSchema = z
       "Where on the referenced screenshot diff the comment points. A point uses normalized (0–1) coordinates; lines is a 1-based inclusive range.",
   });
 
+/**
+ * The coding agent a comment was posted through. An agent acts with its user's
+ * own credentials, so `author` alone cannot tell it apart from the person.
+ */
+const CommentAgentSchema = z
+  .object({
+    id: z.string().meta({
+      description:
+        "Stable id of the agent, e.g. `claude-code`. `unknown` when it could not be identified.",
+    }),
+    name: z.string().nullable().meta({
+      description:
+        "Name to display, e.g. `Claude Code`. Null for an agent we cannot name.",
+    }),
+  })
+  .meta({ description: "A coding agent acting on behalf of a user." });
+
 export const CommentSchema = z
   .object({
     id: z.string().meta({
@@ -93,6 +111,10 @@ export const CommentSchema = z
       .string()
       .meta({ description: "Plain-text rendering of the comment content." }),
     author: UserSchema.nullable(),
+    agent: CommentAgentSchema.nullable().meta({
+      description:
+        "The coding agent that posted the comment on the author's behalf. Null when the author posted it directly.",
+    }),
     screenshotDiffId: z.string().nullable().meta({
       description: "Screenshot diff this comment is anchored to, if any.",
     }),
@@ -245,6 +267,9 @@ export async function serializeComments(
       body: comment.content,
       text: commentText(comment.content),
       author: account ? serializeUser(account) : null,
+      agent: comment.agent
+        ? { id: comment.agent, name: getAgentDisplayName(comment.agent) }
+        : null,
       screenshotDiffId: comment.screenshotDiffId,
       anchor: comment.anchor,
       pending,

--- a/apps/backend/src/auth/oauth-access-token.ts
+++ b/apps/backend/src/auth/oauth-access-token.ts
@@ -162,6 +162,7 @@ export async function getAuthPayloadFromOAuthAccessToken(
     scope: scopeAccounts,
     oauthScopes: accessToken.scopes,
     clientId: client.clientId,
+    knownAppId: client.knownAppId,
     grantId: grant.id,
   };
 }

--- a/apps/backend/src/auth/payload.ts
+++ b/apps/backend/src/auth/payload.ts
@@ -38,6 +38,11 @@ export type AuthOAuthPayload = {
   oauthScopes: string[];
   /** Public identifier of the OAuth client that holds the token. */
   clientId: string;
+  /**
+   * Id of the well-known app the client was matched to at registration
+   * (`oauth/known-apps.ts`), `null` for an unrecognized client.
+   */
+  knownAppId: string | null;
   /** Id of the `oauth_grants` row backing this token. */
   grantId: string;
 };

--- a/apps/backend/src/comment/createComment.ts
+++ b/apps/backend/src/comment/createComment.ts
@@ -62,6 +62,11 @@ export async function createComment(input: {
   anchor?: CommentAnchor | null;
   buildReviewId?: string | null;
   pending?: boolean;
+  /**
+   * The coding agent that wrote this on the author's behalf, if any. See
+   * `agent/request.ts` for how a request is attributed to one.
+   */
+  agent?: string | null;
 }): Promise<Comment> {
   const {
     target,
@@ -71,6 +76,7 @@ export async function createComment(input: {
     anchor = null,
     buildReviewId = null,
     pending = false,
+    agent = null,
   } = input;
 
   if (!validateCommentJson(input.body)) {
@@ -89,8 +95,14 @@ export async function createComment(input: {
 
   // Inserting the comment and loading the project are independent — run them
   // together rather than back-to-back.
+  //
+  // `insertAndFetch` rather than `insert`: the latter returns a model carrying
+  // only the columns we wrote, so everything defaulted by the database
+  // (`resolvedAt`, `editedAt`, …) comes back `undefined` rather than `null`.
+  // Serializing that produces a payload missing those keys, which the MCP
+  // server rejects against the tool's declared output schema.
   const [comment, project] = await Promise.all([
-    Comment.query().insert({
+    Comment.query().insertAndFetch({
       userId,
       ...getCommentTargetColumns(target),
       buildReviewId,
@@ -98,6 +110,7 @@ export async function createComment(input: {
       screenshotDiffId,
       anchor,
       content: body,
+      agent,
     }),
     getCommentTargetProject(target),
   ]);

--- a/apps/backend/src/database/models/Comment.ts
+++ b/apps/backend/src/database/models/Comment.ts
@@ -87,6 +87,7 @@ export class Comment extends Model {
           editedAt: { type: ["string", "null"] },
           deletedAt: { type: ["string", "null"] },
           resolvedAt: { type: ["string", "null"] },
+          agent: { type: ["string", "null"] },
           content: {
             anyOf: [
               { type: "array" },
@@ -139,6 +140,13 @@ export class Comment extends Model {
    */
   resolvedAt!: string | null;
   content!: unknown;
+  /**
+   * The coding agent that posted this comment on the author's behalf — an id
+   * from `src/agent/registry.ts`, or `unknown` for one we can't name. Null when
+   * the author acted directly. An agent uses its user's own credentials, so
+   * without this a comment it wrote is indistinguishable from one they typed.
+   */
+  agent!: string | null;
 
   static override get relationMappings(): RelationMappings {
     return {

--- a/apps/backend/src/graphql/definitions/Comment.ts
+++ b/apps/backend/src/graphql/definitions/Comment.ts
@@ -2,6 +2,7 @@ import { invariant } from "@argos/util/invariant";
 import type { JSONContent } from "@tiptap/core";
 import gqlTag from "graphql-tag";
 
+import { getAgentDisplayName } from "@/agent/registry";
 import { getOrCreatePendingBuildReview } from "@/build/pendingReview";
 import { isReviewableBuildStatus } from "@/build/reviewableStatus";
 import { addCommentReaction } from "@/comment/addCommentReaction";
@@ -224,6 +225,19 @@ export const typeDefs = gql`
   union CommentAnchor = CommentPointAnchor | CommentLinesAnchor
 
   """
+  The coding agent that posted a comment on its author's behalf.
+
+  An agent acts with the user's own credentials, so without this the comment
+  would read as something they typed themselves.
+  """
+  type CommentAgent {
+    "Stable id of the agent, e.g. claude-code. Falls back to the literal id unknown when it could not be identified."
+    id: String!
+    "Name to display, e.g. Claude Code. Null for an agent we cannot name."
+    name: String
+  }
+
+  """
   A comment posted on a build or on a test.
   """
   type Comment implements Node {
@@ -238,6 +252,8 @@ export const typeDefs = gql`
     content: JSONObject!
     "Author of the comment"
     user: User
+    "The coding agent that posted it on the author's behalf, null when they posted it directly"
+    agent: CommentAgent
     "Users mentioned in the comment"
     mentionedUsers: [User!]!
     "Root comment ID when this comment is a reply"
@@ -443,6 +459,15 @@ export const resolvers: IResolvers = {
       });
       invariant(account, "Account not found");
       return account;
+    },
+    agent: (comment) => {
+      if (!comment.agent) {
+        return null;
+      }
+      return {
+        id: comment.agent,
+        name: getAgentDisplayName(comment.agent),
+      };
     },
     mentionedUsers: async (comment, _args, ctx) => {
       const userIds = await ctx.loaders.CommentMentionedUserIds.load(

--- a/apps/backend/src/mcp/README.md
+++ b/apps/backend/src/mcp/README.md
@@ -59,6 +59,16 @@ No operation needs it by default — eligibility is computed from `security`.
   (`assertOAuthScopes`); scope failures come back as `isError` tool results,
   not HTTP 401s, so clients don't needlessly re-authenticate.
 
+## Agent attribution
+
+A tool call carries the user's own credentials, so what it writes is otherwise
+indistinguishable from what that person typed. `src/agent/request.ts` resolves
+the acting agent from the OAuth client behind the token — its `knownAppId` when
+the curated registry recognizes it, `unknown` otherwise, since a client that
+isn't the first-party CLI is an agent by construction here. Comments store the
+result and the UI marks them (see `src/agent/registry.ts`). The CLI carries the
+same information in a `User-Agent` `agent/<name>` token instead.
+
 ## Discovery
 
 `GET /.well-known/mcp/server-card.json` on the MCP origin serves the canonical

--- a/apps/backend/src/mcp/mcp.e2e.test.ts
+++ b/apps/backend/src/mcp/mcp.e2e.test.ts
@@ -4,6 +4,8 @@ import { test as base, describe, expect, vi } from "vitest";
 
 import {
   Account,
+  Build,
+  Comment,
   OAuthClient,
   OAuthGrant,
   OAuthGrantAccount,
@@ -62,6 +64,8 @@ async function createOAuthAccessToken(input: {
   userAccount: Account;
   scopes: OAuthScope[];
   resource: string | null;
+  /** Well-known app the client was matched to at registration, if any. */
+  knownAppId?: string;
 }) {
   const client = await OAuthClient.query().insertAndFetch({
     clientId: "test-mcp-client",
@@ -71,7 +75,8 @@ async function createOAuthAccessToken(input: {
     responseTypes: ["code"],
     tokenEndpointAuthMethod: "none",
     isFirstParty: false,
-    verified: false,
+    verified: input.knownAppId !== undefined,
+    knownAppId: input.knownAppId ?? null,
   });
   const grant = await OAuthGrant.query().insertAndFetch({
     userId: input.userAccount.userId!,
@@ -97,6 +102,7 @@ const test = base.extend<{
   userAccount: Account;
   patToken: string;
   project: Project;
+  build: Build;
 }>({
   user: async ({}, use) => {
     await setupDatabase();
@@ -130,6 +136,16 @@ const test = base.extend<{
       token: "the-awesome-token",
     });
     await use(project);
+  },
+  build: async ({ project }, use) => {
+    const bucket = await factory.ScreenshotBucket.create({
+      projectId: project.id,
+    });
+    const build = await factory.Build.create({
+      projectId: project.id,
+      compareScreenshotBucketId: bucket.id,
+    });
+    await use(build);
   },
 });
 
@@ -287,6 +303,62 @@ describe("MCP server", () => {
     // creation notification. The module mock above is what guarantees a real
     // Discord webhook can never fire from tests.
     expect(vi.mocked(notifyDiscord)).not.toHaveBeenCalled();
+  });
+
+  test("attributes a comment to the agent behind the MCP client", async ({
+    userAccount,
+    build,
+  }) => {
+    const token = await createOAuthAccessToken({
+      userAccount,
+      scopes: ["comments:write"],
+      resource: getMcpResourceUrl(),
+      knownAppId: "claude-code",
+    });
+
+    const res = await rpc(token, "tools/call", {
+      name: "createBuildComment",
+      arguments: {
+        owner: "jane-doe",
+        project: "awesome-project",
+        buildNumber: String(build.number),
+        body: "The header overflows on mobile",
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as RpcResponse;
+    expect(body.result!.isError).toBeUndefined();
+    expect(body.result!.structuredContent).toMatchObject({
+      agent: { id: "claude-code", name: "Claude Code" },
+    });
+
+    const comment = await Comment.query().findOne({ buildId: build.id });
+    expect(comment?.agent).toBe("claude-code");
+  });
+
+  test("still marks a comment as agent-made for an unrecognized MCP client", async ({
+    userAccount,
+    build,
+  }) => {
+    const token = await createOAuthAccessToken({
+      userAccount,
+      scopes: ["comments:write"],
+      resource: getMcpResourceUrl(),
+    });
+
+    const res = await rpc(token, "tools/call", {
+      name: "createBuildComment",
+      arguments: {
+        owner: "jane-doe",
+        project: "awesome-project",
+        buildNumber: String(build.number),
+        body: "Same, from an unknown client",
+      },
+    });
+    expect(res.status).toBe(200);
+    expect((res.body as RpcResponse).result!.structuredContent).toMatchObject({
+      agent: { id: "unknown", name: null },
+    });
   });
 
   test("rejects invalid tool arguments", async ({ patToken }) => {

--- a/apps/backend/src/oauth/known-apps.ts
+++ b/apps/backend/src/oauth/known-apps.ts
@@ -13,6 +13,10 @@
  * pragmatic option. The match rules below are seeded from publicly-known values
  * and should be tightened as we observe real registrations. Adding/adjusting an
  * entry is a code change — appropriate, since verification is a trust decision.
+ *
+ * Ids are shared with the agent registry (`src/agent/registry.ts`) where the
+ * same product appears in both, so an MCP client recognized here resolves to
+ * the agent of the same name — and the frontend keys one logo map by them.
  */
 
 export type KnownApp = {

--- a/apps/frontend/src/containers/Comment/CommentAgentBadge.tsx
+++ b/apps/frontend/src/containers/Comment/CommentAgentBadge.tsx
@@ -1,0 +1,37 @@
+import { BotIcon } from "lucide-react";
+
+import { KNOWN_APP_LOGOS } from "@/containers/brand-logos";
+import { Tooltip } from "@/ui/Tooltip";
+
+export type CommentAgent = {
+  id: string;
+  name?: string | null;
+};
+
+/**
+ * Marks a comment an agent wrote on its author's behalf, pinned to the corner
+ * of their avatar.
+ *
+ * The author stays the author — the agent acted with their credentials — so
+ * this reads as an annotation on them rather than a second identity: their
+ * words came through a tool. Agents we recognize show their own mark; the rest
+ * fall back to a generic bot, which is still the part that matters.
+ */
+export function CommentAgentBadge(props: { agent: CommentAgent }) {
+  const { agent } = props;
+  const Logo = KNOWN_APP_LOGOS[agent.id];
+  const label = agent.name
+    ? `Posted through ${agent.name} on behalf of this user`
+    : "Posted through an AI agent on behalf of this user";
+  return (
+    <Tooltip content={label}>
+      <span
+        role="img"
+        aria-label={label}
+        className="bg-app border-thin text-low absolute -right-1 -bottom-1 flex size-3 items-center justify-center rounded-full"
+      >
+        {Logo ? <Logo className="size-2" /> : <BotIcon className="size-2" />}
+      </span>
+    </Tooltip>
+  );
+}

--- a/apps/frontend/src/containers/Comment/CommentCard.tsx
+++ b/apps/frontend/src/containers/Comment/CommentCard.tsx
@@ -33,6 +33,7 @@ import { getMentionUser, getUserCardData, UserHoverCard } from "@/ui/UserCard";
 import { getErrorMessage } from "@/util/error";
 
 import { CommentActionsMenu } from "./CommentActionsMenu";
+import { CommentAgentBadge } from "./CommentAgentBadge";
 import {
   CommentAddReactionButton,
   CommentReactionList,
@@ -81,6 +82,10 @@ const _CommentFragment = graphql(`
     threadSubscribed
     pending
     permissions
+    agent {
+      id
+      name
+    }
     user {
       ...UserCard_user
     }
@@ -586,14 +591,19 @@ function CommentMessage(props: {
         />
         <div className="relative flex items-center gap-1.5 px-2 py-1.5 pr-1.5 select-none">
           {comment.user ? (
-            <UserHoverCard user={getUserCardData(comment.user)}>
-              <span tabIndex={0} className="shrink-0">
-                <AccountAvatar
-                  avatar={comment.user.avatar}
-                  className="size-5 border"
-                />
-              </span>
-            </UserHoverCard>
+            <span className="relative shrink-0">
+              <UserHoverCard user={getUserCardData(comment.user)}>
+                <span tabIndex={0} className="block">
+                  <AccountAvatar
+                    avatar={comment.user.avatar}
+                    className="size-5 border"
+                  />
+                </span>
+              </UserHoverCard>
+              {comment.agent ? (
+                <CommentAgentBadge agent={comment.agent} />
+              ) : null}
+            </span>
           ) : null}
           <div className="min-w-0 flex-1">
             <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">

--- a/apps/frontend/src/containers/OAuthAppLogo.tsx
+++ b/apps/frontend/src/containers/OAuthAppLogo.tsx
@@ -3,36 +3,7 @@ import { BadgeCheckIcon } from "lucide-react";
 
 import { Chip, type ChipProps } from "@/ui/Chip";
 
-import {
-  ArgosCliLogo,
-  ClaudeCodeLogo,
-  ClaudeLogo,
-  CodexLogo,
-  CursorLogo,
-  VSCodeLogo,
-  WindsurfLogo,
-  ZedLogo,
-} from "./oauth-logos";
-
-/**
- * Official brand logos for verified well-known apps, keyed by `knownAppId`
- * (see the backend `oauth/known-apps.ts` registry). Bundled (not remote-loaded)
- * so they are not subject to the app CSP and monochrome marks adapt to the
- * theme via `currentColor`.
- */
-const KNOWN_APP_LOGOS: Record<
-  string,
-  React.ComponentType<{ className?: string }>
-> = {
-  "argos-cli": ArgosCliLogo,
-  claude: ClaudeLogo,
-  "claude-code": ClaudeCodeLogo,
-  "openai-codex": CodexLogo,
-  cursor: CursorLogo,
-  vscode: VSCodeLogo,
-  windsurf: WindsurfLogo,
-  zed: ZedLogo,
-};
+import { KNOWN_APP_LOGOS } from "./brand-logos";
 
 const SIZE_CLASSES = {
   sm: "size-8",

--- a/apps/frontend/src/containers/brand-logos.tsx
+++ b/apps/frontend/src/containers/brand-logos.tsx
@@ -1,0 +1,35 @@
+import {
+  ArgosCliLogo,
+  ClaudeCodeLogo,
+  ClaudeLogo,
+  CodexLogo,
+  CursorLogo,
+  VSCodeLogo,
+  WindsurfLogo,
+  ZedLogo,
+} from "./oauth-logos";
+
+/**
+ * Official brand logos, keyed by the id the backend uses for a product —
+ * `oauth/known-apps.ts` for a verified OAuth app, `agent/registry.ts` for a
+ * coding agent. The two registries deliberately share ids where they name the
+ * same product, so one map serves both. Bundled (not remote-loaded) so they are
+ * not subject to the app CSP and monochrome marks adapt to the theme via
+ * `currentColor`.
+ *
+ * An id with no entry falls back to whatever the caller shows for an unknown
+ * product (a monogram, or a generic bot).
+ */
+export const KNOWN_APP_LOGOS: Record<
+  string,
+  React.ComponentType<{ className?: string }>
+> = {
+  "argos-cli": ArgosCliLogo,
+  claude: ClaudeLogo,
+  "claude-code": ClaudeCodeLogo,
+  "openai-codex": CodexLogo,
+  cursor: CursorLogo,
+  vscode: VSCodeLogo,
+  windsurf: WindsurfLogo,
+  zed: ZedLogo,
+};

--- a/tests/project-tests.spec.ts
+++ b/tests/project-tests.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "@playwright/test";
 
+import { Comment } from "../apps/backend/src/database/models";
 import {
   createFlakyTestScenario,
   createIgnoredChangeScenario,
@@ -8,6 +9,14 @@ import {
 import { formatTestId } from "../apps/backend/src/util/test-id";
 import { loggedTest } from "./logged-test";
 import { ensureTeamOwner, screenshot } from "./util";
+
+/** A one-line rich-text comment body. */
+function doc(text: string) {
+  return {
+    type: "doc",
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  };
+}
 
 loggedTest.beforeEach(async ({ auth, team }) => {
   await ensureTeamOwner({ team: team.team, user: auth.user });
@@ -145,6 +154,48 @@ loggedTest(
     // And the toggle opts back out.
     await unsubscribe.click();
     await expect(page.getByRole("button", { name: "Subscribe" })).toBeVisible();
+  },
+);
+
+loggedTest(
+  "test view marks a comment an agent posted for its author",
+  async ({ page, auth, team, project }) => {
+    const { test } = await createTestChangeScenario({ projectId: project.id });
+    const testId = formatTestId({ projectName: project.name, testId: test.id });
+
+    // Two comments from the same person: one they typed, one Claude Code posted
+    // with their credentials. Only the second is marked, which is the whole
+    // point — the author is identical on both.
+    await Comment.query().insert([
+      {
+        testId: test.id,
+        userId: auth.user.id,
+        content: doc("This one keeps flapping on CI."),
+      },
+      {
+        testId: test.id,
+        userId: auth.user.id,
+        content: doc("Retried it 20 times — the header animation races."),
+        agent: "claude-code",
+      },
+    ]);
+
+    await page.goto(`/${team.account.slug}/${project.name}/tests/${testId}`);
+
+    await expect(
+      page.getByText("Retried it 20 times — the header animation races."),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("img", {
+        name: "Posted through Claude Code on behalf of this user",
+      }),
+    ).toBeVisible();
+    // The comment the same person typed carries no marker.
+    await expect(page.getByRole("img", { name: /^Posted through/ })).toHaveCount(
+      1,
+    );
+
+    await screenshot(page, "test-view-agent-comment");
   },
 );
 


### PR DESCRIPTION
Closes [ARG-496](https://linear.app/argos/issue/ARG-496). Part 2 of 2 — the CLI half is [argos-ci/argos-javascript#367](https://github.com/argos-ci/argos-javascript/pull/367). They ship independently: the backend reads the header whatever CLI version sent it.

An agent acts with its user's own credentials, so a comment Claude Code or an MCP client writes is indistinguishable from one the person typed. This records which agent was behind the request and marks the comment with it.

[![agent-comment-badge.png](https://files.argos-ci.com/media/9/6c90689e55ad64220c76c2493bb0845f8e96bd1eee420917b7233eebdde1c522.webp)](https://app.argos-ci.com/m/q4xdp3dsecuw983wijmm)

Two comments, same author. Only the one Claude Code posted is marked.

## How a request is attributed

`src/agent/request.ts` resolves an agent from whichever signal the surface carries:

- **CLI** — the `agent/<name>` token in the `User-Agent`.
- **MCP** — the OAuth client behind the access token, via its `knownAppId`. An OAuth client that isn't the first-party CLI is taken to be an agent even when the known-apps registry doesn't recognize it, since OAuth exists here to serve the CLI and MCP clients and MCP is an agent protocol. Those store `unknown` and render as a generic bot: we still know it was an agent, we just can't name it.

Everything else — the web app, a script, a bare personal access token — resolves to `null`.

Names are matched against a curated registry (`src/agent/registry.ts`) rather than stored verbatim. A self-asserted name is untrusted input (`AI_AGENT` is whatever the caller sets), and rendering one next to a real person's avatar is a spoofing vector. Ids are shared with `oauth/known-apps.ts` where the same product appears in both, so the frontend keys one logo map by them.

## The rest

- Migration + `comments.agent`, wired through `createComment`.
- `Comment.agent { id, name }` on GraphQL and REST.
- `CommentAgentBadge` on the author's avatar, matching the existing avatar-badge pattern in `BuildReviewersStatusList`. The logo map moved to `containers/brand-logos.tsx`, now shared with `OAuthAppLogo`.

## Worth a look during review

**An unrelated MCP bug, fixed here.** `Comment.query().insert()` returns a model carrying only the columns written, so `resolvedAt` / `editedAt` came back `undefined` and `createBuildComment` over MCP failed its *own* output-schema validation. Switched to `insertAndFetch`. That tool was broken before this branch; the new MCP e2e test is what surfaced it.

**The second commit is a real-world correction.** Running the built CLI against a local echo server showed Claude Code sets `AI_AGENT=claude-code_2-1-227_agent` — a version suffix the registry didn't match, so the agent most likely to post a comment fell back to the generic bot. `resolveReportedAgentId` now strips the version (`_`, and the `@` the convention documents) before the lookup.

## Verified

`pnpm run static-checks`, unit (654) and integration (1189) suites all green.

New coverage:

- `src/agent/request.test.ts` — header parsing and the resolution order, including the versioned names agents really report.
- `comments.e2e.test.ts` — a comment posted with the exact `User-Agent` the CLI sends today, an unrecognized agent, and a person posting directly.
- `mcp.e2e.test.ts` — a comment through the MCP loopback, attributed from the OAuth client, recognized and not.
- `project-tests.spec.ts` — the badge on an agent comment and *not* on the one the same person typed, plus a screenshot.

One MCP scope test flaked once under full-suite load (`body.result` undefined) and passed on re-run and in isolation — unrelated to this change.

## Not included

User-facing docs. They live in the `docs` repo and the issue didn't scope them; happy to follow up with a page on agent attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
