### PR TITLE
chore(ui): snapshot overlays in their open state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 15
     env:
       NODE_ENV: test
-      TZ: utc
+      TZ: UTC
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
@@ -57,7 +57,7 @@ jobs:
     timeout-minutes: 15
     env:
       NODE_ENV: test
-      TZ: utc
+      TZ: UTC
       ARGOS_TOKEN: ${{ secrets.ARGOS_STORYBOOK_TOKEN }}
 
     steps:
@@ -111,7 +111,7 @@ jobs:
         shard: [1, 2, 3]
     env:
       NODE_ENV: test
-      TZ: utc
+      TZ: UTC
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
@@ -180,7 +180,7 @@ jobs:
     env:
       API_BASE_URL: http://localhost:3000
       NODE_ENV: test
-      TZ: utc
+      TZ: UTC
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}

--- a/apps/frontend/src/ui/Chip.stories.tsx
+++ b/apps/frontend/src/ui/Chip.stories.tsx
@@ -7,6 +7,7 @@ import {
   XIcon,
   ZapIcon,
 } from "lucide-react";
+import { userEvent } from "storybook/test";
 
 import { ButtonGroup } from "./ButtonGroup";
 import { Chip, ChipButton, ChipLink } from "./Chip";
@@ -106,6 +107,27 @@ export const Default: Story = {
           </ButtonGroup>
         ))}
       </div>
+    </div>
+  ),
+};
+
+/**
+ * Keyboard focus on a chip button — the one baseline of the `rac-focus`
+ * utility, which encodes react-aria's "outline on keyboard focus only" contract
+ * and has to be rebuilt on `:focus-visible`.
+ */
+export const KeyboardFocus: Story = {
+  play: async () => {
+    await userEvent.tab();
+  },
+  render: () => (
+    <div className="flex flex-wrap items-center gap-4 p-4">
+      <ChipButton color="primary" icon={ZapIcon} onPress={() => {}}>
+        Focused
+      </ChipButton>
+      <ChipButton color="danger" icon={FlameIcon} onPress={() => {}}>
+        Danger
+      </ChipButton>
     </div>
   ),
 };

--- a/apps/frontend/src/ui/ColorPicker.stories.tsx
+++ b/apps/frontend/src/ui/ColorPicker.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  ColorSwatch,
+  ColorSwatchPicker,
+  ColorSwatchPickerItem,
+} from "./ColorPicker";
+import { StoryTitle } from "./StoryTitle";
+
+const meta = {
+  title: "UI/ColorPicker",
+  component: ColorSwatchPicker,
+} satisfies Meta<typeof ColorSwatchPicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// The palette from the build toolbar's diff-colour setting, the only consumer.
+const COLORS = [
+  "#FF5470",
+  "#FF007C",
+  "#FD3A4A",
+  "#FFAA1D",
+  "#299617",
+  "#2243B6",
+  "#5DADEC",
+  "#5946B2",
+  "#000",
+];
+
+/**
+ * react-aria's colour swatch picker has no Base UI counterpart — it becomes a
+ * plain toggle group — so the selected ring is worth a baseline of its own.
+ */
+export const Default: Story = {
+  render: () => (
+    <div className="flex max-w-xs flex-col">
+      <StoryTitle>Swatches</StoryTitle>
+      <ColorSwatchPicker value="#FFAA1D" aria-label="Diff color">
+        {COLORS.map((color) => (
+          <ColorSwatchPickerItem key={color} color={color}>
+            <ColorSwatch />
+          </ColorSwatchPickerItem>
+        ))}
+      </ColorSwatchPicker>
+    </div>
+  ),
+};

