### PR TITLE
chore: check formatting once from the repo root

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,12 @@ While iterating, use the fast local checks on what you touched:
 `oxfmt <target>`, `tsc --noEmit`, `oxlint <target>`.
 
 Formatting is [oxfmt](https://oxc.rs/docs/guide/usage/formatter.html), configured
-once in `.oxfmtrc.json` at the repository root. It resolves that config — and the
-root `.gitignore` — from any working directory, so `oxfmt --check .` behaves the
-same from the root or from a workspace. It also owns import sorting and Tailwind
-class sorting, which used to be Prettier plugins.
+once in `.oxfmtrc.json` at the repository root — there is no per-workspace config
+and no per-workspace `check-format` script. It formats the whole monorepo in a
+couple of seconds, so `pnpm run check-format` at the root is the only command you
+need. Keep it that way: per-workspace scripts leave root-level sources like
+`tests/` and `vitest/` unchecked, because no workspace owns them. It also owns
+import sorting and Tailwind class sorting, which used to be Prettier plugins.
 
 Linting is [oxlint](https://oxc.rs/docs/guide/usage/linter.html), configured once
 in `.oxlintrc.json` at the repository root — there is no per-workspace config and

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -8,7 +8,6 @@
     "watch-build": "tsdown --watch --silent",
     "setup": "pnpm run db:create && pnpm run db:load",
     "check-types": "tsc --noEmit",
-    "check-format": "oxfmt --check .",
     "db:check-structure": "knex-scripts check-structure",
     "db:create": "knex-scripts create",
     "db:drop": "knex-scripts drop",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "rm -rf dist && NODE_ENV=production vite build",
     "check-types": "tsc --noEmit",
-    "check-format": "oxfmt --check .",
     "watch-build": "vite --logLevel error",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",

--- a/infra/package.json
+++ b/infra/package.json
@@ -8,8 +8,7 @@
     "synth": "cdk synth",
     "deploy": "cdk deploy",
     "diff": "cdk diff",
-    "check-types": "tsc --noEmit",
-    "check-format": "oxfmt --check ."
+    "check-types": "tsc --noEmit"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.1105.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "oxlint --deny-warnings",
     "lint:fix": "oxlint --fix",
     "check-types": "turbo run check-types",
-    "check-format": "turbo run check-format",
+    "check-format": "oxfmt --check .",
     "static-checks": "turbo run static-checks",
     "format": "oxfmt --write .",
     "clean-deps": "rm -rf node_modules && pnpm -r exec rm -rf node_modules",

--- a/packages/knex-scripts/package.json
+++ b/packages/knex-scripts/package.json
@@ -12,8 +12,7 @@
   "scripts": {
     "build": "tsdown",
     "watch-build": "tsdown --watch --silent",
-    "check-types": "tsc --noEmit",
-    "check-format": "oxfmt --check ."
+    "check-types": "tsc --noEmit"
   },
   "sideEffects": false,
   "dependencies": {

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "build": "tsdown",
     "watch-build": "tsdown --watch --silent",
-    "check-types": "tsc --noEmit",
-    "check-format": "oxfmt --check ."
+    "check-types": "tsc --noEmit"
   },
   "sideEffects": false,
   "exports": {

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -4,8 +4,5 @@
     "./react/tsconfig.json": "./react/tsconfig.json",
     "./base/tsconfig.json": "./base/tsconfig.json",
     "./node/tsconfig.json": "./node/tsconfig.json"
-  },
-  "scripts": {
-    "check-format": "oxfmt --check ."
   }
 }

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "build": "tsdown",
     "watch-build": "tsdown --watch --silent",
-    "check-types": "tsc --noEmit",
-    "check-format": "oxfmt --check ."
+    "check-types": "tsc --noEmit"
   },
   "sideEffects": false,
   "exports": {

--- a/packages/vite-plugin-graphql-documents/package.json
+++ b/packages/vite-plugin-graphql-documents/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsdown",
-    "check-types": "tsc --noEmit",
-    "check-format": "oxfmt --check ."
+    "check-types": "tsc --noEmit"
   },
   "sideEffects": false,
   "exports": {

--- a/tests/project-tests.spec.ts
+++ b/tests/project-tests.spec.ts
@@ -191,9 +191,9 @@ loggedTest(
       }),
     ).toBeVisible();
     // The comment the same person typed carries no marker.
