### PR TITLE
refactor(ui): own the field-error context

### DIFF
--- a/apps/frontend/src/ui/CheckboxGroup.tsx
+++ b/apps/frontend/src/ui/CheckboxGroup.tsx
@@ -3,7 +3,6 @@ import {
   CheckboxGroup as AriaCheckboxGroup,
   CheckboxGroupProps as AriaCheckboxGroupProps,
   composeRenderProps,
-  FieldErrorContext,
 } from "react-aria-components";
 import {
   useController,
@@ -13,6 +12,8 @@ import {
 } from "react-hook-form";
 
 import { mergeRefs } from "@/util/merge-refs";
+
+import { FieldErrorContext } from "./FieldError";
 
 interface CheckboxGroupProps
   extends AriaCheckboxGroupProps, React.RefAttributes<HTMLDivElement> {
@@ -59,22 +60,15 @@ export function CheckboxGroupField<TFieldValues extends FieldValues>(
       isInvalid={Boolean(fieldState.error?.message)}
       {...rest}
     >
-      <FieldErrorContext.Provider
+      <FieldErrorContext
         value={
           fieldState.error?.message
-            ? {
-                validationDetails: fieldState.error
-                  .type as unknown as ValidityState,
-                isInvalid: true,
-                validationErrors: fieldState.error?.message
-                  ? [fieldState.error.message]
-                  : [],
-              }
+            ? { message: fieldState.error.message }
             : null
         }
       >
         {rest.children}
-      </FieldErrorContext.Provider>
+      </FieldErrorContext>
     </CheckboxGroup>
   );
 }

--- a/apps/frontend/src/ui/DateRangePicker.stories.tsx
+++ b/apps/frontend/src/ui/DateRangePicker.stories.tsx
@@ -60,3 +60,22 @@ export const Open: Story = {
     </OverlayStage>
   ),
 };
+
+/**
+ * The validation message, which only exists because react-aria runs the
+ * `validate` prop and `DateRangeFieldError` bridges the result into the kit's
+ * own field-error context. Nothing else covers that bridge, and if it breaks the
+ * message simply stops rendering.
+ */
+export const Invalid: Story = {
+  args: {
+    validate: () => "The period must be shorter than 30 days.",
+    validationBehavior: "aria",
+  },
+  render: (args) => (
+    <div className="flex max-w-xs flex-col">
+      <StoryTitle>Invalid</StoryTitle>
+      <DateRangePicker {...args} />
+    </div>
+  ),
+};