--- a/apps/frontend/src/ui/DateRangePicker.stories.tsx
+++ b/apps/frontend/src/ui/DateRangePicker.stories.tsx
@@ -1,0 +1,62 @@
+import { parseDate } from "@internationalized/date";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { DateRangePicker } from "./DateRangePicker";
+import { openOverlayParameters, OverlayStage } from "./storyOverlay";
+import { StoryTitle } from "./StoryTitle";
+
+// A fixed range, so the visible month and the selected cells are the same in
+// every run. `new Date()` here would make the snapshot change every day.
+const VALUE = {
+  from: new Date("2024-03-04T00:00:00"),
+  to: new Date("2024-03-18T00:00:00"),
+};
+
+const meta = {
+  title: "UI/DateRangePicker",
+  component: DateRangePicker,
+  args: {
+    "aria-label": "Custom period",
+    granularity: "day",
+    value: VALUE,
+    onChange: () => {},
+  },
+} satisfies Meta<typeof DateRangePicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// `minValue`/`maxValue` pass straight through to react-aria, which speaks
+// `@internationalized/date` rather than `Date` — unlike `value`, which the
+// wrapper converts.
+const MIN_VALUE = parseDate("2024-03-01");
+const MAX_VALUE = parseDate("2024-03-29");
+
+/**
+ * The field on its own: two segmented date inputs and the calendar button.
+ *
+ * This component has no baseline today and it is the one place the Base UI
+ * migration cannot land like-for-like — Base UI has no calendar, and the
+ * segmented inputs have no replacement in `react-day-picker` either.
+ */
+export const Default: Story = {
+  render: (args) => (
+    <div className="flex max-w-xs flex-col">
+      <StoryTitle>Field</StoryTitle>
+      <DateRangePicker {...args} />
+    </div>
+  ),
+};
+
+/** The range calendar: selected range, its two ends, and out-of-bounds days. */
+export const Open: Story = {
+  parameters: openOverlayParameters,
+  args: { minValue: MIN_VALUE, maxValue: MAX_VALUE, isOpen: true },
+  render: (args) => (
+    <OverlayStage>
+      <div className="w-72">
+        <DateRangePicker {...args} />
+      </div>
+    </OverlayStage>
+  ),
+};

--- a/apps/frontend/src/ui/Dialog.stories.tsx
+++ b/apps/frontend/src/ui/Dialog.stories.tsx
@@ -11,6 +11,7 @@ import {
   DialogTrigger,
 } from "./Dialog";
 import { Modal } from "./Modal";
+import { openOverlayParameters } from "./storyOverlay";
 import { StoryTitle } from "./StoryTitle";
 
 const meta = {
@@ -61,5 +62,89 @@ export const Default: Story = {
         </Modal>
       </DialogTrigger>
     </div>
+  ),
+};
+
+/**
+ * An open `dialog`. This is also the only baseline of `Modal`'s overlay — the
+ * backdrop tint, the blur and the card — which Base UI splits across
+ * `Dialog.Backdrop`, `Dialog.Viewport` and `Dialog.Popup`.
+ */
+export const Open: Story = {
+  parameters: openOverlayParameters,
+  render: () => (
+    <DialogTrigger defaultOpen>
+      <Button variant="secondary">Open Dialog</Button>
+      <Modal isDismissable>
+        <Dialog>
+          <DialogBody>
+            <DialogTitle>Confirm Action</DialogTitle>
+            <DialogText>Are you sure you want to proceed?</DialogText>
+          </DialogBody>
+          <DialogFooter>
+            <DialogDismiss>Cancel</DialogDismiss>
+            <Button variant="primary">Confirm</Button>
+          </DialogFooter>
+        </Dialog>
+      </Modal>
+    </DialogTrigger>
+  ),
+};
+
+/**
+ * `role="alertdialog"` centres the body and lets a footer alert span the full
+ * width — a distinct layout that `DialogRoleContext` drives.
+ */
+export const OpenAlert: Story = {
+  parameters: openOverlayParameters,
+  render: () => (
+    <DialogTrigger defaultOpen>
+      <Button variant="destructive">Delete Project</Button>
+      <Modal isDismissable>
+        <Dialog role="alertdialog">
+          <DialogBody>
+            <DialogTitle>Delete Project</DialogTitle>
+            <DialogText>
+              This action cannot be undone. All data will be permanently
+              deleted.
+            </DialogText>
+          </DialogBody>
+          <DialogFooter>
+            <DialogDismiss>Cancel</DialogDismiss>
+            <Button variant="destructive">Delete</Button>
+          </DialogFooter>
+        </Dialog>
+      </Modal>
+    </DialogTrigger>
+  ),
+};
+
+/**
+ * A dialog whose action is in flight. `Modal` refuses Escape and backdrop
+ * dismissal while pending and disables every `DialogDismiss`, which is the
+ * behaviour Base UI has to reproduce through `onOpenChange`'s event details.
+ */
+export const OpenPending: Story = {
+  parameters: openOverlayParameters,
+  render: () => (
+    <DialogTrigger defaultOpen>
+      <Button variant="secondary">Open Dialog</Button>
+      <Modal isDismissable>
+        <Dialog>
+          <DialogBody>
+            <DialogTitle>Transfer ownership</DialogTitle>
+            <DialogText>
+              The new owner will be billed for this project.
+            </DialogText>
+          </DialogBody>
+          <DialogFooter>
+            <DialogDismiss isDisabled>Cancel</DialogDismiss>
+            <Button variant="primary" isPending>
+              Transfer
+            </Button>
+          </DialogFooter>
+        </Dialog>
+      </Modal>
+    </DialogTrigger>
   ),
 };

