### PR TITLE
feat(ui): move Switch and Checkbox to Base UI

### DIFF
--- a/apps/frontend/src/containers/Build/toolbar/IgnoreButton.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/IgnoreButton.tsx
@@ -195,7 +195,7 @@ function EnabledIgnoreButton(props: {
             <DialogFooter>
               <div className="flex flex-1">
                 <Checkbox
-                  onChange={(value) => {
+                  onCheckedChange={(value) => {
                     if (value) {
                       sessionStorage.setItem(dontShowAgainKey, "true");
                     } else {

--- a/apps/frontend/src/containers/Team/SAMLSSO.tsx
+++ b/apps/frontend/src/containers/Team/SAMLSSO.tsx
@@ -252,8 +252,8 @@ export function TeamSAMLSSO(props: {
               <div className="text-low border-t-thin flex items-center justify-between gap-4 p-4">
                 Require Team Members to login with SAML to access this Team.
                 <Switch
-                  isSelected={team.samlSso.enforced}
-                  onChange={(isSelected) => {
+                  checked={team.samlSso.enforced}
+                  onCheckedChange={(isSelected) => {
                     invariant(team.samlSso);
                     apolloClient.mutate({
                       mutation: ConfigureTeamSamlMutation,

--- a/apps/frontend/src/containers/User/NotificationPreferences.tsx
+++ b/apps/frontend/src/containers/User/NotificationPreferences.tsx
@@ -67,9 +67,9 @@ export function UserNotificationPreferences(props: {
               </div>
               <Switch
                 aria-label={preference.label}
-                isSelected={preference.enabled}
-                isDisabled={pendingIds.has(preference.id)}
-                onChange={(enabled) => {
+                checked={preference.enabled}
+                disabled={pendingIds.has(preference.id)}
+                onCheckedChange={(enabled) => {
                   setPendingIds((ids) => new Set(ids).add(preference.id));
                   client
                     .mutate({

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -334,6 +334,26 @@
   }
 }
 
+/**
+ * The same focus contract as `rac-focus`, on an element that is itself
+ * focusable rather than a child of one. Base UI parts are the control — a
+ * `Switch.Root` *is* the button — so they need no `group` indirection, and no
+ * `data-focus-visible` either: the browser's own `:focus-visible` is what
+ * react-aria's modality tracking was standing in for.
+ *
+ * Text inputs are the exception and must not use this — see the comment in
+ * `ui/TextInput.tsx`.
+ */
+@utility focus-ring {
+  &:focus:not(:focus-visible) {
+    @apply outline-none;
+  }
+
+  &:focus-visible {
+    @apply outline-1 outline-offset-1 outline-(--violet-10);
+  }
+}
+
 @utility underline-emphasis {
   @apply underline decoration-dotted decoration-1 underline-offset-1;
 }

--- a/apps/frontend/src/pages/Build/RejectCommentDialog.tsx
+++ b/apps/frontend/src/pages/Build/RejectCommentDialog.tsx
@@ -268,7 +268,7 @@ function RejectCommentDialog(props: {
       <DialogFooter>
         <div className="flex flex-1">
           <Checkbox
-            onChange={(value) => {
+            onCheckedChange={(value) => {
               if (value) {
                 sessionStorage.setItem(dontAskAgainKey, "true");
               } else {

--- a/apps/frontend/src/pages/Staff/Trials.tsx
+++ b/apps/frontend/src/pages/Staff/Trials.tsx
@@ -528,9 +528,9 @@ function ContactCell(props: { team: PipelineTeam }) {
         <Switch
           size="sm"
           aria-label="Outreach email sent"
-          isSelected={Boolean(contactedAt)}
-          isDisabled={loading}
-          onChange={markContacted}
+          checked={Boolean(contactedAt)}
+          disabled={loading}
+          onCheckedChange={markContacted}
         />
       </span>
     </div>

--- a/apps/frontend/src/ui/Checkbox.stories.tsx
+++ b/apps/frontend/src/ui/Checkbox.stories.tsx
@@ -14,10 +14,10 @@ export const Default: Story = {
   render: () => (
     <div className="flex flex-col gap-3">
       <Checkbox>Unchecked</Checkbox>
-      <Checkbox defaultSelected>Checked</Checkbox>
-      <Checkbox isIndeterminate>Indeterminate</Checkbox>
-      <Checkbox isDisabled>Disabled</Checkbox>
-      <Checkbox isDisabled defaultSelected>
+      <Checkbox defaultChecked>Checked</Checkbox>
+      <Checkbox indeterminate>Indeterminate</Checkbox>
+      <Checkbox disabled>Disabled</Checkbox>
+      <Checkbox disabled defaultChecked>
         Disabled Checked
       </Checkbox>
     </div>

--- a/apps/frontend/src/ui/Checkbox.tsx
+++ b/apps/frontend/src/ui/Checkbox.tsx
@@ -1,10 +1,6 @@
+import { Checkbox as BaseCheckbox } from "@base-ui/react/checkbox";
 import clsx from "clsx";
 import { Check, Minus } from "lucide-react";
-import {
-  Checkbox as AriaCheckbox,
-  composeRenderProps,
-  type CheckboxProps as AriaCheckboxProps,
-} from "react-aria-components";
 import {
   useController,
   type FieldValues,
@@ -15,54 +11,75 @@ import {
 import { mergeRefs } from "@/util/merge-refs";
 
 interface CheckboxProps
-  extends AriaCheckboxProps, React.RefAttributes<HTMLLabelElement> {}
+  // `ref` too: Base UI points it at the box it renders, and this component's
+  // ref has always addressed the row, which is what `CheckboxField` hands to
+  // react-hook-form.
+  extends
+    Omit<BaseCheckbox.Root.Props, "className" | "ref">,
+    React.RefAttributes<HTMLLabelElement> {
+  className?: string;
+  /**
+   * Mark the field as failing validation. Base UI sources this from a
+   * `Field.Root`; the kit takes it as a prop, since these checkboxes are driven
+   * by react-hook-form rather than by Base UI's own validation.
+   */
+  invalid?: boolean;
+}
 
 export function Checkbox(props: CheckboxProps) {
-  const { ref, className, children, ...rest } = props;
+  const {
+    ref,
+    className,
+    children,
+    disabled,
+    invalid,
+    indeterminate,
+    ...rest
+  } = props;
   return (
-    <AriaCheckbox
+    // `Checkbox.Root` is the box, not the row, so the label around it stays a
+    // plain element. It carries the state as data attributes because the row
+    // styles itself by them and `FormCheckbox`'s sibling label reads them
+    // through `peer-data-disabled:`.
+    <label
       ref={ref}
-      className={composeRenderProps(className, (className) =>
-        clsx(
-          "group/checkbox peer flex items-center gap-x-2",
-          /* Disabled */
-          "data-disabled:opacity-disabled",
-          /* Invalid */
-          "data-invalid:text-danger-low",
-          /* Resets */
-          "focus:outline-none focus-visible:outline-none",
-          className,
-        ),
+      data-disabled={disabled ? "" : undefined}
+      data-invalid={invalid ? "" : undefined}
+      className={clsx(
+        "group/checkbox peer flex items-center gap-x-2",
+        "data-disabled:opacity-disabled",
+        "data-invalid:text-danger-low",
+        className,
       )}
-      {...rest}
     >
-      {composeRenderProps(children, (children, renderProps) => (
-        <>
-          <div
-            className={clsx(
-              "border-primary flex size-4 shrink-0 items-center justify-center rounded-sm border",
-              /* Focus Visible */
-              "group-data-focus-visible/checkbox:ring-primary group-data-focus-visible/checkbox:ring-4 group-data-focus-visible/checkbox:ring-offset-2 group-data-focus-visible/checkbox:outline-hidden",
-              /* Selected */
-              "group-data-indeterminate/checkbox:bg-primary-active group-data-selected/checkbox:bg-primary-active group-data-indeterminate/checkbox:text-primary group-data-selected/checkbox:text-primary",
-              /* Disabled */
-              "group-data-disabled/checkbox:opacity-disabled group-data-disabled/checkbox:cursor-not-allowed",
-              /* Hover  */
-              "group-data-hovered/checkbox:border-primary-hover group-data-hovered/checkbox:bg-primary-hover",
-              /* Invalid */
-              "group-data-invalid/checkbox:border-danger group-data-invalid/checkbox:group-data-hovered/checkbox:border-danger-hover group-data-invalid/checkbox:group-data-hovered/checkbox:bg-danger-hover group-data-invalid/checkbox:group-data-selected/checkbox:bg-danger-subtle group-data-invalid/checkbox:group-data-selected/checkbox:text-danger-low",
-            )}
-          >
-            {renderProps.isIndeterminate ? (
-              <Minus className="size-4" />
-            ) : renderProps.isSelected ? (
-              <Check className="size-4" />
-            ) : null}
-          </div>
-          {children}
-        </>
-      ))}
-    </AriaCheckbox>
+      <BaseCheckbox.Root
+        {...rest}
+        disabled={disabled}
+        indeterminate={indeterminate}
+        className={clsx(
+          "border-primary flex size-4 shrink-0 items-center justify-center rounded-sm border",
+          /* Focus visible */
+          "focus-visible:ring-primary focus-visible:ring-4 focus-visible:ring-offset-2 focus-visible:outline-hidden",
+          /* Checked */
+          "data-indeterminate:bg-primary-active data-checked:bg-primary-active data-indeterminate:text-primary data-checked:text-primary",
+          /* Disabled */
+          "data-disabled:opacity-disabled data-disabled:cursor-not-allowed",
+          /* Hover */
+          "hover:border-primary-hover hover:bg-primary-hover",
+          /* Invalid — read from the row, which is where the prop lands */
+          "group-data-invalid/checkbox:border-danger group-data-invalid/checkbox:hover:border-danger-hover group-data-invalid/checkbox:hover:bg-danger-hover group-data-invalid/checkbox:data-checked:bg-danger-subtle group-data-invalid/checkbox:data-checked:text-danger-low",
+        )}
+      >
+        <BaseCheckbox.Indicator className="flex">
+          {indeterminate ? (
+            <Minus className="size-4" />
+          ) : (
+            <Check className="size-4" />
+          )}
+        </BaseCheckbox.Indicator>
+      </BaseCheckbox.Root>
+      {children}
+    </label>
   );
 }
 
@@ -88,17 +105,17 @@ export function CheckboxField<
     <Checkbox
       {...rest}
       ref={mergedRef}
-      isDisabled={field.disabled || props.isDisabled}
+      disabled={field.disabled || props.disabled}
       onBlur={(event) => {
         field.onBlur();
         props.onBlur?.(event);
       }}
       name={field.name}
-      onChange={(isSelected) => {
-        field.onChange(isSelected);
-        props.onChange?.(isSelected);
+      onCheckedChange={(checked, eventDetails) => {
+        field.onChange(checked);
+        props.onCheckedChange?.(checked, eventDetails);
       }}
-      isSelected={field.value}
+      checked={field.value}
     />
   );
 }

--- a/apps/frontend/src/ui/Switch.stories.tsx
+++ b/apps/frontend/src/ui/Switch.stories.tsx
@@ -1,4 +1,6 @@
+import { useId } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
 
 import { StoryTitle } from "./StoryTitle";
 import { Switch } from "./Switch";
@@ -33,14 +35,64 @@ export const Default: Story = {
           Off
         </label>
         <label className="flex items-center gap-2 text-sm">
-          <Switch defaultSelected />
+          <Switch defaultChecked />
           On
         </label>
         <label className="flex items-center gap-2 text-sm">
-          <Switch isDisabled />
+          <Switch disabled />
           Disabled
         </label>
       </div>
     </div>
   ),
+};
+
+/**
+ * Clicking the label must toggle the switch, both ways it is labelled in this
+ * codebase.
+ *
+ * This is the one thing the move to Base UI could have broken silently.
+ * react-aria rendered a `<label>` wrapping a hidden `<input>`, so `htmlFor`
+ * pointed at an input and clicking the text toggled it. Base UI's `Switch.Root`
+ * *is* a `<button>` — still a labelable element, so the association survives
+ * and the accessible name is right, but a label click only *focuses* a button,
+ * it does not activate it. `FormSwitch` labels its switch by `htmlFor`, so a
+ * regression here would be invisible to every screenshot.
+ */
+function LabelledSwitches() {
+  const id = useId();
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Wrapping label, as the stories and most call sites do. */}
+      <label className="flex w-fit items-center gap-2 text-sm">
+        <Switch data-testid="implicit" />
+        Wrapped by its label
+      </label>
+
+      {/* Separate label pointing at the control, as `FormSwitch` does. */}
+      <div className="flex items-center gap-2">
+        <Switch id={id} data-testid="explicit" />
+        <label htmlFor={id} className="text-sm">
+          Labelled by htmlFor
+        </label>
+      </div>
+    </div>
+  );
+}
+
+export const LabelClickToggles: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const implicit = canvasElement.querySelector("[data-testid='implicit']");
+    const explicit = canvasElement.querySelector("[data-testid='explicit']");
+
+    await expect(implicit).toHaveAttribute("aria-checked", "false");
+    await userEvent.click(canvas.getByText("Wrapped by its label"));
+    await expect(implicit).toHaveAttribute("aria-checked", "true");
+
+    await expect(explicit).toHaveAttribute("aria-checked", "false");
+    await userEvent.click(canvas.getByText("Labelled by htmlFor"));
+    await expect(explicit).toHaveAttribute("aria-checked", "true");
+  },
+  render: () => <LabelledSwitches />,
 };

--- a/apps/frontend/src/ui/Switch.tsx
+++ b/apps/frontend/src/ui/Switch.tsx
@@ -1,34 +1,38 @@
-import { ComponentPropsWithRef } from "react";
+import { Switch as BaseSwitch } from "@base-ui/react/switch";
 import { clsx } from "clsx";
-import { Switch as RACSwitch } from "react-aria-components";
 import { Control, FieldValues, Path, useController } from "react-hook-form";
 
 import { mergeRefs } from "@/util/merge-refs";
 
-type SwitchProps = ComponentPropsWithRef<typeof RACSwitch> & {
+type SwitchProps = BaseSwitch.Root.Props & {
   size?: "sm" | "md";
 };
 
 export function Switch(props: SwitchProps) {
-  const { size = "md", ...rest } = props;
+  const { size = "md", className, ...rest } = props;
   return (
-    <RACSwitch {...rest} className={clsx("group", rest.className)}>
-      <div
+    // `Switch.Root` is the track *and* the button, so the state lives on it
+    // directly — react-aria needed a wrapping label plus a `group` to get the
+    // same classes onto a child.
+    <BaseSwitch.Root
+      {...rest}
+      className={clsx(
+        "focus-ring bg-ui border-thin box-border flex shrink-0 cursor-default rounded-full bg-clip-padding shadow-inner transition duration-200 ease-in-out",
+        "active:bg-primary-active data-checked:bg-primary-solid data-checked:active:bg-primary-solid-active",
+        "data-disabled:opacity-disabled",
+        size === "sm" && "h-4.5 w-7.75 p-0.5",
+        size === "md" && "h-6.5 w-11 p-0.75",
+        className,
+      )}
+    >
+      <BaseSwitch.Thumb
         className={clsx(
-          "rac-focus-group group-data-pressed:bg-primary-active group-data-selected:bg-primary-solid group-data-selected:group-data-pressed:bg-primary-solid-active bg-ui group-data-disabled:opacity-disabled border-thin box-border flex shrink-0 cursor-default rounded-full bg-clip-padding shadow-inner transition duration-200 ease-in-out",
-          size === "sm" && "h-4.5 w-7.75 p-0.5",
-          size === "md" && "h-6.5 w-11 p-0.75",
+          "translate-x-0 rounded-full bg-[#FDFCFD] shadow-sm transition duration-200 ease-in-out data-checked:translate-x-full",
+          size === "sm" && "size-3",
+          size === "md" && "size-4.5",
         )}
-      >
-        <span
-          className={clsx(
-            "translate-x-0 rounded-full bg-[#FDFCFD] shadow-sm transition duration-200 ease-in-out group-data-selected:translate-x-full",
-            size === "sm" && "size-3",
-            size === "md" && "size-4.5",
-          )}
-        />
-      </div>
-    </RACSwitch>
+      />
+    </BaseSwitch.Root>
   );
 }
 
@@ -47,17 +51,17 @@ export function SwitchField<TFieldValues extends FieldValues>(
     <Switch
       {...rest}
       ref={mergedRef}
-      isDisabled={field.disabled || props.isDisabled}
+      disabled={field.disabled || props.disabled}
       onBlur={(event) => {
         field.onBlur();
         props.onBlur?.(event);
       }}
       name={field.name}
-      onChange={(isSelected) => {
-        field.onChange(isSelected);
-        props.onChange?.(isSelected);
+      onCheckedChange={(checked, eventDetails) => {
+        field.onChange(checked);
+        props.onCheckedChange?.(checked, eventDetails);
       }}
-      isSelected={field.value}
+      checked={field.value}
     />
   );
 }


### PR DESCRIPTION
Third slice of the react-aria → Base UI migration: the first two real form
controls. Continues #2475 and #2476.

These two are here because they are genuinely independent — neither is wrapped
by a react-aria trigger, which is the constraint that pushed Button to the back
of the queue (see #2476 for the `PressResponder` finding).

## Switch (`9ef78cea`)

`Switch.Root` is the track *and* the button, so the state lives on it directly.
react-aria needed a wrapping label plus a `group` to get the same classes onto a
child; that indirection goes, along with `rac-focus-group`. Variants map across
cleanly: `group-data-selected:` → `data-checked:`, `group-data-pressed:` →
`active:`, `group-data-disabled:` → `data-disabled:`.

Adds a `focus-ring` utility beside `rac-focus`, for parts that *are* the
focusable control and so need neither a `group` nor `data-focus-visible` — the
browser's `:focus-visible` is what react-aria's modality tracking stood in for.
Text inputs stay on the react-aria version; the comment in `ui/TextInput.tsx`
explains why that one is not interchangeable.

**The risk here was invisible, and worth reading before reviewing.** Base UI puts
`id` on the button rather than on a hidden input, and a label click normally only
*focuses* a button. That should have stopped `FormSwitch`'s `<label htmlFor={id}>`
from toggling — with every screenshot still green. It does not, because Base UI
tracks the associated label itself
(`useAriaLabelledBy(…, inputRef, !nativeButton, hiddenInputId)`) and wires
activation. Both label shapes used in this codebase now have a story asserting
`aria-checked` flips after clicking the label, since nothing else can see it.

Snapshot byte-identical to main.

## Checkbox (`1c58ce1a`)

`Checkbox.Root` is the box, not the row, so the row stays a plain `<label>`. It
keeps `group/checkbox` and `peer`, and mirrors `disabled`/`invalid` onto itself
as data attributes — the row styles by them, and `FormCheckbox`'s sibling label
reads `peer-data-disabled:`, which react-aria used to provide for free.

`invalid` becomes an explicit prop: Base UI sources it from a `Field.Root`, and
these checkboxes are driven by react-hook-form rather than Base UI validation.
The invalid rules therefore stay `group-data-invalid/checkbox:`, reading the row;
everything else moves onto Base UI's own state.

**Not byte-identical, unlike Switch and Separator** — 13 bytes out of 19.4KB,
same dimensions, five states indistinguishable side by side. The cause is a real
DOM change: the box was a `<div>` and is now a `<button role="checkbox">` with a
`<span>` indicator inside, so user-agent defaults shift rendering by a fraction
of a pixel. Flagging it rather than quietly re-baselining — if Argos calls it a
change, that is why.

## Not in this PR, and why

**`CheckboxGroup` / `FieldError`.** They hang off react-aria's
`FieldErrorContext`, which `Select` also provides — and Select is a
trigger-based component, so it is blocked behind the same `PressResponder`
constraint. `DateRangePicker` renders a `<FieldError />` too and relies on
react-aria computing the validation. Untangling that means owning the
field-error context locally (the way `Heading`/`Text` were owned in #2475), and
it deserves its own change rather than being tacked on here.

## Verification

Storybook 60/60, `static-checks` green, both components compared against main by
byte-comparing their story snapshots.

One operational note for anyone hitting it: adding a new Base UI subpath import
mid-session makes Vite re-optimize deps and fails the run with *"Failed to fetch
dynamically imported module"*. It is not a real failure —
`rm -rf apps/frontend/node_modules/.cache/storybook` and re-run. It also produces
one stale snapshot immediately afterwards, which briefly had me believe Checkbox
was byte-identical when it is not.