### PR TITLE
fix(build): stop cutting the pull request title in its tooltip

### DIFF
--- a/apps/frontend/src/containers/PullRequestButton.tsx
+++ b/apps/frontend/src/containers/PullRequestButton.tsx
@@ -91,26 +91,26 @@ function PullRequestInfo(props: {
   }
   return (
     <div className="flex gap-2">
-      <div className="mt-1 flex">
+      <div className="mt-1 flex shrink-0">
         <PullRequestStatusIcon pullRequest={pullRequest} />
       </div>
-      <div>
+      {/* `min-w-0` lets this column shrink to the tooltip's width. Without it
+          the column keeps its max-content width, and the title runs past the
+          rounded corner and is sliced off by the popup's `overflow-hidden`. */}
+      <div className="min-w-0">
         <div>
+          {/* The title wraps rather than truncating: this tooltip exists to
+              show the title the button had to cut short, so cutting it a
+              second time would leave it unreadable either way. */}
           <a
             href={pullRequest.url}
             onClick={(event) => {
               event.stopPropagation();
             }}
-            className="hover:bg-hover inline-flex items-center gap-2 rounded-sm px-1"
+            className="hover:bg-hover rounded-sm px-1 wrap-break-word"
           >
-            <span className="flex max-w-prose min-w-0 items-center gap-2">
-              <span className="min-w-0 flex-1 truncate">
-                {pullRequest.title}
-              </span>
-              <span className="text-low font-normal">
-                #{pullRequest.number}
-              </span>
-            </span>
+            {pullRequest.title}{" "}
+            <span className="text-low font-normal">#{pullRequest.number}</span>
           </a>
         </div>
         <div className="text-low flex items-center gap-1 px-1">


### PR DESCRIPTION
Fixes ARG-502.

The pull-request tooltip exists to show the title the button had to cut short — and it cut it again, mid-word, past the rounded corner, taking the `#number` with it.

<img width="467" alt="before" src="https://uploads.linear.app/acf5a5ba-11b6-4409-8c98-76f8aff6d3fd/094cac7e-f11b-4a8a-9190-bbd5ec644aee/f8763a31-21d1-42f1-ad38-b828bb8d3875" />

## Why

The tooltip's text column is a flex item, so it kept `min-width: auto` and refused to shrink below its max-content width. The `truncate` inside it therefore never had a narrower box to truncate against: the column ran past the popup, and the popup's `overflow-hidden` did the slicing.

## Fix

- `min-w-0` on the column, so it shrinks to the tooltip's width.
- The title **wraps** instead of truncating. Truncating a second time would leave it unreadable either way, which is the whole point of the tooltip.
- `wrap-break-word` so a title that is one long unbreakable token still breaks rather than overflowing.
- `shrink-0` on the status icon.

Verified against a standalone repro of the exact class chain: the current markup reproduces the report, the new one wraps onto two lines, keeps the `#number`, and breaks a 70-character token cleanly.

No test: this is a rendering detail behind a hover, and the tooltip specs we have are already the flakiest in the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)