--- a/apps/frontend/src/ui/EmojiPicker.stories.tsx
+++ b/apps/frontend/src/ui/EmojiPicker.stories.tsx
@@ -10,6 +10,7 @@ import {
   EmojiPickerPopover,
   EmojiPickerTrigger,
 } from "./EmojiPicker";
+import { openOverlayParameters, OverlayStage } from "./storyOverlay";
 import { StoryTitle } from "./StoryTitle";
 
 const meta = {
@@ -69,4 +70,22 @@ function FieldStory() {
 
 export const Field: Story = {
   render: () => <FieldStory />,
+};
+
+/**
+ * The picker in its popover. `Default` renders the grid inline, so this adds the
+ * popover surface and the sizing the trigger imposes on it.
+ */
+export const Open: Story = {
+  parameters: openOverlayParameters,
+  render: () => (
+    <OverlayStage>
+      <EmojiPickerTrigger defaultOpen>
+        <Button variant="secondary" iconOnly aria-label="Add reaction">
+          <SmilePlusIcon />
+        </Button>
+        <EmojiPickerPopover onEmojiSelect={() => {}} />
+      </EmojiPickerTrigger>
+    </OverlayStage>
+  ),
 };

--- a/apps/frontend/src/ui/Form.stories.tsx
+++ b/apps/frontend/src/ui/Form.stories.tsx
@@ -1,0 +1,115 @@
+import { useEffect } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useForm } from "react-hook-form";
+
+import { Card, CardBody, CardTitle } from "./Card";
+import { Form } from "./Form";
+import { FormCardFooter } from "./FormCardFooter";
+import { FormCheckbox } from "./FormCheckbox";
+import { FormSwitch } from "./FormSwitch";
+import { FormTextInput } from "./FormTextInput";
+import { StoryTitle } from "./StoryTitle";
+
+type Values = {
+  name: string;
+  email: string;
+  notifications: boolean;
+  terms: boolean;
+};
+
+const DEFAULT_VALUES: Values = {
+  name: "Argos",
+  email: "not-an-email",
+  notifications: true,
+  terms: false,
+};
+
+/**
+ * The whole form layer in one frame: `FormTextInput`, `FormCheckbox`,
+ * `FormSwitch` and `FormCardFooter` (which is itself `FormRootError` +
+ * `FormSuccess` + `FormSubmit`). None of these have a baseline today, and the
+ * error path is what changes when `FieldErrorContext` gives way to Base UI's
+ * `Field.Error`.
+ */
+function FormFixture({ errors = false }: { errors?: boolean }) {
+  const form = useForm<Values>({ defaultValues: DEFAULT_VALUES });
+  const { setError } = form;
+  useEffect(() => {
+    if (!errors) {
+      return;
+    }
+    setError("email", { type: "manual", message: "Enter a valid email." });
+    setError("terms", {
+      type: "manual",
+      message: "You must accept the terms.",
+    });
+    setError("root.serverError", {
+      type: "manual",
+      message: "Something went wrong.",
+    });
+  }, [errors, setError]);
+  return (
+    <Form form={form} onSubmit={() => {}}>
+      <Card>
+        <CardBody>
+          <CardTitle>Account</CardTitle>
+          <div className="flex flex-col gap-4">
+            {/* `register` is how call sites bind the value — `name` alone
+                leaves the input uncontrolled and empty. */}
+            <FormTextInput
+              control={form.control}
+              {...form.register("name")}
+              label="Name"
+            />
+            <FormTextInput
+              control={form.control}
+              {...form.register("email")}
+              label="Email"
+              description="Where we send build notifications."
+            />
+            <FormSwitch
+              control={form.control}
+              name="notifications"
+              label="Notifications"
+            />
+            <FormCheckbox
+              control={form.control}
+              name="terms"
+              label="I accept the terms"
+            />
+          </div>
+        </CardBody>
+        <FormCardFooter control={form.control} />
+      </Card>
+    </Form>
+  );
+}
+
+// The component under test needs a `useForm` result, which only exists inside a
+// render, so the fixture stands in for `Form` as the story's component.
+const meta = {
+  title: "UI/Form",
+  component: FormFixture,
+} satisfies Meta<typeof FormFixture>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <div className="flex max-w-lg flex-col">
+      <StoryTitle>Fields</StoryTitle>
+      <FormFixture {...args} />
+    </div>
+  ),
+};
+
+export const Invalid: Story = {
+  args: { errors: true },
+  render: (args) => (
+    <div className="flex max-w-lg flex-col">
+      <StoryTitle>Field and root errors</StoryTitle>
+      <FormFixture {...args} />
+    </div>
+  ),
+};

