### PR TITLE
feat(ui): move CheckboxGroup to Base UI

### DIFF
--- a/apps/frontend/src/containers/User/tokens/CreateTokenDialog.tsx
+++ b/apps/frontend/src/containers/User/tokens/CreateTokenDialog.tsx
@@ -270,13 +270,16 @@ export function CreateTokenDialog(props: {
             <div>
               <Label>Scope — accounts this token can access</Label>
 
-              <CheckboxGroupField
-                control={form.control}
-                name="accountIds"
-                isInvalid={Boolean(form.formState.errors.accountIds)}
-              >
+              {/* react-aria's group pushed `isInvalid` down to its checkboxes
+                  through context; Base UI's does not, so the flag is passed to
+                  each one to keep them turning red together. */}
+              <CheckboxGroupField control={form.control} name="accountIds">
                 {availableAccounts.map((acc) => (
-                  <Checkbox key={acc.id} value={acc.id}>
+                  <Checkbox
+                    key={acc.id}
+                    name={acc.id}
+                    invalid={Boolean(form.formState.errors.accountIds)}
+                  >
                     {acc.name ? (
                       <>
                         <AccountAvatar avatar={acc.avatar} className="size-4" />

--- a/apps/frontend/src/ui/CheckboxGroup.tsx
+++ b/apps/frontend/src/ui/CheckboxGroup.tsx
@@ -1,9 +1,5 @@
+import { CheckboxGroup as BaseCheckboxGroup } from "@base-ui/react/checkbox-group";
 import clsx from "clsx";
-import {
-  CheckboxGroup as AriaCheckboxGroup,
-  CheckboxGroupProps as AriaCheckboxGroupProps,
-  composeRenderProps,
-} from "react-aria-components";
 import {
   useController,
   type Control,
@@ -16,18 +12,26 @@ import { mergeRefs } from "@/util/merge-refs";
 import { FieldErrorContext } from "./FieldError";
 
 interface CheckboxGroupProps
-  extends AriaCheckboxGroupProps, React.RefAttributes<HTMLDivElement> {
+  extends
+    Omit<BaseCheckboxGroup.Props, "className" | "ref">,
+    React.RefAttributes<HTMLDivElement> {
+  className?: string;
   label?: string;
   description?: string;
 }
 
+/**
+ * A set of checkboxes sharing one value.
+ *
+ * Members are identified by each checkbox's `name`, not its `value` — that is
+ * the one behavioural difference from react-aria's version, and the group's
+ * value is an array of the ticked checkboxes' names.
+ */
 function CheckboxGroup({ ref, className, ...props }: CheckboxGroupProps) {
   return (
-    <AriaCheckboxGroup
+    <BaseCheckboxGroup
       ref={ref}
-      className={composeRenderProps(className, (className) =>
-        clsx("group flex flex-col gap-2", className),
-      )}
+      className={clsx("group flex flex-col gap-2", className)}
       {...props}
     />
   );
@@ -42,22 +46,16 @@ type CheckboxGroupFieldProps<TFieldValues extends FieldValues> = {
 export function CheckboxGroupField<TFieldValues extends FieldValues>(
   props: CheckboxGroupFieldProps<TFieldValues>,
 ) {
-  const { ref, control, name, isDisabled, onBlur, ...rest } = props;
+  const { ref, control, name, disabled, ...rest } = props;
   const { field, fieldState } = useController({ control, name });
   const mergedRef = mergeRefs(field.ref, ref);
   return (
     <CheckboxGroup
       ref={mergedRef}
-      isDisabled={field.disabled || isDisabled}
-      onBlur={(event) => {
-        field.onBlur();
-        onBlur?.(event);
-      }}
-      onChange={field.onChange}
+      disabled={field.disabled || disabled}
+      onValueChange={field.onChange}
       value={field.value}
-      name={field.name}
-      validationBehavior="aria"
-      isInvalid={Boolean(fieldState.error?.message)}
+      onBlur={field.onBlur}
       {...rest}
     >
       <FieldErrorContext


### PR DESCRIPTION
**Stacked on #2481** (which is stacked on #2480) — review those first; this
PR's own diff is two files. Sixth slice of the react-aria → Base UI migration.

## Why it did not ride along with `Checkbox` in #2479

Base UI identifies group members by each checkbox's **`name`**, not its `value`,
and the group's value is an array of the ticked names. The one call site
(`CreateTokenDialog`) keyed its checkboxes by `value`. That is a semantic change
rather than a rename, so it was held back rather than bundled into a PR that was
otherwise mechanical.

## The part that would have broken quietly

`isInvalid` on the group is gone, and it was not decorative. react-aria pushed
it down to the child checkboxes through context, so setting it turned **every
box in the group red**. Base UI has no such propagation, so the flag is passed
to each `Checkbox` instead — which is what the explicit `invalid` prop added in
#2479 is for.

Dropping it without noticing would have left the group styled as perfectly valid
while an error message sat underneath it. Nothing would have failed.

## Where this leaves the form controls

Done: Separator, Switch, Checkbox, Slider, ColorPicker, CheckboxGroup, and the
field-error context.

`TextInput` and `Label` are **not** independent, contrary to the plan's original
grouping. `BuildNameFilter` renders `ui/TextInput` inside a react-aria
`SearchField`, which is what supplies its value and clear behaviour through
`InputContext`; swapping the input for a plain one would break that search field
with nothing failing. Both move with the filter menus.

So what remains is `DateRangePicker` (isolated, but a real rewrite onto
`react-day-picker`) and then the overlay cluster, which unblocks everything else
including `Button`.

## Verification

Storybook 61/61, `static-checks` green. No visual change expected — the group
renders the same `<div>` wrapper, and its children were already migrated in
#2479.