### PR TITLE
fix(analytics): explain why a custom period is rejected

### DIFF
--- a/apps/frontend/src/pages/Account/Analytics.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.tsx
@@ -1,4 +1,11 @@
-import { Suspense, useCallback, useEffect, useId, useMemo } from "react";
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+} from "react";
 import { useSuspenseQuery } from "@apollo/client/react";
 import {
   addDays,
@@ -233,33 +240,9 @@ export function Component() {
               </Suspense>
               <PeriodSelect value={period} onChange={setPeriod} />
               {period === "custom" && customPeriod ? (
-                <DateRangePicker
-                  aria-label="Custom analytics period"
-                  granularity="day"
+                <CustomPeriodPicker
                   value={customPeriod}
-                  minValue={today(getLocalTimeZone()).subtract({
-                    days: MAX_DURATION_DAYS - 1,
-                  })}
-                  maxValue={today(getLocalTimeZone())}
-                  onChange={(value) => {
-                    if (!checkIsDurationValid(value)) {
-                      return;
-                    }
-                    setCustomPeriod(value);
-                  }}
-                  validate={(value) => {
-                    if (!value) {
-                      return null;
-                    }
-                    const range = {
-                      from: new Date(`${value.start}T00:00:00`),
-                      to: new Date(`${value.end}T00:00:00`),
-                    };
-                    if (checkIsDurationValid(range)) {
-                      return null;
-                    }
-                    return `Date range cannot exceed ${MAX_DURATION_DAYS} days.`;
-                  }}
+                  onChange={setCustomPeriod}
                 />
               ) : null}
             </div>
@@ -1419,6 +1402,65 @@ function PeriodSelect(props: {
         </ListBox>
       </Popover>
     </Select>
+  );
+}
+
+/**
+ * The custom period field.
+ *
+ * It keeps the range being edited in local state instead of driving the query
+ * params directly. A date typed into the segments arrives one edit at a time,
+ * so committing only valid ranges would revert the segment under the cursor
+ * and leave `validate` nothing invalid to report on — the field would refuse
+ * the range without ever saying why. Only a range within the limit is
+ * committed; the rest stays in the field, flagged.
+ */
+function CustomPeriodPicker(props: {
+  value: { from: Date; to: Date };
+  onChange: (value: { from: Date; to: Date }) => void;
+}) {
+  const { value, onChange } = props;
+  const [draft, setDraft] = useState(value);
+
+  // `value` is rebuilt from the query params on every render, so re-sync on its
+  // content rather than on its identity.
+  const committedKey = `${getDateQueryValue(value.from)}/${getDateQueryValue(value.to)}`;
+  const [lastCommittedKey, setLastCommittedKey] = useState(committedKey);
+  if (committedKey !== lastCommittedKey) {
+    setLastCommittedKey(committedKey);
+    setDraft(value);
+  }
+
+  const maxDay = startOfDay(new Date());
+
+  return (
+    <DateRangePicker
+      aria-label="Custom analytics period"
+      granularity="day"
+      value={draft}
+      maxValue={today(getLocalTimeZone())}
+      onChange={(next) => {
+        setDraft(next);
+        if (checkIsDurationValid(next) && next.to <= maxDay) {
+          onChange(next);
+        }
+      }}
+      validate={(entered) => {
+        if (!entered) {
+          return null;
+        }
+        const range = {
+          from: new Date(`${entered.start}T00:00:00`),
+          to: new Date(`${entered.end}T00:00:00`),
+        };
+        // Only the duration limit — react-aria reports a reversed range and a
+        // day past `maxValue` itself, with a message specific to each.
+        if (getDurationInDays(range) <= MAX_DURATION_DAYS) {
+          return null;
+        }
+        return `Date range cannot exceed ${MAX_DURATION_DAYS} days.`;
+      }}
+    />
   );
 }
 

--- a/apps/frontend/src/ui/DateRangePicker.stories.tsx
+++ b/apps/frontend/src/ui/DateRangePicker.stories.tsx
@@ -66,11 +66,14 @@ export const Open: Story = {
  * `validate` prop and `DateRangeFieldError` bridges the result into the kit's
  * own field-error context. Nothing else covers that bridge, and if it breaks the
  * message simply stops rendering.
+ *
+ * It rides on the component's `validationBehavior="aria"` default rather than
+ * setting the prop here, so this also guards that default: under react-aria's
+ * own `"native"`, the message would wait for a form submit that never comes.
  */
 export const Invalid: Story = {
   args: {
     validate: () => "The period must be shorter than 30 days.",
-    validationBehavior: "aria",
   },
   render: (args) => (
     <div className="flex max-w-xs flex-col">

--- a/apps/frontend/src/ui/DateRangePicker.tsx
+++ b/apps/frontend/src/ui/DateRangePicker.tsx
@@ -55,6 +55,11 @@ export function DateRangePicker({
 }: DateRangePickerProps) {
   return (
     <AriaDateRangePicker
+      // react-aria defaults to "native", which only surfaces errors through
+      // native form validation on submit. Nothing renders this picker inside a
+      // <form>, so that default would leave the <FieldError /> below
+      // permanently empty.
+      validationBehavior="aria"
       {...props}
       value={{
         start: parseDate(formatDateValue(value.from)),
@@ -164,7 +169,7 @@ export function DateRangePicker({
                           "flex size-8 items-center justify-center rounded-full",
                           renderProps.isSelectionEnd ||
                             renderProps.isSelectionStart
-                            ? "bg-primary-solid group-invalid:bg-danger-solid text-white"
+                            ? "bg-primary-solid group-data-invalid:bg-danger-solid text-white"
                             : "group-data-hovered:bg-(--violet-5)",
                         )}
                       >


### PR DESCRIPTION
The custom-period picker on Analytics refused an over-long range without saying why. It passed a `validate` returning `Date range cannot exceed 365 days.`, and `ui/DateRangePicker` rendered a `<FieldError />` for it, but that message could never reach the screen.

## Why it never showed

Two independent reasons, both of which had to be fixed:

1. **`validationBehavior` defaults to `"native"`**, which surfaces errors only through native form validation on submit. Nothing renders this picker inside a `<form>`, so the `<FieldError />` was permanently empty.
2. **`useDateRangePickerState` validates `controlledValue`** — the `value` prop. The page rejected an invalid range in `onChange` before it could ever reach that prop, so `validate` was never called with a failing range.

Point 2 is the one that matters: fixing only `validationBehavior` changes nothing. I confirmed that by driving both variants in a browser — identical result, no message, no border. The `validate` prop was unreachable code, not merely undisplayed.

## Changes

**`Analytics.tsx`** — extracted `CustomPeriodPicker`, which holds the range being edited in local state and commits only valid ones. Without it, a date typed into the segments is reverted under the cursor and there is nothing invalid left to report on.

Also dropped `minValue`. It was `today - 364`, stricter than the backend (`apps/backend/src/metrics/account.ts:29` caps duration only — there is no lookback window) and stricter than `parseCustomPeriod`. It made the calendar unable to reach any historical window, and once errors display it would have flagged a bookmarked historical range on load. `maxValue={today}` stays, and the commit guard now checks it too, so a future date cannot slip through while an error is showing.

`validate` is scoped to the duration rule alone. That lets react-aria report a reversed range and a day past `maxValue` with a message specific to each, instead of a misleading duration one.

**`DateRangePicker.tsx`** — defaults to `validationBehavior="aria"` (overridable), since the component renders a `<FieldError />` and nothing puts it in a form. Also `group-invalid:` → `group-data-invalid:`: the former compiles to `.group:invalid &`, a pseudo-class that never matches a `div`, so the danger-coloured selected day was dead style. This change is what made it observable — the field went red while the selected day stayed violet.

## Verified in a browser

| Case | Result |
|---|---|
| Over-long range typed | Held in field, red border, `Date range cannot exceed 365 days.`, not committed |
| Selected day when invalid | Now red, matching the field |
| Reversed range | react-aria's `Start date must be before end date.` |
| End date past today | react-aria's `Value must be 8/14/2026 or earlier.`, not committed |
| Valid range | Commits normally |

## Reviewer notes

- **Layout shift:** the message adds a line under the picker inside the `items-center` header row, so the row grows and the other controls shift when it appears. Worth a look in situ if that bothers you — a non-reflowing treatment (tooltip/overlay) is the alternative.
- **New Argos baseline:** the added `Invalid` story covers the field treatment. The invalid *calendar* is not separately baselined, so the `group-data-invalid:` fix has no visual guard.
- **Base UI migration:** `DateRangePicker` is next up for the `react-day-picker` rewrite. The ui-side change here is 2 lines; the draft-state logic in `Analytics.tsx` is framework-agnostic and should survive it intact.
- `check-types`, `check-format` and `lint` pass. `knip` fails, but byte-identically with and without this change (unused `pg` dep, pre-existing) — verified by diffing both runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)