### PR TITLE
fix(media): put a floor under the pull request media rows

### DIFF
--- a/apps/frontend/src/containers/Media/MediaPullRequestList.tsx
+++ b/apps/frontend/src/containers/Media/MediaPullRequestList.tsx
@@ -164,7 +164,11 @@ function MediaListItem(props: {
       aria-current={isActive ? "true" : undefined}
       className="shrink-0"
     >
-      <DiffCard isActive={isActive} variant="primary" className="p-2">
+      {/* `min-h-25` is the floor the build list puts under its own rows: a
+          wide, short upload — a header strip, a toolbar — fits the sidebar's
+          width at a handful of pixels tall, and a card that height is a pill
+          with a file name in it, indistinguishable from a button. */}
+      <DiffCard isActive={isActive} variant="primary" className="min-h-25 p-2">
         <MediaThumbnail version={latestVersion} dimensions={dimensions} />
         <DiffCardFooter alwaysVisible>
           {latestVersion.isVideo ? (


### PR DESCRIPTION
Closes ARG-500.

A wide, short upload — a build header, a toolbar strip — fits the share page's
sidebar at a handful of pixels tall, and the card around it collapses to a 24px
pill with a file name in it: indistinguishable from a button, with no picture
left to recognise the media by. The same happened to a recording whose poster
had not landed, whose film icon was clipped by the footer.

`min-h-25` is the floor the build list already puts under its own rows
(`DIFF_IMAGE_CONFIG.minHeight`), so the two lists now behave the same whatever
shape lands in them.

Measured on a seeded 1280×52 upload: the row goes from **24px** to **100px**,
and the video row from 48px to 100px. Rows taller than the floor are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)