--- a/apps/frontend/src/ui/DateRangePicker.tsx
+++ b/apps/frontend/src/ui/DateRangePicker.tsx
@@ -1,3 +1,4 @@
+import { use } from "react";
 import { parseDate } from "@internationalized/date";
 import { clsx } from "clsx";
 import { CalendarIcon, ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
@@ -14,12 +15,13 @@ import {
   Dialog,
   Group,
   Heading,
+  FieldErrorContext as RACFieldErrorContext,
   RangeCalendar,
   type DateRangePickerProps as AriaDateRangePickerProps,
   type DateValue,
 } from "react-aria-components";
 
-import { FieldError } from "./FieldError";
+import { FieldError, FieldErrorContext } from "./FieldError";
 import { Popover } from "./Popover";
 
 type DateRange = {
@@ -117,7 +119,7 @@ export function DateRangePicker({
           <CalendarIcon className="size-4" />
         </Button>
       </Group>
-      <FieldError />
+      <DateRangeFieldError />
       <Popover>
         <Dialog className="p-3">
           <RangeCalendar className="flex flex-col gap-3">
@@ -177,5 +179,26 @@ export function DateRangePicker({
         </Dialog>
       </Popover>
     </AriaDateRangePicker>
+  );
+}
+
+/**
+ * Bridges react-aria's validation into the kit's own field-error context.
+ *
+ * `AriaDateRangePicker` runs the `validate` prop and publishes the result on
+ * react-aria's `FieldErrorContext`; `ui/FieldError` now reads the kit's own.
+ * Without this the message would simply stop rendering, with nothing failing.
+ * Both sides go when this component moves to `react-day-picker`.
+ */
+function DateRangeFieldError() {
+  const validation = use(RACFieldErrorContext);
+  const message =
+    validation?.isInvalid && validation.validationErrors.length > 0
+      ? validation.validationErrors.join(" ")
+      : null;
+  return (
+    <FieldErrorContext value={message ? { message } : null}>
+      <FieldError />
+    </FieldErrorContext>
   );
 }

--- a/apps/frontend/src/ui/FieldError.tsx
+++ b/apps/frontend/src/ui/FieldError.tsx
@@ -1,14 +1,40 @@
+import { createContext, use, type ComponentPropsWithRef } from "react";
 import { clsx } from "clsx";
-import {
-  FieldError as AriaFieldError,
-  FieldErrorProps as AriaFieldErrorProps,
-} from "react-aria-components";
 
-export function FieldError({ className, ...props }: AriaFieldErrorProps) {
+/**
+ * The error a field is currently showing, `null` when it is valid.
+ *
+ * A control provides this so the `<FieldError />` placed anywhere beneath it
+ * renders the message without the call site threading it down. `SelectField`
+ * and `CheckboxGroupField` fill it from react-hook-form's `fieldState`.
+ *
+ * This replaces react-aria's `FieldErrorContext`, whose shape carried a
+ * `ValidityState` and an array of messages because react-aria ran the
+ * validation itself. Here react-hook-form owns validation and hands over one
+ * message, so that is all this holds.
+ */
+export const FieldErrorContext = createContext<{ message: string } | null>(
+  null,
+);
+
+export function FieldError({
+  className,
+  children,
+  ...props
+}: ComponentPropsWithRef<"span">) {
+  const context = use(FieldErrorContext);
+  // An explicit child wins, for the call sites that render their own message
+  // without a surrounding field.
+  const content = children ?? context?.message;
+  if (!content) {
+    return null;
+  }
   return (
-    <AriaFieldError
-      className={clsx("text-danger-low inline-block text-sm", className)}
+    <span
       {...props}
-    />
+      className={clsx("text-danger-low inline-block text-sm", className)}
+    >
+      {content}
+    </span>
   );
 }

--- a/apps/frontend/src/ui/Select.tsx
+++ b/apps/frontend/src/ui/Select.tsx
@@ -5,7 +5,6 @@ import {
   Select as AriaSelect,
   Button,
   ButtonProps,
-  FieldErrorContext,
   type SelectProps as AriaSelectSelectProps,
 } from "react-aria-components";
 import {
@@ -16,6 +15,8 @@ import {
 } from "react-hook-form";
 
 import { mergeRefs } from "@/util/merge-refs";
+
+import { FieldErrorContext } from "./FieldError";
 
 export { SelectValue } from "react-aria-components";
 
@@ -77,22 +78,15 @@ export function SelectField<TFieldValues extends FieldValues>(
       isInvalid={fieldState.invalid}
       {...rest}
     >
-      <FieldErrorContext.Provider
+      <FieldErrorContext
         value={
           fieldState.error?.message
-            ? {
-                validationDetails: fieldState.error
-                  .type as unknown as ValidityState,
-                isInvalid: true,
-                validationErrors: fieldState.error?.message
-                  ? [fieldState.error.message]
-                  : [],
-              }
+            ? { message: fieldState.error.message }
             : null
         }
       >
         {rest.children}
-      </FieldErrorContext.Provider>
+      </FieldErrorContext>
     </Select>
   );
 }


### PR DESCRIPTION
Fourth slice of the react-aria → Base UI migration. Continues #2475, #2476, #2479.

## Why this one

`CheckboxGroup` and `FieldError` were pinned: both hang off react-aria's
`FieldErrorContext`, which `Select` also provides — and `Select` is a
trigger-based component, so it cannot move until the overlay cluster does (see
#2476 for the `PressResponder` constraint). Owning the context locally unpins
them, the same way `Heading`/`Text` were unpinned in #2475.

## What changed

react-aria's context shape carried a `ValidityState` and an array of messages,
because react-aria ran the validation. Here react-hook-form owns validation and
produces one message, so both providers were assembling that shape only for
`FieldError` to flatten it again — via an `as unknown as ValidityState` cast in
two places, now gone.

The context holds `{ message }`. `SelectField` and `CheckboxGroupField` fill it
from `fieldState`; the `<FieldError />` beneath them is unchanged at all twelve
call sites. Nothing depended on react-aria's `slot="errorMessage"` or its
`react-aria-FieldError` class, so the rendered markup is the same `<span>`.

## The part worth reviewing

`DateRangePicker` is the one place react-aria still computes the validation, so
it gets an explicit bridge: `DateRangeFieldError` reads react-aria's context and
republishes it as ours. **Without it the message would simply have stopped
rendering** — `tsc` cannot see that, and no story covered it. There is now an
`Invalid` story that does.

Writing that story surfaced a **pre-existing user-facing bug**, filed separately
rather than fixed here: the message never reaches users on the real page.
react-aria's `validationBehavior` defaults to `"native"`, which surfaces
validation only through native form submission, and the analytics picker is not
inside a `<form>`. So choosing an over-long period is silently rejected by
`onChange` with the explanation invisible. The story only renders anything once
`validationBehavior="aria"` is set, which is how it came to light.

## Not done, and why

`CheckboxGroup` stays on react-aria. Base UI's `CheckboxGroup` identifies its
members by each checkbox's `name`; the single call site
(`CreateTokenDialog`) keys them by `value`. That is a semantic change rather
than a swap, and it belongs with the wider `Checkbox` work, not here.

## Verification

Storybook 61/61, `static-checks` green. Files importing
`react-aria-components`: **74 → 71**.