### PR TITLE
chore(ui): retire react-aria's hooks

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -23,6 +23,7 @@
     "@argos/tsconfig": "workspace:*",
     "@argos/util": "workspace:*",
     "@argos/vite-plugin-graphql-documents": "workspace:*",
+    "@base-ui/react": "^1.7.0",
     "@fontsource-variable/inter": "^5.3.0",
     "@graphql-typed-document-node/core": "^3.2.0",
     "@hookform/resolvers": "^5.7.1",

--- a/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
@@ -23,7 +23,6 @@ import {
   Layers2Icon,
   type LucideIcon,
 } from "lucide-react";
-import { useObjectRef } from "react-aria";
 
 import {
   CopyImageSubmenu,
@@ -42,6 +41,7 @@ import { ImageKitPicture } from "@/ui/ImageKitPicture";
 import { MenuItem, MenuItemIcon, MenuSeparator } from "@/ui/Menu";
 import { Time } from "@/ui/Time";
 import { Tooltip } from "@/ui/Tooltip";
+import { useObjectRef } from "@/ui/useObjectRef";
 import { useResizeObserver } from "@/ui/useResizeObserver";
 import { useColoredRects } from "@/util/color-detection/hook";
 import { checkIsImageContentType } from "@/util/content-type";

--- a/apps/frontend/src/containers/Build/BuildDiffListPrimitives.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffListPrimitives.tsx
@@ -2,18 +2,14 @@ import { ComponentPropsWithRef, memo, Suspense } from "react";
 import { assertNever } from "@argos/util/assertNever";
 import { invariant } from "@argos/util/invariant";
 import { clsx } from "clsx";
-import {
-  AriaButtonProps,
-  HoverProps,
-  useButton,
-  useObjectRef,
-} from "react-aria";
+import { AriaButtonProps, HoverProps, useButton } from "react-aria";
 
 import { useOverlayStyle } from "@/containers/Build/OverlayStyle";
 import { graphql, type DocumentType } from "@/gql";
 import { ScreenshotDiffStatus } from "@/gql/graphql";
 import { ImageKitPicture, ImageKitPictureProps } from "@/ui/ImageKitPicture";
 import { Truncable, type TruncableProps } from "@/ui/Truncable";
+import { useObjectRef } from "@/ui/useObjectRef";
 import { checkIsImageContentType } from "@/util/content-type";
 
 import { RemoteMinimap } from "./RemoteMinimap";

--- a/apps/frontend/src/containers/Build/Zoomer.tsx
+++ b/apps/frontend/src/containers/Build/Zoomer.tsx
@@ -17,11 +17,11 @@ import { pointer, select, Selection } from "d3-selection";
 import { transition } from "d3-transition";
 import { zoom, ZoomBehavior, zoomIdentity, ZoomTransform } from "d3-zoom";
 import { MaximizeIcon, MinusIcon, PlusIcon } from "lucide-react";
-import { useObjectRef } from "react-aria";
 
 import { Button } from "@/ui/Button";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 import { Tooltip } from "@/ui/Tooltip";
+import { useObjectRef } from "@/ui/useObjectRef";
 import { useResizeObserver } from "@/ui/useResizeObserver";
 
 import { useBuildHotkey } from "./BuildHotkeys";

--- a/apps/frontend/src/containers/Test/FlakinessCircleIndicator.tsx
+++ b/apps/frontend/src/containers/Test/FlakinessCircleIndicator.tsx
@@ -1,9 +1,9 @@
 import type { ComponentPropsWithRef } from "react";
 import clsx from "clsx";
-import { useNumberFormatter } from "react-aria";
 
 import { CircleProgress } from "@/ui/Progress";
 import { bgSolidColors, lowTextColors } from "@/util/colors";
+import { compactNumberFormatter } from "@/util/intl";
 
 import { getFlakinessUIColor } from "./Flakiness";
 
@@ -17,7 +17,6 @@ export function FlakinessCircleIndicator(props: FlakinessCircleIndicatorProps) {
   const uiColor = getFlakinessUIColor(value);
   const bgColor = bgSolidColors[uiColor];
   const textColor = lowTextColors[uiColor];
-  const compactFormatter = useNumberFormatter({ notation: "compact" });
   return (
     <div
       ref={ref}
@@ -47,7 +46,7 @@ export function FlakinessCircleIndicator(props: FlakinessCircleIndicatorProps) {
           fill={textColor}
           fontFamily="inherit"
         >
-          {label ?? compactFormatter.format(value * 100)}
+          {label ?? compactNumberFormatter.format(value * 100)}
         </text>
       </svg>
     </div>

--- a/apps/frontend/src/pages/Account/Tests.tsx
+++ b/apps/frontend/src/pages/Account/Tests.tsx
@@ -12,7 +12,6 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import clsx from "clsx";
 import { FileImageIcon, SearchIcon } from "lucide-react";
 import { parseAsString, useQueryStates } from "nuqs";
-import { useNumberFormatter } from "react-aria";
 import { Helmet } from "react-helmet";
 
 import {
@@ -45,6 +44,7 @@ import { TextInput, TextInputGroup, TextInputIcon } from "@/ui/TextInput";
 import { Tooltip } from "@/ui/Tooltip";
 import { Truncable } from "@/ui/Truncable";
 import { useEventCallback } from "@/ui/useEventCallback";
+import { compactNumberFormatter } from "@/util/intl";
 import { checkAreDefaultValues } from "@/util/search-params";
 
 import {
@@ -330,7 +330,6 @@ function TestRow(props: {
   style: React.CSSProperties;
 }) {
   const { accountSlug, test, style } = props;
-  const compactFormatter = useNumberFormatter({ notation: "compact" });
   const projectName = test.project.name;
   const rowParams = { accountSlug, projectName };
   return (
@@ -394,11 +393,11 @@ function TestRow(props: {
         {test.metrics.all.changes}
       </div>
       <div className="w-20 text-right tabular-nums">
-        {compactFormatter.format(test.metrics.all.stability * 100)}
+        {compactNumberFormatter.format(test.metrics.all.stability * 100)}
         <small className="text-low ml-0.5">%</small>
       </div>
       <div className="w-20 text-right tabular-nums">
-        {compactFormatter.format(test.metrics.all.consistency * 100)}
+        {compactNumberFormatter.format(test.metrics.all.consistency * 100)}
         <small className="text-low ml-0.5">%</small>
       </div>
     </ListRowLink>

--- a/apps/frontend/src/pages/Build/sidebar/TestChangeSection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/TestChangeSection.tsx
@@ -1,13 +1,13 @@
 import { invariant } from "@argos/util/invariant";
 import clsx from "clsx";
 import { CircleCheckIcon, FlagOffIcon, WavesIcon } from "lucide-react";
-import { useNumberFormatter } from "react-aria";
 
 import { AccountAvatar } from "@/containers/AccountAvatar";
 import { graphql, type DocumentType } from "@/gql";
 import { HeadlessLink } from "@/ui/Link";
 import { Panel, PanelHeader, PanelTitle } from "@/ui/Panel";
 import { getUserCardData, UserHoverCard } from "@/ui/UserCard";
+import { compactNumberFormatter } from "@/util/intl";
 
 import { useProjectParams } from "../../Project/ProjectParams";
 import { getTestURL } from "../../Test/TestParams";
@@ -40,7 +40,6 @@ export function TestChangeSection(props: {
   occurrences: number;
 }) {
   const { test, change, occurrences } = props;
-  const compactFormatter = useNumberFormatter({ notation: "compact" });
   const params = useProjectParams();
   invariant(params, "can't be used outside of a project route");
   const lastTrail = change.trails.at(-1) ?? null;
@@ -77,8 +76,8 @@ export function TestChangeSection(props: {
             occurrences > 1 ? "text-danger-low" : "text-success-low",
           )}
         >
-          {compactFormatter.format(occurrences)} /{" "}
-          {compactFormatter.format(test.last7daysMetrics.all.total)}
+          {compactNumberFormatter.format(occurrences)} /{" "}
+          {compactNumberFormatter.format(test.last7daysMetrics.all.total)}
         </div>
       </div>
       <div className="mt-4 flex items-center gap-1.5 px-4 text-xs">

--- a/apps/frontend/src/pages/Build/sidebar/TestInsightsSection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/TestInsightsSection.tsx
@@ -1,6 +1,5 @@
 import { invariant } from "@argos/util/invariant";
 import clsx from "clsx";
-import { useNumberFormatter } from "react-aria";
 
 import { FlakinessCircleIndicator } from "@/containers/Test/FlakinessCircleIndicator";
 import { graphql, type DocumentType } from "@/gql";
@@ -8,6 +7,7 @@ import { HeadlessLink } from "@/ui/Link";
 import { Panel, PanelHeader, PanelTitle } from "@/ui/Panel";
 import { Tooltip } from "@/ui/Tooltip";
 import { TooltipIndicator } from "@/ui/TooltipIndicator";
+import { compactNumberFormatter } from "@/util/intl";
 
 import { useProjectParams } from "../../Project/ProjectParams";
 import { getTestURL } from "../../Test/TestParams";
@@ -39,7 +39,6 @@ export function TestInsightsSection(props: {
   test: DocumentType<typeof _TestFragment>;
 }) {
   const { test } = props;
-  const compactFormatter = useNumberFormatter({ notation: "compact" });
   const params = useProjectParams();
   invariant(params, "can't be used outside of a project route");
   return (
@@ -77,7 +76,7 @@ export function TestInsightsSection(props: {
               tooltip={<BuildsTooltip periodLabel="over last 7 days" />}
             />
             <InsightValue>
-              {compactFormatter.format(test.last7daysMetrics.all.total)}
+              {compactNumberFormatter.format(test.last7daysMetrics.all.total)}
             </InsightValue>
           </InsightRow>
           <InsightRow>
@@ -86,13 +85,13 @@ export function TestInsightsSection(props: {
               tooltip={<ChangesTooltip periodLabel="over last 7 days" />}
             />
             <InsightValue>
-              {compactFormatter.format(test.last7daysMetrics.all.changes)}
+              {compactNumberFormatter.format(test.last7daysMetrics.all.changes)}
             </InsightValue>
           </InsightRow>
           <InsightRow>
             <InsightTitle title="Stability" tooltip={<StabilityTooltip />} />
             <InsightValue>
-              {compactFormatter.format(
+              {compactNumberFormatter.format(
                 test.last7daysMetrics.all.stability * 100,
               )}
               <InsightUnit>%</InsightUnit>
@@ -104,7 +103,7 @@ export function TestInsightsSection(props: {
               tooltip={<ConsistencyTooltip />}
             />
             <InsightValue>
-              {compactFormatter.format(
+              {compactNumberFormatter.format(
                 test.last7daysMetrics.all.consistency * 100,
               )}
               <InsightUnit>%</InsightUnit>

--- a/apps/frontend/src/pages/Project/IgnoredChanges.tsx
+++ b/apps/frontend/src/pages/Project/IgnoredChanges.tsx
@@ -15,7 +15,6 @@ import {
   WavesIcon,
   ZapIcon,
 } from "lucide-react";
-import { useNumberFormatter } from "react-aria";
 
 import { AccountAvatar } from "@/containers/AccountAvatar";
 import {
@@ -64,6 +63,7 @@ import { Tooltip, TooltipContainer, TooltipHeader } from "@/ui/Tooltip";
 import { Truncable } from "@/ui/Truncable";
 import { useEventCallback } from "@/ui/useEventCallback";
 import { getUserCardData, UserHoverCard } from "@/ui/UserCard";
+import { compactNumberFormatter } from "@/util/intl";
 
 import { NotFound } from "../NotFound";
 import { getTestURL } from "../Test/TestParams";
@@ -597,7 +597,6 @@ function IgnoredChangeRow(props: {
 }) {
   const { ignoredChange, params, style, onUnignore } = props;
   const { permissions } = useProjectOutletContext();
-  const compactFormatter = useNumberFormatter({ notation: "compact" });
   const { test, lastSeenDiff, ignoredBy } = ignoredChange;
   const testURL = getTestURL(
     { ...params, testId: test.id },
@@ -689,7 +688,7 @@ function IgnoredChangeRow(props: {
           ignoredChange.occurrencesSinceIgnored === 0 && "text-low",
         )}
       >
-        {compactFormatter.format(ignoredChange.occurrencesSinceIgnored)}
+        {compactNumberFormatter.format(ignoredChange.occurrencesSinceIgnored)}
       </div>
       {/* Positioned like the cell above: `Time` carries a tooltip with the full
           timestamp, which the stretched link would otherwise cover. */}

--- a/apps/frontend/src/pages/Project/Tests.tsx
+++ b/apps/frontend/src/pages/Project/Tests.tsx
@@ -22,7 +22,6 @@ import {
   SearchIcon,
 } from "lucide-react";
 import { parseAsString, useQueryStates } from "nuqs";
-import { useNumberFormatter } from "react-aria";
 import { useResolvedPath } from "react-router";
 
 import {
@@ -58,6 +57,7 @@ import { TextInput, TextInputGroup, TextInputIcon } from "@/ui/TextInput";
 import { Tooltip } from "@/ui/Tooltip";
 import { Truncable } from "@/ui/Truncable";
 import { useEventCallback } from "@/ui/useEventCallback";
+import { compactNumberFormatter } from "@/util/intl";
 import { checkAreDefaultValues } from "@/util/search-params";
 
 import { NotFound } from "../NotFound";
@@ -462,7 +462,6 @@ function TestRow(props: { test: Test; style: React.CSSProperties }) {
   const params = useProjectParams();
   invariant(params);
   const resolvedTest = useResolvedPath(test.id);
-  const compactFormatter = useNumberFormatter({ notation: "compact" });
   return (
     <ListRowLink
       href={resolvedTest.pathname}
@@ -516,11 +515,11 @@ function TestRow(props: { test: Test; style: React.CSSProperties }) {
         {test.metrics.all.changes}
       </div>
       <div className="w-20 text-right tabular-nums">
-        {compactFormatter.format(test.metrics.all.stability * 100)}
+        {compactNumberFormatter.format(test.metrics.all.stability * 100)}
         <small className="text-low ml-0.5">%</small>
       </div>
       <div className="w-20 text-right tabular-nums">
-        {compactFormatter.format(test.metrics.all.consistency * 100)}
+        {compactNumberFormatter.format(test.metrics.all.consistency * 100)}
         <small className="text-low ml-0.5">%</small>
       </div>
     </ListRowLink>

--- a/apps/frontend/src/pages/Signup.tsx
+++ b/apps/frontend/src/pages/Signup.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState, type ReactNode } from "react";
 import { assertNever } from "@argos/util/assertNever";
 import clsx from "clsx";
 import { CheckIcon } from "lucide-react";
-import { useObjectRef } from "react-aria";
 import { Radio, RadioGroup } from "react-aria-components";
 import { Helmet } from "react-helmet";
 import {
@@ -29,6 +28,7 @@ import { Heading } from "@/ui/Heading";
 import { Label } from "@/ui/Label";
 import { StandalonePage } from "@/ui/Layout";
 import { Link } from "@/ui/Link";
+import { useObjectRef } from "@/ui/useObjectRef";
 import { formatCurrency } from "@/util/intl";
 
 import mermaidImg from "./signup/mermaid.svg";

--- a/apps/frontend/src/pages/Test/ChangesChart.tsx
+++ b/apps/frontend/src/pages/Test/ChangesChart.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 import { invariant } from "@argos/util/invariant";
-import { useDateFormatter } from "react-aria";
 import { Bar, ComposedChart, XAxis, YAxis } from "recharts";
 
 import type { TestMetricDataPoint } from "@/gql/graphql";
@@ -11,6 +10,7 @@ import {
   getTimeTicks,
   type ChartConfig,
 } from "@/ui/Charts";
+import { chartTickDateFormatter } from "@/util/intl";
 
 const chartConfig = {
   changes: {
@@ -54,13 +54,6 @@ export function ChangesChart(props: {
   className?: string;
 }) {
   const { series, from, className } = props;
-  const tickFormatter = useDateFormatter({
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
   const ticks = useMemo(() => getTicksFromBoundaries(from), [from]);
   const transformedSeries = useMemo(() => {
     return series.map((item) => ({
@@ -145,7 +138,9 @@ export function ChangesChart(props: {
           domain={["auto", "auto"]}
           padding={{ left: 8 }}
           ticks={ticks}
-          tickFormatter={(value) => tickFormatter.format(new Date(value))}
+          tickFormatter={(value) =>
+            chartTickDateFormatter.format(new Date(value))
+          }
           height={14}
         />
         <YAxis

--- a/apps/frontend/src/pages/Test/Widgets.tsx
+++ b/apps/frontend/src/pages/Test/Widgets.tsx
@@ -1,7 +1,6 @@
-import { useNumberFormatter } from "react-aria";
-
 import { FlakinessCircleIndicator } from "@/containers/Test/FlakinessCircleIndicator";
 import { Tooltip } from "@/ui/Tooltip";
+import { compactNumberFormatter } from "@/util/intl";
 
 import {
   Counter,
@@ -40,13 +39,12 @@ export function BuildsTooltip(props: { periodLabel: string }) {
 }
 
 export function BuildsCounter(props: { value: number; periodLabel: string }) {
-  const compactFormatter = useNumberFormatter({ notation: "compact" });
   return (
     <Counter>
       <Tooltip content={<BuildsTooltip periodLabel={props.periodLabel} />}>
         <CounterLabel>Builds</CounterLabel>
       </Tooltip>
-      <CounterValue>{compactFormatter.format(props.value)}</CounterValue>
+      <CounterValue>{compactNumberFormatter.format(props.value)}</CounterValue>
     </Counter>
   );
 }
@@ -61,13 +59,12 @@ export function ChangesTooltip(props: { periodLabel: string }) {
 }
 
 export function ChangesCounter(props: { value: number; periodLabel: string }) {
-  const compactFormatter = useNumberFormatter({ notation: "compact" });
   return (
     <Counter>
       <Tooltip content={<ChangesTooltip periodLabel={props.periodLabel} />}>
         <CounterLabel>Changes</CounterLabel>
       </Tooltip>
-      <CounterValue>{compactFormatter.format(props.value)}</CounterValue>
+      <CounterValue>{compactNumberFormatter.format(props.value)}</CounterValue>
     </Counter>
   );
 }
@@ -84,14 +81,13 @@ export function StabilityTooltip() {
 }
 
 export function StabilityCounter(props: { value: number }) {
-  const compactFormatter = useNumberFormatter({ notation: "compact" });
   return (
     <Counter>
       <Tooltip content={<StabilityTooltip />}>
         <CounterLabel>Stability</CounterLabel>
       </Tooltip>
       <CounterValue>
-        {compactFormatter.format(props.value * 100)}
+        {compactNumberFormatter.format(props.value * 100)}
         <CounterValueUnit>%</CounterValueUnit>
       </CounterValue>
     </Counter>
@@ -110,14 +106,13 @@ export function ConsistencyTooltip() {
 }
 
 export function ConsistencyCounter(props: { value: number }) {
-  const compactFormatter = useNumberFormatter({ notation: "compact" });
   return (
     <Counter>
       <Tooltip content={<ConsistencyTooltip />}>
         <CounterLabel>Consistency</CounterLabel>
       </Tooltip>
       <CounterValue>
-        {compactFormatter.format(props.value * 100)}
+        {compactNumberFormatter.format(props.value * 100)}
         <CounterValueUnit>%</CounterValueUnit>
       </CounterValue>
     </Counter>

--- a/apps/frontend/src/pages/Test/index.tsx
+++ b/apps/frontend/src/pages/Test/index.tsx
@@ -9,7 +9,6 @@ import {
   TriangleAlertIcon,
 } from "lucide-react";
 import { useQueryState } from "nuqs";
-import { useNumberFormatter } from "react-aria";
 import { Helmet } from "react-helmet";
 
 import { BuildDiffDetail } from "@/containers/Build/BuildDiffDetail";
@@ -57,6 +56,7 @@ import { Separator } from "@/ui/Separator";
 import { Text } from "@/ui/Text";
 import { Tooltip } from "@/ui/Tooltip";
 import useViewportSize from "@/ui/useViewportSize";
+import { compactNumberFormatter } from "@/util/intl";
 
 import { NotFound } from "../NotFound";
 import { ActivitySection } from "./ActivitySection";
@@ -452,8 +452,6 @@ function BuildHeader(props: {
   const params = useTestParams();
   invariant(params, "Can't be used outside of a test route");
 
-  const compactFormatter = useNumberFormatter({ notation: "compact" });
-
   const changeIndex = test.changes.edges.findIndex((c) => c.id === change.id);
   const previousChange = test.changes.edges[changeIndex - 1];
   const nextChange = test.changes.edges[changeIndex + 1];
@@ -504,8 +502,10 @@ function BuildHeader(props: {
                 : "text-success-low",
             )}
           >
-            {compactFormatter.format(change.stats.totalOccurrences)}{" "}
-            <small>/ {compactFormatter.format(test.metrics.all.total)}</small>
+            {compactNumberFormatter.format(change.stats.totalOccurrences)}{" "}
+            <small>
+              / {compactNumberFormatter.format(test.metrics.all.total)}
+            </small>
           </CounterValue>
         </Counter>
         <Separator
@@ -541,9 +541,6 @@ function ChangesList(props: {
   onSelect: (diffId: string) => void;
 }) {
   const { test, onSelect, activeChange } = props;
-  const compactFormatter = useNumberFormatter({
-    notation: "compact",
-  });
   return (
     <div
       role="region"
@@ -579,7 +576,9 @@ function ChangesList(props: {
                     <>
                       <TriangleAlertIcon className="text-danger-low mr-1 inline size-3" />
                       Recurring -{" "}
-                      {compactFormatter.format(change.stats.totalOccurrences)}
+                      {compactNumberFormatter.format(
+                        change.stats.totalOccurrences,
+                      )}
                       <small>x</small>
                     </>
                   ) : (

--- a/apps/frontend/src/ui/Details.stories.tsx
+++ b/apps/frontend/src/ui/Details.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
 
 import { Details, Summary } from "./Details";
 
@@ -11,6 +12,34 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  render: () => (
+    <Details>
+      <Summary>Advanced Settings</Summary>
+      <div className="text-sm">
+        <p>Here are additional configuration options.</p>
+      </div>
+    </Details>
+  ),
+};
+
+/**
+ * The toggle itself, which no snapshot can see. `Summary` used to suppress the
+ * click and re-open its parent `<details>` by hand; it now lets the native
+ * element do it, and that is worth pinning.
+ */
+export const Toggles: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const details = canvasElement.querySelector("details");
+    await expect(details).not.toBeNull();
+    await expect(details).not.toHaveAttribute("open");
+
+    await userEvent.click(canvas.getByText("Advanced Settings"));
+    await expect(details).toHaveAttribute("open");
+
+    await userEvent.click(canvas.getByText("Advanced Settings"));
+    await expect(details).not.toHaveAttribute("open");
+  },
   render: () => (
     <Details>
       <Summary>Advanced Settings</Summary>

--- a/apps/frontend/src/ui/Details.stories.tsx
+++ b/apps/frontend/src/ui/Details.stories.tsx
@@ -26,6 +26,11 @@ export const Default: Story = {
  * The toggle itself, which no snapshot can see. `Summary` used to suppress the
  * click and re-open its parent `<details>` by hand; it now lets the native
  * element do it, and that is worth pinning.
+ *
+ * Ends open on purpose. Clicking twice would leave the story in its initial
+ * state, and the snapshot would then be a duplicate of `Default` — a baseline
+ * that costs a review and shows nothing new. This way the same assertions also
+ * buy the only picture of the expanded state in the kit.
  */
 export const Toggles: Story = {
   play: async ({ canvasElement }) => {
@@ -36,9 +41,6 @@ export const Toggles: Story = {
 
     await userEvent.click(canvas.getByText("Advanced Settings"));
     await expect(details).toHaveAttribute("open");
-
-    await userEvent.click(canvas.getByText("Advanced Settings"));
-    await expect(details).not.toHaveAttribute("open");
   },
   render: () => (
     <Details>

--- a/apps/frontend/src/ui/Details.tsx
+++ b/apps/frontend/src/ui/Details.tsx
@@ -1,7 +1,5 @@
-import { useRef } from "react";
 import clsx from "clsx";
 import { ChevronRightIcon } from "lucide-react";
-import { usePress } from "react-aria";
 
 export function Details(props: React.ComponentPropsWithRef<"details">) {
   return (
@@ -26,37 +24,16 @@ export function Summary(props: {
   icon?: React.ComponentType<{ className?: string }>;
 }) {
   const { icon: Icon } = props;
-  const ref = useRef<HTMLElement>(null);
-  const { pressProps, isPressed } = usePress({
-    onPress: () => {
-      if (ref.current) {
-        const parentDetails = ref.current.parentElement;
-        if (!parentDetails) {
-          return;
-        }
-
-        const open = parentDetails.getAttribute("open") !== null;
-        if (open) {
-          parentDetails.removeAttribute("open");
-        } else {
-          parentDetails.setAttribute("open", "");
-        }
-      }
-    },
-  });
   return (
+    // The native toggle does the work. This used to `preventDefault` the click
+    // and then re-open the parent `<details>` by hand through react-aria's
+    // `usePress`, which is the same outcome by a longer route — `<summary>`
+    // already toggles on click, Enter and Space.
     <summary
-      ref={ref}
       className={clsx(
-        "group/summary hover:bg-hover data-pressed:bg-active -mx-1 flex cursor-default list-none items-center gap-1.5 rounded-sm px-1 py-0.5 font-medium transition group-open/details:mb-2",
+        "group/summary hover:bg-hover active:bg-active -mx-1 flex cursor-default list-none items-center gap-1.5 rounded-sm px-1 py-0.5 font-medium transition group-open/details:mb-2",
         props.className,
       )}
-      data-pressed={isPressed ? "" : undefined}
-      {...pressProps}
-      onClick={(event) => {
-        event.preventDefault();
-        pressProps.onClick?.(event);
-      }}
     >
       {Icon ? (
         // The two icons share one slot so swapping them on hover does not move

--- a/apps/frontend/src/ui/Separator.tsx
+++ b/apps/frontend/src/ui/Separator.tsx
@@ -1,19 +1,20 @@
+import { Separator as BaseSeparator } from "@base-ui/react/separator";
 import { clsx } from "clsx";
-import { SeparatorProps, useSeparator } from "react-aria";
 
 export function Separator(
-  props: SeparatorProps & {
+  props: BaseSeparator.Props & {
     className?: string;
   },
 ) {
-  const { separatorProps } = useSeparator(props);
+  const { className, orientation = "horizontal", ...rest } = props;
   return (
-    <div
-      {...separatorProps}
+    <BaseSeparator
+      {...rest}
+      orientation={orientation}
       className={clsx(
         "shrink-0 bg-(--border-color-default)",
-        props.orientation === "vertical" ? "w-px" : "h-px w-full",
-        props.className,
+        orientation === "vertical" ? "w-px" : "h-px w-full",
+        className,
       )}
     />
   );

--- a/apps/frontend/src/ui/Truncable.tsx
+++ b/apps/frontend/src/ui/Truncable.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
 import { invariant } from "@argos/util/invariant";
 import { clsx } from "clsx";
-import { useObjectRef } from "react-aria";
 
 import { Tooltip, type TooltipProps } from "./Tooltip";
+import { useObjectRef } from "./useObjectRef";
 
 export interface TruncableProps extends Omit<
   React.ComponentPropsWithRef<"div">,

--- a/apps/frontend/src/ui/useObjectRef.ts
+++ b/apps/frontend/src/ui/useObjectRef.ts
@@ -1,0 +1,68 @@
+import { useCallback, useMemo, useRef, type Ref, type RefObject } from "react";
+
+/**
+ * Turn a forwarded ref — callback or object — into one this component can also
+ * read from.
+ *
+ * `mergeRefs` in `@/util/merge-refs` solves the neighbouring problem: it fans
+ * one element out to several refs, but returns a callback, so the component
+ * cannot read the node back. This returns a ref *object* and still forwards to
+ * whatever it was given.
+ *
+ * The returned object is stable and its `current` is a setter, so assigning to
+ * it is what forwards — the caller just passes it as `ref` and reads
+ * `ref.current` like any other. Cleanups follow React 19's convention: a
+ * callback ref that returns a function has that function called on detach,
+ * and one that does not is called with `null` instead.
+ */
+export function useObjectRef<T>(
+  forwardedRef?: Ref<T> | null,
+): RefObject<T | null> {
+  const objectRef = useRef<T | null>(null);
+  const cleanupRef = useRef<(() => void) | undefined>(undefined);
+
+  const attach = useCallback(
+    (instance: T) => {
+      if (typeof forwardedRef === "function") {
+        const cleanup = forwardedRef(instance);
+        return () => {
+          if (typeof cleanup === "function") {
+            cleanup();
+          } else {
+            forwardedRef(null);
+          }
+        };
+      }
+      if (forwardedRef) {
+        // React types object refs as readonly, but assigning to a forwarded
+        // one is the whole point here — same cast as `util/merge-refs.ts`.
+        const objectForwardedRef = forwardedRef as { current: T | null };
+        objectForwardedRef.current = instance;
+        return () => {
+          objectForwardedRef.current = null;
+        };
+      }
+      return undefined;
+    },
+    [forwardedRef],
+  );
+
+  return useMemo(
+    () => ({
+      get current() {
+        return objectRef.current;
+      },
+      set current(value: T | null) {
+        objectRef.current = value;
+        if (cleanupRef.current) {
+          cleanupRef.current();
+          cleanupRef.current = undefined;
+        }
+        if (value != null) {
+          cleanupRef.current = attach(value);
+        }
+      },
+    }),
+    [attach],
+  );
+}

--- a/apps/frontend/src/util/intl.ts
+++ b/apps/frontend/src/util/intl.ts
@@ -24,6 +24,28 @@ export function formatCurrency(
   return getCurrencyFormatter(currency, digits).format(value);
 }
 
+/**
+ * Compact notation — 1.2K, 3.4M — for counts that would otherwise blow out a
+ * narrow column.
+ *
+ * A module-level formatter rather than a hook: react-aria's
+ * `useNumberFormatter` existed to read the locale from its `I18nProvider`, and
+ * this app never rendered one, so it always resolved to the browser locale —
+ * which is what `undefined` selects here.
+ */
+export const compactNumberFormatter = new Intl.NumberFormat(undefined, {
+  notation: "compact",
+});
+
+/** Axis ticks on the changes chart: "12 Mar, 14:30". */
+export const chartTickDateFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+
 export function formatList(items: string[]) {
   if (items.length === 0) {
     return "";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -452,6 +452,9 @@ importers:
       '@argos/vite-plugin-graphql-documents':
         specifier: workspace:*
         version: link:../../packages/vite-plugin-graphql-documents
+      '@base-ui/react':
+        specifier: ^1.7.0
+        version: 1.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@fontsource-variable/inter':
         specifier: ^5.3.0
         version: 5.3.0
@@ -1236,6 +1239,33 @@ packages:
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
+  '@base-ui/react@1.7.0':
+    resolution: {integrity: sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^19.2.18
+      date-fns: ^4.0.0
+      react: ^19.2.8
+      react-dom: ^19.2.8
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.3.2':
+    resolution: {integrity: sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==}
+    peerDependencies:
+      '@types/react': ^19.2.18
+      react: ^19.2.8
+      react-dom: ^19.2.8
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
@@ -1467,6 +1497,12 @@ packages:
 
   '@floating-ui/dom@1.8.0':
     resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
+  '@floating-ui/react-dom@2.1.9':
+    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
+    peerDependencies:
+      react: ^19.2.8
+      react-dom: ^19.2.8
 
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
@@ -8979,6 +9015,29 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@base-ui/react@1.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.2(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@floating-ui/utils': 0.2.12
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      use-sync-external-store: 1.6.0(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+
+  '@base-ui/utils@0.3.2(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@floating-ui/utils': 0.2.12
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+
   '@blazediff/core@1.9.1': {}
 
   '@borewit/text-codec@0.2.2': {}
@@ -9174,6 +9233,12 @@ snapshots:
     dependencies:
       '@floating-ui/core': 1.8.0
       '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/react-dom@2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   '@floating-ui/utils@0.2.12': {}
 


### PR DESCRIPTION
Second slice of the react-aria → Base UI migration. Three hooks that were never
doing anything react-aria-specific, plus the first real Base UI component.

Continues #2475. Plan: `migrate-from-react-aria-to-humming-bachman.md`.

## A correction to the plan's ordering, found while starting B1

The plan had **Button first**, on the grounds that everything visual reads
`getButtonClassName()`. That is wrong, and worth recording before someone else
tries it.

react-aria's trigger components do not pass props to their child button through
props. They wrap it in a **`PressResponder`**, which publishes them on
`PressResponderContext` — and only react-aria's `usePress`, inside RAC `Button`,
consumes it:

```js
// react-aria-components/dist/private/Menu.mjs
React.createElement(PressResponder, { ...menuTriggerProps, ref, isPressed: state.isOpen }, props.children)
```

So a Base UI `Button` inside a react-aria `MenuTrigger` gets no press handler,
no `aria-expanded`, and does not open the menu. `ui/Button` is a leaf in the
*styling* graph but a **dependent** in the behavioural one — it is wrapped by 16
`MenuTrigger`s, 9 `DialogTrigger`s, every `Tooltip`, `Select` and `Popover`. It
migrates with or after those, not before.

That leaves the hook sweep and the standalone form controls as the genuinely
independent work. This PR is the first of those.

## What changed

**`useNumberFormatter` / `useDateFormatter` → `Intl` (`6e375fd6`).** Both exist
to read a locale from react-aria's `I18nProvider`. This app has never rendered
one, so both always fell through to the browser locale — exactly what `Intl`'s
`undefined` locale selects. All ten `useNumberFormatter` calls asked for the
same `{ notation: "compact" }`, so they collapse into one module-level formatter
in `util/intl.ts`, next to the `formatCurrency`/`formatList` helpers already
there.

**`useObjectRef` → `ui/useObjectRef.ts` (`ff77bcf9`).** The sibling of the
existing `util/merge-refs.ts`: that one fans an element out to several refs but
returns a callback, so a component cannot read the node back — which is what
these 5 call sites need. Reimplemented from react-aria's own version rather than
approximated, including React 19's ref-cleanup convention.

**`Separator` → Base UI.** The first real Base UI part in the codebase. Snapshot
byte-identical to main.

**`Summary` drops `usePress`.** It was suppressing the click on a `<summary>`
and then re-opening the parent `<details>` by hand — the native behaviour by a
longer route. `data-pressed:bg-active` becomes `active:bg-active`.

Between them, **`react-aria` imports drop from 12 to 6**, and what remains is
genuinely behavioural (`useFocusable`, `useButton`, `useFilter`, `PressEvent`),
moving with the components that use it.

## Deliberately not done

`createHideableComponent` in `FilterButton` stays. The plan says delete it, but
it works around react-aria rendering collection children twice
(adobe/react-spectrum#9011) and react-aria's Menu is still here — removing it now
reintroduces the bug it fixes. It goes when Menu does.

I also stopped before `Switch`. Base UI's `Switch.Root` *is* the button, so
`FormSwitch`'s `<label htmlFor={id}>` would point at a `<button>`, which HTML
labels do not associate with — silently breaking label-click toggling. That
needs a `Field.Root` decision rather than a quick swap.

## Verification

Storybook 59/59. `static-checks` green.

The `Summary` change alters a mechanism no snapshot can see, so it gets an
interaction test. Being precise about what that test is worth: it passes against
*both* the old and new implementations, so it is not a regression guard for this
change — it is the check that the two are equivalent, which is what I wanted to
establish, and it pins the toggle from here on.

Locally, 46 of 54 e2e screenshots are byte-identical to main. The 8 that differ
are all `build-*`: a same-code control run reproduced 4 of them outright, a
previous control caught a 5th, and the remaining three differ by **1–4 bytes** on
47KB–436KB files, which is PNG compression noise rather than a content change.
Leaving those to the Argos build here, which compares perceptually against the
real baseline — my local runs are noisy in a way CI's are not.