### PR TITLE
fix(media): let a recording play

### DIFF
--- a/apps/backend/src/web/security-headers.test.ts
+++ b/apps/backend/src/web/security-headers.test.ts
@@ -109,6 +109,41 @@ describe("app security headers", () => {
     });
   });
 
+  describe("media-src", () => {
+    const originalBaseUrl = config.get("s3.publicImageBaseUrl");
+
+    afterEach(() => {
+      config.set("s3.publicImageBaseUrl", originalBaseUrl);
+    });
+
+    it("allows the origins a recording plays from", async () => {
+      // Media has no fallback to `img-src`, only to `default-src`. Without the
+      // directive, `'self'` there refused every video in the media library:
+      // the element failed to load without a request ever being made.
+      config.set(
+        "s3.publicImageBaseUrl",
+        "https://files.argos-ci.com/production/",
+      );
+      const csp = await getCsp();
+      expect(csp["media-src"]).toContain("'self'");
+      expect(csp["media-src"]).toContain("https://files.argos-ci.com");
+    });
+
+    it("reaches everywhere a poster frame is served from", async () => {
+      // A recording and its poster are one upload served two ways, so an origin
+      // one directive can reach and the other cannot leaves a video that shows
+      // its first frame and then refuses to play.
+      config.set(
+        "s3.publicImageBaseUrl",
+        "https://files.argos-ci.com/production/",
+      );
+      const csp = await getCsp();
+      for (const origin of csp["media-src"] ?? []) {
+        expect(csp["img-src"]).toContain(origin);
+      }
+    });
+  });
+
   describe("cross-origin isolation", () => {
     it("severs window.opener for cross-origin openers", async () => {
       const headers = await getHeaders();

--- a/apps/backend/src/web/security-headers.ts
+++ b/apps/backend/src/web/security-headers.ts
@@ -21,6 +21,7 @@ export function createAppSecurityHeaders(options: {
 }): RequestHandler[] {
   const { configScriptCspHash, cspReportUri } = options;
   const assetsOrigin = getAssetsOrigin();
+  const fileOrigins = getFileOrigins();
   return [
     helmet({
       // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
@@ -36,10 +37,8 @@ export function createAppSecurityHeaders(options: {
             "data:",
             "blob:",
             "https://argos-ci.com",
-            // ImageKit images
-            "https://files.argos-ci.com",
-            // S3 images
-            getScreenshotsBucketOrigin(),
+            // Screenshots, media, and the poster frame of a recording
+            ...fileOrigins,
             // GitHub and GitLab avatars
             "https://github.com",
             "https://avatars.githubusercontent.com",
@@ -47,6 +46,12 @@ export function createAppSecurityHeaders(options: {
             "https://secure.gravatar.com",
             ...assetsOrigin,
           ],
+          // A recording plays from the same places its poster frame is served
+          // from, so it needs its own directive: media has no fallback to
+          // `img-src`, only to `default-src`, and `'self'` there refused every
+          // video in the media library outright — the element failed to load
+          // with no request ever leaving the browser.
+          "media-src": ["'self'", ...fileOrigins],
           // The one directive the asset origin is deliberately absent from: a
           // worker's top-level script has to be same-origin whatever CORS says,
           // so the colour-detection worker is inlined as a blob instead of
@@ -104,6 +109,28 @@ export function createAppSecurityHeaders(options: {
 /** Virtual-hosted-style origin of the screenshots bucket. */
 function getScreenshotsBucketOrigin(): string {
   return `https://${config.get("s3.screenshotsBucket")}.s3.${config.get("s3.region")}.amazonaws.com`;
+}
+
+/**
+ * Origins the stored files are served from: the image CDN when a file goes
+ * through it, and the bucket itself for everything else — larger images, videos
+ * the CDN is not configured for, and signed downloads. See
+ * `storage/public-url.ts`.
+ *
+ * One list rather than one literal per directive, because a file reaches the
+ * page through more than one of them: a recording is a `media-src`, its poster
+ * frame an `img-src`, and downloading either is a `connect-src`. Writing the
+ * origins out per directive is how `media-src` came to be missing altogether.
+ *
+ * Derived from config for the same reason as `getConnectSrc()` below: the CDN
+ * origin was a literal sitting next to the config entry that decides whether the
+ * CDN is used at all, so the two could disagree.
+ */
+function getFileOrigins(): string[] {
+  const origins = new Set<string>();
+  addOrigin(origins, config.get("s3.publicImageBaseUrl"));
+  origins.add(getScreenshotsBucketOrigin());
+  return Array.from(origins);
 }
 
 /**
@@ -171,11 +198,11 @@ export function getConnectSrc(): string[] {
 
   // Screenshots and text snapshots are *fetched*, not just displayed — for pixel
   // diffing, colour detection and text diffs — so they need connect-src as well
-  // as img-src. Images come from the image CDN when small enough
-  // (`publicImageBaseUrl`); everything larger, and every non-image file, comes
-  // from a signed S3 URL. See `storage/public-url.ts`.
-  addOrigin(origins, config.get("s3.publicImageBaseUrl"));
-  origins.add(getScreenshotsBucketOrigin());
+  // as img-src. The same goes for a media's Download action, whichever of the
+  // two origins that media is served from.
+  for (const origin of getFileOrigins()) {
+    origins.add(origin);
+  }
 
   // Sentry posts envelopes to its DSN's ingest host.
   addOrigin(origins, config.get("sentry.clientDsn"));


### PR DESCRIPTION
Fixes ARG-504.

## The bug

A video on a media page never played. Reported as CORS; it is CSP.

The app's `Content-Security-Policy` names every origin a screenshot is served from — `img-src`, `connect-src` — and none for a video. Media has no fallback to `img-src`, only to `default-src`, which is `'self'`, so the browser refused the file outright and no request ever left the page:

```
Loading media from 'https://files.argos-ci.com/test/dummy-375x1024.png' violates the
following Content Security Policy directive: "default-src 'self'". Note that
'media-src' was not explicitly set, so 'default-src' is used as a fallback.
The action has been blocked.
```

That is also why it looked like a decoding or streaming problem rather than a policy one: the poster frame is an image, so it loaded through `img-src` and the player sat dead on it.

Production is affected today — `curl -sSI https://app.argos-ci.com/` returns a policy with no `media-src`.

## The fix

Add `media-src`, and take the origins for all three directives from one derived list rather than a literal repeated per directive. A file reaches the page as a `media-src` (the recording), as an `img-src` (its poster frame) and, when downloaded, as a `connect-src` — writing the origins out per directive is how one of them came to be missing altogether. The list is derived from config for the same reason `connect-src` already was: the CDN origin used to be a literal sitting next to the config entry that decides whether the CDN is used at all.

Served policy on the media share page, after:

```
media-src 'self' https://files.argos-ci.com https://argos-ci-test.s3.eu-west-1.amazonaws.com
```

## Verified

- Reproduced against the built app: with the directive removed, the seeded video share page logs the CSP error above; with it in place, the console is clean and the request goes out.
- Unit test fails without the fix (checked by reverting it).
- `pnpm run static-checks` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)