### PR TITLE
feat(ui): move Slider and ColorPicker to Base UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,11 @@ permissions: {}
 on:
   push:
     branches: [main]
+  # Any base branch, not just `main`, so a pull request stacked on another one
+  # is checked while it is still stacked rather than only once its base merges
+  # and GitHub retargets it.
   pull_request:
-    branches: [main]
+    branches: ["**"]
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/apps/frontend/src/containers/Build/BlendControls.tsx
+++ b/apps/frontend/src/containers/Build/BlendControls.tsx
@@ -178,10 +178,10 @@ export function OnionOpacityControl(props: {
       <Slider
         aria-label="Onion skin opacity"
         className="flex-1"
-        minValue={0}
-        maxValue={100}
+        min={0}
+        max={100}
         value={value * 100}
-        onChange={(next) => {
+        onValueChange={(next) => {
           invariant(typeof next === "number", "Opacity must be a number");
           onChange(next / 100);
         }}

--- a/apps/frontend/src/containers/Build/toolbar/SettingsButton.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/SettingsButton.tsx
@@ -5,15 +5,17 @@ import { PaintbrushIcon } from "lucide-react";
 import { Heading } from "react-aria-components";
 
 import { Button } from "@/ui/Button";
-import {
-  ColorSwatch,
-  ColorSwatchPicker,
-  ColorSwatchPickerItem,
-} from "@/ui/ColorPicker";
+import { ColorSwatchPicker, ColorSwatchPickerItem } from "@/ui/ColorPicker";
 import { Dialog, DialogBody, DialogTrigger } from "@/ui/Dialog";
 import { Label } from "@/ui/Label";
 import { Popover } from "@/ui/Popover";
-import { Slider, SliderOutput, SliderThumb, SliderTrack } from "@/ui/Slider";
+import {
+  Slider,
+  SliderLabel,
+  SliderOutput,
+  SliderThumb,
+  SliderTrack,
+} from "@/ui/Slider";
 import { Tooltip } from "@/ui/Tooltip";
 
 import { overlayColorAtom, overlayOpacityAtom } from "../OverlayStyle";
@@ -53,15 +55,15 @@ function OpacityPicker() {
   const [opacity, setOpacity] = useAtom(overlayOpacityAtom);
   return (
     <Slider
-      minValue={50}
-      maxValue={100}
+      min={50}
+      max={100}
       value={opacity * 100}
-      onChange={(value) => {
+      onValueChange={(value) => {
         invariant(typeof value === "number", "Opacity must be a number");
         setOpacity(value / 100);
       }}
     >
-      <Label>Opacity</Label>
+      <SliderLabel>Opacity</SliderLabel>
       <SliderOutput />
       <SliderTrack>
         <SliderThumb />
@@ -75,37 +77,16 @@ function ColorPicker() {
   return (
     <div>
       <Label>Color</Label>
-      <ColorSwatchPicker
-        value={color}
-        onChange={(color) => setColor(color.toString("css"))}
-      >
-        <ColorSwatchPickerItem color="#FF5470">
-          <ColorSwatch />
-        </ColorSwatchPickerItem>
-        <ColorSwatchPickerItem color="#FF007C">
-          <ColorSwatch />
-        </ColorSwatchPickerItem>
-        <ColorSwatchPickerItem color="#FD3A4A">
-          <ColorSwatch />
-        </ColorSwatchPickerItem>
-        <ColorSwatchPickerItem color="#FFAA1D">
-          <ColorSwatch />
-        </ColorSwatchPickerItem>
-        <ColorSwatchPickerItem color="#299617">
-          <ColorSwatch />
-        </ColorSwatchPickerItem>
-        <ColorSwatchPickerItem color="#2243B6">
-          <ColorSwatch />
-        </ColorSwatchPickerItem>
-        <ColorSwatchPickerItem color="#5DADEC">
-          <ColorSwatch />
-        </ColorSwatchPickerItem>
-        <ColorSwatchPickerItem color="#5946B2">
-          <ColorSwatch />
-        </ColorSwatchPickerItem>
-        <ColorSwatchPickerItem color="#000">
-          <ColorSwatch />
-        </ColorSwatchPickerItem>
+      <ColorSwatchPicker value={color} onChange={setColor}>
+        <ColorSwatchPickerItem color="#FF5470" />
+        <ColorSwatchPickerItem color="#FF007C" />
+        <ColorSwatchPickerItem color="#FD3A4A" />
+        <ColorSwatchPickerItem color="#FFAA1D" />
+        <ColorSwatchPickerItem color="#299617" />
+        <ColorSwatchPickerItem color="#2243B6" />
+        <ColorSwatchPickerItem color="#5DADEC" />
+        <ColorSwatchPickerItem color="#5946B2" />
+        <ColorSwatchPickerItem color="#000" />
       </ColorSwatchPicker>
     </div>
   );

--- a/apps/frontend/src/ui/ColorPicker.stories.tsx
+++ b/apps/frontend/src/ui/ColorPicker.stories.tsx
@@ -1,19 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import {
-  ColorSwatch,
-  ColorSwatchPicker,
-  ColorSwatchPickerItem,
-} from "./ColorPicker";
+import { ColorSwatchPicker, ColorSwatchPickerItem } from "./ColorPicker";
 import { StoryTitle } from "./StoryTitle";
-
-const meta = {
-  title: "UI/ColorPicker",
-  component: ColorSwatchPicker,
-} satisfies Meta<typeof ColorSwatchPicker>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
 
 // The palette from the build toolbar's diff-colour setting, the only consumer.
 const COLORS = [
@@ -28,21 +16,30 @@ const COLORS = [
   "#000",
 ];
 
+const meta = {
+  title: "UI/ColorPicker",
+  component: ColorSwatchPicker,
+  args: {
+    value: "#FFAA1D",
+    onChange: () => {},
+    children: COLORS.map((color) => (
+      <ColorSwatchPickerItem key={color} color={color} />
+    )),
+  },
+} satisfies Meta<typeof ColorSwatchPicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
 /**
- * react-aria's colour swatch picker has no Base UI counterpart — it becomes a
- * plain toggle group — so the selected ring is worth a baseline of its own.
+ * react-aria's colour swatch picker has no Base UI counterpart — it is a toggle
+ * group now — so the selected ring is worth a baseline of its own.
  */
 export const Default: Story = {
-  render: () => (
+  render: (args) => (
     <div className="flex max-w-xs flex-col">
       <StoryTitle>Swatches</StoryTitle>
-      <ColorSwatchPicker value="#FFAA1D" aria-label="Diff color">
-        {COLORS.map((color) => (
-          <ColorSwatchPickerItem key={color} color={color}>
-            <ColorSwatch />
-          </ColorSwatchPickerItem>
-        ))}
-      </ColorSwatchPicker>
+      <ColorSwatchPicker {...args} />
     </div>
   ),
 };

--- a/apps/frontend/src/ui/ColorPicker.tsx
+++ b/apps/frontend/src/ui/ColorPicker.tsx
@@ -1,52 +1,66 @@
+import { Toggle } from "@base-ui/react/toggle";
+import { ToggleGroup } from "@base-ui/react/toggle-group";
 import { clsx } from "clsx";
-import {
-  ColorSwatchPickerItemProps,
-  ColorSwatchPickerProps,
-  ColorSwatchProps,
-  ColorSwatch as RACColorSwatch,
-  ColorSwatchPicker as RACColorSwatchPicker,
-  ColorSwatchPickerItem as RACColorSwatchPickerItem,
-} from "react-aria-components";
 
-export function ColorSwatchPicker(
-  props: ColorSwatchPickerProps & {
-    ref?: React.Ref<HTMLDivElement>;
-  },
-) {
+/**
+ * A row of colour swatches, one of which is selected.
+ *
+ * react-aria had a dedicated colour-swatch picker that parsed the colour and
+ * painted the swatch for you. Base UI has no colour components, and this only
+ * ever needed "pick one of a fixed list", which is a toggle group — so the
+ * colour is a plain CSS string throughout rather than a parsed `Color` object.
+ */
+export function ColorSwatchPicker(props: {
+  value: string;
+  onChange: (value: string) => void;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  const { value, onChange, className, children } = props;
   return (
-    <RACColorSwatchPicker
-      {...props}
-      className={clsx("flex flex-wrap gap-2", props.className)}
-    />
+    <ToggleGroup
+      value={[value]}
+      onValueChange={(groupValue) => {
+        // Single-select: the group hands back every pressed value, and the one
+        // just pressed is last. Ignore an empty array so clicking the current
+        // swatch cannot leave the overlay with no colour at all.
+        const next = groupValue.at(-1);
+        if (next) {
+          onChange(next);
+        }
+      }}
+      className={clsx("flex flex-wrap gap-2", className)}
+    >
+      {children}
+    </ToggleGroup>
   );
 }
 
-export function ColorSwatchPickerItem(
-  props: ColorSwatchPickerItemProps & {
-    ref?: React.Ref<HTMLDivElement>;
-  },
-) {
+export function ColorSwatchPickerItem(props: {
+  color: string;
+  className?: string;
+}) {
+  const { color, className } = props;
   return (
-    <RACColorSwatchPickerItem
-      {...props}
+    <Toggle
+      value={color}
+      aria-label={color}
       className={clsx(
-        "rac-focus relative w-fit rounded-sm outline-hidden forced-color-adjust-none",
-        "data-selected:ring-primary-active data-selected:ring-1 data-selected:ring-offset-1",
-        props.className,
+        "focus-ring relative w-fit rounded-sm outline-hidden forced-color-adjust-none",
+        "data-pressed:ring-primary-active data-pressed:ring-1 data-pressed:ring-offset-1",
+        className,
       )}
-    />
+    >
+      <ColorSwatch color={color} />
+    </Toggle>
   );
 }
 
-export function ColorSwatch(
-  props: ColorSwatchProps & {
-    ref?: React.Ref<HTMLDivElement>;
-  },
-) {
+function ColorSwatch(props: { color: string; className?: string }) {
   return (
-    <RACColorSwatch
-      {...props}
+    <div
       className={clsx("size-6 rounded-sm border", props.className)}
+      style={{ backgroundColor: props.color }}
     />
   );
 }

--- a/apps/frontend/src/ui/Slider.stories.tsx
+++ b/apps/frontend/src/ui/Slider.stories.tsx
@@ -14,7 +14,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   render: () => (
     <div className="max-w-xs">
-      <Slider defaultValue={50} minValue={0} maxValue={100}>
+      <Slider defaultValue={50} min={0} max={100}>
         <Label>Threshold</Label>
         <SliderOutput />
         <SliderTrack>

--- a/apps/frontend/src/ui/Slider.tsx
+++ b/apps/frontend/src/ui/Slider.tsx
@@ -1,22 +1,9 @@
+import { Slider as BaseSlider } from "@base-ui/react/slider";
 import { clsx } from "clsx";
-import {
-  Slider as RACSlider,
-  SliderOutput as RACSliderOutput,
-  SliderOutputProps as RACSliderOutputProps,
-  SliderProps as RACSliderProps,
-  SliderThumb as RACSliderThumb,
-  SliderThumbProps as RACSliderThumbProps,
-  SliderTrack as RACSliderTrack,
-  SliderTrackProps as RACSliderTrackProps,
-} from "react-aria-components";
 
-type SliderProps = RACSliderProps & {
-  ref?: React.ForwardedRef<HTMLDivElement>;
-};
-
-export function Slider(props: SliderProps) {
+export function Slider(props: BaseSlider.Root.Props) {
   return (
-    <RACSlider
+    <BaseSlider.Root
       {...props}
       className={clsx(
         "grid grid-cols-[1fr_auto] flex-col [grid-template-areas:'label_output''track_track'] [&>label]:[grid-area:label]",
@@ -26,13 +13,26 @@ export function Slider(props: SliderProps) {
   );
 }
 
-type SliderOutputProps = RACSliderOutputProps & {
-  ref?: React.ForwardedRef<HTMLOutputElement>;
-};
-
-export function SliderOutput(props: SliderOutputProps) {
+/**
+ * The slider's own label part rather than `ui/Label`.
+ *
+ * `ui/Label` is react-aria's, which takes its association from whichever
+ * react-aria field wraps it. Inside a Base UI slider there is no such context,
+ * so it would render an unassociated `<label>` and the slider would lose its
+ * accessible name — visible to nothing but a screen reader.
+ */
+export function SliderLabel(props: BaseSlider.Label.Props) {
   return (
-    <RACSliderOutput
+    <BaseSlider.Label
+      {...props}
+      className={clsx("mb-2 inline-block text-sm font-medium", props.className)}
+    />
+  );
+}
+
+export function SliderOutput(props: BaseSlider.Value.Props) {
+  return (
+    <BaseSlider.Value
       {...props}
       className={clsx(
         "text-low text-sm tabular-nums [grid-area:output]",
@@ -42,32 +42,37 @@ export function SliderOutput(props: SliderOutputProps) {
   );
 }
 
-type SliderTrackProps = RACSliderTrackProps & {
-  ref?: React.ForwardedRef<HTMLDivElement>;
-};
-
-export function SliderTrack(props: SliderTrackProps) {
+/**
+ * The hit area and the rail. react-aria had one element for both, drawing the
+ * rail as a `before:` pseudo-element on the box the pointer works against; Base
+ * UI splits them, so `Control` keeps the box and `Track` becomes the rail
+ * itself. The thumb goes inside `Track`, which is what positions it.
+ */
+export function SliderTrack(props: {
+  className?: string;
+  children?: React.ReactNode;
+}) {
+  const { className, children } = props;
   return (
-    <RACSliderTrack
-      {...props}
-      className={clsx(
-        "relative h-4 w-full [grid-area:track] before:absolute before:top-1/2 before:block before:h-1 before:w-full before:-translate-y-1/2 before:rounded-sm before:bg-(--border-color-default) before:content-['']",
-        props.className,
-      )}
-    />
+    <BaseSlider.Control
+      className={clsx("relative h-4 w-full [grid-area:track]", className)}
+    >
+      <BaseSlider.Track className="absolute top-1/2 h-1 w-full -translate-y-1/2 rounded-sm bg-(--border-color-default)">
+        {children}
+      </BaseSlider.Track>
+    </BaseSlider.Control>
   );
 }
 
-type SliderThumbProps = RACSliderThumbProps & {
-  ref?: React.ForwardedRef<HTMLDivElement>;
-};
-
-export function SliderThumb(props: SliderThumbProps) {
+export function SliderThumb(props: BaseSlider.Thumb.Props) {
   return (
-    <RACSliderThumb
+    <BaseSlider.Thumb
       {...props}
       className={clsx(
-        "bg-primary-solid data-dragging:bg-primary-solid-active rac-focus top-1/2 size-4 rounded-full",
+        "bg-primary-solid data-dragging:bg-primary-solid-active size-4 rounded-full",
+        // The focusable element is the hidden input inside the thumb, so the
+        // ring keys off that rather than the thumb itself.
+        "has-[:focus-visible]:outline-1 has-[:focus-visible]:outline-offset-1 has-[:focus-visible]:outline-(--violet-10)",
         props.className,
       )}
     />


### PR DESCRIPTION
**Stacked on #2480** — review that one first; this PR's diff is only the two
components. Fifth slice of the react-aria → Base UI migration.

Both are isolated: neither is wrapped by a react-aria trigger, which is what
still blocks Button and the overlay cluster (see #2476).

## Slider

react-aria used one element for both the pointer target and the rail, drawing
the rail as a `before:` pseudo-element. Base UI splits them, so `Control` keeps
the box and `Track` becomes the rail itself, with the thumb inside `Track` —
which is what positions it. **Byte-identical despite the restructure.**

**Adds `SliderLabel`, and this is the part worth reviewing.** `ui/Label` is
react-aria's: it takes its association from whichever react-aria field wraps it.
Inside a Base UI slider there is no such context, so it would have rendered an
unassociated `<label>` and the slider would have silently lost its accessible
name — nothing visual, nothing failing. Base UI has a `Slider.Label` part for
exactly this, and the two call sites now use it.

The focus ring moves to `has-[:focus-visible]:` because the focusable element is
the hidden input inside the thumb, not the thumb.

## ColorPicker

react-aria's colour swatch picker parsed the colour and painted the swatch. Base
UI has no colour components, and this only ever needed "pick one of a fixed
list" — a toggle group. The colour is a plain CSS string throughout now, so the
call site loses its `color.toString("css")` and each swatch loses its
`<ColorSwatch />` child. **Also byte-identical.**

The single-select handling is deliberate: the group reports every pressed value
with the newest last, and an empty array is ignored, so clicking the currently
selected swatch cannot leave the build overlay with no colour at all.

## Verification

Storybook 61/61, `static-checks` green. Both components' snapshots byte-compared
against `main` — identical, verified with a cleared Vite cache and repeated runs,
since a stale module graph produced a misleading match earlier in this series.

`react-aria-components` imports: **71 → 69 files.** Components on Base UI: 6
(Separator, Switch, Checkbox, Slider, ColorPicker, plus the field-error context).

---

Also widens the CI trigger to `pull_request: branches: ["**"]`. It was `[main]`, so a stacked pull request got no run at all until its base merged and GitHub retargeted it — which made a stack reviewable only in series. `push` is unchanged.