--- a/apps/frontend/src/ui/ListBox.stories.tsx
+++ b/apps/frontend/src/ui/ListBox.stories.tsx
@@ -1,6 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { ListBox, ListBoxItem, ListBoxSeparator } from "./ListBox";
+import {
+  ListBox,
+  ListBoxItem,
+  ListBoxItemDescription,
+  ListBoxItemLabel,
+  ListBoxSeparator,
+} from "./ListBox";
 import { StoryTitle } from "./StoryTitle";
 
 const meta = {
@@ -31,6 +37,28 @@ export const Default: Story = {
           <ListBoxItem id="firefox">Firefox</ListBoxItem>
           <ListBoxItem id="safari">Safari</ListBoxItem>
           <ListBoxItem id="edge">Edge</ListBoxItem>
+        </ListBox>
+      </div>
+
+      {/* Label and description rows are styled through the `slot` DOM attribute
+          (`has-[[slot=description]]:flex-wrap`, `**:[[slot=label]]:truncate`),
+          which react-aria's `Text` sets for us. Nothing snapshots them today,
+          and a replacement that drops the attribute breaks silently. */}
+      <StoryTitle>Label and description</StoryTitle>
+      <div className="border-thin max-w-xs rounded-lg">
+        <ListBox aria-label="Reviewers" selectionMode="single">
+          <ListBoxItem id="jane" textValue="Jane Doe">
+            <ListBoxItemLabel>Jane Doe</ListBoxItemLabel>
+            <ListBoxItemDescription>jane@argos-ci.com</ListBoxItemDescription>
+          </ListBoxItem>
+          <ListBoxItem id="long" textValue="A very long name">
+            <ListBoxItemLabel>
+              A reviewer whose name is long enough to be truncated
+            </ListBoxItemLabel>
+            <ListBoxItemDescription>
+              someone.with.a.long.address@example.com
+            </ListBoxItemDescription>
+          </ListBoxItem>
         </ListBox>
       </div>
     </div>

--- a/apps/frontend/src/ui/ListBox.stories.tsx
+++ b/apps/frontend/src/ui/ListBox.stories.tsx
@@ -39,11 +39,19 @@ export const Default: Story = {
           <ListBoxItem id="edge">Edge</ListBoxItem>
         </ListBox>
       </div>
+    </div>
+  ),
+};
 
-      {/* Label and description rows are styled through the `slot` DOM attribute
-          (`has-[[slot=description]]:flex-wrap`, `**:[[slot=label]]:truncate`),
-          which react-aria's `Text` sets for us. Nothing snapshots them today,
-          and a replacement that drops the attribute breaks silently. */}
+/**
+ * Label and description rows are styled through the `slot` DOM attribute
+ * (`has-[[slot=description]]:flex-wrap`, `**:[[slot=label]]:truncate`), which
+ * react-aria's `Text` sets for us. A replacement that drops the attribute
+ * breaks these silently.
+ */
+export const LabelAndDescription: Story = {
+  render: () => (
+    <div className="flex flex-col">
       <StoryTitle>Label and description</StoryTitle>
       <div className="border-thin max-w-xs rounded-lg">
         <ListBox aria-label="Reviewers" selectionMode="single">

--- a/apps/frontend/src/ui/Menu.stories.tsx
+++ b/apps/frontend/src/ui/Menu.stories.tsx
@@ -1,16 +1,23 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { CopyIcon, PencilIcon, Trash2Icon } from "lucide-react";
+import { SubmenuTrigger } from "react-aria-components";
 
 import { Button } from "./Button";
 import {
   Menu,
   MenuItem,
   MenuItemIcon,
+  MenuItemShortcut,
   MenuSeparator,
   MenuTitle,
   MenuTrigger,
 } from "./Menu";
 import { Popover } from "./Popover";
+import {
+  openOverlayParameters,
+  OverlaySlot,
+  OverlayStage,
+} from "./storyOverlay";
 
 const meta = {
   title: "UI/Menu",
@@ -49,5 +56,96 @@ export const Default: Story = {
         </Menu>
       </Popover>
     </MenuTrigger>
+  ),
+};
+
+/**
+ * The menu popup itself. `Default` only ever photographs the closed trigger, so
+ * without this the surface, the row states and the three `MenuItem` shapes
+ * (plain, submenu, single- and multi-selection) have no visual baseline at all.
+ */
+export const Open: Story = {
+  parameters: openOverlayParameters,
+  render: () => (
+    <OverlayStage>
+      <MenuTrigger defaultOpen>
+        <Button variant="secondary">Actions</Button>
+        <Popover placement="bottom start">
+          <Menu>
+            <MenuTitle>Actions</MenuTitle>
+            <MenuItem>
+              <MenuItemIcon>
+                <PencilIcon />
+              </MenuItemIcon>
+              Edit
+              <MenuItemShortcut>⌘E</MenuItemShortcut>
+            </MenuItem>
+            <MenuItem>
+              <MenuItemIcon>
+                <CopyIcon />
+              </MenuItemIcon>
+              Duplicate
+            </MenuItem>
+            <SubmenuTrigger>
+              <MenuItem>Move to</MenuItem>
+              <Popover>
+                <Menu>
+                  <MenuItem>Archive</MenuItem>
+                  <MenuItem>Backlog</MenuItem>
+                </Menu>
+              </Popover>
+            </SubmenuTrigger>
+            <MenuSeparator />
+            <MenuItem isDisabled>Transfer ownership</MenuItem>
+            <MenuItem variant="danger">
+              <MenuItemIcon>
+                <Trash2Icon />
+              </MenuItemIcon>
+              Delete
+            </MenuItem>
+          </Menu>
+        </Popover>
+      </MenuTrigger>
+    </OverlayStage>
+  ),
+};
+
+/** Single selection draws a check mark; multiple draws a checkbox. */
+export const OpenWithSelection: Story = {
+  parameters: openOverlayParameters,
+  render: () => (
+    <OverlayStage>
+      <OverlaySlot>
+        <MenuTrigger defaultOpen>
+          <Button variant="secondary">Sort by</Button>
+          <Popover placement="bottom start">
+            <Menu selectionMode="single" selectedKeys={["recent"]}>
+              <MenuItem id="recent">Most recent</MenuItem>
+              <MenuItem id="name">Name</MenuItem>
+              <MenuItem id="status">Status</MenuItem>
+            </Menu>
+          </Popover>
+        </MenuTrigger>
+      </OverlaySlot>
+
+      <OverlaySlot>
+        <MenuTrigger defaultOpen>
+          <Button variant="secondary">Status</Button>
+          <Popover placement="bottom start">
+            <Menu
+              selectionMode="multiple"
+              selectedKeys={["accepted", "pending"]}
+            >
+              <MenuItem id="accepted">Accepted</MenuItem>
+              <MenuItem id="rejected">Rejected</MenuItem>
+              <MenuItem id="pending">Pending</MenuItem>
+              <MenuItem id="expired" isDisabled>
+                Expired
+              </MenuItem>
+            </Menu>
+          </Popover>
+        </MenuTrigger>
+      </OverlaySlot>
+    </OverlayStage>
   ),
 };

--- a/apps/frontend/src/ui/Popover.stories.tsx
+++ b/apps/frontend/src/ui/Popover.stories.tsx
@@ -3,6 +3,11 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Button } from "./Button";
 import { DialogTrigger } from "./Dialog";
 import { Popover } from "./Popover";
+import {
+  openOverlayParameters,
+  OverlaySlot,
+  OverlayStage,
+} from "./storyOverlay";
 
 const meta = {
   title: "UI/Popover",
@@ -22,5 +27,31 @@ export const Default: Story = {
         </Popover>
       </DialogTrigger>
     </div>
+  ),
+};
+
+/**
+ * The popover surface at each placement. `getPopoverOriginClassName` derives
+ * the transform origin from the requested placement, and that whole mechanism
+ * is what Base UI replaces with a `--transform-origin` custom property — so
+ * every placement needs a baseline of its own.
+ */
+export const Open: Story = {
+  parameters: openOverlayParameters,
+  render: () => (
+    <OverlayStage className="items-center">
+      {(["bottom start", "bottom end", "top", "left", "right"] as const).map(
+        (placement) => (
+          <OverlaySlot key={placement} className="flex justify-center">
+            <DialogTrigger defaultOpen>
+              <Button variant="secondary">{placement}</Button>
+              <Popover placement={placement}>
+                <div className="p-3 text-sm">Popover content here</div>
+              </Popover>
+            </DialogTrigger>
+          </OverlaySlot>
+        ),
+      )}
+    </OverlayStage>
   ),
 };

--- a/apps/frontend/src/ui/Select.stories.tsx
+++ b/apps/frontend/src/ui/Select.stories.tsx
@@ -3,7 +3,12 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Label } from "./Label";
 import { ListBox, ListBoxItem } from "./ListBox";
 import { Popover } from "./Popover";
-import { Select, SelectButton } from "./Select";
+import { Select, SelectButton, SelectValue } from "./Select";
+import {
+  openOverlayParameters,
+  OverlaySlot,
+  OverlayStage,
+} from "./storyOverlay";
 
 const meta = {
   title: "UI/Select",
@@ -37,5 +42,49 @@ export const Default: Story = {
         </Popover>
       </Select>
     </div>
+  ),
+};
+
+/**
+ * The list box a select drops. Worth pinning carefully: Base UI's
+ * `Select.Positioner` defaults to aligning the selected item over the trigger
+ * rather than dropping below it, so this is the baseline that catches it.
+ */
+export const Open: Story = {
+  parameters: openOverlayParameters,
+  render: () => (
+    <OverlayStage>
+      <OverlaySlot>
+        <Select selectedKey="b" aria-label="Small" defaultOpen>
+          <SelectButton size="sm">
+            <SelectValue />
+          </SelectButton>
+          <Popover>
+            <ListBox>
+              <ListBoxItem id="a">Option A</ListBoxItem>
+              <ListBoxItem id="b">Option B</ListBoxItem>
+              <ListBoxItem id="c">Option C</ListBoxItem>
+            </ListBox>
+          </Popover>
+        </Select>
+      </OverlaySlot>
+
+      <OverlaySlot>
+        <Select selectedKey="b" aria-label="Medium" defaultOpen>
+          <SelectButton size="md">
+            <SelectValue />
+          </SelectButton>
+          <Popover>
+            <ListBox>
+              <ListBoxItem id="a">Option A</ListBoxItem>
+              <ListBoxItem id="b">Option B</ListBoxItem>
+              <ListBoxItem id="c" isDisabled>
+                Option C
+              </ListBoxItem>
+            </ListBox>
+          </Popover>
+        </Select>
+      </OverlaySlot>
+    </OverlayStage>
   ),
 };

--- a/apps/frontend/src/ui/TextInput.stories.tsx
+++ b/apps/frontend/src/ui/TextInput.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent } from "storybook/test";
 
 import { Label } from "./Label";
 import { StoryTitle } from "./StoryTitle";
