### PR TITLE
chore(ui): groundwork for the Base UI migration

### DIFF
--- a/apps/frontend/src/containers/Build/BuildEmptyStates.tsx
+++ b/apps/frontend/src/containers/Build/BuildEmptyStates.tsx
@@ -1,8 +1,9 @@
 import { ImagesIcon, SquareSlashIcon } from "lucide-react";
-import { Heading, Text } from "react-aria-components";
 
 import { LinkButton } from "@/ui/Button";
+import { Heading } from "@/ui/Heading";
 import { EmptyState, EmptyStateActions, EmptyStateIcon } from "@/ui/Layout";
+import { Text } from "@/ui/Text";
 
 export function SkippedBuildEmptyState() {
   return (

--- a/apps/frontend/src/containers/GitlabProjectList.tsx
+++ b/apps/frontend/src/containers/GitlabProjectList.tsx
@@ -1,12 +1,13 @@
 import { useQuery } from "@apollo/client/react";
 import { FolderCodeIcon } from "lucide-react";
-import { Heading, Text } from "react-aria-components";
 
 import { graphql } from "@/gql";
 import { Button } from "@/ui/Button";
+import { Heading } from "@/ui/Heading";
 import { EmptyState, EmptyStateIcon } from "@/ui/Layout";
 import { List, ListRow } from "@/ui/List";
 import { Loader } from "@/ui/Loader";
+import { Text } from "@/ui/Text";
 import { Time } from "@/ui/Time";
 import { Truncable } from "@/ui/Truncable";
 

--- a/apps/frontend/src/containers/Passkey.tsx
+++ b/apps/frontend/src/containers/Passkey.tsx
@@ -133,7 +133,7 @@ export function useRegisterPasskey(): () => Promise<void> {
  * the user picks one.
  */
 export function PasskeyLoginButton(
-  props: Omit<ButtonProps, "children" | "variant" | "onAction"> & {
+  props: Omit<ButtonProps, "children" | "variant" | "onAsyncAction"> & {
     children?: React.ReactNode;
     redirect?: string | null;
     onSuccess?: () => void;
@@ -146,7 +146,7 @@ export function PasskeyLoginButton(
     <Button
       variant="secondary"
       {...rest}
-      onAction={async () => {
+      onAsyncAction={async () => {
         const { data } = await client.mutate({
           mutation: CreateAuthenticationOptionsMutation,
         });

--- a/apps/frontend/src/containers/PaymentBanner.tsx
+++ b/apps/frontend/src/containers/PaymentBanner.tsx
@@ -84,7 +84,7 @@ function ExtendTrialButton(props: { accountId: string }) {
   const client = useApolloClient();
   return (
     <Button
-      onAction={async () => {
+      onAsyncAction={async () => {
         const result = await client.mutate({
           mutation: ExtendTrialMutation,
           variables: {

--- a/apps/frontend/src/containers/ProjectList.tsx
+++ b/apps/frontend/src/containers/ProjectList.tsx
@@ -1,11 +1,11 @@
 import { GitBranchIcon } from "@primer/octicons-react";
 import { FolderIcon, PlusCircleIcon } from "lucide-react";
-import { Heading, Text } from "react-aria-components";
 
 import { DocumentType, graphql } from "@/gql";
 import { DeploymentStatus } from "@/gql/graphql";
 import { ButtonIcon, LinkButton, LinkButtonProps } from "@/ui/Button";
 import { Chip } from "@/ui/Chip";
+import { Heading } from "@/ui/Heading";
 import {
   EmptyState,
   EmptyStateActions,
@@ -16,6 +16,7 @@ import {
   PageHeaderContent,
 } from "@/ui/Layout";
 import { HeadlessLink, Link } from "@/ui/Link";
+import { Text } from "@/ui/Text";
 import { Time } from "@/ui/Time";
 
 import { RepositoryIcons } from "./Repository";

--- a/apps/frontend/src/containers/Team/GitHubSSO/index.tsx
+++ b/apps/frontend/src/containers/Team/GitHubSSO/index.tsx
@@ -92,7 +92,7 @@ export const DisableGitHubSSOButton = memo(
               {error && <ErrorMessage>{getErrorMessage(error)}</ErrorMessage>}
               <DialogDismiss>Cancel</DialogDismiss>
               <DialogActionButton
-                onAction={async () => {
+                onAsyncAction={async () => {
                   await disable().catch(() => {});
                 }}
               >

--- a/apps/frontend/src/containers/Team/Invite.tsx
+++ b/apps/frontend/src/containers/Team/Invite.tsx
@@ -1,32 +1,23 @@
 import type { ComponentProps } from "react";
-import {
-  Heading,
-  HeadingContext,
-  Provider,
-  Text,
-  TextContext,
-} from "react-aria-components";
 
 import { getAccountURL } from "@/pages/Account/AccountParams";
 import { LinkButton } from "@/ui/Button";
 import { Container } from "@/ui/Container";
+import { Heading, HeadingContext } from "@/ui/Heading";
+import { Text, TextContext } from "@/ui/Text";
 
 import { AccountAvatar } from "../AccountAvatar";
 
 export function InviteContainer(props: { children: React.ReactNode }) {
   return (
     <Container className="mt-32 flex max-w-3xl flex-col items-center text-center">
-      <Provider
-        values={[
-          [
-            HeadingContext,
-            { level: 1, className: "mb-2 text-2xl font-medium" },
-          ],
-          [TextContext, { className: "text-low" }],
-        ]}
+      <HeadingContext
+        value={{ level: 1, className: "mb-2 text-2xl font-medium" }}
       >
-        {props.children}
-      </Provider>
+        <TextContext value={{ className: "text-low" }}>
+          {props.children}
+        </TextContext>
+      </HeadingContext>
     </Container>
   );
 }

--- a/apps/frontend/src/containers/Team/SAMLSSOAddOn.tsx
+++ b/apps/frontend/src/containers/Team/SAMLSSOAddOn.tsx
@@ -116,7 +116,7 @@ function EnableSAMLSSODialog(props: {
             {error && <ErrorMessage>{getErrorMessage(error)}</ErrorMessage>}
             <DialogDismiss>Cancel</DialogDismiss>
             <DialogActionButton
-              onAction={async () => {
+              onAsyncAction={async () => {
                 try {
                   await enable();
                   close();
@@ -159,7 +159,7 @@ export function DisableSAMLSSOAddOnButton(props: { teamAccountId: string }) {
                 {error && <ErrorMessage>{getErrorMessage(error)}</ErrorMessage>}
                 <DialogDismiss>Cancel</DialogDismiss>
                 <DialogActionButton
-                  onAction={async () => {
+                  onAsyncAction={async () => {
                     await disable()
                       .then(() => close())
                       .catch(() => {});

--- a/apps/frontend/src/containers/Team/members/GitHubMembersList.tsx
+++ b/apps/frontend/src/containers/Team/members/GitHubMembersList.tsx
@@ -1,7 +1,6 @@
 import { useDeferredValue, useState } from "react";
 import { useSuspenseQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
-import { Heading, Text } from "react-aria-components";
 
 import { AccountAvatar } from "@/containers/AccountAvatar";
 import { useAssertAuthAccount } from "@/containers/Auth";
@@ -9,8 +8,10 @@ import { TeamMemberLabel } from "@/containers/UserList";
 import { DocumentType, graphql } from "@/gql";
 import { Button } from "@/ui/Button";
 import { Chip } from "@/ui/Chip";
+import { Heading } from "@/ui/Heading";
 import { EmptyState, EmptyStateActions } from "@/ui/Layout";
 import { List, ListLoadMore, ListRow } from "@/ui/List";
+import { Text } from "@/ui/Text";
 import { Tooltip } from "@/ui/Tooltip";
 
 import { MemberLevelEditor } from "./MemberLevelEditor";

--- a/apps/frontend/src/containers/Team/members/InviteDialog.tsx
+++ b/apps/frontend/src/containers/Team/members/InviteDialog.tsx
@@ -224,7 +224,7 @@ function ResetInviteLinkButton(props: {
   const client = useApolloClient();
   return (
     <DialogActionButton
-      onAction={async () => {
+      onAsyncAction={async () => {
         await client.mutate({
           mutation: ResetInviteLinkMutation,
           variables: { teamAccountId: props.teamAccountId },

--- a/apps/frontend/src/containers/Team/members/InvitesList.tsx
+++ b/apps/frontend/src/containers/Team/members/InvitesList.tsx
@@ -8,7 +8,7 @@ import {
   MailIcon,
   MoreVerticalIcon,
 } from "lucide-react";
-import { Heading, MenuTrigger, Text } from "react-aria-components";
+import { MenuTrigger } from "react-aria-components";
 
 import { AccountAvatar } from "@/containers/AccountAvatar";
 import { TeamMemberLabel } from "@/containers/UserList";
@@ -16,11 +16,13 @@ import { graphql, type DocumentType } from "@/gql";
 import { Button } from "@/ui/Button";
 import { Chip } from "@/ui/Chip";
 import { DialogTrigger } from "@/ui/Dialog";
+import { Heading } from "@/ui/Heading";
 import { EmptyState, EmptyStateActions } from "@/ui/Layout";
 import { List, ListLoadMore, ListRow } from "@/ui/List";
 import { Menu, MenuItem, MenuItemIcon } from "@/ui/Menu";
 import { Modal } from "@/ui/Modal";
 import { Popover } from "@/ui/Popover";
+import { Text } from "@/ui/Text";
 import { toast } from "@/ui/Toaster";
 
 import { InviteDialog } from "./InviteDialog";

--- a/apps/frontend/src/containers/Team/members/MembersList.tsx
+++ b/apps/frontend/src/containers/Team/members/MembersList.tsx
@@ -2,7 +2,6 @@ import { useDeferredValue, useMemo, useState } from "react";
 import { useSuspenseQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { MarkGithubIcon } from "@primer/octicons-react";
-import { Heading, Text } from "react-aria-components";
 
 import { useAssertAuthAccount } from "@/containers/Auth";
 import {
@@ -14,8 +13,10 @@ import { graphql } from "@/gql";
 import { TeamMembersOrderBy } from "@/gql/graphql";
 import { Button } from "@/ui/Button";
 import { Chip } from "@/ui/Chip";
+import { Heading } from "@/ui/Heading";
 import { EmptyState, EmptyStateActions } from "@/ui/Layout";
 import { List, ListLoadMore } from "@/ui/List";
+import { Text } from "@/ui/Text";
 import { Tooltip } from "@/ui/Tooltip";
 
 import { MemberLevelEditor } from "./MemberLevelEditor";

--- a/apps/frontend/src/containers/User/OAuthApps.tsx
+++ b/apps/frontend/src/containers/User/OAuthApps.tsx
@@ -116,7 +116,7 @@ function RevokeAppDialog(props: {
         <DialogDismiss>Cancel</DialogDismiss>
         <DialogActionButton
           variant="destructive"
-          onAction={async () => {
+          onAsyncAction={async () => {
             try {
               await revoke();
               state.close();

--- a/apps/frontend/src/containers/User/providers/PasskeyAuth.tsx
+++ b/apps/frontend/src/containers/User/providers/PasskeyAuth.tsx
@@ -81,8 +81,8 @@ const DeletePasskeyMutation = graphql(`
  * Explains what is about to happen before the OS prompt takes over the screen,
  * and gives the user somewhere to retry from if the authenticator refuses.
  *
- * The registration is driven from `onAction` so the modal stays undismissable
- * while the browser prompt is up.
+ * The registration is driven from `onAsyncAction` so the modal stays
+ * undismissable while the browser prompt is up.
  */
 function CreatePasskeyDialog() {
   const state = useOverlayTriggerState();
@@ -107,7 +107,7 @@ function CreatePasskeyDialog() {
         {error ? <ErrorMessage className="flex-1">{error}</ErrorMessage> : null}
         <DialogDismiss>Cancel</DialogDismiss>
         <DialogActionButton
-          onAction={async () => {
+          onAsyncAction={async () => {
             setError(null);
             try {
               await registerPasskey();
@@ -202,7 +202,7 @@ function DeletePasskeyDialog(props: { passkey: Passkey }) {
         <DialogDismiss>Cancel</DialogDismiss>
         <DialogActionButton
           variant="destructive"
-          onAction={async () => {
+          onAsyncAction={async () => {
             await deletePasskey();
             state.close();
             toast.success("Passkey deleted", { id: "passkey-deleted" });

--- a/apps/frontend/src/pages/Account/Analytics.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.tsx
@@ -25,11 +25,9 @@ import {
 import { useFilter } from "react-aria";
 import {
   Autocomplete,
-  Heading,
   Input,
   MenuTrigger,
   SearchField,
-  Text,
 } from "react-aria-components";
 import { Helmet } from "react-helmet";
 import { Navigate, useSearchParams } from "react-router";
@@ -63,6 +61,7 @@ import {
   getTimeTicks,
 } from "@/ui/Charts";
 import { DateRangePicker } from "@/ui/DateRangePicker";
+import { Heading } from "@/ui/Heading";
 import {
   Page,
   PageContainer,
@@ -76,6 +75,7 @@ import { PageLoader } from "@/ui/PageLoader";
 import { Popover } from "@/ui/Popover";
 import { Select, SelectButton } from "@/ui/Select";
 import { StatTile } from "@/ui/StatTile";
+import { Text } from "@/ui/Text";
 import { Tooltip } from "@/ui/Tooltip";
 
 import { useAccountParams } from "./AccountParams";

--- a/apps/frontend/src/pages/Account/NewProject.tsx
+++ b/apps/frontend/src/pages/Account/NewProject.tsx
@@ -1,7 +1,6 @@
 import type { ApolloCache } from "@apollo/client";
 import { useApolloClient, useMutation } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
-import { Heading, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
@@ -13,6 +12,7 @@ import { Form } from "@/ui/Form";
 import { FormRootError } from "@/ui/FormRootError";
 import { FormSubmit } from "@/ui/FormSubmit";
 import { FormTextInput } from "@/ui/FormTextInput";
+import { Heading } from "@/ui/Heading";
 import {
   Page,
   PageContainer,
@@ -20,6 +20,7 @@ import {
   PageHeaderContent,
 } from "@/ui/Layout";
 import { Separator } from "@/ui/Separator";
+import { Text } from "@/ui/Text";
 import { toast } from "@/ui/Toaster";
 import { getErrorMessage } from "@/util/error";
 

--- a/apps/frontend/src/pages/Account/Settings.tsx
+++ b/apps/frontend/src/pages/Account/Settings.tsx
@@ -7,7 +7,6 @@ import {
 } from "react";
 import { useSuspenseQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
-import { Heading, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
 import { Route, Routes } from "react-router";
 
@@ -38,6 +37,7 @@ import { UserAccessTokens } from "@/containers/User/UserAccessTokens";
 import { graphql } from "@/gql";
 import { AccountPermission } from "@/gql/graphql";
 import { NotFound } from "@/pages/NotFound";
+import { Heading } from "@/ui/Heading";
 import {
   Page,
   PageContainer,
@@ -46,6 +46,7 @@ import {
 } from "@/ui/Layout";
 import { Nav, NavLink, NavList, NavListItem } from "@/ui/Nav";
 import { PageLoader } from "@/ui/PageLoader";
+import { Text } from "@/ui/Text";
 import { useScrollToHash } from "@/ui/useScrollToHash";
 
 import { useAccountContext } from ".";

--- a/apps/frontend/src/pages/Account/Tests.tsx
+++ b/apps/frontend/src/pages/Account/Tests.tsx
@@ -13,7 +13,6 @@ import clsx from "clsx";
 import { FileImageIcon, SearchIcon } from "lucide-react";
 import { parseAsString, useQueryStates } from "nuqs";
 import { useNumberFormatter } from "react-aria";
-import { Heading, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
 
 import {
@@ -27,6 +26,7 @@ import { useTestPeriodState } from "@/containers/Test/Period";
 import { SeenChange } from "@/containers/Test/SeenChange";
 import { graphql, type DocumentType } from "@/gql";
 import { Button } from "@/ui/Button";
+import { Heading } from "@/ui/Heading";
 import {
   EmptyState,
   EmptyStateActions,
@@ -40,6 +40,7 @@ import {
 import { HeadlessLink } from "@/ui/Link";
 import { List, ListHeaderRow, ListRowLink, ListRowLoader } from "@/ui/List";
 import { PageLoader } from "@/ui/PageLoader";
+import { Text } from "@/ui/Text";
 import { TextInput, TextInputGroup, TextInputIcon } from "@/ui/TextInput";
 import { Tooltip } from "@/ui/Tooltip";
 import { Truncable } from "@/ui/Truncable";

--- a/apps/frontend/src/pages/Automation/AutomationFormActionsStep.tsx
+++ b/apps/frontend/src/pages/Automation/AutomationFormActionsStep.tsx
@@ -3,7 +3,6 @@ import { useSuspenseQuery } from "@apollo/client/react";
 import { assertNever } from "@argos/util/assertNever";
 import { invariant } from "@argos/util/invariant";
 import { TriangleAlertIcon } from "lucide-react";
-import { Text } from "react-aria-components";
 import { useFieldArray } from "react-hook-form";
 
 import { useRefetchWhenActive } from "@/containers/Apollo";
@@ -14,7 +13,12 @@ import { graphql } from "@/gql";
 import { ButtonIcon, LinkButton } from "@/ui/Button";
 import { FieldError } from "@/ui/FieldError";
 import { FormTextInput } from "@/ui/FormTextInput";
-import { ListBox, ListBoxItem, ListBoxItemIcon } from "@/ui/ListBox";
+import {
+  ListBox,
+  ListBoxItem,
+  ListBoxItemIcon,
+  ListBoxItemLabel,
+} from "@/ui/ListBox";
 import { Popover } from "@/ui/Popover";
 import { SelectButton, SelectField, SelectValue } from "@/ui/Select";
 import { getSlackAuthURL } from "@/util/slack";
@@ -221,7 +225,7 @@ function SendWebhookMessageAction(props: {
                 <ListBoxItemIcon>
                   <Logo />
                 </ListBoxItemIcon>
-                <Text slot="label">{webhook.name}</Text>
+                <ListBoxItemLabel>{webhook.name}</ListBoxItemLabel>
               </ListBoxItem>
             ))}
           </ListBox>
@@ -392,7 +396,7 @@ export function AutomationActionsStep(props: { form: AutomationForm }) {
                   <ListBoxItemIcon>
                     <action.icon />
                   </ListBoxItemIcon>
-                  <Text slot="label">{action.label}</Text>
+                  <ListBoxItemLabel>{action.label}</ListBoxItemLabel>
                 </ListBoxItem>
               ))}
             </ListBox>

--- a/apps/frontend/src/pages/Automation/AutomationFormConditionsStep.tsx
+++ b/apps/frontend/src/pages/Automation/AutomationFormConditionsStep.tsx
@@ -3,13 +3,12 @@ import type { AutomationInputCondition } from "@argos/schemas/automation-conditi
 import { assertNever } from "@argos/util/assertNever";
 import { invariant } from "@argos/util/invariant";
 import { GitPullRequestIcon, TowerControlIcon } from "lucide-react";
-import { Text } from "react-aria-components";
 import { useFieldArray } from "react-hook-form";
 
 import { BuildMode, BuildStatus, BuildType } from "@/gql/graphql";
 import { FieldError } from "@/ui/FieldError";
 import { FormTextInput } from "@/ui/FormTextInput";
-import { ListBox, ListBoxItem } from "@/ui/ListBox";
+import { ListBox, ListBoxItem, ListBoxItemLabel } from "@/ui/ListBox";
 import { MenuItemIcon } from "@/ui/Menu";
 import { Popover } from "@/ui/Popover";
 import { Select, SelectButton, SelectField, SelectValue } from "@/ui/Select";
@@ -239,7 +238,7 @@ function BuildModeCondition(props: {
                 <MenuItemIcon>
                   <Icon />
                 </MenuItemIcon>
-                <Text slot="label">{label}</Text>
+                <ListBoxItemLabel>{label}</ListBoxItemLabel>
               </ListBoxItem>
             ))}
           </ListBox>
@@ -289,7 +288,7 @@ function BuildTypeCondition(props: {
                       className={lowTextColorClassNames[descriptor.color]}
                     />
                   </MenuItemIcon>
-                  <Text slot="label">{descriptor.label}</Text>
+                  <ListBoxItemLabel>{descriptor.label}</ListBoxItemLabel>
                 </ListBoxItem>
               );
             })}

--- a/apps/frontend/src/pages/Automation/EditAutomation.tsx
+++ b/apps/frontend/src/pages/Automation/EditAutomation.tsx
@@ -3,7 +3,7 @@ import { invariant } from "@argos/util/invariant";
 import { zodResolver } from "@hookform/resolvers/zod";
 import clsx from "clsx";
 import { CheckCircle2Icon, CircleDotIcon, XCircleIcon } from "lucide-react";
-import { DialogTrigger, Heading, Text } from "react-aria-components";
+import { DialogTrigger } from "react-aria-components";
 import { Helmet } from "react-helmet";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
@@ -21,6 +21,7 @@ import {
 } from "@/ui/Card";
 import { Form } from "@/ui/Form";
 import { FormRootError } from "@/ui/FormRootError";
+import { Heading } from "@/ui/Heading";
 import {
   Page,
   PageContainer,
@@ -28,6 +29,7 @@ import {
   PageHeaderContent,
 } from "@/ui/Layout";
 import { Modal } from "@/ui/Modal";
+import { Text } from "@/ui/Text";
 import { Tooltip } from "@/ui/Tooltip";
 
 import { Time } from "../../ui/Time";

--- a/apps/frontend/src/pages/Automation/NewAutomation.tsx
+++ b/apps/frontend/src/pages/Automation/NewAutomation.tsx
@@ -1,7 +1,6 @@
 import { useApolloClient, useSuspenseQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Heading, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
@@ -13,12 +12,14 @@ import { Button, LinkButton } from "@/ui/Button";
 import { Card, CardBody, CardFooter } from "@/ui/Card";
 import { Form } from "@/ui/Form";
 import { FormRootError } from "@/ui/FormRootError";
+import { Heading } from "@/ui/Heading";
 import {
   Page,
   PageContainer,
   PageHeader,
   PageHeaderContent,
 } from "@/ui/Layout";
+import { Text } from "@/ui/Text";
 
 import { NotFound } from "../NotFound";
 import { useProjectOutletContext } from "../Project/ProjectOutletContext";

--- a/apps/frontend/src/pages/Automation/index.tsx
+++ b/apps/frontend/src/pages/Automation/index.tsx
@@ -1,12 +1,12 @@
 import { useSuspenseQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { FilterIcon, PlusCircleIcon, SendIcon, ZapIcon } from "lucide-react";
-import { Heading, Text } from "react-aria-components";
 import { useParams } from "react-router";
 
 import { AutomationsIllustration } from "@/containers/EmptyStateIllustrations";
 import { DocumentType, graphql } from "@/gql";
 import { ButtonIcon, LinkButton, LinkButtonProps } from "@/ui/Button";
+import { Heading } from "@/ui/Heading";
 import {
   EmptyState,
   EmptyStateActions,
@@ -20,6 +20,7 @@ import {
   PageHeaderActions,
   PageHeaderContent,
 } from "@/ui/Layout";
+import { Text } from "@/ui/Text";
 
 import { NotFound } from "../NotFound";
 import { useProjectParams, type ProjectParams } from "../Project/ProjectParams";

--- a/apps/frontend/src/pages/Build/BuildDiffList.tsx
+++ b/apps/frontend/src/pages/Build/BuildDiffList.tsx
@@ -16,10 +16,8 @@ import {
 } from "lucide-react";
 import memoize from "memoize";
 import {
-  Heading,
   Button as RACButton,
   ButtonProps as RACButtonProps,
-  Text,
 } from "react-aria-components";
 
 import {
@@ -41,8 +39,10 @@ import { NoScreenshotsBuildEmptyState } from "@/containers/Build/BuildEmptyState
 import { useBuildHotkey } from "@/containers/Build/BuildHotkeys";
 import { Badge } from "@/ui/Badge";
 import { Button, ButtonIcon, ButtonProps, LinkButton } from "@/ui/Button";
+import { Heading } from "@/ui/Heading";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 import { EmptyState, EmptyStateIcon } from "@/ui/Layout";
+import { Text } from "@/ui/Text";
 import { Tooltip } from "@/ui/Tooltip";
 import { useEventCallback } from "@/ui/useEventCallback";
 import { useLiveRef } from "@/ui/useLiveRef";

--- a/apps/frontend/src/pages/Build/BuildReviewForm.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewForm.tsx
@@ -222,7 +222,7 @@ export function BuildReviewForm(props: {
                   // Keep the ring on the focused button (not only keyboard focus)
                   // so the default action Enter triggers stays visible.
                   showFocusRing
-                  onAction={() => submitReview(event)}
+                  onAsyncAction={() => submitReview(event)}
                 >
                   <ButtonIcon
                     colorClassName={

--- a/apps/frontend/src/pages/Build/sidebar/ReviewersSection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewersSection.tsx
@@ -459,7 +459,10 @@ function DismissReviewDialog(props: {
           <ErrorMessage>{getErrorMessage(props.error)}</ErrorMessage>
         ) : null}
         <DialogDismiss>Cancel</DialogDismiss>
-        <DialogActionButton variant="destructive" onAction={props.onDismiss}>
+        <DialogActionButton
+          variant="destructive"
+          onAsyncAction={props.onDismiss}
+        >
           Dismiss review
         </DialogActionButton>
       </DialogFooter>

--- a/apps/frontend/src/pages/Invite.tsx
+++ b/apps/frontend/src/pages/Invite.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
-import { Heading, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
 import { useNavigate, useParams } from "react-router";
 
@@ -13,7 +12,9 @@ import {
 } from "@/containers/Team/Invite";
 import { graphql } from "@/gql";
 import { Button, type ButtonProps } from "@/ui/Button";
+import { Heading } from "@/ui/Heading";
 import { PageLoader } from "@/ui/PageLoader";
+import { Text } from "@/ui/Text";
 import { toast } from "@/ui/Toaster";
 import { getErrorMessage } from "@/util/error";
 

--- a/apps/frontend/src/pages/MediaShare.tsx
+++ b/apps/frontend/src/pages/MediaShare.tsx
@@ -18,7 +18,7 @@ import {
   MessagesSquareIcon,
   TerminalIcon,
 } from "lucide-react";
-import { Heading, MenuTrigger, Text } from "react-aria-components";
+import { MenuTrigger } from "react-aria-components";
 import { Helmet } from "react-helmet";
 import { Navigate, useLocation, useNavigate, useParams } from "react-router";
 import { useClipboard } from "use-clipboard-copy";
@@ -59,6 +59,7 @@ import { Button, LinkButton } from "@/ui/Button";
 import { ButtonGroup } from "@/ui/ButtonGroup";
 import { Chip } from "@/ui/Chip";
 import { Code } from "@/ui/Code";
+import { Heading } from "@/ui/Heading";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 import {
   EmptyState,
@@ -71,6 +72,7 @@ import {
 import { HeadlessLink } from "@/ui/Link";
 import { Menu, MenuItem } from "@/ui/Menu";
 import { Popover } from "@/ui/Popover";
+import { Text } from "@/ui/Text";
 import { toast } from "@/ui/Toaster";
 import { Tooltip } from "@/ui/Tooltip";
 import { getMentionUser } from "@/ui/UserCard";

--- a/apps/frontend/src/pages/NewTeam.tsx
+++ b/apps/frontend/src/pages/NewTeam.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useEffectEvent } from "react";
-import { Heading, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
 import { useSearchParams } from "react-router";
 
@@ -8,6 +7,7 @@ import {
   TeamNewForm,
   useCreateTeamAndRedirect,
 } from "@/containers/Team/NewForm";
+import { Heading } from "@/ui/Heading";
 import {
   Page,
   PageContainer,
@@ -16,6 +16,7 @@ import {
 } from "@/ui/Layout";
 import { PageLoader } from "@/ui/PageLoader";
 import { Separator } from "@/ui/Separator";
+import { Text } from "@/ui/Text";
 
 const AutoCreateTeam = ({ name }: { name: string }) => {
   const createTeamAndRedirect = useCreateTeamAndRedirect();

--- a/apps/frontend/src/pages/NotFound.tsx
+++ b/apps/frontend/src/pages/NotFound.tsx
@@ -1,14 +1,15 @@
 import { CircleXIcon } from "lucide-react";
-import { Heading, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
 
 import { LinkButton } from "@/ui/Button";
+import { Heading } from "@/ui/Heading";
 import {
   EmptyState,
   EmptyStateActions,
   EmptyStateIcon,
   Page,
 } from "@/ui/Layout";
+import { Text } from "@/ui/Text";
 
 export function NotFound() {
   return (

--- a/apps/frontend/src/pages/Project/Builds.tsx
+++ b/apps/frontend/src/pages/Project/Builds.tsx
@@ -16,7 +16,6 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { clsx } from "clsx";
 import { BoxesIcon, MessageSquareIcon, SearchIcon } from "lucide-react";
 import { parseAsString, useQueryStates } from "nuqs";
-import { Heading, Text } from "react-aria-components";
 import { useResolvedPath } from "react-router";
 
 import { BuildBaselineEligibilityChip } from "@/containers/BuildBaselineEligibilityChip";
@@ -28,6 +27,7 @@ import { PullRequestButton } from "@/containers/PullRequestButton";
 import { DocumentType, graphql } from "@/gql";
 import { ProjectPermission } from "@/gql/graphql";
 import { Button, LinkButton } from "@/ui/Button";
+import { Heading } from "@/ui/Heading";
 import {
   EmptyState,
   EmptyStateActions,
@@ -39,6 +39,7 @@ import {
   PageHeaderContent,
 } from "@/ui/Layout";
 import { List, ListRowLink, ListRowLoader } from "@/ui/List";
+import { Text } from "@/ui/Text";
 import { TextInput, TextInputGroup, TextInputIcon } from "@/ui/TextInput";
 import { Time } from "@/ui/Time";
 import { Tooltip } from "@/ui/Tooltip";

--- a/apps/frontend/src/pages/Project/Deployments.tsx
+++ b/apps/frontend/src/pages/Project/Deployments.tsx
@@ -10,13 +10,13 @@ import {
   GlobeIcon,
   UploadCloudIcon,
 } from "lucide-react";
-import { Heading, Text } from "react-aria-components";
 
 import { DeploymentsIllustration } from "@/containers/EmptyStateIllustrations";
 import { PullRequestButton } from "@/containers/PullRequestButton";
 import { DocumentType, graphql } from "@/gql";
 import type { DeploymentEnvironment, DeploymentStatus } from "@/gql/graphql";
 import { Chip } from "@/ui/Chip";
+import { Heading } from "@/ui/Heading";
 import {
   EmptyState,
   EmptyStateIllustration,
@@ -30,6 +30,7 @@ import {
 } from "@/ui/Layout";
 import { Link } from "@/ui/Link";
 import { List, ListRow, ListRowLoader } from "@/ui/List";
+import { Text } from "@/ui/Text";
 import { Time } from "@/ui/Time";
 import { Tooltip } from "@/ui/Tooltip";
 import { Truncable } from "@/ui/Truncable";

--- a/apps/frontend/src/pages/Project/IgnoredChanges.tsx
+++ b/apps/frontend/src/pages/Project/IgnoredChanges.tsx
@@ -796,7 +796,7 @@ function UnignoreChangeDialog(props: {
         <DialogDismiss>Cancel</DialogDismiss>
         <DialogActionButton
           variant="destructive"
-          onAction={async () => {
+          onAsyncAction={async () => {
             try {
               await unignore();
               state.close();

--- a/apps/frontend/src/pages/Project/IgnoredChanges.tsx
+++ b/apps/frontend/src/pages/Project/IgnoredChanges.tsx
@@ -16,7 +16,6 @@ import {
   ZapIcon,
 } from "lucide-react";
 import { useNumberFormatter } from "react-aria";
-import { Heading, Text } from "react-aria-components";
 
 import { AccountAvatar } from "@/containers/AccountAvatar";
 import {
@@ -41,6 +40,7 @@ import {
   useOverlayTriggerState,
 } from "@/ui/Dialog";
 import { ErrorMessage } from "@/ui/ErrorMessage";
+import { Heading } from "@/ui/Heading";
 import {
   EmptyState,
   EmptyStateActions,
@@ -57,6 +57,7 @@ import {
 import { HeadlessLink, Link } from "@/ui/Link";
 import { List, ListHeaderRow, ListRow, ListRowLoader } from "@/ui/List";
 import { Modal } from "@/ui/Modal";
+import { Text } from "@/ui/Text";
 import { Time } from "@/ui/Time";
 import { toast } from "@/ui/Toaster";
 import { Tooltip, TooltipContainer, TooltipHeader } from "@/ui/Tooltip";

--- a/apps/frontend/src/pages/Project/Settings.tsx
+++ b/apps/frontend/src/pages/Project/Settings.tsx
@@ -7,7 +7,6 @@ import {
 } from "react";
 import { useSuspenseQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
-import { Heading, Text } from "react-aria-components";
 import { Navigate, Route, Routes } from "react-router";
 
 import { SettingsLayout, SettingsPage } from "@/containers/Layout";
@@ -28,6 +27,7 @@ import { ProjectVisibility } from "@/containers/Project/Visibility";
 import { graphql } from "@/gql";
 import { ProjectPermission } from "@/gql/graphql";
 import { NotFound } from "@/pages/NotFound";
+import { Heading } from "@/ui/Heading";
 import {
   Page,
   PageContainer,
@@ -36,6 +36,7 @@ import {
 } from "@/ui/Layout";
 import { Nav, NavLink, NavList, NavListItem } from "@/ui/Nav";
 import { PageLoader } from "@/ui/PageLoader";
+import { Text } from "@/ui/Text";
 import { useScrollToHash } from "@/ui/useScrollToHash";
 
 import { useProjectOutletContext } from "./ProjectOutletContext";

--- a/apps/frontend/src/pages/Project/Tests.tsx
+++ b/apps/frontend/src/pages/Project/Tests.tsx
@@ -23,7 +23,6 @@ import {
 } from "lucide-react";
 import { parseAsString, useQueryStates } from "nuqs";
 import { useNumberFormatter } from "react-aria";
-import { Heading, Text } from "react-aria-components";
 import { useResolvedPath } from "react-router";
 
 import {
@@ -38,6 +37,7 @@ import { useTestPeriodState } from "@/containers/Test/Period";
 import { SeenChange } from "@/containers/Test/SeenChange";
 import { graphql, type DocumentType } from "@/gql";
 import { Button } from "@/ui/Button";
+import { Heading } from "@/ui/Heading";
 import {
   EmptyState,
   EmptyStateActions,
@@ -53,6 +53,7 @@ import {
   PageHeaderContent,
 } from "@/ui/Layout";
 import { List, ListHeaderRow, ListRowLink, ListRowLoader } from "@/ui/List";
+import { Text } from "@/ui/Text";
 import { TextInput, TextInputGroup, TextInputIcon } from "@/ui/TextInput";
 import { Tooltip } from "@/ui/Tooltip";
 import { Truncable } from "@/ui/Truncable";

--- a/apps/frontend/src/pages/Signup.tsx
+++ b/apps/frontend/src/pages/Signup.tsx
@@ -3,7 +3,7 @@ import { assertNever } from "@argos/util/assertNever";
 import clsx from "clsx";
 import { CheckIcon } from "lucide-react";
 import { useObjectRef } from "react-aria";
-import { Heading, Radio, RadioGroup } from "react-aria-components";
+import { Radio, RadioGroup } from "react-aria-components";
 import { Helmet } from "react-helmet";
 import {
   useController,
@@ -25,6 +25,7 @@ import { Details, Summary } from "@/ui/Details";
 import { Form } from "@/ui/Form";
 import { FormSubmit } from "@/ui/FormSubmit";
 import { FormTextInput } from "@/ui/FormTextInput";
+import { Heading } from "@/ui/Heading";
 import { Label } from "@/ui/Label";
 import { StandalonePage } from "@/ui/Layout";
 import { Link } from "@/ui/Link";

--- a/apps/frontend/src/pages/Staff/Teams.tsx
+++ b/apps/frontend/src/pages/Staff/Teams.tsx
@@ -2,7 +2,6 @@ import { useDeferredValue, useMemo, useState } from "react";
 import { CombinedGraphQLErrors } from "@apollo/client";
 import { useQuery } from "@apollo/client/react";
 import { CreditCardIcon, SearchIcon } from "lucide-react";
-import { Heading, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
 
 import { AccountAvatar } from "@/containers/AccountAvatar";
@@ -12,6 +11,7 @@ import { graphql } from "@/gql";
 import { AccountSubscriptionStatus } from "@/gql/graphql";
 import { Alert, AlertText, AlertTitle } from "@/ui/Alert";
 import { Button } from "@/ui/Button";
+import { Heading } from "@/ui/Heading";
 import {
   Page,
   PageContainer,
@@ -22,6 +22,7 @@ import {
 import { Link } from "@/ui/Link";
 import { PageLoader } from "@/ui/PageLoader";
 import { SortHeader, type SortDirection } from "@/ui/SortHeader";
+import { Text } from "@/ui/Text";
 import { TextInput, TextInputGroup, TextInputIcon } from "@/ui/TextInput";
 import { Time } from "@/ui/Time";
 import { Tooltip } from "@/ui/Tooltip";

--- a/apps/frontend/src/pages/Staff/Trials.tsx
+++ b/apps/frontend/src/pages/Staff/Trials.tsx
@@ -19,7 +19,6 @@ import {
   XIcon,
   type LucideIcon,
 } from "lucide-react";
-import { Heading, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
 
 import { AccountAvatar } from "@/containers/AccountAvatar";
@@ -30,6 +29,7 @@ import { graphql } from "@/gql";
 import { AccountSubscriptionStatus, SignupSource } from "@/gql/graphql";
 import { Alert, AlertText, AlertTitle } from "@/ui/Alert";
 import { LinkButton } from "@/ui/Button";
+import { Heading } from "@/ui/Heading";
 import {
   Page,
   PageContainer,
@@ -42,6 +42,7 @@ import { PageLoader } from "@/ui/PageLoader";
 import { SortHeader, type SortDirection } from "@/ui/SortHeader";
 import { StatTile } from "@/ui/StatTile";
 import { Switch } from "@/ui/Switch";
+import { Text } from "@/ui/Text";
 import { TextInput, TextInputGroup, TextInputIcon } from "@/ui/TextInput";
 import { Time } from "@/ui/Time";
 import { toast } from "@/ui/Toaster";

--- a/apps/frontend/src/pages/Teams.tsx
+++ b/apps/frontend/src/pages/Teams.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useSuspenseQuery } from "@apollo/client/react";
 import { PlusCircleIcon } from "lucide-react";
-import { Heading } from "react-aria-components";
 import { Helmet } from "react-helmet";
 import { useNavigate, useSearchParams } from "react-router";
 
@@ -8,6 +7,7 @@ import { AccountAvatar } from "@/containers/AccountAvatar";
 import { AuthGuard, RedirectToWebsite } from "@/containers/AuthGuard";
 import { graphql } from "@/gql";
 import { Button, type ButtonProps } from "@/ui/Button";
+import { Heading } from "@/ui/Heading";
 import { StandalonePage } from "@/ui/Layout";
 import { Link } from "@/ui/Link";
 import { List, ListHeaderRow, ListRow, ListRowLink } from "@/ui/List";

--- a/apps/frontend/src/pages/TeamsInvite.tsx
+++ b/apps/frontend/src/pages/TeamsInvite.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
-import { Heading, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
 import { useLocation, useNavigate, useParams } from "react-router";
 
@@ -14,8 +13,10 @@ import {
 import { graphql } from "@/gql";
 import { Button, LinkButton } from "@/ui/Button";
 import { Chip } from "@/ui/Chip";
+import { Heading } from "@/ui/Heading";
 import { PageLoader } from "@/ui/PageLoader";
 import { Separator } from "@/ui/Separator";
+import { Text } from "@/ui/Text";
 
 import { getAccountURL } from "./Account/AccountParams";
 

--- a/apps/frontend/src/pages/Test/index.tsx
+++ b/apps/frontend/src/pages/Test/index.tsx
@@ -10,7 +10,6 @@ import {
 } from "lucide-react";
 import { useQueryState } from "nuqs";
 import { useNumberFormatter } from "react-aria";
-import { Heading, Text } from "react-aria-components";
 import { Helmet } from "react-helmet";
 
 import { BuildDiffDetail } from "@/containers/Build/BuildDiffDetail";
@@ -43,6 +42,7 @@ import { TestStatusIndicator } from "@/containers/TestStatusIndicator";
 import { graphql, type DocumentType } from "@/gql";
 import { Button } from "@/ui/Button";
 import { Chip } from "@/ui/Chip";
+import { Heading } from "@/ui/Heading";
 import {
   EmptyState,
   EmptyStateActions,
@@ -54,6 +54,7 @@ import {
 } from "@/ui/Layout";
 import { Panel } from "@/ui/Panel";
 import { Separator } from "@/ui/Separator";
+import { Text } from "@/ui/Text";
 import { Tooltip } from "@/ui/Tooltip";
 import useViewportSize from "@/ui/useViewportSize";
 

--- a/apps/frontend/src/pages/Welcome.tsx
+++ b/apps/frontend/src/pages/Welcome.tsx
@@ -10,7 +10,7 @@ import {
   SparklesIcon,
   UsersIcon,
 } from "lucide-react";
-import { Heading, Radio, RadioGroup } from "react-aria-components";
+import { Radio, RadioGroup } from "react-aria-components";
 import { Helmet } from "react-helmet";
 import {
   useController,
@@ -31,6 +31,7 @@ import { FormCheckbox } from "@/ui/FormCheckbox";
 import { FormRootError } from "@/ui/FormRootError";
 import { FormSubmit } from "@/ui/FormSubmit";
 import { FormTextInput } from "@/ui/FormTextInput";
+import { Heading } from "@/ui/Heading";
 import { Label } from "@/ui/Label";
 import { LinkButton } from "@/ui/Link";
 import { resolveWelcomeRedirect } from "@/util/welcome";

--- a/apps/frontend/src/ui/Button.tsx
+++ b/apps/frontend/src/ui/Button.tsx
@@ -264,16 +264,23 @@ export interface ButtonProps
    * Run an asynchronous action when the button is pressed.
    * Automatically set the button in pending mode and
    * handles errors.
+   *
+   * Deliberately *not* named `onAction`: react-aria spells a menu item's
+   * activation handler that way, and once `onPress` becomes `onClick` the two
+   * would be indistinguishable at a call site — `onClick={async () => …}` on a
+   * Button still type-checks and still runs, but silently loses the pending
+   * state, the error handling and the toast.
+   *
    * @example
    * <Button
-   *   onAction={async () => {
+   *   onAsyncAction={async () => {
    *     await resetLink();
    *   }}
    * >
    *  Reset link
    * </Button>
    */
-  onAction?: () => Promise<void>;
+  onAsyncAction?: () => Promise<void>;
 }
 
 export function Button({
@@ -283,7 +290,7 @@ export function Button({
   iconOnly,
   showFocusRing,
   children,
-  onAction,
+  onAsyncAction,
   onPress,
   ...props
 }: ButtonProps) {
@@ -301,7 +308,7 @@ export function Button({
       isPending={props.isPending ?? isPending}
       onPress={(event) => {
         onPress?.(event);
-        const promise = onAction?.();
+        const promise = onAsyncAction?.();
         if (promise) {
           setIsPending(true);
           promise

--- a/apps/frontend/src/ui/Dialog.tsx
+++ b/apps/frontend/src/ui/Dialog.tsx
@@ -126,19 +126,21 @@ export function DialogDismiss(props: {
  * up automatically.
  */
 export function DialogActionButton(
-  props: ButtonProps & { onAction: NonNullable<ButtonProps["onAction"]> },
+  props: ButtonProps & {
+    onAsyncAction: NonNullable<ButtonProps["onAsyncAction"]>;
+  },
 ) {
-  const { onAction, ...rest } = props;
+  const { onAsyncAction, ...rest } = props;
   const actionContext = use(ModalActionContext);
   invariant(actionContext, "DialogActionButton must be used within a Modal");
   return (
     <Button
       {...rest}
       isPending={actionContext.isPending ?? undefined}
-      onAction={async () => {
+      onAsyncAction={async () => {
         actionContext.setIsPending(true);
         try {
-          await onAction();
+          await onAsyncAction();
         } finally {
           actionContext.setIsPending(false);
         }

--- a/apps/frontend/src/ui/Heading.tsx
+++ b/apps/frontend/src/ui/Heading.tsx
@@ -1,0 +1,40 @@
+import { createContext, use, type ComponentPropsWithRef } from "react";
+import { clsx } from "clsx";
+
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+type HeadingContextValue = {
+  level?: HeadingLevel;
+  className?: string;
+};
+
+/**
+ * Lets a layout set the level and the style of the headings inside it, so a
+ * page's own markup says `<Heading>` and the surrounding layout decides whether
+ * that is an `<h1>` or an `<h2>`. `PageHeader`, `EmptyState` and
+ * `StandalonePage` all provide it.
+ */
+export const HeadingContext = createContext<HeadingContextValue>({});
+
+/**
+ * A heading whose level and style come from the layout it sits in.
+ *
+ * Defaults to `<h3>` with no styling of its own, which is what an unwrapped
+ * heading rendered as before this replaced react-aria's.
+ */
+export function Heading({
+  level,
+  className,
+  ...props
+}: ComponentPropsWithRef<"h1"> & { level?: HeadingLevel }) {
+  const context = use(HeadingContext);
+  const Tag = `h${level ?? context.level ?? 3}` as `h${HeadingLevel}`;
+  return (
+    <Tag
+      {...props}
+      // `|| undefined` so an unstyled heading renders no attribute at all
+      // rather than `class=""`.
+      className={clsx(context.className, className) || undefined}
+    />
+  );
+}

--- a/apps/frontend/src/ui/Layout.tsx
+++ b/apps/frontend/src/ui/Layout.tsx
@@ -1,33 +1,26 @@
 import { ComponentPropsWithRef } from "react";
 import clsx from "clsx";
-import { HeadingContext, Provider, TextContext } from "react-aria-components";
 
 import { Container, type ContainerProps } from "./Container";
+import { HeadingContext } from "./Heading";
 import { Link } from "./Link";
+import { TextContext } from "./Text";
 
 export function PageHeader(props: ComponentPropsWithRef<"div">) {
   return (
-    <Provider
-      values={[
-        [HeadingContext, { level: 1, className: "text-2xl font-medium" }],
-        [
-          TextContext,
-          {
-            slots: {
-              headline: { className: "text-low text-sm" },
-            },
-          },
-        ],
-      ]}
-    >
-      <div
-        {...props}
-        className={clsx(
-          "mb-6 flex items-end justify-between gap-x-4",
-          props.className,
-        )}
-      />
-    </Provider>
+    <HeadingContext value={{ level: 1, className: "text-2xl font-medium" }}>
+      <TextContext
+        value={{ slots: { headline: { className: "text-low text-sm" } } }}
+      >
+        <div
+          {...props}
+          className={clsx(
+            "mb-6 flex items-end justify-between gap-x-4",
+            props.className,
+          )}
+        />
+      </TextContext>
+    </HeadingContext>
   );
 }
 
@@ -50,31 +43,27 @@ export function PageContainer(props: ComponentPropsWithRef<"div">) {
 
 export function EmptyState(props: ComponentPropsWithRef<"div">) {
   return (
-    <Provider
-      values={[
-        [HeadingContext, { level: 2, className: "font-medium text-base" }],
-        [
-          TextContext,
-          {
-            slots: {
-              description: {
-                // A fixed measure keeps the description readable and gives every
-                // empty state the same silhouette, whatever its copy length.
-                className: "text-low max-w-lg text-center text-sm text-balance",
-              },
+    <HeadingContext value={{ level: 2, className: "font-medium text-base" }}>
+      <TextContext
+        value={{
+          slots: {
+            description: {
+              // A fixed measure keeps the description readable and gives every
+              // empty state the same silhouette, whatever its copy length.
+              className: "text-low max-w-lg text-center text-sm text-balance",
             },
           },
-        ],
-      ]}
-    >
-      <Container
-        {...props}
-        className={clsx(
-          "flex flex-col items-center justify-center gap-1 py-10",
-          props.className,
-        )}
-      />
-    </Provider>
+        }}
+      >
+        <Container
+          {...props}
+          className={clsx(
+            "flex flex-col items-center justify-center gap-1 py-10",
+            props.className,
+          )}
+        />
+      </TextContext>
+    </HeadingContext>
   );
 }
 
@@ -194,17 +183,12 @@ export function Page(props: ComponentPropsWithRef<"div">) {
  */
 export function StandalonePage(props: ContainerProps) {
   return (
-    <Provider
-      values={[
-        [
-          HeadingContext,
-          {
-            level: 1,
-            className:
-              "mx-auto text-balance text-center text-2xl font-semibold leading-tight",
-          },
-        ],
-      ]}
+    <HeadingContext
+      value={{
+        level: 1,
+        className:
+          "mx-auto text-balance text-center text-2xl font-semibold leading-tight",
+      }}
     >
       <Container
         {...props}
@@ -213,6 +197,6 @@ export function StandalonePage(props: ContainerProps) {
           props.className,
         )}
       />
-    </Provider>
+    </HeadingContext>
   );
 }

--- a/apps/frontend/src/ui/Text.tsx
+++ b/apps/frontend/src/ui/Text.tsx
@@ -1,0 +1,62 @@
+import { createContext, use, type ComponentPropsWithRef } from "react";
+import { invariant } from "@argos/util/invariant";
+import { clsx } from "clsx";
+
+/**
+ * The roles a layout can style text by. `headline` is the subtitle under a
+ * `PageHeader`'s title, `description` the body of an `EmptyState`.
+ */
+export type TextSlot = "headline" | "description";
+
+type TextStyle = { className?: string };
+
+type TextContextValue = TextStyle & {
+  /**
+   * Styles keyed by slot. A context without `slots` styles every `Text` inside
+   * it, whatever slot it asks for.
+   */
+  slots?: Partial<Record<TextSlot, TextStyle>>;
+};
+
+/** Lets a layout style the text inside it, by slot or wholesale. */
+export const TextContext = createContext<TextContextValue>({});
+
+/**
+ * Text whose style comes from the layout it sits in.
+ *
+ * `slot` stays on the element: `ListBoxItem` selects on it
+ * (`has-[[slot=description]]:flex-wrap`, `**:[[slot=label]]:truncate`), so
+ * dropping it from the DOM would break that styling silently.
+ */
+export function Text({
+  slot,
+  className,
+  ...props
+}: ComponentPropsWithRef<"span"> & { slot?: TextSlot }) {
+  const context = use(TextContext);
+  const style = useTextStyle(context, slot);
+  return (
+    <span
+      {...props}
+      slot={slot}
+      // `|| undefined` so unstyled text renders no attribute at all rather
+      // than `class=""`.
+      className={clsx(style?.className, className) || undefined}
+    />
+  );
+}
+
+function useTextStyle(context: TextContextValue, slot: TextSlot | undefined) {
+  if (!context.slots) {
+    // No slots: the context styles everything under it, slot or not. An
+    // unwrapped `Text` lands here too, with an empty context.
+    return context;
+  }
+  invariant(
+    slot && context.slots[slot],
+    slot
+      ? `Invalid Text slot "${slot}". This layout styles ${Object.keys(context.slots).join(", ")}.`
+      : `A Text inside this layout needs a slot. Valid slots are ${Object.keys(context.slots).join(", ")}.`,
+  );
+  return context.slots[slot];
+}


### PR DESCRIPTION
Two self-contained refactors that the react-aria → Base UI migration needs in
place before any component internals change. Neither swaps a library; both are
finished on their own terms.

Plan: `migrate-from-react-aria-to-humming-bachman.md`. Baselines landed in #2474.

## 1. `onAction` → `onAsyncAction` on Button (`3ced00a9`)

`ui/Button` and `DialogActionButton` expose a custom prop that runs an async
action, sets the pending state, catches and toasts. It was called `onAction` —
the same name react-aria gives a menu item's activation handler, which 41
`<MenuItem>`s and 2 `<Menu>`s use.

The type tells them apart today. It will not once `onPress` becomes `onClick`:
a mechanical `onAction` → `onClick` sweep would also hit
`<Button onAction={async () => …}>`, and `<Button onClick={async () => …}>`
still type-checks and still runs the handler — silently losing the spinner, the
error handling and the toast. The compiler cannot catch that, so the collision
has to go before any codemod runs. `onAction` now means exactly one thing: a
react-aria leftover.

The 12 call sites came from `tsc`, not grep — `AutomationAction` contains
`onAction` as a substring, so a plain search reports 65 hits across 34 files
where only 43 are the prop. Verified afterwards that all 12 renamed lines sat on
a `<Button>` or `<DialogActionButton>`, and every remaining `onAction=` sits on
a `<MenuItem>` (41) or `<Menu>` (2).

**Silent breakage caught here:** `PasskeyLoginButton` did
`Omit<ButtonProps, … | "onAction">` to stop callers overriding its own handler.
TypeScript happily omits a key that does not exist, so this would have become a
no-op and leaked the prop back into its public type, with nothing failing.

## 2. Own `Heading` and `Text` (`c7b6b065`)

The two most-imported react-aria components in the app (34 + 31), and neither is
there for behaviour: they exist so a layout can declare that headings inside it
are `<h1>`s styled one way, and that `<Text slot="headline">` is a page
subtitle. Base UI has no equivalent, so this has to be ours regardless — and it
is about forty lines.

Reproduces react-aria's semantics rather than approximating them:

- `Heading` defaults to `<h3>`, so an unwrapped heading renders as before.
- `Text` keeps `slot` **on the element**. `ListBoxItem` selects on it
  (`has-[[slot=description]]:flex-wrap`, `**:[[slot=label]]:truncate`), so
  dropping it from the DOM would have broken that styling with nothing failing.
- Context className comes before the local one, matching `mergeProps`.
- A context with `slots` requires a valid slot and names the available ones; a
  context without them styles everything beneath, which `InviteContainer` needs.

**Four files deliberately keep react-aria's versions**, because there the slot is
wiring rather than styling: `ui/ListBox`, `ui/Dialog` and `SettingsButton` use it
to get `aria-labelledby`/`aria-describedby` onto the option or the dialog, and
`ui/DateRangePicker`'s heading is the calendar's own month title. Swapping those
would have cost accessibility, not pixels. They move when those components do.

The four `<Text slot="label">` in the automation forms now use the kit's
`ListBoxItemLabel`, which is exactly that — react-aria stays behind `ui/` rather
than leaking into a page.

**Files importing react-aria: 100 → 74.**

## Verification

Both commits are behaviour-neutral, so the check that matters is pixels, and the
Playwright suite passing does not provide it — Argos does the comparing, and a
spec that navigates and screenshots passes either way.

Ran the project, account, team-settings, staff and personal-settings specs on
`main` and on this branch and byte-compared: **all 31 screenshots identical.**
Storybook 58/58. `pnpm run static-checks` green.

Two things learned about the local e2e loop, worth knowing:

- **A full local run is not usable for visual comparison.** `app.rateLimit`
  allows 1000 requests/minute with no env override, a full suite exceeds it (the
  frontend is split into many chunks, so each page load is many requests), and
  the Redis counters carry across runs. My first comparison showed 41 of 117
  screenshots differing, including all 32 notification previews — which are
  rendered entirely by the backend and cannot be affected by a frontend change.
  They were **429 pages**, and the specs screenshot those perfectly happily.
- A control run of identical code showed **8 genuinely nondeterministic
  screenshots**, which is the baseline noise to expect.

## What is not here

The migration proper. Next up is B1 (Button/Link/RouterLink onto Base UI), which
forces `onPress` → `onClick` and `isDisabled` → `disabled` across the app. That
rename is not a sweep: wrappers like `MarkButton` (`onPress(chain)`) and
`RemoveButton` (`onPress(PressEvent)`) declare their *own* props of the same
name and forward them to `Button`, so `tsc` reports the error at the declaration
and line-scoped edits cascade rather than converge. It needs per-wrapper edits
and belongs in its own PR.

Worth recording: `tsc` puts that rename at **86 `onPress` + 45 `isDisabled` +
19 `isPending`** — roughly 2.5× smaller than the plan's grep-derived estimate of
219/172, because those counts swept in react-aria components that keep the props.