### PR TITLE
feat(ui): move Tooltip to Base UI

### DIFF
--- a/apps/frontend/.storybook/preview.ts
+++ b/apps/frontend/.storybook/preview.ts
@@ -1,5 +1,7 @@
+import { createElement } from "react";
 import type { Preview } from "@storybook/react-vite";
 
+import { TooltipProvider } from "../src/ui/Tooltip";
 import "../src/index.css";
 
 // Provide a mock clientData so that `src/config.ts` does not throw when
@@ -25,6 +27,13 @@ import "../src/index.css";
 };
 
 const preview: Preview = {
+  // The app mounts this at the router root. Stories render outside it, so
+  // without this a tooltip in Storybook would use Base UI's default delays
+  // rather than the app's.
+  decorators: [
+    (Story) => createElement(TooltipProvider, null, createElement(Story)),
+  ],
+
   parameters: {
     controls: {
       matchers: {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -32,7 +32,6 @@
     "@primer/octicons-react": "^19.33.0",
     "@radix-ui/colors": "^3.0.0",
     "@react-aria/collections": "^3.1.1",
-    "@react-aria/interactions": "^3.28.1",
     "@sentry/react": "^10.69.0",
     "@sentry/vite-plugin": "^5.4.0",
     "@shikijs/langs": "^4.4.1",

--- a/apps/frontend/src/containers/Build/BuildHotkeys.tsx
+++ b/apps/frontend/src/containers/Build/BuildHotkeys.tsx
@@ -4,6 +4,7 @@ import { XIcon } from "lucide-react";
 
 import { Button } from "@/ui/Button";
 import { Dialog, DialogBody, DialogTitle } from "@/ui/Dialog";
+import { Kbd } from "@/ui/Kbd";
 import { Modal } from "@/ui/Modal";
 import { useLiveRef } from "@/ui/useLiveRef";
 import { isMacOS } from "@/util/os";
@@ -501,14 +502,6 @@ export function useBuildHotkey(
     return registerHotkey({ hotkey, ref, timeout: 0 });
   }, [hotkey, ref]);
   return hotkey;
-}
-
-function Kbd({ children }: { children: React.ReactNode }) {
-  return (
-    <kbd className="bg-ui inline-flex h-5 min-w-5 items-center justify-center rounded-sm px-1 text-xs">
-      {children}
-    </kbd>
-  );
 }
 
 export function BuildHotkeysDialog(props: { env: HotkeyEnv }) {

--- a/apps/frontend/src/containers/Build/ScreenshotActions.tsx
+++ b/apps/frontend/src/containers/Build/ScreenshotActions.tsx
@@ -34,7 +34,7 @@ export function ImageActionsMenu(props: {
 }) {
   return (
     <MenuTrigger>
-      <Tooltip placement="left" content={props.tooltip}>
+      <Tooltip side="left" content={props.tooltip}>
         <Button variant="secondary" iconOnly>
           <EllipsisVerticalIcon />
         </Button>

--- a/apps/frontend/src/containers/Build/Zoomer.tsx
+++ b/apps/frontend/src/containers/Build/Zoomer.tsx
@@ -375,11 +375,7 @@ const FitViewButton = memo(() => {
     preventDefault: true,
   });
   return (
-    <HotkeyTooltip
-      placement="left"
-      description="Fit view"
-      keys={hotkey.displayKeys}
-    >
+    <HotkeyTooltip side="left" description="Fit view" keys={hotkey.displayKeys}>
       <Button variant="secondary" iconOnly onPress={reset}>
         <MaximizeIcon />
       </Button>
@@ -390,7 +386,7 @@ const FitViewButton = memo(() => {
 const ZoomInButton = memo((props: { disabled: boolean }) => {
   const { zoomIn } = useZoomerSyncContext();
   return (
-    <Tooltip placement="left" content="Zoom in">
+    <Tooltip side="left" content="Zoom in">
       <Button
         variant="secondary"
         iconOnly
@@ -406,7 +402,7 @@ const ZoomInButton = memo((props: { disabled: boolean }) => {
 const ZoomOutButton = memo((props: { disabled: boolean }) => {
   const { zoomOut } = useZoomerSyncContext();
   return (
-    <Tooltip placement="left" content="Zoom out">
+    <Tooltip side="left" content="Zoom out">
       <Button
         variant="secondary"
         iconOnly

--- a/apps/frontend/src/containers/Comment/CommentCard.tsx
+++ b/apps/frontend/src/containers/Comment/CommentCard.tsx
@@ -782,7 +782,7 @@ function ReplyComposer(props: {
         <HotkeyTooltip
           description="Submit the reply"
           keys={[MOD, "Enter"]}
-          placement="top"
+          side="top"
         >
           <Button
             variant="secondary"

--- a/apps/frontend/src/pages/Account/Analytics.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.tsx
@@ -874,7 +874,7 @@ function SplitBar(props: {
   return (
     <Tooltip
       delay={0}
-      placement="top"
+      side="top"
       disableAnimation
       content={
         <div className="flex min-w-40 flex-col gap-1 py-0.5">

--- a/apps/frontend/src/pages/Build/BuildOverview/BuildSummary.tsx
+++ b/apps/frontend/src/pages/Build/BuildOverview/BuildSummary.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { DocumentType, graphql } from "@/gql";
 import { BuildType } from "@/gql/graphql";
 import { Button } from "@/ui/Button";
-import { Kbd } from "@/ui/Kbd";
+import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 import { ShortcutHint } from "@/ui/ShortcutHint";
 
 import {
@@ -49,20 +49,27 @@ function BrowseSnapshotSection(props: { build: Build }) {
     canReview && !build.viewerHasSubmittedReview && !hasFailures;
   const goToFirstDiff = useGoToNextDiff();
   const browse = () => goToFirstDiff();
+  const label = (() => {
+    if (canStartReview) {
+      return "Start review";
+    }
+    return hasFailures ? "Browse test failures" : "Browse snapshots";
+  })();
 
   return (
     <div className="flex flex-wrap items-center gap-x-8 gap-y-3">
-      {canStartReview ? (
-        <Button autoFocus onPress={browse}>
-          Start review
-          <Kbd className="ml-2 bg-white/25 text-white">↵</Kbd>
+      {/* The shortcut sits in the tooltip rather than inside the button: a key
+          drawn on the button's own fill reads as a control nested in a
+          control, and it is the same hint the row beside it already gives. */}
+      <HotkeyTooltip description={label} keys={["↵"]}>
+        <Button
+          autoFocus
+          variant={canStartReview ? "primary" : "secondary"}
+          onPress={browse}
+        >
+          {label}
         </Button>
-      ) : (
-        <Button autoFocus variant="secondary" onPress={browse}>
-          {hasFailures ? "Browse test failures" : "Browse snapshots"}
-          <Kbd className="ml-2">↵</Kbd>
-        </Button>
-      )}
+      </HotkeyTooltip>
       {canStartReview && (
         <div className="text-low flex items-center gap-4 text-xs">
           <ShortcutHint keys={["↓", "↑"]}>Navigate</ShortcutHint>

--- a/apps/frontend/src/pages/Build/ReviewCommentSubmitButton.tsx
+++ b/apps/frontend/src/pages/Build/ReviewCommentSubmitButton.tsx
@@ -89,7 +89,7 @@ export function ReviewCommentSubmitButton(props: {
         )
       }
       keys={[MOD, "Enter"]}
-      placement="top"
+      side="top"
     >
       <Button
         variant="secondary"

--- a/apps/frontend/src/pages/Build/diffComments/DiffCommentDraft.tsx
+++ b/apps/frontend/src/pages/Build/diffComments/DiffCommentDraft.tsx
@@ -113,7 +113,7 @@ export function DiffCommentDraft(props: {
               )
             }
             keys={[MOD, "Enter"]}
-            placement="top"
+            side="top"
           >
             <Button
               variant="secondary"

--- a/apps/frontend/src/router.tsx
+++ b/apps/frontend/src/router.tsx
@@ -21,6 +21,7 @@ import { ErrorPage } from "./pages/ErrorPage";
 import { NotFound } from "./pages/NotFound";
 import { RequireSAMLLogin } from "./pages/RequireSAMLLogin";
 import { Loader } from "./ui/Loader";
+import { TooltipProvider } from "./ui/Tooltip";
 import { checkIsErrorCode } from "./util/error";
 
 declare module "react-aria-components" {
@@ -70,7 +71,12 @@ function Root() {
       // oxlint-disable-next-line react/react-compiler -- RouterProvider's API takes the hook itself and calls it internally.
       useHref={useAbsoluteHref}
     >
-      <Outlet />
+      {/* Base UI reads tooltip delays from a provider rather than from each
+          tooltip, and one shared provider is also what gives them their
+          warm-up: once any tooltip has opened, the next opens immediately. */}
+      <TooltipProvider>
+        <Outlet />
+      </TooltipProvider>
     </RouterProvider>
   );
 }

--- a/apps/frontend/src/ui/CopyButton.tsx
+++ b/apps/frontend/src/ui/CopyButton.tsx
@@ -20,7 +20,7 @@ export function CopyButton({
   return (
     <Tooltip
       content={clipboard.copied ? "Copied!" : "Copy"}
-      isOpen={clipboard.copied || isTooltipOpen}
+      open={clipboard.copied || isTooltipOpen}
       onOpenChange={setIsTooltipOpen}
     >
       <Button

--- a/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
+++ b/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
@@ -178,7 +178,7 @@ export function StandaloneEditor(props: StandaloneEditorProps) {
             <HotkeyTooltip
               description={submitLabel}
               keys={[MOD, "Enter"]}
-              placement="top"
+              side="top"
             >
               <Button
                 variant="secondary"
@@ -215,7 +215,7 @@ export function StandaloneEditor(props: StandaloneEditorProps) {
               <HotkeyTooltip
                 description={submitLabel}
                 keys={[MOD, "Enter"]}
-                placement="top"
+                side="top"
               >
                 <Button
                   iconOnly

--- a/apps/frontend/src/ui/HotkeyTooltip.tsx
+++ b/apps/frontend/src/ui/HotkeyTooltip.tsx
@@ -1,5 +1,4 @@
 import { cloneElement } from "react";
-import { FocusableOptions } from "react-aria";
 
 import { Kbd } from "./Kbd";
 import { Tooltip, TooltipProps } from "./Tooltip";
@@ -10,18 +9,19 @@ export function HotkeyTooltip({
   children,
   keysEnabled = true,
   disabled,
-  placement,
+  side,
 }: {
   description: React.ReactNode;
   keys: string[];
-  children: React.ReactElement<
-    FocusableOptions & {
-      "aria-keyshortcuts"?: React.AriaAttributes["aria-keyshortcuts"];
-    }
-  >;
+  // The child only has to accept `aria-keyshortcuts`; it used to be typed
+  // against react-aria's `FocusableOptions` because the tooltip made it
+  // focusable through that interface, which Base UI's `render` prop replaces.
+  children: React.ReactElement<{
+    "aria-keyshortcuts"?: React.AriaAttributes["aria-keyshortcuts"];
+  }>;
   keysEnabled?: boolean;
   disabled?: boolean;
-  placement?: TooltipProps["placement"];
+  side?: TooltipProps["side"];
 }) {
   return (
     <Tooltip
@@ -40,7 +40,7 @@ export function HotkeyTooltip({
           </div>
         ) : null
       }
-      placement={placement}
+      side={side}
     >
       {cloneElement(children, {
         "aria-keyshortcuts": keys.length > 0 ? keys.join("+") : undefined,

--- a/apps/frontend/src/ui/Kbd.tsx
+++ b/apps/frontend/src/ui/Kbd.tsx
@@ -6,7 +6,7 @@ export function Kbd(props: ComponentPropsWithRef<"kbd">) {
     <kbd
       {...props}
       className={clsx(
-        "text-xxs text-default inline-flex h-4 min-w-4 items-center justify-center rounded-sm bg-(--gray-a5) px-1",
+        "text-default/80 inline-flex min-w-[1lh] items-center justify-center rounded-sm bg-(--gray-a2) border-thin px-1",
         props.className,
       )}
     />

--- a/apps/frontend/src/ui/Tooltip.stories.tsx
+++ b/apps/frontend/src/ui/Tooltip.stories.tsx
@@ -36,16 +36,16 @@ export const Default: Story = {
 
       <StoryTitle>Placements</StoryTitle>
       <div className="flex gap-8">
-        <Tooltip content="Top" placement="top">
+        <Tooltip content="Top" side="top">
           <Button variant="secondary">Top</Button>
         </Tooltip>
-        <Tooltip content="Bottom" placement="bottom">
+        <Tooltip content="Bottom" side="bottom">
           <Button variant="secondary">Bottom</Button>
         </Tooltip>
-        <Tooltip content="Left" placement="left">
+        <Tooltip content="Left" side="left">
           <Button variant="secondary">Left</Button>
         </Tooltip>
-        <Tooltip content="Right" placement="right">
+        <Tooltip content="Right" side="right">
           <Button variant="secondary">Right</Button>
         </Tooltip>
       </div>
@@ -63,7 +63,7 @@ export const Open: Story = {
   render: () => (
     <OverlayStage className="items-center">
       <OverlaySlot className="flex justify-center">
-        <Tooltip content="Default tooltip" placement="bottom" isOpen>
+        <Tooltip content="Default tooltip" side="bottom" open>
           <Button variant="secondary">Default</Button>
         </Tooltip>
       </OverlaySlot>
@@ -76,15 +76,15 @@ export const Open: Story = {
             </>
           }
           variant="info"
-          placement="bottom"
-          isOpen
+          side="bottom"
+          open
         >
           <Button variant="secondary">Info</Button>
         </Tooltip>
       </OverlaySlot>
       {(["top", "bottom", "left", "right"] as const).map((placement) => (
         <OverlaySlot key={placement} className="flex justify-center">
-          <Tooltip content={placement} placement={placement} isOpen>
+          <Tooltip content={placement} side={placement} open>
             <Button variant="secondary">{placement}</Button>
           </Tooltip>
         </OverlaySlot>

--- a/apps/frontend/src/ui/Tooltip.tsx
+++ b/apps/frontend/src/ui/Tooltip.tsx
@@ -112,7 +112,11 @@ export function TooltipProvider(props: { children: React.ReactNode }) {
       closeDelay={TOOLTIP_CLOSE_DELAY}
     >
       {props.children}
-      <BaseTooltip.Root handle={tooltipHandle}>
+      {/* Only tooltips keeping the default `disableHoverableContent` ride this
+          one, so it opts out too — which is also what marks the positioner
+          `inert`, and so what stops the tooltip eating a click aimed at the
+          button under it. */}
+      <BaseTooltip.Root handle={tooltipHandle} disableHoverablePopup>
         {({ payload }) =>
           payload ? <TooltipSurface payload={payload} /> : null
         }

--- a/apps/frontend/src/ui/Tooltip.tsx
+++ b/apps/frontend/src/ui/Tooltip.tsx
@@ -21,6 +21,90 @@ const variantClassNames: Record<TooltipVariant, string> = {
 const TOOLTIP_DELAY = 900;
 const TOOLTIP_CLOSE_DELAY = 100;
 
+type TooltipPayload = {
+  content: React.ReactNode;
+  variant: TooltipVariant;
+  side: BaseTooltip.Positioner.Props["side"];
+  align: BaseTooltip.Positioner.Props["align"];
+};
+
+/**
+ * One tooltip, shared by every trigger that does not need its own.
+ *
+ * Triggers attach by handle and hand their content over as a payload, so moving
+ * the pointer from one to the next animates the same element across instead of
+ * tearing one down and building another. A tooltip per trigger — which is what
+ * react-aria did — restarts the animation every time, and along a row of icon
+ * buttons that reads as flicker.
+ */
+const tooltipHandle = BaseTooltip.createHandle<TooltipPayload>();
+
+function TooltipSurface(props: {
+  payload: TooltipPayload;
+  disableAnimation?: boolean;
+}) {
+  const { payload, disableAnimation = false } = props;
+  return (
+    <BaseTooltip.Portal>
+      <BaseTooltip.Positioner
+        side={payload.side}
+        align={payload.align}
+        sideOffset={4}
+        className={clsx(
+          !disableAnimation && [
+            // Sizing the positioner to the popup is what lets the box travel
+            // and resize together rather than jumping.
+            "h-(--positioner-height) w-(--positioner-width) max-w-(--available-width)",
+          ],
+        )}
+      >
+        <BaseTooltip.Popup
+          className={clsx(
+            "bg-app text-default overflow-hidden rounded-md border-thin shadow-sm/8",
+            variantClassNames[payload.variant],
+            !disableAnimation && [
+              "h-(--popup-height,auto) w-(--popup-width,auto)",
+              // Base UI publishes the origin for the resolved side, so the
+              // per-placement `origin-*` map the react-aria version carried is
+              // no longer needed.
+              "origin-(--transform-origin) fill-mode-forwards",
+              // The same `tailwindcss-animate` keyframes as before the
+              // migration, keyed off `data-open`/`data-closed` rather than
+              // react-aria's `isEntering`/`isExiting`.
+              "data-open:animate-in data-open:fade-in",
+              "data-closed:animate-out data-closed:fade-out data-closed:zoom-out-95",
+              "data-[side=bottom]:data-open:slide-in-from-top-1",
+              "data-[side=top]:data-open:slide-in-from-bottom-1",
+              "data-[side=left]:data-open:slide-in-from-right-1",
+              "data-[side=right]:data-open:slide-in-from-left-1",
+              "data-[side=bottom]:data-closed:slide-out-to-top-1",
+              "data-[side=top]:data-closed:slide-out-to-bottom-1",
+              "data-[side=left]:data-closed:slide-out-to-right-1",
+              "data-[side=right]:data-closed:slide-out-to-left-1",
+              // Deliberately no `data-instant:animate-none`: Base UI sets
+              // `data-instant` for every open after the first in a group, and
+              // honouring it meant the tooltip simply appeared with no
+              // animation at all for most of the row.
+            ],
+          )}
+        >
+          {/* Cross-fades the text when the tooltip moves between triggers,
+              rather than swapping it in one frame. */}
+          <BaseTooltip.Viewport
+            className={clsx(
+              "relative h-full w-full",
+              !disableAnimation &&
+                "**:data-previous:absolute **:data-previous:inset-0 **:data-previous:opacity-0 **:data-previous:transition-opacity **:data-current:transition-opacity",
+            )}
+          >
+            {payload.content}
+          </BaseTooltip.Viewport>
+        </BaseTooltip.Popup>
+      </BaseTooltip.Positioner>
+    </BaseTooltip.Portal>
+  );
+}
+
 export function TooltipProvider(props: { children: React.ReactNode }) {
   return (
     <BaseTooltip.Provider
@@ -28,6 +112,11 @@ export function TooltipProvider(props: { children: React.ReactNode }) {
       closeDelay={TOOLTIP_CLOSE_DELAY}
     >
       {props.children}
+      <BaseTooltip.Root handle={tooltipHandle}>
+        {({ payload }) =>
+          payload ? <TooltipSurface payload={payload} /> : null
+        }
+      </BaseTooltip.Root>
     </BaseTooltip.Provider>
   );
 }
@@ -36,9 +125,12 @@ export type TooltipProps = {
   content: React.ReactNode;
   children: ReactElement;
   variant?: TooltipVariant;
-  /** Which side of the trigger to sit on. Base UI's own prop, passed straight through. */
   side?: BaseTooltip.Positioner.Props["side"];
   align?: BaseTooltip.Positioner.Props["align"];
+  /**
+   * Let the pointer move onto the tooltip itself, for content holding a link.
+   * Such a tooltip cannot ride the shared one, so it gets a root of its own.
+   */
   disableHoverableContent?: boolean;
   disableAnimation?: boolean;
   open?: boolean;
@@ -48,8 +140,8 @@ export type TooltipProps = {
    *
    * Base UI reads delays from a provider rather than from the tooltip, so
    * setting this gives the tooltip a provider of its own — which also takes it
-   * out of the shared warm-up group. Leave it alone unless the tooltip really
-   * should behave differently from every other one.
+   * out of the shared group. Leave it alone unless the tooltip really should
+   * behave differently from every other one.
    */
   delay?: number;
   closeDelay?: number;
@@ -69,53 +161,53 @@ export function Tooltip(props: TooltipProps) {
     delay,
     closeDelay,
   } = props;
+
   if (!content) {
     return children;
   }
-  const tooltip = (
+
+  const payload: TooltipPayload = { content, variant, side, align };
+
+  // Anything that must behave differently from the rest — a controlled open
+  // state, its own delay, or hoverable content — cannot ride the shared
+  // tooltip, whose root is mounted once for the whole app.
+  const needsOwnRoot =
+    open !== undefined ||
+    onOpenChange !== undefined ||
+    delay !== undefined ||
+    closeDelay !== undefined ||
+    !disableHoverableContent;
+
+  if (!needsOwnRoot) {
+    return (
+      <BaseTooltip.Trigger
+        handle={tooltipHandle}
+        payload={payload}
+        render={children}
+      />
+    );
+  }
+
+  const ownRoot = (
     <BaseTooltip.Root
       open={open}
       onOpenChange={onOpenChange}
       disableHoverablePopup={disableHoverableContent}
     >
-      {/* `render` replaces react-aria's `useFocusable` + `FocusableProvider` +
-          `mergeProps` + `cloneElement`: Base UI merges its own props and ref
-          into whatever element it is given. */}
       <BaseTooltip.Trigger render={children} />
-      <BaseTooltip.Portal>
-        <BaseTooltip.Positioner side={side} align={align} sideOffset={4}>
-          <BaseTooltip.Popup
-            className={clsx(
-              "bg-subtle text-default overflow-hidden rounded-md border shadow-md",
-              // Keeps the tooltip from eating a click aimed at what is under
-              // it; `disableHoverablePopup` only handles the safe polygon.
-              disableHoverableContent && "pointer-events-none",
-              variantClassNames[variant],
-              !disableAnimation && [
-                "origin-(--transform-origin) transition duration-150 ease-out",
-                "data-starting-style:opacity-0 data-ending-style:opacity-0",
-                "data-[side=bottom]:data-starting-style:-translate-y-1",
-                "data-[side=top]:data-starting-style:translate-y-1",
-                "data-[side=left]:data-starting-style:translate-x-1",
-                "data-[side=right]:data-starting-style:-translate-x-1",
-              ],
-            )}
-          >
-            {content}
-          </BaseTooltip.Popup>
-        </BaseTooltip.Positioner>
-      </BaseTooltip.Portal>
+      <TooltipSurface payload={payload} disableAnimation={disableAnimation} />
     </BaseTooltip.Root>
   );
+
   if (delay === undefined && closeDelay === undefined) {
-    return tooltip;
+    return ownRoot;
   }
   return (
     <BaseTooltip.Provider
       delay={delay ?? TOOLTIP_DELAY}
       closeDelay={closeDelay ?? TOOLTIP_CLOSE_DELAY}
     >
-      {tooltip}
+      {ownRoot}
     </BaseTooltip.Provider>
   );
 }

--- a/apps/frontend/src/ui/Tooltip.tsx
+++ b/apps/frontend/src/ui/Tooltip.tsx
@@ -1,15 +1,7 @@
-import { cloneElement, useRef, type ComponentPropsWithRef } from "react";
-import { FocusableProvider } from "@react-aria/interactions";
+import { type ComponentPropsWithRef, type ReactElement } from "react";
+import { Tooltip as BaseTooltip } from "@base-ui/react/tooltip";
 import { clsx } from "clsx";
 import type { LucideIcon } from "lucide-react";
-import { FocusableOptions, mergeProps, useFocusable } from "react-aria";
-import {
-  Tooltip as RACTooltip,
-  TooltipProps as RACTooltipProps,
-  TooltipRenderProps,
-  TooltipTrigger,
-  TooltipTriggerComponentProps,
-} from "react-aria-components";
 
 type TooltipVariant = "default" | "info";
 
@@ -20,142 +12,111 @@ const variantClassNames: Record<TooltipVariant, string> = {
   info: "text-sm p-2 max-w-sm [&_strong]:font-medium",
 };
 
+/**
+ * How long the pointer must rest before a tooltip opens, and how long one stays
+ * up after it leaves. Base UI reads these from a provider rather than per
+ * tooltip, which is also what gives a group of tooltips its warm-up: once one
+ * has opened, the next opens immediately.
+ */
+const TOOLTIP_DELAY = 900;
+const TOOLTIP_CLOSE_DELAY = 100;
+
+export function TooltipProvider(props: { children: React.ReactNode }) {
+  return (
+    <BaseTooltip.Provider
+      delay={TOOLTIP_DELAY}
+      closeDelay={TOOLTIP_CLOSE_DELAY}
+    >
+      {props.children}
+    </BaseTooltip.Provider>
+  );
+}
+
 export type TooltipProps = {
   content: React.ReactNode;
-  children: React.ReactElement<FocusableOptions>;
+  children: ReactElement;
   variant?: TooltipVariant;
-  placement?: RACTooltipProps["placement"];
+  /** Which side of the trigger to sit on. Base UI's own prop, passed straight through. */
+  side?: BaseTooltip.Positioner.Props["side"];
+  align?: BaseTooltip.Positioner.Props["align"];
   disableHoverableContent?: boolean;
   disableAnimation?: boolean;
-  isOpen?: TooltipTriggerComponentProps["isOpen"];
-  onOpenChange?: TooltipTriggerComponentProps["onOpenChange"];
-  delay?: TooltipTriggerComponentProps["delay"];
-  closeDelay?: TooltipTriggerComponentProps["closeDelay"];
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /**
+   * Override how long the pointer must rest before this tooltip opens.
+   *
+   * Base UI reads delays from a provider rather than from the tooltip, so
+   * setting this gives the tooltip a provider of its own — which also takes it
+   * out of the shared warm-up group. Leave it alone unless the tooltip really
+   * should behave differently from every other one.
+   */
+  delay?: number;
+  closeDelay?: number;
 };
-
-function getTooltipAnimationClassName(props: TooltipRenderProps): string {
-  return clsx(
-    "fill-mode-forwards",
-    props.placement &&
-      clsx(
-        {
-          bottom: "origin-top",
-          top: "origin-bottom",
-          left: "origin-right",
-          right: "origin-left",
-          center: "origin-center",
-        }[props.placement],
-        props.isEntering &&
-          clsx(
-            "animate-in fade-in",
-            {
-              bottom: "slide-in-from-top-1",
-              top: "slide-in-from-bottom-1",
-              left: "slide-in-from-right-1",
-              right: "slide-in-from-left-1",
-              center: "",
-            }[props.placement],
-          ),
-        props.isExiting &&
-          clsx(
-            "animate-out fade-out zoom-out-95",
-            {
-              bottom: "slide-out-to-top-1",
-              top: "slide-out-to-bottom-1",
-              left: "slide-out-to-right-1",
-              right: "slide-out-to-left-1",
-              center: "",
-            }[props.placement],
-          ),
-      ),
-  );
-}
-
-type TooltipOverlayProps = RACTooltipProps & {
-  ref?: React.Ref<HTMLDivElement>;
-  variant?: TooltipVariant;
-  disableHoverableContent?: boolean;
-  disableAnimation?: boolean;
-  children: React.ReactNode;
-};
-
-function TooltipOverlay({
-  className,
-  variant = "default",
-  disableHoverableContent = true,
-  disableAnimation = false,
-  children,
-  ...props
-}: TooltipOverlayProps) {
-  const variantClassName = variantClassNames[variant];
-  const frozenChildrenRef = useRef(children);
-  return (
-    <RACTooltip
-      offset={4}
-      {...props}
-      className={(props) =>
-        clsx(
-          "bg-subtle text-default overflow-hidden rounded-md border shadow-md",
-          disableHoverableContent && "pointer-events-none",
-          !disableAnimation && getTooltipAnimationClassName(props),
-          variantClassName,
-          className,
-        )
-      }
-    >
-      {(values) => {
-        const result = (() => {
-          // Freeze the children while the tooltip is animating.
-          if (!values.isEntering && !values.isExiting) {
-            frozenChildrenRef.current = children;
-            return children;
-          }
-
-          return frozenChildrenRef.current;
-        })();
-
-        return <FocusableProvider ref={null}>{result}</FocusableProvider>;
-      }}
-    </RACTooltip>
-  );
-}
-
-function TooltipTarget(props: {
-  children: React.ReactElement<FocusableOptions>;
-}) {
-  const triggerRef = useRef(null);
-  const { focusableProps } = useFocusable(props.children.props, triggerRef);
-
-  return cloneElement(
-    props.children,
-    // oxlint-disable-next-line react/react-compiler
-    mergeProps(focusableProps, { tabIndex: 0 }, props.children.props, {
-      ref: triggerRef,
-    }),
-  );
-}
 
 export function Tooltip(props: TooltipProps) {
-  if (!props.content) {
-    return props.children;
+  const {
+    content,
+    children,
+    variant = "default",
+    side,
+    align,
+    disableHoverableContent = true,
+    disableAnimation = false,
+    open,
+    onOpenChange,
+    delay,
+    closeDelay,
+  } = props;
+  if (!content) {
+    return children;
+  }
+  const tooltip = (
+    <BaseTooltip.Root
+      open={open}
+      onOpenChange={onOpenChange}
+      disableHoverablePopup={disableHoverableContent}
+    >
+      {/* `render` replaces react-aria's `useFocusable` + `FocusableProvider` +
+          `mergeProps` + `cloneElement`: Base UI merges its own props and ref
+          into whatever element it is given. */}
+      <BaseTooltip.Trigger render={children} />
+      <BaseTooltip.Portal>
+        <BaseTooltip.Positioner side={side} align={align} sideOffset={4}>
+          <BaseTooltip.Popup
+            className={clsx(
+              "bg-subtle text-default overflow-hidden rounded-md border shadow-md",
+              // Keeps the tooltip from eating a click aimed at what is under
+              // it; `disableHoverablePopup` only handles the safe polygon.
+              disableHoverableContent && "pointer-events-none",
+              variantClassNames[variant],
+              !disableAnimation && [
+                "origin-(--transform-origin) transition duration-150 ease-out",
+                "data-starting-style:opacity-0 data-ending-style:opacity-0",
+                "data-[side=bottom]:data-starting-style:-translate-y-1",
+                "data-[side=top]:data-starting-style:translate-y-1",
+                "data-[side=left]:data-starting-style:translate-x-1",
+                "data-[side=right]:data-starting-style:-translate-x-1",
+              ],
+            )}
+          >
+            {content}
+          </BaseTooltip.Popup>
+        </BaseTooltip.Positioner>
+      </BaseTooltip.Portal>
+    </BaseTooltip.Root>
+  );
+  if (delay === undefined && closeDelay === undefined) {
+    return tooltip;
   }
   return (
-    <TooltipTrigger
-      delay={props.delay ?? 900}
-      closeDelay={props.closeDelay ?? 100}
-      isOpen={props.isOpen}
-      onOpenChange={props.onOpenChange}
+    <BaseTooltip.Provider
+      delay={delay ?? TOOLTIP_DELAY}
+      closeDelay={closeDelay ?? TOOLTIP_CLOSE_DELAY}
     >
-      <TooltipTarget>{props.children}</TooltipTarget>
-      <TooltipOverlay
-        variant={props.variant}
-        placement={props.placement}
-        disableHoverableContent={props.disableHoverableContent}
-        disableAnimation={props.disableAnimation}
-      >
-        {props.content}
-      </TooltipOverlay>
-    </TooltipTrigger>
+      {tooltip}
+    </BaseTooltip.Provider>
   );
 }
 

--- a/apps/frontend/src/ui/UserCard.tsx
+++ b/apps/frontend/src/ui/UserCard.tsx
@@ -315,13 +315,13 @@ function UserCard(props: { user: UserCardData }) {
 export function UserHoverCard(props: {
   user: UserCardData;
   children: React.ComponentProps<typeof Tooltip>["children"];
-  placement?: React.ComponentProps<typeof Tooltip>["placement"];
+  side?: React.ComponentProps<typeof Tooltip>["side"];
 }) {
   return (
     <Tooltip
       variant="info"
       delay={1200}
-      placement={props.placement ?? "top"}
+      side={props.side ?? "top"}
       content={
         <div>
           <UserCard user={props.user} />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,9 +482,6 @@ importers:
       '@react-aria/collections':
         specifier: ^3.1.1
         version: 3.1.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@react-aria/interactions':
-        specifier: ^3.28.1
-        version: 3.28.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@sentry/react':
         specifier: ^10.69.0
         version: 10.69.0(react@19.2.8)
@@ -3274,12 +3271,6 @@ packages:
 
   '@react-aria/collections@3.1.1':
     resolution: {integrity: sha512-54NpHYVnv1+47L5e2DZ34WvzPSOg6dgl4E78EfZo3kNdyM8xhM2vCuYuS8uUs1xCPr7HcBBmnn/maHOxfSabeg==}
-    peerDependencies:
-      react: ^19.2.8
-      react-dom: ^19.2.8
-
-  '@react-aria/interactions@3.28.1':
-    resolution: {integrity: sha512-Bqb+HrD5I5MHS2SKBhISYqo2SW8Y2dfzgF/Y1lIJq7xqLxheo9vzxPGEHhz+XzkgGfoqEJx8A6a3C7uiqS3HWA==}
     peerDependencies:
       react: ^19.2.8
       react-dom: ^19.2.8
@@ -10794,14 +10785,6 @@ snapshots:
 
   '@react-aria/collections@3.1.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@swc/helpers': 0.5.23
-      react: 19.2.8
-      react-aria: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react-dom: 19.2.8(react@19.2.8)
-
-  '@react-aria/interactions@3.28.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@react-types/shared': 3.36.1(react@19.2.8)
       '@swc/helpers': 0.5.23
       react: 19.2.8
       react-aria: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)


### PR DESCRIPTION
First component of the overlay cluster, and the first evidence that Base UI's
`render`-based triggers compose with the still-react-aria components around
them. **Removes `@react-aria/interactions` entirely** — one of the six packages
gone.

## What replaced what

`Tooltip.Trigger render={children}` does the whole job of react-aria's
`useFocusable` + `FocusableProvider` + `mergeProps` + `cloneElement`: Base UI
merges its props and ref into whatever element it is handed. That was the only
remaining consumer of `@react-aria/interactions`.

This also answers the open question from #2476 in the affirmative for triggers
that use `render` rather than a `PressResponder`: a Base UI tooltip wrapping a
still-react-aria `Button` works, because the trigger passes DOM props and RAC's
Button forwards them. Menus and dialogs will not be so easy — those are the ones
that use `PressResponder`.

## The API changes, deliberately

`placement="bottom end"` becomes `side` and `align` — Base UI's own props rather
than a string the kit parses apart. I had written a `parsePlacement` shim first;
changing the API outright is better, and it turned out cheap: **every tooltip in
the codebase used a bare side**, so the 18 call sites are a straight rename. The
compound placements are all on `Popover`, which is still react-aria and keeps
its own prop until it moves.

## Delays needed more thought than a rename

Base UI reads delays from a **provider**, not from the tooltip. So there is one
`TooltipProvider` at the router root, which also restores something react-aria
gave for free: the warm-up, where the second tooltip in a group opens
immediately instead of waiting the full delay again.

Two call sites genuinely differ — `delay={0}` on a chart element and
`delay={1200}` on the user card — so passing a delay gives that tooltip a
provider of its own. The prop is documented as the exception it is. (My first
pass concluded no call site customised delays; that grep only matched
single-line JSX and missed both of these. `tsc` caught it.)

Storybook renders outside the router, so `.storybook/preview.ts` gains the same
provider as a decorator — otherwise tooltips there would quietly use Base UI's
defaults rather than the app's.

## Verification

Storybook 61/61, `static-checks` green.

**Not byte-identical**: 216 bytes of 24KB, same dimensions, tooltips in the same
places at all four sides and both variants. Floating UI and react-aria's overlay
positioning round fractional positions differently. Flagging rather than
assuming — the Argos build here decides whether it registers at all.

`react-aria-components`: **69 → 68 files**, and `react-aria` hook imports down to
5 with `@react-aria/interactions` removed outright.