@@ -35,6 +36,32 @@ export const Default: Story = {
       <div className="flex max-w-xs flex-col gap-4">
         <TextInput placeholder="Default" />
         <TextInput placeholder="Disabled" disabled />
+        <TextInput placeholder="Invalid" aria-invalid="true" />
+      </div>
+    </div>
+  ),
+};
+
+/**
+ * Keyboard focus, reached by tabbing. This is the one place `:focus-visible` is
+ * not a drop-in for react-aria's modality tracking — a text input matches
+ * `:focus-visible` on a plain click too, so the ring here has to keep coming
+ * from "was the keyboard used", not from the browser's own heuristic. Argos
+ * moves the pointer away before capturing but does not blur, so the ring
+ * survives the shutter.
+ */
+export const KeyboardFocus: Story = {
+  play: async () => {
+    await userEvent.tab();
+  },
+  render: () => (
+    <div className="flex max-w-xs flex-col gap-4 p-4">
+      <div>
+        <Label>Focused</Label>
+        <TextInput placeholder="Focused" />
+      </div>
+      <div>
+        <Label invalid>Invalid</Label>
         <TextInput placeholder="Invalid" aria-invalid="true" />
       </div>
     </div>

--- a/apps/frontend/src/ui/Tooltip.stories.tsx
+++ b/apps/frontend/src/ui/Tooltip.stories.tsx
@@ -1,6 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Button } from "./Button";
+import {
+  openOverlayParameters,
+  OverlaySlot,
+  OverlayStage,
+} from "./storyOverlay";
 import { StoryTitle } from "./StoryTitle";
 import { Tooltip } from "./Tooltip";
 
@@ -45,5 +50,45 @@ export const Default: Story = {
         </Tooltip>
       </div>
     </div>
+  ),
+};
+
+/**
+ * Opened through `isOpen` rather than by hovering: Argos moves the pointer to
+ * (0, 0) before every capture, so a hover-opened tooltip is dismissed before
+ * the shutter.
+ */
+export const Open: Story = {
+  parameters: openOverlayParameters,
+  render: () => (
+    <OverlayStage className="items-center">
+      <OverlaySlot className="flex justify-center">
+        <Tooltip content="Default tooltip" placement="bottom" isOpen>
+          <Button variant="secondary">Default</Button>
+        </Tooltip>
+      </OverlaySlot>
+      <OverlaySlot className="flex justify-center">
+        <Tooltip
+          content={
+            <>
+              An <strong>info</strong> tooltip, long enough to reach the maximum
+              measure and wrap onto a second line.
+            </>
+          }
+          variant="info"
+          placement="bottom"
+          isOpen
+        >
+          <Button variant="secondary">Info</Button>
+        </Tooltip>
+      </OverlaySlot>
+      {(["top", "bottom", "left", "right"] as const).map((placement) => (
+        <OverlaySlot key={placement} className="flex justify-center">
+          <Tooltip content={placement} placement={placement} isOpen>
+            <Button variant="secondary">{placement}</Button>
+          </Tooltip>
+        </OverlaySlot>
+      ))}
+    </OverlayStage>
   ),
 };

