### PR TITLE
feat(media): default a media's visibility to its project's

### DIFF
--- a/apps/backend/src/api/handlers/media.e2e.test.ts
+++ b/apps/backend/src/api/handlers/media.e2e.test.ts
@@ -36,6 +36,8 @@ const app = createTestHandlerApp(
 );
 
 const HASH = "a".repeat(64);
+/** Different bytes, for the upload that has to land as a second version. */
+const OTHER_HASH = "b".repeat(64);
 /** The routed project: the account slug plus the project factory's name. */
 const PROJECT_PATH = "acme/awesome-project";
 
@@ -58,6 +60,35 @@ vi.mock("@aws-sdk/s3-presigned-post", () => ({
   })),
 }));
 
+/**
+ * A team account owned by `user`, on a plan of the given name.
+ *
+ * Team features need a plan at all — the same gate build creation applies — and
+ * which plan it is decides the media limits: `free` is Hobby, anything else is
+ * Pro. That is the difference between a public-only account and one that can hold
+ * a team-scoped share page, so the tests that care create their own.
+ */
+async function createTeamAccountOnPlan(args: {
+  user: User;
+  planName: string;
+}): Promise<Account> {
+  const account = await factory.TeamAccount.create({ slug: "acme" });
+  await factory.TeamUser.create({
+    teamId: account.teamId,
+    userId: args.user.id,
+    userLevel: "owner",
+  });
+  const plan = await factory.Plan.create({
+    name: args.planName,
+    includedScreenshots: 5000,
+  });
+  await factory.Subscription.create({
+    accountId: account.id,
+    planId: plan.id,
+  });
+  return account;
+}
+
 const test = base.extend<{
   user: User;
   account: Account;
@@ -72,24 +103,9 @@ const test = base.extend<{
     await use(user);
   },
   account: async ({ user }, use) => {
-    const account = await factory.TeamAccount.create({ slug: "acme" });
-    await factory.TeamUser.create({
-      teamId: account.teamId,
-      userId: user.id,
-      userLevel: "owner",
-    });
-    // Team features need a plan — the same gate build creation applies. The free
-    // plan puts the account on the Hobby media limits, which is what most of
-    // these tests are about.
-    const plan = await factory.Plan.create({
-      name: "free",
-      includedScreenshots: 5000,
-    });
-    await factory.Subscription.create({
-      accountId: account.id,
-      planId: plan.id,
-    });
-    await use(account);
+    // The free plan puts the account on the Hobby media limits, which is what
+    // most of these tests are about.
+    await use(await createTeamAccountOnPlan({ user, planName: "free" }));
   },
   project: async ({ account }, use) => {
     await use(
@@ -327,6 +343,94 @@ describe("createMedia", () => {
     expect(second.body.media.id).toBe(first.body.media.id);
     expect(second.body.media.url).toBe(first.body.media.url);
   });
+});
+
+/**
+ * Who can open the share page of a media that did not ask for a visibility.
+ *
+ * The everyday upload takes no flag, so this default is what most share pages
+ * actually get — and getting it wrong either leaks a private product's
+ * screenshots or breaks the link for the reviewer the feature exists for. Worth
+ * pinning end to end.
+ */
+describe("createMedia default visibility", () => {
+  // Hobby is public-only, so it cannot show what the project's visibility does.
+  const proTest = test.extend<{ account: Account }>({
+    account: async ({ user }, use) => {
+      await use(await createTeamAccountOnPlan({ user, planName: "pro" }));
+    },
+  });
+
+  async function upload(args: {
+    projectToken: string;
+    hash: string;
+    visibility?: "team" | "public";
+  }) {
+    return request(app)
+      .post("/media")
+      .set("Authorization", `Bearer ${args.projectToken}`)
+      .send({
+        name: "before.png",
+        contentType: "image/png",
+        size: 1024,
+        hash: args.hash,
+        ...(args.visibility ? { visibility: args.visibility } : {}),
+      })
+      .expect(201);
+  }
+
+  proTest(
+    "is public on a public project",
+    async ({ project, projectToken }) => {
+      await project.$query().patch({ private: false });
+
+      const res = await upload({ projectToken, hash: HASH });
+
+      // Nothing the project does not already show, and the link works for a
+      // reviewer with no Argos account.
+      expect(res.body.media.visibility).toBe("public");
+    },
+  );
+
+  proTest(
+    "is team-only on a private project",
+    async ({ project, projectToken }) => {
+      await project.$query().patch({ private: true });
+
+      const res = await upload({ projectToken, hash: HASH });
+
+      // Uploading a screenshot of a private product must not publish it.
+      expect(res.body.media.visibility).toBe("team");
+    },
+  );
+
+  test("falls back to public on a private project whose plan has no team-scoped page", async ({
+    project,
+    projectToken,
+  }) => {
+    await project.$query().patch({ private: true });
+
+    const res = await upload({ projectToken, hash: HASH });
+
+    // Hobby sells no team-scoped share page, so this is the whole of what the
+    // plan can offer — and what its documentation promises.
+    expect(res.body.media.visibility).toBe("public");
+  });
+
+  proTest(
+    "leaves a visibility chosen once alone on the next upload",
+    async ({ project, projectToken }) => {
+      await project.$query().patch({ private: false });
+      await upload({ projectToken, hash: HASH, visibility: "team" });
+
+      // Same name, so this is a new version of that media — and it names no
+      // visibility. Handing it back to the project's default here would publish a
+      // deliberately team-only screenshot, silently.
+      const res = await upload({ projectToken, hash: OTHER_HASH });
+
+      expect(res.body.media).toMatchObject({ version: 2, visibility: "team" });
+    },
+  );
 });
 
 describe("getMedia", () => {

--- a/apps/backend/src/api/schema/primitives/media.ts
+++ b/apps/backend/src/api/schema/primitives/media.ts
@@ -181,7 +181,10 @@ export const MediaInputSchema = z.object({
     description:
       "SHA-256 of the file contents, hex encoded. Uploading the same file twice is free: Argos recognizes the hash and skips the transfer, and byte-identical bytes do not create a new version.",
   }),
-  visibility: MediaVisibilitySchema.nullish(),
+  visibility: MediaVisibilitySchema.nullish().meta({
+    description:
+      "Who can open the media share page. `team` requires an Argos session with access to the owning account; `public` only requires the share URL. Omit it — the usual case — and the media follows its project's visibility: `public` for a public project, `team` for a private one. `team` requires a paid plan.",
+  }),
 });
 
 /** Serialize one stored upload. */

--- a/apps/backend/src/media/create.ts
+++ b/apps/backend/src/media/create.ts
@@ -66,6 +66,10 @@ export type CreateMediaParams = {
   sizeBytes: number;
   /** SHA-256 of the file contents, hex encoded. Makes the key content-addressed. */
   hash: string;
+  /**
+   * Who can open the share page, when the caller has an opinion. `null` means it
+   * follows the project's visibility — see {@link resolveDefaultVisibility}.
+   */
   visibility: MediaVisibility | null;
 };
 
@@ -98,8 +102,9 @@ export async function createMedia(
   const limits = await getMediaLimits(account);
 
   assertWithinFileSizeLimit({ sizeBytes: params.sizeBytes, limits });
-  const visibility = resolveVisibility({
-    requested: params.visibility,
+  assertVisibilityAllowedByPlan({ requested: params.visibility, limits });
+  const defaultVisibility = await resolveDefaultVisibility({
+    project: params.project,
     limits,
   });
 
@@ -113,7 +118,7 @@ export async function createMedia(
   const { media, version } = await upsertMediaVersion({
     ...params,
     key,
-    visibility,
+    defaultVisibility,
     expiresAt,
   });
 
@@ -157,7 +162,7 @@ export async function createMedia(
 async function upsertMediaVersion(
   params: CreateMediaParams & {
     key: string;
-    visibility: MediaVisibility;
+    defaultVisibility: MediaVisibility;
     expiresAt: Date;
   },
 ): Promise<{ media: Media; version: MediaVersion }> {
@@ -170,6 +175,7 @@ async function upsertMediaVersion(
     description,
     key,
     visibility,
+    defaultVisibility,
     expiresAt,
   } = params;
 
@@ -247,7 +253,12 @@ async function upsertMediaVersion(
         ? // The description travels with the newest upload that supplied one, so
           // re-uploading with better wording updates what the comment says.
           await existing.$query().patchAndFetch({
-            visibility,
+            // Only when the caller named one. Visibility is a decision somebody
+            // made about *this* media, so re-uploading without repeating it must
+            // not hand the media back to the project's default — that would turn
+            // a deliberately team-only screenshot on a public project world-
+            // readable on the next upload, silently.
+            ...(visibility === null ? {} : { visibility }),
             ...(description === null ? {} : { description }),
             // A published media learns the branch it came from when a later
             // upload names one. It never loses it: identity ignores the branch
@@ -264,7 +275,7 @@ async function upsertMediaVersion(
               name,
               state,
               description,
-              visibility,
+              visibility: visibility ?? defaultVisibility,
               shareToken: generateShareToken(),
             })
             .catch(async (error: unknown) => {
@@ -408,19 +419,45 @@ function assertWithinFileSizeLimit(args: {
   }
 }
 
-function resolveVisibility(args: {
+function assertVisibilityAllowedByPlan(args: {
   requested: MediaVisibility | null;
   limits: MediaLimits;
-}): MediaVisibility {
+}): void {
   const { requested, limits } = args;
-  if (!requested) {
-    return limits.defaultVisibility;
-  }
-  if (!limits.allowedVisibilities.includes(requested)) {
+  if (requested && !limits.allowedVisibilities.includes(requested)) {
     throw boom(
       402,
       `The \`${requested}\` visibility requires a paid plan. Media uploaded on the Hobby plan is reachable by anyone holding its share URL.`,
     );
   }
-  return requested;
+}
+
+/**
+ * The visibility a new media gets when the upload does not name one: its
+ * project's.
+ *
+ * A public project's screenshots are already visible to anyone who can see the
+ * project, so a public share page gives away nothing the project does not — and
+ * it is what makes the link work for the pull request reviewer with no Argos
+ * account the feature exists for. A private project's must not become
+ * world-readable by being uploaded, so they stay team-only.
+ *
+ * Inferred rather than stored, so a project switched from public to private stops
+ * producing public share pages from the next upload on, with nothing to migrate.
+ * Media already created keeps the visibility it was created with: its share URL
+ * is pasted in pull requests, and retroactively closing those pages is a decision
+ * for whoever flipped the project, not a side effect of the next upload.
+ *
+ * The plan is still the outer bound: a private project on a public-only plan gets
+ * a public share page, which is what the Hobby tier is.
+ */
+async function resolveDefaultVisibility(args: {
+  project: Project;
+  limits: MediaLimits;
+}): Promise<MediaVisibility> {
+  const { project, limits } = args;
+  const inferred = (await project.$checkIsPublic()) ? "public" : "team";
+  return limits.allowedVisibilities.includes(inferred)
+    ? inferred
+    : limits.fallbackVisibility;
 }

--- a/apps/backend/src/media/limits.test.ts
+++ b/apps/backend/src/media/limits.test.ts
@@ -6,7 +6,7 @@ const limits: MediaLimits = {
   maxFileBytes: 50 * 1024 * 1024,
   retentionDays: 30,
   allowedVisibilities: ["public"],
-  defaultVisibility: "public",
+  fallbackVisibility: "public",
 };
 
 const now = new Date("2026-08-08T12:00:00.000Z");

--- a/apps/backend/src/media/limits.ts
+++ b/apps/backend/src/media/limits.ts
@@ -25,8 +25,15 @@ export type MediaLimits = {
   retentionDays: number;
   /** Visibilities the caller may choose from. */
   allowedVisibilities: MediaVisibility[];
-  /** Visibility applied when the caller doesn't choose one. */
-  defaultVisibility: MediaVisibility;
+  /**
+   * Visibility applied when the project's own maps to one this plan does not
+   * allow — the most private option left.
+   *
+   * Not the default an upload gets: that comes from the **project**, so a
+   * screenshot of a private product is not made world-readable by being
+   * uploaded. This is only what is left when the plan cannot honour it.
+   */
+  fallbackVisibility: MediaVisibility;
 };
 
 const HOBBY_LIMITS: MediaLimits = {
@@ -36,16 +43,16 @@ const HOBBY_LIMITS: MediaLimits = {
   // the free tier usable for its actual job — reviewers of a pull request who
   // have never heard of Argos can still open the link.
   allowedVisibilities: ["public"],
-  defaultVisibility: "public",
+  fallbackVisibility: "public",
 };
 
 const PRO_LIMITS: MediaLimits = {
   maxFileBytes: 500 * 1024 * 1024,
   retentionDays: 365,
   allowedVisibilities: ["team", "public"],
-  // Private by default. Uploading a screenshot of a private product must not
-  // make it world-readable, which is exactly what every free alternative does.
-  defaultVisibility: "team",
+  // Never reached — a Pro plan can honour either project visibility. Kept as the
+  // most private option so it stays a safe answer if the allowed set narrows.
+  fallbackVisibility: "team",
 };
 
 /**

--- a/apps/frontend/src/containers/Project/Visibility.tsx
+++ b/apps/frontend/src/containers/Project/Visibility.tsx
@@ -89,7 +89,10 @@ export const ProjectVisibility = (props: {
           <CardTitle>Project visibility</CardTitle>
           <CardParagraph>
             Make a public project private in order to restrict access to builds
-            and screenshots to only authorized users.
+            and screenshots to only authorized users. It also sets what media
+            uploaded from now on defaults to: a public project's share pages are
+            open to anyone with the link, a private project's require an Argos
+            session. Media already uploaded keeps the visibility it has.
           </CardParagraph>
           <FormRadioGroup>
             <FormRadio

--- a/packages/schemas/src/media.ts
+++ b/packages/schemas/src/media.ts
@@ -71,11 +71,14 @@ export const MediaContentTypeSchema = z
 /**
  * Who can open a media share page.
  *
- * - `team` — requires an Argos session with access to the owning account. This
- *   is the default, and the reason a private repository's screenshots don't
- *   become world-readable by being uploaded.
+ * - `team` — requires an Argos session with access to the owning account.
  * - `public` — anyone holding the (unguessable) share URL. Needed when the
  *   reviewers of a pull request have no Argos account.
+ *
+ * An upload that names neither follows its **project's** visibility: public
+ * project, public media; private project, team-only media. That is what keeps a
+ * private repository's screenshots from becoming world-readable by being
+ * uploaded, without making the everyday public-project case take a flag.
  */
 export const MEDIA_VISIBILITIES = ["team", "public"] as const;
 


### PR DESCRIPTION
Closes ARG-501.

A media uploaded without naming a visibility now follows the visibility of the project it belongs to: a **public** project's media is `public`, a **private** project's is `team`. Before, the default came from the plan alone — every Pro upload was team-only, so the public-project case the share link exists for took an explicit `--visibility public` every time.

The plan stays the outer bound: a private project on a public-only plan still gets a public share page, which is what the Hobby tier is. Asking for `team` there is still a 402 rather than a silent downgrade.

### What changed

- `resolveVisibility` in `media/create.ts` is split into `assertVisibilityAllowedByPlan` (the plan gate, unchanged) and `resolveDefaultVisibility` (reads `project.$checkIsPublic()`).
- `MediaLimits.defaultVisibility` → `fallbackVisibility`. The plan no longer names the default, only what is left when it cannot honour the project's.
- `MediaVisibilitySchema` and `MediaInputSchema.visibility` descriptions rewritten. The MCP tool surface is generated from the OpenAPI document, so `createMedia`'s agent-facing docs follow with no MCP code touched.
- The project visibility settings card now says visibility also sets the media default. **This moves a visual baseline.**

### One fix beyond the issue

`upsertMediaVersion` used to patch `visibility` on every re-upload. Under the new default that becomes a leak: re-uploading a deliberately team-only media on a *public* project, without repeating `--visibility`, would hand it back to the project's default and publish it silently. It now only patches when the caller names a visibility, so a visibility chosen once survives later uploads.

Visibility is inferred at creation rather than looked up per view, so flipping a project to private closes the share pages of media uploaded from then on and leaves the URLs already pasted into pull requests working. That is deliberate — retroactively breaking those embeds should be an explicit act, not a side effect of the next upload — and it is documented in the docs PR.

### Testing

4 e2e tests in `media.e2e.test.ts` covering public project, private project, the Hobby fallback, and the re-upload guard. The guard test was verified to fail without the fix. 113 media integration tests pass; `check-types`, `check-format` and `lint` are clean.

`knip` fails on this branch, identically to `main` with these changes stashed (242 unused migration files, unused `pg` dependency) — pre-existing, not from this work.

### Companion PRs

- argos-ci/argos-javascript — CLI flag, SDK option, upload skill
- argos-ci/docs — share links, upload guide, CLI and SDK references

🤖 Generated with [Claude Code](https://claude.com/claude-code)