### PR TITLE
feat(build): offer the next build to review, and switch between them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,17 @@ jobs:
         #   --health-timeout 5s
         #   --health-retries 5
 
+      # Named after the host in `AMQP_URL` below: the web server runs inside
+      # the Playwright container and reaches services by their label. Without
+      # it, anything that enqueues a job — submitting a build review, say —
+      # blocks forever on a broker that does not resolve, and the request that
+      # triggered it never answers.
+      rabbitmq:
+        # Keep in sync with docker-compose.yml and production (Amazon MQ 4.2).
+        image: rabbitmq:4.2-alpine
+        ports:
+          - 5672:5672
+
     steps:
       - name: Check out repository code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -1010,6 +1010,125 @@ export async function createFallbackBaselineScenario(input: {
 }
 
 /**
+ * Two builds sharing one head commit and branch, told apart by their build
+ * name — the shape a project gets when a commit runs several suites. Both end
+ * up with changes waiting, so finishing one leaves the other to review.
+ */
+export async function createSiblingBuildsScenario(input: {
+  projectId: string;
+}): Promise<{ defaultBuild: Build; storybookBuild: Build }> {
+  const { projectId } = input;
+  const seededAt = getSeedInstant();
+  const branch = "feat/sparkle";
+  const baseCommit = "b1a7a4a1e5f0c3d2b9a8e7f6c5d4b3a2f1e0d9c8";
+  const headCommit = "c2b8b5b2f6a1d4e3c0b9f8a7d6e5c4b3a2f1e0d9";
+
+  const [baseFile, compareFile, diffFile] = await Promise.all([
+    ensureFile({
+      type: "screenshot",
+      width: 375,
+      height: 1024,
+      key: "dummy-375x1024.png",
+      contentType: "image/png",
+    }),
+    ensureFile({
+      type: "screenshot",
+      width: 375,
+      height: 720,
+      key: "dummy-375x720.png",
+      contentType: "image/png",
+    }),
+    ensureFile({
+      type: "screenshotDiff",
+      width: 375,
+      height: 1024,
+      key: "diff-1024-to-720.png",
+      contentType: "image/png",
+    }),
+  ]);
+
+  async function createSiblingBuild(options: { name: string; number: number }) {
+    const { name, number } = options;
+    const bucketProps = {
+      name,
+      projectId,
+      complete: true,
+      valid: true,
+      screenshotCount: 1,
+      storybookScreenshotCount: 0,
+      createdAt: seededAt,
+      updatedAt: seededAt,
+    };
+    const [baseBucket, compareBucket] =
+      await ScreenshotBucket.query().insertAndFetch([
+        { ...bucketProps, branch: "main", commit: baseCommit },
+        { ...bucketProps, branch, commit: headCommit },
+      ]);
+    invariant(baseBucket && compareBucket);
+
+    const test = await Test.query().insertAndFetch({
+      name: "home.png",
+      buildName: name,
+      projectId,
+    });
+
+    const [baseScreenshot, compareScreenshot] =
+      await Screenshot.query().insertAndFetch([
+        {
+          screenshotBucketId: baseBucket.id,
+          testId: test.id,
+          name: "home.png",
+          s3Id: baseFile.key,
+          fileId: baseFile.id,
+        },
+        {
+          screenshotBucketId: compareBucket.id,
+          testId: test.id,
+          name: "home.png",
+          s3Id: compareFile.key,
+          fileId: compareFile.id,
+        },
+      ]);
+    invariant(baseScreenshot && compareScreenshot);
+
+    const build = await Build.query().insertAndFetch({
+      name,
+      number,
+      type: "check" as const,
+      jobStatus: "complete" as const,
+      baseScreenshotBucketId: baseBucket.id,
+      compareScreenshotBucketId: compareBucket.id,
+      projectId,
+      createdAt: seededAt,
+      updatedAt: seededAt,
+    });
+
+    await ScreenshotDiff.query().insert({
+      buildId: build.id,
+      baseScreenshotId: baseScreenshot.id,
+      compareScreenshotId: compareScreenshot.id,
+      testId: test.id,
+      score: 0.3,
+      jobStatus: "complete" as const,
+      s3Id: diffFile.key,
+      fileId: diffFile.id,
+      createdAt: seededAt,
+      updatedAt: seededAt,
+    });
+
+    // Computes the build stats and conclusion the build page relies on.
+    await concludeBuild({ build, notify: false });
+
+    return build;
+  }
+
+  return {
+    defaultBuild: await createSiblingBuild({ name: "default", number: 1 }),
+    storybookBuild: await createSiblingBuild({ name: "storybook", number: 2 }),
+  };
+}
+
+/**
  * Manifest for the "real world" build scenario below.
  *
  * The referenced assets (screenshots, diffs, Playwright traces and markdown

--- a/apps/backend/src/graphql/definitions/Build.ts
+++ b/apps/backend/src/graphql/definitions/Build.ts
@@ -140,7 +140,7 @@ export const typeDefs = gql`
     commentsCount: Int!
     "Previous approved diffs from a build with the same branch"
     branchApprovedDiffs: [ID!]!
-    "Other builds covering the same head commit and branch, one per build name"
+    "The commit's other suites on this branch: one build per name, latest run, this build's own name excluded"
     siblingBuilds: [Build!]!
     "Build is triggered in a merge queue"
     mergeQueue: Boolean!
@@ -489,9 +489,14 @@ export const resolvers: IResolvers = {
         .orderBy("builds.name")
         .orderBy("builds.id", "desc");
 
+      // Told apart by name, not by id: siblings are the commit's *other*
+      // suites. Dropping this build's name rather than this build drops its
+      // own earlier runs with it — a re-run of one suite is the same suite,
+      // and offering it as somewhere else to go would list the same word
+      // twice and put a switcher on every build of every re-run commit.
       return Build.query()
         .whereIn("builds.id", latestPerName)
-        .whereNot("builds.id", build.id)
+        .whereNot("builds.name", build.name)
         .orderBy("builds.name");
     },
     subscribed: async (build, _args, ctx) => {

--- a/apps/backend/src/graphql/definitions/Build.ts
+++ b/apps/backend/src/graphql/definitions/Build.ts
@@ -9,6 +9,7 @@ import {
 } from "@/build/baselineEligibility";
 import { getBuildImpactAnalysis } from "@/build/impact-analysis";
 import { Build, BuildNotificationSubscription } from "@/database/models";
+import { queryBuilds } from "@/database/services/build";
 import { sortScreenshotDiffsForBuild } from "@/database/services/screenshot-diffs";
 import { getProjectMemberIds } from "@/project/members";
 
@@ -139,6 +140,8 @@ export const typeDefs = gql`
     commentsCount: Int!
     "Previous approved diffs from a build with the same branch"
     branchApprovedDiffs: [ID!]!
+    "Other builds covering the same head commit and branch, one per build name"
+    siblingBuilds: [Build!]!
     "Build is triggered in a merge queue"
     mergeQueue: Boolean!
     "Indicates whether this build contains only a subset of screenshots"
@@ -464,6 +467,32 @@ export const resolvers: IResolvers = {
         compareBucket,
         userId: ctx.auth.user.id,
       });
+    },
+    siblingBuilds: async (build, _args, ctx) => {
+      const compareBucket = await getCompareScreenshotBucket(ctx, build);
+      // Without a branch we cannot tell a sibling from any other build that
+      // happens to share the commit.
+      if (!compareBucket.branch) {
+        return [];
+      }
+      // One build per name: a suite that was re-run leaves older builds behind
+      // on the same commit, and only its latest run is worth reviewing.
+      const latestPerName = queryBuilds({
+        projectId: build.projectId,
+        filters: {
+          branch: compareBucket.branch,
+          commit: build.prHeadCommit ?? compareBucket.commit,
+        },
+      })
+        .select("builds.id")
+        .distinctOn("builds.name")
+        .orderBy("builds.name")
+        .orderBy("builds.id", "desc");
+
+      return Build.query()
+        .whereIn("builds.id", latestPerName)
+        .whereNot("builds.id", build.id)
+        .orderBy("builds.name");
     },
     subscribed: async (build, _args, ctx) => {
       if (!ctx.auth) {

--- a/apps/frontend/src/pages/Build/BuildNextReviewDialog.tsx
+++ b/apps/frontend/src/pages/Build/BuildNextReviewDialog.tsx
@@ -1,0 +1,183 @@
+import { createContext, use, useEffect, useMemo } from "react";
+import { invariant } from "@argos/util/invariant";
+
+import { BuildStatusChip } from "@/containers/BuildStatusChip";
+import { DocumentType, graphql } from "@/gql";
+import { BuildStatus } from "@/gql/graphql";
+import { LinkButton } from "@/ui/Button";
+import {
+  Dialog,
+  DialogBody,
+  DialogDismiss,
+  DialogFooter,
+  DialogText,
+  DialogTitle,
+  useDialogValueState,
+} from "@/ui/Dialog";
+import { List, ListRowLink } from "@/ui/List";
+import { Modal } from "@/ui/Modal";
+import { Truncable } from "@/ui/Truncable";
+import { useEventCallback } from "@/ui/useEventCallback";
+
+import { useProjectParams } from "../Project/ProjectParams";
+import { getBuildOverviewURL } from "./BuildParams";
+import { BuildStatsIndicator } from "./BuildStatsIndicator";
+
+const _BuildFragment = graphql(`
+  fragment BuildNextReviewDialog_Build on Build {
+    siblingBuilds {
+      id
+      number
+      name
+      status
+      subset
+      viewerHasSubmittedReview
+      stats {
+        ...BuildStatsIndicator_BuildStats
+      }
+      ...BuildStatusChip_Build
+    }
+  }
+`);
+
+export type SiblingBuild = DocumentType<
+  typeof _BuildFragment
+>["siblingBuilds"][number];
+
+/**
+ * The builds still waiting for the viewer to make a call: nobody has concluded
+ * them yet, and the viewer hasn't weighed in either.
+ */
+function getBuildsAwaitingReview(builds: SiblingBuild[]): SiblingBuild[] {
+  return builds.filter(
+    (build) =>
+      build.status === BuildStatus.ChangesDetected &&
+      !build.viewerHasSubmittedReview,
+  );
+}
+
+type ContextValue = {
+  /**
+   * Offer to move on to the next build of the same commit awaiting a review.
+   * Does nothing when there is none — the reviewer is done with this commit.
+   */
+  promptNextReview: (builds: SiblingBuild[]) => void;
+};
+
+const BuildNextReviewDialogContext = createContext<ContextValue | null>(null);
+
+export function useBuildNextReviewPrompt(): ContextValue {
+  const context = use(BuildNextReviewDialogContext);
+  invariant(
+    context,
+    "useBuildNextReviewPrompt must be called in BuildNextReviewDialogProvider",
+  );
+  return context;
+}
+
+export function BuildNextReviewDialogProvider(props: {
+  buildNumber: number;
+  children: React.ReactNode;
+}) {
+  const { buildNumber, children } = props;
+  const dialog = useDialogValueState<SiblingBuild[] | null>(null);
+
+  const promptNextReview = useEventCallback((builds: SiblingBuild[]) => {
+    if (getBuildsAwaitingReview(builds).length === 0) {
+      return;
+    }
+    dialog.open(builds);
+  });
+  const value = useMemo(() => ({ promptNextReview }), [promptNextReview]);
+
+  // The prompt belongs to the build that was just reviewed. Jumping to another
+  // build keeps this provider mounted (same route, different param), so close
+  // the dialog by hand — otherwise it outlives the navigation and keeps
+  // offering the previous build's siblings.
+  const close = useEventCallback(() => dialog.onOpenChange(false));
+  useEffect(() => {
+    close();
+  }, [buildNumber, close]);
+
+  return (
+    <>
+      {dialog.value ? (
+        <Modal
+          isOpen={dialog.isOpen}
+          onOpenChange={dialog.onOpenChange}
+          isDismissable
+        >
+          <BuildNextReviewDialog builds={dialog.value} />
+        </Modal>
+      ) : null}
+      <BuildNextReviewDialogContext value={value}>
+        {children}
+      </BuildNextReviewDialogContext>
+    </>
+  );
+}
+
+function BuildNextReviewDialog(props: { builds: SiblingBuild[] }) {
+  const { builds } = props;
+  const projectParams = useProjectParams();
+  invariant(projectParams, "The build page always has project params");
+  const awaitingReview = getBuildsAwaitingReview(builds);
+  const [nextBuild] = awaitingReview;
+  invariant(nextBuild, "The dialog only opens when a build awaits a review");
+
+  return (
+    <Dialog size="medium">
+      <DialogBody>
+        <DialogTitle>Review the next build</DialogTitle>
+        <DialogText>
+          {awaitingReview.length === 1
+            ? "One more build ran on this commit and still needs your review."
+            : `${awaitingReview.length} more builds ran on this commit and still need your review.`}
+        </DialogText>
+        <List>
+          {builds.map((build) => (
+            <ListRowLink
+              key={build.id}
+              href={getBuildOverviewURL({
+                ...projectParams,
+                buildNumber: build.number,
+              })}
+              className="flex items-center gap-4 p-3 text-sm"
+            >
+              <div className="w-28 shrink-0">
+                <div className="tabular-nums">Build {build.number}</div>
+                <Truncable className="text-low mt-0.5 text-xs">
+                  {build.name}
+                </Truncable>
+              </div>
+              <div className="w-44 shrink-0">
+                <BuildStatusChip build={build} scale="sm" />
+              </div>
+              <div className="hidden grow justify-end sm:flex">
+                {build.stats ? (
+                  <BuildStatsIndicator
+                    stats={build.stats}
+                    isSubsetBuild={build.subset}
+                    className="flex-wrap justify-end"
+                  />
+                ) : null}
+              </div>
+            </ListRowLink>
+          ))}
+        </List>
+      </DialogBody>
+      <DialogFooter>
+        <DialogDismiss>Not now</DialogDismiss>
+        <LinkButton
+          href={getBuildOverviewURL({
+            ...projectParams,
+            buildNumber: nextBuild.number,
+          })}
+          autoFocus
+        >
+          Review build {nextBuild.number}
+        </LinkButton>
+      </DialogFooter>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/pages/Build/BuildNextReviewDialog.tsx
+++ b/apps/frontend/src/pages/Build/BuildNextReviewDialog.tsx
@@ -103,9 +103,9 @@ export function BuildNextReviewDialogProvider(props: {
     <>
       {dialog.value ? (
         <Modal
-          isOpen={dialog.isOpen}
+          open={dialog.isOpen}
           onOpenChange={dialog.onOpenChange}
-          isDismissable
+          dismissible
         >
           <BuildNextReviewDialog builds={dialog.value} />
         </Modal>

--- a/apps/frontend/src/pages/Build/BuildNextReviewDialog.tsx
+++ b/apps/frontend/src/pages/Build/BuildNextReviewDialog.tsx
@@ -144,11 +144,16 @@ function BuildNextReviewDialog(props: { builds: SiblingBuild[] }) {
               })}
               className="flex items-center gap-4 p-3 text-sm"
             >
+              {/*
+               * Named by its build name, not its number: on one commit the
+               * name is what tells the builds apart, and it is the same word
+               * the reviewer configured in CI.
+               */}
               <div className="w-28 shrink-0">
-                <div className="tabular-nums">Build {build.number}</div>
-                <Truncable className="text-low mt-0.5 text-xs">
-                  {build.name}
-                </Truncable>
+                <Truncable className="font-medium">{build.name}</Truncable>
+                <div className="text-low mt-0.5 text-xs tabular-nums">
+                  Build {build.number}
+                </div>
               </div>
               <div className="w-44 shrink-0">
                 <BuildStatusChip build={build} scale="sm" />
@@ -175,7 +180,7 @@ function BuildNextReviewDialog(props: { builds: SiblingBuild[] }) {
           })}
           autoFocus
         >
-          Review build {nextBuild.number}
+          Review {nextBuild.name}
         </LinkButton>
       </DialogFooter>
     </Dialog>

--- a/apps/frontend/src/pages/Build/BuildPage.tsx
+++ b/apps/frontend/src/pages/Build/BuildPage.tsx
@@ -9,6 +9,7 @@ import { BuildStatus } from "@/gql/graphql";
 import { Loader } from "@/ui/Loader";
 
 import { BuildDiffProvider } from "./BuildDiffState";
+import { BuildNextReviewDialogProvider } from "./BuildNextReviewDialog";
 import { BuildNotFound } from "./BuildNotFound";
 import type { BuildParams } from "./BuildParams";
 import { BuildReviewDialogProvider } from "./BuildReviewDialog";
@@ -97,41 +98,43 @@ export const BuildPage = ({ params }: { params: BuildParams }) => {
         >
           <BuildDiffProvider params={params} build={build}>
             <BuildReviewDialogProvider project={data?.project ?? null}>
-              <RejectCommentDialogProvider build={build}>
-                <div className="flex h-screen min-h-0 flex-col">
-                  {data?.project?.account && (
-                    <>
-                      <PaymentBanner account={data.project.account} />
-                      <OvercapacityBanner
-                        account={data.project.account}
-                        accountSlug={params.accountSlug}
-                      />
-                    </>
-                  )}
-                  <BuildHeader
-                    buildNumber={params.buildNumber}
-                    accountSlug={params.accountSlug}
-                    projectName={params.projectName}
-                    build={build}
-                    project={data?.project ?? null}
-                  />
-                  {project && build ? (
-                    <BuildWorkspace
-                      params={params}
+              <BuildNextReviewDialogProvider buildNumber={params.buildNumber}>
+                <RejectCommentDialogProvider build={build}>
+                  <div className="flex h-screen min-h-0 flex-col">
+                    {data?.project?.account && (
+                      <>
+                        <PaymentBanner account={data.project.account} />
+                        <OvercapacityBanner
+                          account={data.project.account}
+                          accountSlug={params.accountSlug}
+                        />
+                      </>
+                    )}
+                    <BuildHeader
+                      buildNumber={params.buildNumber}
+                      accountSlug={params.accountSlug}
+                      projectName={params.projectName}
                       build={build}
-                      project={project}
+                      project={data?.project ?? null}
                     />
-                  ) : (
-                    // Initial load: the query is still in flight (a missing
-                    // build is caught by BuildNotFound above). Render a loader
-                    // with `aria-busy` so Argos waits for the build to render
-                    // before screenshotting, instead of catching a blank body.
-                    <div className="flex min-h-0 flex-1 items-center justify-center">
-                      <Loader className="size-16" />
-                    </div>
-                  )}
-                </div>
-              </RejectCommentDialogProvider>
+                    {project && build ? (
+                      <BuildWorkspace
+                        params={params}
+                        build={build}
+                        project={project}
+                      />
+                    ) : (
+                      // Initial load: the query is still in flight (a missing
+                      // build is caught by BuildNotFound above). Render a loader
+                      // with `aria-busy` so Argos waits for the build to render
+                      // before screenshotting, instead of catching a blank body.
+                      <div className="flex min-h-0 flex-1 items-center justify-center">
+                        <Loader className="size-16" />
+                      </div>
+                    )}
+                  </div>
+                </RejectCommentDialogProvider>
+              </BuildNextReviewDialogProvider>
             </BuildReviewDialogProvider>
           </BuildDiffProvider>
         </BuildReviewStateProvider>

--- a/apps/frontend/src/pages/Build/BuildReviewAction.ts
+++ b/apps/frontend/src/pages/Build/BuildReviewAction.ts
@@ -8,6 +8,7 @@ import { useProjectParams } from "@/pages/Project/ProjectParams";
 import { EditorValue } from "@/ui/Editor/Editor";
 import { useEventCallback } from "@/ui/useEventCallback";
 
+import { useBuildNextReviewPrompt } from "./BuildNextReviewDialog";
 import {
   useBuildReviewAPI,
   useGetReviewedDiffStatuses,
@@ -25,6 +26,10 @@ const CreateBuildReviewMutation = graphql(`
       id
       status
       ...BuildReviewAction_Build
+      # Re-read the siblings on the way out: the prompt is about what is left
+      # to review right now, and someone else may have settled one of them
+      # since this page loaded.
+      ...BuildNextReviewDialog_Build
     }
   }
 `);
@@ -48,6 +53,7 @@ export function useCreateBuildReviewMutation(
 ) {
   const api = useBuildReviewAPI();
   const openReviewSidebar = useOpenReviewSidebar();
+  const { promptNextReview } = useBuildNextReviewPrompt();
   const projectParams = useProjectParams();
   const client = useApolloClient();
 
@@ -89,6 +95,13 @@ export function useCreateBuildReviewMutation(
       options?.onCompleted?.();
       api.setDiffStatuses(diffStatuses);
       openReviewSidebar();
+      // Approving or rejecting settles this build, so it's the moment to offer
+      // the next one. A neutral comment deliberately leaves the build
+      // undecided — sending the reviewer elsewhere would fight that intent.
+      const siblingBuilds = result.data?.createBuildReview.siblingBuilds;
+      if (siblingBuilds && input.event !== BuildReviewEvent.Comment) {
+        promptNextReview(siblingBuilds);
+      }
       return result;
     },
   );

--- a/apps/frontend/src/pages/Build/header/BuildHeader.tsx
+++ b/apps/frontend/src/pages/Build/header/BuildHeader.tsx
@@ -218,7 +218,13 @@ export const BuildHeader = memo(
             <SyncingIcon />
           </div>
           <div className="flex min-w-0 flex-col justify-center">
-            <div className="mb-1 flex min-w-0 items-start gap-1">
+            {/*
+             * Centered rather than top-aligned: the title truncates instead of
+             * wrapping, so there is no second line for the mode indicator and
+             * the build switcher to hang off — they read as misaligned against
+             * a single line of text.
+             */}
+            <div className="mb-1 flex min-w-0 items-center gap-1">
               <BuildModeIndicator
                 mode={build ? build.mode : BuildMode.Ci}
                 scale="sm"

--- a/apps/frontend/src/pages/Build/header/BuildHeader.tsx
+++ b/apps/frontend/src/pages/Build/header/BuildHeader.tsx
@@ -29,6 +29,7 @@ import {
 } from "../BuildReviewButton";
 import { ReviewProgressBadge } from "../ReviewProgressBadge";
 import { createBuildReviewPrompt } from "./BuildReviewPrompt";
+import { BuildSwitcher } from "./BuildSwitcher";
 
 const _BuildFragment = graphql(`
   fragment BuildHeader_Build on Build {
@@ -46,6 +47,7 @@ const _BuildFragment = graphql(`
     ...BuildTestStatusChip_Build
     ...BuildBaselineEligibilityChip_Build
     ...BuildReviewability_Build
+    ...BuildSwitcher_Build
   }
 `);
 
@@ -234,6 +236,13 @@ export const BuildHeader = memo(
                   {build && build.name !== "default" ? ` • ${build.name}` : ""}
                 </HeadlessLink>
               </Tooltip>
+              {build ? (
+                <BuildSwitcher
+                  accountSlug={props.accountSlug}
+                  projectName={props.projectName}
+                  build={build}
+                />
+              ) : null}
             </div>
             <div className="flex min-w-0">
               <ProjectLink

--- a/apps/frontend/src/pages/Build/header/BuildSwitcher.tsx
+++ b/apps/frontend/src/pages/Build/header/BuildSwitcher.tsx
@@ -1,17 +1,17 @@
-import { CheckIcon } from "lucide-react";
-import { MenuTrigger } from "react-aria-components";
-
-import { BuildStatusChip } from "@/containers/BuildStatusChip";
 import { DocumentType, graphql } from "@/gql";
+import { BuildStatus, BuildType } from "@/gql/graphql";
+import { UpDownMenuButton } from "@/ui/Menu";
 import {
   Menu,
+  MenuHeading,
   MenuItem,
-  MenuItemIcon,
-  MenuTitle,
-  UpDownMenuButton,
-} from "@/ui/Menu";
-import { Popover } from "@/ui/Popover";
+  MenuRoot,
+  MenuSection,
+  MenuTrigger,
+} from "@/ui/menu-kit";
 import { Tooltip } from "@/ui/Tooltip";
+import { getBuildDescriptor } from "@/util/build";
+import { lowTextColorClassNames } from "@/util/colors";
 
 import { getBuildOverviewURL } from "../BuildParams";
 
@@ -20,17 +20,42 @@ const _BuildFragment = graphql(`
     id
     number
     name
-    ...BuildStatusChip_Build
+    type
+    status
     siblingBuilds {
       id
       number
       name
-      ...BuildStatusChip_Build
+      type
+      status
     }
   }
 `);
 
 type Build = DocumentType<typeof _BuildFragment>;
+
+/**
+ * Where a build's review stands, as the icon alone. The full status chip says
+ * the same thing with a label and the reviewers' avatars, which is more than a
+ * menu row can carry — the build name is what the reader scans for, and a
+ * column of chips buries it. These are the same icons the build list and the
+ * status filter use, and the label rides along as the icon's `aria-label`
+ * rather than a tooltip: one per row would fire over the neighbouring rows as
+ * the pointer runs down the column.
+ */
+function BuildStatusIcon(props: {
+  type: BuildType | null;
+  status: BuildStatus;
+}) {
+  const descriptor = getBuildDescriptor(props.type, props.status);
+  const Icon = descriptor.icon;
+  return (
+    <Icon
+      aria-label={descriptor.label}
+      className={lowTextColorClassNames[descriptor.color]}
+    />
+  );
+}
 
 /**
  * Hops between the builds a single commit produced. A commit that runs several
@@ -51,13 +76,15 @@ export function BuildSwitcher(props: {
     a.name.localeCompare(b.name),
   );
   return (
-    <MenuTrigger>
+    <MenuRoot>
       <Tooltip content="Switch build">
-        <UpDownMenuButton aria-label="Switch build" className="shrink-0" />
+        <MenuTrigger>
+          <UpDownMenuButton aria-label="Switch build" className="shrink-0" />
+        </MenuTrigger>
       </Tooltip>
-      <Popover placement="bottom start">
-        <Menu>
-          <MenuTitle>Builds on this commit</MenuTitle>
+      <Menu side="bottom" align="start">
+        <MenuSection>
+          <MenuHeading>Builds on this commit</MenuHeading>
           {builds.map((item) => (
             <MenuItem
               key={item.id}
@@ -66,29 +93,22 @@ export function BuildSwitcher(props: {
                 projectName,
                 buildNumber: item.number,
               })}
+              icon={<BuildStatusIcon type={item.type} status={item.status} />}
+              checked={item.id === build.id}
+              textValue={item.name}
             >
-              <MenuItemIcon>
-                <CheckIcon
-                  className={item.id === build.id ? undefined : "opacity-0"}
-                />
-              </MenuItemIcon>
               {/*
                * Named by its build name, not its number: on one commit the
                * name is what tells the builds apart, and it is the same word
                * the reviewer configured in CI. The number follows it, muted,
                * to tie the row back to the header.
                */}
-              <span className="flex min-w-0 items-center gap-3">
-                <span className="truncate">
-                  {item.name}{" "}
-                  <span className="text-low tabular-nums">#{item.number}</span>
-                </span>
-                <BuildStatusChip build={item} scale="sm" />
-              </span>
+              {item.name}{" "}
+              <span className="text-low tabular-nums">#{item.number}</span>
             </MenuItem>
           ))}
-        </Menu>
-      </Popover>
-    </MenuTrigger>
+        </MenuSection>
+      </Menu>
+    </MenuRoot>
   );
 }

--- a/apps/frontend/src/pages/Build/header/BuildSwitcher.tsx
+++ b/apps/frontend/src/pages/Build/header/BuildSwitcher.tsx
@@ -53,10 +53,7 @@ export function BuildSwitcher(props: {
   return (
     <MenuTrigger>
       <Tooltip content="Switch build">
-        <UpDownMenuButton
-          aria-label="Switch build"
-          className="mt-px shrink-0"
-        />
+        <UpDownMenuButton aria-label="Switch build" className="shrink-0" />
       </Tooltip>
       <Popover placement="bottom start">
         <Menu>
@@ -75,10 +72,16 @@ export function BuildSwitcher(props: {
                   className={item.id === build.id ? undefined : "opacity-0"}
                 />
               </MenuItemIcon>
+              {/*
+               * Named by its build name, not its number: on one commit the
+               * name is what tells the builds apart, and it is the same word
+               * the reviewer configured in CI. The number follows it, muted,
+               * to tie the row back to the header.
+               */}
               <span className="flex min-w-0 items-center gap-3">
                 <span className="truncate">
-                  Build {item.number}
-                  {item.name === "default" ? "" : ` • ${item.name}`}
+                  {item.name}{" "}
+                  <span className="text-low tabular-nums">#{item.number}</span>
                 </span>
                 <BuildStatusChip build={item} scale="sm" />
               </span>

--- a/apps/frontend/src/pages/Build/header/BuildSwitcher.tsx
+++ b/apps/frontend/src/pages/Build/header/BuildSwitcher.tsx
@@ -1,0 +1,91 @@
+import { CheckIcon } from "lucide-react";
+import { MenuTrigger } from "react-aria-components";
+
+import { BuildStatusChip } from "@/containers/BuildStatusChip";
+import { DocumentType, graphql } from "@/gql";
+import {
+  Menu,
+  MenuItem,
+  MenuItemIcon,
+  MenuTitle,
+  UpDownMenuButton,
+} from "@/ui/Menu";
+import { Popover } from "@/ui/Popover";
+import { Tooltip } from "@/ui/Tooltip";
+
+import { getBuildOverviewURL } from "../BuildParams";
+
+const _BuildFragment = graphql(`
+  fragment BuildSwitcher_Build on Build {
+    id
+    number
+    name
+    ...BuildStatusChip_Build
+    siblingBuilds {
+      id
+      number
+      name
+      ...BuildStatusChip_Build
+    }
+  }
+`);
+
+type Build = DocumentType<typeof _BuildFragment>;
+
+/**
+ * Hops between the builds a single commit produced. A commit that runs several
+ * suites leaves one build per suite, and the header only names the one being
+ * looked at — so without this the others are reachable only through the build
+ * list. Renders nothing when the commit produced this build alone.
+ */
+export function BuildSwitcher(props: {
+  accountSlug: string;
+  projectName: string;
+  build: Build;
+}) {
+  const { accountSlug, projectName, build } = props;
+  if (build.siblingBuilds.length === 0) {
+    return null;
+  }
+  const builds = [build, ...build.siblingBuilds].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+  return (
+    <MenuTrigger>
+      <Tooltip content="Switch build">
+        <UpDownMenuButton
+          aria-label="Switch build"
+          className="mt-px shrink-0"
+        />
+      </Tooltip>
+      <Popover placement="bottom start">
+        <Menu>
+          <MenuTitle>Builds on this commit</MenuTitle>
+          {builds.map((item) => (
+            <MenuItem
+              key={item.id}
+              href={getBuildOverviewURL({
+                accountSlug,
+                projectName,
+                buildNumber: item.number,
+              })}
+            >
+              <MenuItemIcon>
+                <CheckIcon
+                  className={item.id === build.id ? undefined : "opacity-0"}
+                />
+              </MenuItemIcon>
+              <span className="flex min-w-0 items-center gap-3">
+                <span className="truncate">
+                  Build {item.number}
+                  {item.name === "default" ? "" : ` • ${item.name}`}
+                </span>
+                <BuildStatusChip build={item} scale="sm" />
+              </span>
+            </MenuItem>
+          ))}
+        </Menu>
+      </Popover>
+    </MenuTrigger>
+  );
+}

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -4,6 +4,7 @@ import { BuildReview } from "../apps/backend/src/database/models";
 import {
   BuildScenario,
   createFallbackBaselineScenario,
+  createSiblingBuildsScenario,
 } from "../apps/backend/src/database/seeds";
 import { loggedTest } from "./logged-test";
 import { ensureTeamOwner, screenshot } from "./util";
@@ -173,6 +174,94 @@ loggedTest(
     });
   },
 );
+loggedTest(
+  "offers the next build of the commit once a review is submitted",
+  async ({ page, auth, team, project }) => {
+    await ensureTeamOwner({ team: team.team, user: auth.user });
+    const { defaultBuild, storybookBuild } = await createSiblingBuildsScenario({
+      projectId: project.id,
+    });
+
+    await page.goto(
+      `/${team.account.slug}/${project.name}/builds/${defaultBuild.number}`,
+    );
+    await page.getByRole("button", { name: "Submit review" }).click();
+    await page.getByRole("button", { name: "Approve" }).click();
+
+    // The other build ran on the same commit and nobody has reviewed it, so
+    // finishing this one hands the reviewer straight to it.
+    const dialog = page.getByRole("dialog", { name: "Review the next build" });
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.getByText("One more build ran on this commit"),
+    ).toBeVisible();
+    // The row carries what the reviewer needs to choose: which build it is,
+    // and where its review stands.
+    await expect(
+      dialog.getByRole("link", {
+        name: `Build ${storybookBuild.number} storybook Changes detected`,
+      }),
+    ).toBeVisible();
+
+    await screenshot(page, "build-next-review-dialog", {
+      replacements: {
+        [team.account.slug]: "acme",
+      },
+    });
+
+    await dialog
+      .getByRole("link", { name: `Review build ${storybookBuild.number}` })
+      .click();
+    await expect(page).toHaveURL(
+      new RegExp(`/builds/${storybookBuild.number}/overview$`),
+    );
+    // The prompt belongs to the build it was raised on: it must not survive
+    // the jump and keep pointing at the build the reviewer just left.
+    await expect(dialog).toBeHidden();
+  },
+);
+
+loggedTest(
+  "header switches between the builds of a commit",
+  async ({ page, auth, team, project }) => {
+    await ensureTeamOwner({ team: team.team, user: auth.user });
+    const { defaultBuild, storybookBuild } = await createSiblingBuildsScenario({
+      projectId: project.id,
+    });
+
+    await page.goto(
+      `/${team.account.slug}/${project.name}/builds/${defaultBuild.number}`,
+    );
+    await page.getByRole("button", { name: "Switch build" }).click();
+
+    // Every build of the commit is listed with where its review stands, the
+    // one being looked at included.
+    const menu = page.getByRole("menu");
+    await expect(
+      menu.getByRole("menuitem", {
+        name: `Build ${defaultBuild.number} Changes detected`,
+      }),
+    ).toBeVisible();
+    const storybookItem = menu.getByRole("menuitem", {
+      name: new RegExp(
+        `Build ${storybookBuild.number}.*storybook Changes detected`,
+      ),
+    });
+    await expect(storybookItem).toBeVisible();
+
+    await screenshot(page, "build-switcher", {
+      replacements: {
+        [team.account.slug]: "acme",
+      },
+    });
+
+    await storybookItem.click();
+    await expect(page).toHaveURL(
+      new RegExp(`/builds/${storybookBuild.number}/overview$`),
+    );
+  },
+);
+
 loggedTest(
   "build sidebar marks a review an agent submitted for its reviewer",
   async ({ page, auth, team, project, builds }) => {

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -239,15 +239,16 @@ loggedTest(
     await page.getByRole("button", { name: "Switch build" }).click();
 
     // Every build of the commit is listed with where its review stands, the
-    // one being looked at included.
-    const menu = page.getByRole("menu");
+    // one being looked at included. The menu kit is a listbox driven by a
+    // search field, so its rows are options rather than menu items.
+    const menu = page.getByRole("listbox");
     await expect(
-      menu.getByRole("menuitem", {
-        name: `${defaultBuild.name} #${defaultBuild.number} Changes detected`,
+      menu.getByRole("option", {
+        name: `Changes detected ${defaultBuild.name} #${defaultBuild.number}`,
       }),
     ).toBeVisible();
-    const storybookItem = menu.getByRole("menuitem", {
-      name: `${storybookBuild.name} #${storybookBuild.number} Changes detected`,
+    const storybookItem = menu.getByRole("option", {
+      name: `Changes detected ${storybookBuild.name} #${storybookBuild.number}`,
     });
     await expect(storybookItem).toBeVisible();
 

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -193,9 +193,9 @@ loggedTest(
     //
     // The prompt waits on the review mutation's response, and the server only
     // answers it once the build notifications and the automations have been
-    // dispatched — which on CI outruns the default expect timeout.
+    // enqueued — a broker round-trip on top of the request.
     const dialog = page.getByRole("dialog", { name: "Review the next build" });
-    await expect(dialog).toBeVisible({ timeout: 20_000 });
+    await expect(dialog).toBeVisible({ timeout: 15_000 });
     await expect(
       dialog.getByText("One more build ran on this commit"),
     ).toBeVisible();

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -190,8 +190,12 @@ loggedTest(
 
     // The other build ran on the same commit and nobody has reviewed it, so
     // finishing this one hands the reviewer straight to it.
+    //
+    // The prompt waits on the review mutation's response, and the server only
+    // answers it once the build notifications and the automations have been
+    // dispatched — which on CI outruns the default expect timeout.
     const dialog = page.getByRole("dialog", { name: "Review the next build" });
-    await expect(dialog).toBeVisible();
+    await expect(dialog).toBeVisible({ timeout: 20_000 });
     await expect(
       dialog.getByText("One more build ran on this commit"),
     ).toBeVisible();
@@ -199,7 +203,7 @@ loggedTest(
     // and where its review stands.
     await expect(
       dialog.getByRole("link", {
-        name: `Build ${storybookBuild.number} storybook Changes detected`,
+        name: `storybook Build ${storybookBuild.number} Changes detected`,
       }),
     ).toBeVisible();
 
@@ -210,7 +214,7 @@ loggedTest(
     });
 
     await dialog
-      .getByRole("link", { name: `Review build ${storybookBuild.number}` })
+      .getByRole("link", { name: `Review ${storybookBuild.name}` })
       .click();
     await expect(page).toHaveURL(
       new RegExp(`/builds/${storybookBuild.number}/overview$`),
@@ -239,13 +243,11 @@ loggedTest(
     const menu = page.getByRole("menu");
     await expect(
       menu.getByRole("menuitem", {
-        name: `Build ${defaultBuild.number} Changes detected`,
+        name: `${defaultBuild.name} #${defaultBuild.number} Changes detected`,
       }),
     ).toBeVisible();
     const storybookItem = menu.getByRole("menuitem", {
-      name: new RegExp(
-        `Build ${storybookBuild.number}.*storybook Changes detected`,
-      ),
+      name: `${storybookBuild.name} #${storybookBuild.number} Changes detected`,
     });
     await expect(storybookItem).toBeVisible();
 


### PR DESCRIPTION
Closes ARG-503.

A commit that runs several suites leaves one Argos build per suite. Finishing a review on one of them said nothing about the others — the only way to find them was to go back to the build list, which is exactly where a reviewer stops looking.

## Demo

Approving `default` offers `storybook`, jumping to it, then switching back from the header:

[![next-build-review-demo.webm](https://files.argos-ci.com/media/9/6860d02b83d181fdf2c1c4a3d088d8d15b9c80607c4b40d84a1faaf7fb613141.webm/ik-thumbnail.jpg?tr=so-1)](https://app.argos-ci.com/m/dyql3guihxwfmhs8ht9r)

## What changed

A new `Build.siblingBuilds` field returns the commit's **other suites** on this branch — one build per name, latest run each, this build's own name excluded. Two surfaces use it:

### 1. After a review, the next build is offered

Approving or rejecting opens a window listing every build of the commit with where its review stands, and a button jumping to the next one still awaiting the reviewer. It stays quiet when nothing is left. A neutral `Comment` review deliberately leaves the build undecided, so it does not prompt.

**Before** — the review lands and the other build is never mentioned:

[![next-build-prompt.png](https://files.argos-ci.com/media/9/1d03b13672be718b83d5c124826f91a29ccb46a8fb65b6d8f3211a213628c750.webp)](https://app.argos-ci.com/m/rnl3ruqfviz6cr1b453k)

**After**:

[![next-build-prompt.png](https://files.argos-ci.com/media/9/3f8e7a8e0515c3fa824709b46b1ec3d82f9d85c9b1ea232d6b4eab1851f9303d.webp)](https://app.argos-ci.com/m/sqgb88ukk8b42x8rlma3)

### 2. A switcher in the header

Next to the build name, shown only when the commit produced more than one build **name**, listing them all with their status.

**Before** / **After**:

[![build-header.png](https://files.argos-ci.com/media/9/42d0ed9a6161acb8e801a34a4277052778d34671d6e643770c446ebca480e932.webp)](https://app.argos-ci.com/m/7uwtjphhhiuvtbn6uejf)

[![build-header.png](https://files.argos-ci.com/media/9/3b03405501328408b0b3dee01b7c82091c6484017243d3e05eef3611f1b6ee94.webp)](https://app.argos-ci.com/m/tbqictra3ddp1hg8g7pj)

[![build-switcher-menu.png](https://files.argos-ci.com/media/9/865b1f6cabc33eeff942bfb833ff40c5b2e171e0b7896d96578c6298189cc4fb.webp)](https://app.argos-ci.com/m/1bfjk68c9dzj39gtd1jw)

## Notes

- Builds are identified by their **build name**, not their number — on one commit the name is what tells them apart, and it is the word the reviewer configured in CI. The number follows it, muted.
- Scope is the head **commit + branch**, not the whole pull request: builds from an earlier push are stale and would be noise. For a PR build, the head commit's builds *are* the PR's builds at its current state. Everything is scoped to a single project, so no cross-project permission surface is opened.
- Siblings are told apart by **name**, and this build's own name is excluded rather than its id. A re-run of one suite is the same suite, so its earlier runs drop out with it. Excluding the id instead made a re-run its own sibling: the latest run read as somewhere else to go, the menu listed the same name twice, and every build of every re-run commit grew a switcher with nothing to switch to.
- A row carries its status as the **icon alone**. The full chip repeats it with a label and the reviewers' avatars, which buries the build name — the word the reader is scanning for. Same icons the build list and the status filter use; the label rides along as the icon's `aria-label` rather than a tooltip, since one per row fires over the neighbouring rows as the pointer runs down the column.
- The mutation re-selects the siblings on the way out, so the prompt reflects what is left to review at submit time rather than at page load.
- The header row now centers its items instead of top-aligning them. The title truncates rather than wraps, so there was no second line for the mode indicator and the switcher to hang off. On the rebased branch this turns out to cost nothing visually: build #5630 reports **no change on any existing build page** — the row's items already share a height. (The earlier claim of a one-pixel nudge on every build page was measured before the UI-kit migration.)
- Rebased onto the `react-aria-components` → Base UI migration. The switcher hangs off the menu kit (`MenuRoot` / `MenuTrigger` / `Menu`), whose surface is its own popover — the separate `Popover` wrapper and `placement` are gone, and the tooltip sits outside the trigger so Base UI's triggers compose through `render`. `Modal` renamed `isOpen` / `isDismissable` to `open` / `dismissible`.

## Tests

Two Playwright specs in `tests/build.spec.ts`, on a new `createSiblingBuildsScenario` seed (two builds, one commit, both with changes):

- `offers the next build of the commit once a review is submitted` — approves the first build, asserts the window lists the sibling with its status, jumps to it, and asserts the window does not survive the navigation. Verified to fail without the fix.
- `header switches between the builds of a commit` — opens the switcher, asserts every build is listed with its status, and switches. The menu kit is a listbox driven by a search field, so the rows are located as options rather than menu items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