--- a/apps/frontend/src/ui/storyOverlay.tsx
+++ b/apps/frontend/src/ui/storyOverlay.tsx
@@ -1,0 +1,52 @@
+import type { ComponentPropsWithRef } from "react";
+import { clsx } from "clsx";
+
+/**
+ * Story parameters for a story that renders an overlay open.
+ *
+ * Argos screenshots a story by cropping `<body>` to its content
+ * (`fitToContent`, on by default). An open menu, dialog, popover or tooltip is
+ * portalled and positioned out of flow, so it contributes nothing to that
+ * measurement and lands outside the crop — which is why every closed-trigger
+ * story photographs only the trigger. Opting out captures the full viewport
+ * instead.
+ */
+export const openOverlayParameters = {
+  argos: { fitToContent: false },
+  // Pins the width only — the viewport addon is not installed, so nothing but
+  // Argos reads this, and with fit-to-content off the height comes from the
+  // full-page capture instead.
+  viewport: { defaultViewport: 900 },
+};
+
+/**
+ * The stage an open overlay is photographed on. `h-screen` makes `<body>`'s box
+ * equal the viewport — the box a fixed-position overlay fills. Without it
+ * `<body>` is only as tall as the trigger and the overlay is cropped off.
+ *
+ * Wrap each trigger in an `OverlaySlot` when a story opens more than one at
+ * once: popups are positioned against their trigger and ignore each other, so
+ * adjacent triggers overlap their popups and clip the one underneath.
+ */
+export function OverlayStage({
+  className,
+  ...props
+}: ComponentPropsWithRef<"div">) {
+  return (
+    <div
+      {...props}
+      className={clsx(
+        "flex h-screen w-full flex-wrap items-start justify-center gap-8 p-16",
+        className,
+      )}
+    />
+  );
+}
+
+/** Reserves enough width for one open popup to stand clear of its neighbours. */
+export function OverlaySlot({
+  className,
+  ...props
+}: ComponentPropsWithRef<"div">) {
+  return <div {...props} className={clsx("w-64", className)} />;
+}