-    await expect(page.getByRole("img", { name: /^Posted through/ })).toHaveCount(
-      1,
-    );
+    await expect(
+      page.getByRole("img", { name: /^Posted through/ }),
+    ).toHaveCount(1);
 
     await screenshot(page, "test-view-agent-comment");
   },

--- a/turbo.json
+++ b/turbo.json
@@ -18,6 +18,9 @@
       "dependsOn": ["//#codegen"],
       "outputs": []
     },
+    "//#check-format": {
+      "outputs": []
+    },
     "//#knip": {
       "dependsOn": ["//#codegen"],
       "outputs": []
@@ -31,12 +34,8 @@
       "dependsOn": ["//#codegen", "^check-types"],
       "outputs": []
     },
-    "check-format": {
-      "dependsOn": [],
-      "outputs": []
-    },
     "static-checks": {
-      "dependsOn": ["check-types", "check-format", "//#lint", "//#knip"]
+      "dependsOn": ["check-types", "//#check-format", "//#lint", "//#knip"]
     },
     "watch-build": {
       "dependsOn": ["build"],


### PR DESCRIPTION
## The gap

`check-format` only existed as a per-workspace script (`apps/backend`, `apps/frontend`, each `packages/*`, `infra`), so nothing owned the repo-root directories. On `main`, `tests/project-tests.spec.ts` fails `oxfmt --check` — and CI is green.

The unowned set was wider than just `tests/`:

| Location | Formattable files |
|---|---|
| `tests/` | 22 |
| `vitest/` | 7 |
| `aws/tasks/` | 3 |
| `tools/` | 1 |
| root configs (`codegen.ts`, `playwright.config.mts`, `knip.json`, …) | ~10 |

`packages/config-types` and `packages/error-types` have no scripts at all and were never format-checked either.

## The fix

Rather than adding a second task alongside the per-workspace ones, `check-format` becomes a single root task — mirroring how `//#lint` already works in this repo:

- `//#check-format` in `turbo.json`, running `oxfmt --check .`
- the eight per-workspace `check-format` scripts removed
- root script changed from `turbo run check-format` to `oxfmt --check .` (it would otherwise recurse into the new task)

One process means no double-reporting, and coverage is defined by "everything oxfmt sees" rather than a hand-maintained path list that would drift again the next time someone adds a root directory.

Also included: the actual formatting fix for `tests/project-tests.spec.ts` (the only drift in the repo), and an `AGENTS.md` update — its note that oxfmt "behaves the same from the root or from a workspace" was the reasoning that produced the gap, so it now mirrors the oxlint paragraph.

## Caching — the part worth reviewing

If turbo's root-task hash ignored workspace files, this task would go false-green, which is worse than the original bug. It doesn't. I broke formatting in five places one at a time:

| Probe | Result |
|---|---|
| `apps/frontend/src/config.ts` | cache miss, caught |
| `packages/util/src/assertNever.ts` | cache miss, caught |
| `tests/util.ts` | cache miss, caught |
| `vitest/vitest.unit.config.mts` | cache miss, caught |
| `codegen.ts` | cache miss, caught |

Each produced a distinct hash; an unchanged re-run is a clean cache hit.

The real trade-off: caching granularity is coarser — any repo change now invalidates the single task, where before a backend-only change left the frontend's check cached. In exchange, the full run is ~1.5s over 1772 files, less than the eight process spawns it replaces. Worth a look if you'd rather keep per-workspace granularity, but I don't think it buys anything at this runtime.

## Verification

- `pnpm run static-checks` → 11/11 pass, with `//#check-format` in the task graph
- Guard, both directions: restoring the original drift makes `static-checks` **fail** (`Failed: //#check-format`) where `main` is green; re-applying the fix returns it to 11/11

## Lint was already fine

Confirmed `//#lint` covers `tests/` — dropped a `debugger` statement into both `tests/` and `apps/backend/src/`, and root `oxlint --deny-warnings` flagged both. No change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)