--- a/apps/frontend/vitest.config.mts
+++ b/apps/frontend/vitest.config.mts
@@ -51,8 +51,16 @@ export default mergeConfig(
             name: "storybook",
             browser: {
               enabled: true,
-              provider:
-                playwright() as unknown as BrowserProviderOption<object>,
+              provider: playwright({
+                // Pin the browser's locale and time zone rather than inheriting
+                // the host's. Two reasons: any story that formats a date or a
+                // number would otherwise render differently on a contributor's
+                // machine and in CI, and `Intl.DateTimeFormat().resolvedOptions()
+                // .timeZone` returns `Etc/Unknown` on a host ICU cannot resolve
+                // — which `@internationalized/date` rejects outright, taking the
+                // calendar stories down with it.
+                contextOptions: { locale: "en-US", timezoneId: "UTC" },
+              }) as unknown as BrowserProviderOption<object>,
               headless: true,
               instances: [{ browser: "chromium" }],
             },


### PR DESCRIPTION
## Why

Every overlay story in the UI kit renders its trigger **closed**, and Argos crops
each story to `<body>`'s content by default (`fitToContent`, `{padding: 16, zoom: 2}`).
An open menu, dialog, popover, select or tooltip is portalled and positioned out of
flow, so it contributes nothing to that measurement and falls outside the crop.

The committed `ui-menu--default.png` is **272×128** — the "Open Menu" button and
nothing else. So the popup surface, the row states, the backdrop and the enter/exit
styling have never had a visual baseline anywhere.

This is groundwork for migrating the design system off `react-aria-components`: most
of that work is invisible to CI until these baselines exist. It is useful on its own
regardless — these are 17 states the kit could regress in silently today.

## What changed

`storyOverlay.tsx` holds the two things an open-overlay story needs: the parameters
that turn the crop off, and a stage tall enough that a fixed-position popup lands
inside the frame.

Then, a sibling `Open` story wherever a trigger can be opened at mount — the existing
closed `Default` stories are untouched, so their green baselines stay green:

- **Menu** — all three `MenuItem` shapes (plain, submenu, single- and multi-selection),
  plus section header, separator, danger and disabled rows
- **Select** — both sizes, with a selected option so the check indicator is in frame
- **Popover** — one per placement, since the transform origin is derived from it
- **Tooltip** — both variants and all four placements
- **Dialog** — `dialog`, `alertdialog`, and a pending state, which is also the only
  baseline of `Modal`'s backdrop, blur and card
- **EmojiPicker** — the popover variant
- **ListBox** — label/description rows, styled through the `slot` DOM attribute

And first stories for components that had none: **Form** (covers 8 untested `Form*`
files in one frame, including field and root errors), **ColorPicker**, and
**DateRangePicker** — the second-heaviest file in the kit with zero coverage until now.
It gets a fixed date range so the visible month is deterministic.

Also two keyboard-focus stories, on **TextInput** and **Chip**. Argos moves the pointer
away before the shutter but does not drop focus, so a `play` that tabs is captured.
TextInput's ring is the interesting one: it cannot be expressed as `:focus-visible`,
because a text input matches that on a plain click too.

## The second commit: a latent CI bug this uncovered

`DateRangePicker > Open` passed locally and crashed in CI with
`RangeError: Invalid time zone specified: Etc/Unknown`, from `@internationalized/date`
via `useRangeCalendar`.

`Etc/Unknown` is what `Intl.DateTimeFormat().resolvedOptions().timeZone` returns when
ICU cannot resolve the host zone. CI set **`TZ: utc`** — lowercase, which is not an
IANA zone id, so ICU on Linux fails to map it; macOS resolves it anyway, which is why
this never showed up locally. Nothing had exercised that path before, because the
calendar had no story.

Fixed at the source (`TZ: UTC`, 4 jobs) and additionally by pinning `locale` and
`timezoneId` on the Playwright browser context, which does not depend on the host
resolving an env var. The second half matters beyond the crash: **any** story
formatting a date or a number previously rendered differently on a contributor's
machine than in CI. Verified byte-identical calendar output under three host zones
that previously produced three different renders.

## Notes for review

- **Expect ~17 new Argos snapshots on the Storybook project, all additions.** 41 → 58
  stories. The first CI run reported `1 changed` — that was me appending a section to
  ListBox's existing `Default` story instead of adding a sibling. Fixed in `9abbe961`;
  `ui-listbox--default.png` is byte-identical to main again, verified by generating it
  from both versions and comparing hashes.
- `parameters.argos.fitToContent` is **per-story, not per-screenshot**, which is why
  each open state is a separate story rather than a second capture on an existing one.
- Tooltips are opened with `isOpen`, never `userEvent.hover` — the Argos capture runs
  `page.mouse.move(0, 0)` first and would dismiss a hover-opened tooltip.
- Stories that open more than one overlay wrap each trigger in an `OverlaySlot`.
  Popups are positioned against their own trigger and ignore each other, so adjacent
  triggers clip the popup underneath — the first draft of the Menu selection story
  did exactly that.
- `TabLink` and `FilterSearchMenu` are deliberately **not** included. `.storybook/preview.ts`
  has no react-router or Apollo provider, so both need decorators built first; that is
  its own piece of work rather than something to half-do here.

## Verification

`pnpm --dir apps/frontend run test-storybook` — 58 passed, 0 failed. Screenshots
inspected individually. `pnpm run static-checks` green.