### PR TITLE
feat(staff): price trial rows on the last closed billing month

### DIFF
--- a/apps/backend/src/database/models/Subscription.ts
+++ b/apps/backend/src/database/models/Subscription.ts
@@ -1,4 +1,5 @@
 import { assertNever } from "@argos/util/assertNever";
+import { invariant } from "@argos/util/invariant";
 import type { RelationMappings } from "objection";
 
 import { Model } from "../util/model";
@@ -110,23 +111,53 @@ export class Subscription extends Model {
   plan?: Plan;
 
   getLastResetDate(now: Date, interval: SubscriptionInterval) {
-    const startOfPeriod = getStartOf(now, interval);
-    const startDate = new Date(this.startDate);
-    const periodDuration = now.getTime() - startOfPeriod.getTime();
-    const subscriptionPeriodDuration =
-      startDate.getTime() - getStartOf(startDate, interval).getTime();
-    const billingHasResetThisPeriod =
-      periodDuration > subscriptionPeriodDuration;
+    const [lastResetDate] = this.getPeriodStarts(now, interval, 1);
+    invariant(lastResetDate, "a period always has a start");
+    return lastResetDate;
+  }
 
-    return billingHasResetThisPeriod
-      ? new Date(startOfPeriod.getTime() + subscriptionPeriodDuration)
-      : new Date(
-          Math.min(
-            getStartOfPrevious(now, interval).getTime() +
-              subscriptionPeriodDuration,
-            startOfPeriod.getTime(), // end of previous period
-          ),
-        );
+  /**
+   * Start of the billing period holding `now`, then the start of each period
+   * before it, most recent first.
+   *
+   * The anniversary is read as the offset `startDate` sits at inside its own
+   * interval, and that offset is applied to each interval walked back — rather
+   * than counting periods down from `startDate`, which is the *current* period
+   * start and moves forward at every renewal.
+   */
+  getPeriodStarts(
+    now: Date,
+    interval: SubscriptionInterval,
+    count: number,
+  ): Date[] {
+    const startDate = new Date(this.startDate);
+    const anniversaryOffset =
+      startDate.getTime() - getStartOf(startDate, interval).getTime();
+
+    const getResetDateAt = (index: number) => {
+      const intervalStart = shiftIntervals(
+        getStartOf(now, interval),
+        interval,
+        -index,
+      );
+      const nextIntervalStart = shiftIntervals(intervalStart, interval, 1);
+      // A subscription that started on the 31st has no anniversary in a
+      // 30-day month: it resets when the next interval opens.
+      return new Date(
+        Math.min(
+          intervalStart.getTime() + anniversaryOffset,
+          nextIntervalStart.getTime(),
+        ),
+      );
+    };
+
+    // The period holding `now` opens on this interval's own anniversary once
+    // that anniversary has passed, and on the previous one until then.
+    const currentIndex = getResetDateAt(0).getTime() < now.getTime() ? 0 : 1;
+
+    return Array.from({ length: count }, (_, index) =>
+      getResetDateAt(currentIndex + index),
+    );
   }
 }
 
@@ -141,12 +172,17 @@ function getStartOf(date: Date, interval: SubscriptionInterval) {
   }
 }
 
-function getStartOfPrevious(date: Date, interval: SubscriptionInterval) {
+/** Moves a date sitting on an interval boundary by `count` whole intervals. */
+function shiftIntervals(
+  date: Date,
+  interval: SubscriptionInterval,
+  count: number,
+) {
   switch (interval) {
     case "month":
-      return new Date(date.getFullYear(), date.getMonth() - 1, 1);
+      return new Date(date.getFullYear(), date.getMonth() + count, 1);
     case "year":
-      return new Date(date.getFullYear() - 1, 0, 1);
+      return new Date(date.getFullYear() + count, 0, 1);
     default:
       assertNever(interval);
   }

--- a/apps/backend/src/database/services/period-usage.e2e.test.ts
+++ b/apps/backend/src/database/services/period-usage.e2e.test.ts
@@ -3,12 +3,12 @@ import { beforeEach, describe, expect, it } from "vitest";
 import type { Account, Plan, Project } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
 
-import type { AccountPeriodUsage } from "./period-usage";
-import { getAccountPeriodUsages } from "./period-usage";
+import type { AccountBilling } from "./period-usage";
+import { getAccountBillings } from "./period-usage";
 
 /** Overage of the period still running, which is the first one returned. */
-function getRunningCost(usage: AccountPeriodUsage | null | undefined) {
-  return usage?.billingPeriods[0]?.additionalScreenshotCost;
+function getRunningCost(billing: AccountBilling | undefined) {
+  return billing?.periodUsage?.billingPeriods[0]?.additionalScreenshotCost;
 }
 
 describe("getAccountPeriodUsages", () => {
@@ -56,12 +56,12 @@ describe("getAccountPeriodUsages", () => {
     });
   }
 
-  it("returns null for an account without a usage-based subscription", async () => {
-    const usages = await getAccountPeriodUsages([account]);
-    expect(usages.get(account.id)).toBeNull();
+  it("reports no plan and no usage for an account without a subscription", async () => {
+    const usages = await getAccountBillings([account]);
+    expect(usages.get(account.id)).toEqual({ plan: null, periodUsage: null });
   });
 
-  it("returns null for a granted plan, even with a subscription still on file", async () => {
+  it("reports a granted plan, and no usage under it", async () => {
     // Open source and comped accounts read as `active` everywhere because a
     // forced plan short-circuits the status, and they bill nothing.
     await createUsageBasedSubscription();
@@ -74,9 +74,13 @@ describe("getAccountPeriodUsages", () => {
     await account.$query().patch({ forcedPlanId: usageBasedPlan.id });
     const grantedAccount = await account.$query();
 
-    const usages = await getAccountPeriodUsages([grantedAccount]);
+    const usages = await getAccountBillings([grantedAccount]);
 
-    expect(usages.get(grantedAccount.id)).toBeNull();
+    // The plan still comes back: it is what explains why nothing is billed.
+    expect(usages.get(grantedAccount.id)).toEqual({
+      plan: expect.objectContaining({ id: usageBasedPlan.id }),
+      periodUsage: null,
+    });
   });
 
   it("resolves the same subscription as the account manager does", async () => {
@@ -108,9 +112,12 @@ describe("getAccountPeriodUsages", () => {
       storybookScreenshotCount: 0,
     });
 
-    const usages = await getAccountPeriodUsages([account]);
+    const usages = await getAccountBillings([account]);
 
-    expect(usages.get(account.id)).toBeNull();
+    expect(usages.get(account.id)).toEqual({
+      plan: expect.objectContaining({ id: flatPlan.id }),
+      periodUsage: null,
+    });
   });
 
   it("returns zero cost when the account stays inside its quota", async () => {
@@ -122,11 +129,14 @@ describe("getAccountPeriodUsages", () => {
       storybookScreenshotCount: 0,
     });
 
-    const usage = await getAccountPeriodUsages([account]).then((usages) =>
+    const usage = await getAccountBillings([account]).then((usages) =>
       usages.get(account.id),
     );
 
-    expect(usage).toMatchObject({ storybookRatio: 0, storybookCount: 0 });
+    expect(usage?.periodUsage).toMatchObject({
+      storybookRatio: 0,
+      storybookCount: 0,
+    });
     expect(getRunningCost(usage)).toBe(0);
   });
 
@@ -139,7 +149,7 @@ describe("getAccountPeriodUsages", () => {
       storybookScreenshotCount: 0,
     });
 
-    const usage = await getAccountPeriodUsages([account]).then((usages) =>
+    const usage = await getAccountBillings([account]).then((usages) =>
       usages.get(account.id),
     );
 
@@ -156,15 +166,15 @@ describe("getAccountPeriodUsages", () => {
       storybookScreenshotCount: 1000,
     });
 
-    const usage = await getAccountPeriodUsages([account]).then((usages) =>
+    const usage = await getAccountBillings([account]).then((usages) =>
       usages.get(account.id),
     );
 
     // 500 neutral fit under the 1000 included, so 500 of the Storybook
     // screenshots absorb the rest of the quota and 500 are billed at $0.10.
     expect(getRunningCost(usage)).toBeCloseTo(50);
-    expect(usage?.storybookRatio).toBeCloseTo(1000 / 1500);
-    expect(usage?.storybookCount).toBe(1000);
+    expect(usage?.periodUsage?.storybookRatio).toBeCloseTo(1000 / 1500);
+    expect(usage?.periodUsage?.storybookCount).toBe(1000);
   });
 
   it("clamps a bucket's Storybook count to its total", async () => {
@@ -179,15 +189,15 @@ describe("getAccountPeriodUsages", () => {
       storybookScreenshotCount: 1600,
     });
 
-    const usage = await getAccountPeriodUsages([account]).then((usages) =>
+    const usage = await getAccountBillings([account]).then((usages) =>
       usages.get(account.id),
     );
 
     // Read as 1500 Storybook and 0 neutral: 1000 absorb the quota and 500 are
     // billed at $0.10.
     expect(getRunningCost(usage)).toBeCloseTo(50);
-    expect(usage?.storybookRatio).toBe(1);
-    expect(usage?.storybookCount).toBe(1500);
+    expect(usage?.periodUsage?.storybookRatio).toBe(1);
+    expect(usage?.periodUsage?.storybookCount).toBe(1500);
   });
 
   it("ignores screenshots uploaded before the period started", async () => {
@@ -199,13 +209,13 @@ describe("getAccountPeriodUsages", () => {
       storybookScreenshotCount: 0,
     });
 
-    const usage = await getAccountPeriodUsages([account]).then((usages) =>
+    const usage = await getAccountBillings([account]).then((usages) =>
       usages.get(account.id),
     );
 
     // Out of period for the cost, still part of the lifetime mix.
     expect(getRunningCost(usage)).toBe(0);
-    expect(usage?.storybookRatio).toBe(0);
+    expect(usage?.periodUsage?.storybookRatio).toBe(0);
   });
 
   it("prices each period against its own quota", async () => {
@@ -226,11 +236,11 @@ describe("getAccountPeriodUsages", () => {
       storybookScreenshotCount: 0,
     });
 
-    const usage = await getAccountPeriodUsages([account]).then((usages) =>
+    const usage = await getAccountBillings([account]).then((usages) =>
       usages.get(account.id),
     );
 
-    const [running, closed] = usage?.billingPeriods ?? [];
+    const [running, closed] = usage?.periodUsage?.billingPeriods ?? [];
     // 200 over in the running period, 400 over in the one before it.
     expect(running).toMatchObject({
       closed: false,
@@ -259,11 +269,11 @@ describe("getAccountPeriodUsages", () => {
       storybookScreenshotCount: 0,
     });
 
-    const usage = await getAccountPeriodUsages([account]).then((usages) =>
+    const usage = await getAccountBillings([account]).then((usages) =>
       usages.get(account.id),
     );
 
-    expect(usage?.billingPeriods).toHaveLength(1);
+    expect(usage?.periodUsage?.billingPeriods).toHaveLength(1);
     expect(getRunningCost(usage)).toBe(0);
   });
 
@@ -283,11 +293,11 @@ describe("getAccountPeriodUsages", () => {
       storybookScreenshotCount: 0,
     });
 
-    const usage = await getAccountPeriodUsages([account]).then((usages) =>
+    const usage = await getAccountBillings([account]).then((usages) =>
       usages.get(account.id),
     );
 
-    expect(usage?.billingPeriods).toHaveLength(1);
+    expect(usage?.periodUsage?.billingPeriods).toHaveLength(1);
     expect(getRunningCost(usage)).toBe(100);
   });
 
@@ -327,7 +337,7 @@ describe("getAccountPeriodUsages", () => {
 
     const noSubscriptionAccount = await factory.TeamAccount.create();
 
-    const usages = await getAccountPeriodUsages([
+    const usages = await getAccountBillings([
       account,
       otherAccount,
       noSubscriptionAccount,
@@ -335,6 +345,9 @@ describe("getAccountPeriodUsages", () => {
 
     expect(getRunningCost(usages.get(account.id))).toBe(100);
     expect(getRunningCost(usages.get(otherAccount.id))).toBe(50);
-    expect(usages.get(noSubscriptionAccount.id)).toBeNull();
+    expect(usages.get(noSubscriptionAccount.id)).toEqual({
+      plan: null,
+      periodUsage: null,
+    });
   });
 });

--- a/apps/backend/src/database/services/period-usage.e2e.test.ts
+++ b/apps/backend/src/database/services/period-usage.e2e.test.ts
@@ -3,7 +3,13 @@ import { beforeEach, describe, expect, it } from "vitest";
 import type { Account, Plan, Project } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
 
+import type { AccountPeriodUsage } from "./period-usage";
 import { getAccountPeriodUsages } from "./period-usage";
+
+/** Overage of the period still running, which is the first one returned. */
+function getRunningCost(usage: AccountPeriodUsage | null | undefined) {
+  return usage?.billingPeriods[0]?.additionalScreenshotCost;
+}
 
 describe("getAccountPeriodUsages", () => {
   beforeEach(async () => {
@@ -42,6 +48,9 @@ describe("getAccountPeriodUsages", () => {
       provider: "stripe",
       stripeSubscriptionId: "sub_period_usage",
       subscriberId: user.id,
+      // A subscription running since 2021: its periods reset on the 1st, and
+      // every one of them is old enough to have been invoiced.
+      createdAt: new Date("2021-01-01").toISOString(),
       startDate: new Date("2021-01-01").toISOString(),
       status: "active",
     });
@@ -117,11 +126,8 @@ describe("getAccountPeriodUsages", () => {
       usages.get(account.id),
     );
 
-    expect(usage).toEqual({
-      additionalScreenshotCost: 0,
-      storybookRatio: 0,
-      storybookCount: 0,
-    });
+    expect(usage).toMatchObject({ storybookRatio: 0, storybookCount: 0 });
+    expect(getRunningCost(usage)).toBe(0);
   });
 
   it("bills the overage at the neutral price", async () => {
@@ -138,7 +144,7 @@ describe("getAccountPeriodUsages", () => {
     );
 
     // 200 over the 1000 included, at $0.50.
-    expect(usage?.additionalScreenshotCost).toBe(100);
+    expect(getRunningCost(usage)).toBe(100);
   });
 
   it("bills Storybook screenshots at their own price and reports the mix", async () => {
@@ -156,7 +162,7 @@ describe("getAccountPeriodUsages", () => {
 
     // 500 neutral fit under the 1000 included, so 500 of the Storybook
     // screenshots absorb the rest of the quota and 500 are billed at $0.10.
-    expect(usage?.additionalScreenshotCost).toBeCloseTo(50);
+    expect(getRunningCost(usage)).toBeCloseTo(50);
     expect(usage?.storybookRatio).toBeCloseTo(1000 / 1500);
     expect(usage?.storybookCount).toBe(1000);
   });
@@ -179,7 +185,7 @@ describe("getAccountPeriodUsages", () => {
 
     // Read as 1500 Storybook and 0 neutral: 1000 absorb the quota and 500 are
     // billed at $0.10.
-    expect(usage?.additionalScreenshotCost).toBeCloseTo(50);
+    expect(getRunningCost(usage)).toBeCloseTo(50);
     expect(usage?.storybookRatio).toBe(1);
     expect(usage?.storybookCount).toBe(1500);
   });
@@ -198,8 +204,91 @@ describe("getAccountPeriodUsages", () => {
     );
 
     // Out of period for the cost, still part of the lifetime mix.
-    expect(usage?.additionalScreenshotCost).toBe(0);
+    expect(getRunningCost(usage)).toBe(0);
     expect(usage?.storybookRatio).toBe(0);
+  });
+
+  it("prices each period against its own quota", async () => {
+    // The included screenshots reset at every period, so an account that goes
+    // slightly over twice owes twice — summing the two months and pricing the
+    // total against a single quota would report roughly half of that.
+    await createUsageBasedSubscription();
+    await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      createdAt: new Date(inPeriod.getTime() + 1000).toISOString(),
+      screenshotCount: 1200,
+      storybookScreenshotCount: 0,
+    });
+    await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      createdAt: new Date(inPeriod.getTime() - 86_400_000).toISOString(),
+      screenshotCount: 1400,
+      storybookScreenshotCount: 0,
+    });
+
+    const usage = await getAccountPeriodUsages([account]).then((usages) =>
+      usages.get(account.id),
+    );
+
+    const [running, closed] = usage?.billingPeriods ?? [];
+    // 200 over in the running period, 400 over in the one before it.
+    expect(running).toMatchObject({
+      closed: false,
+      additionalScreenshotCost: 100,
+    });
+    expect(closed).toMatchObject({
+      closed: true,
+      additionalScreenshotCost: 200,
+    });
+    // Contiguous: each period ends where the next one opens.
+    expect(closed?.to).toEqual(running?.from);
+  });
+
+  it("leaves out the periods the trial covers", async () => {
+    // Stripe never bills usage consumed during a trial, and converting one
+    // opens a fresh period at the moment it ends. Pricing the periods before
+    // that would invoice the trial.
+    const subscription = await createUsageBasedSubscription();
+    await subscription
+      .$query()
+      .patch({ trialEndDate: new Date(inPeriod.getTime()).toISOString() });
+    await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      createdAt: new Date(inPeriod.getTime() - 86_400_000).toISOString(),
+      screenshotCount: 50_000,
+      storybookScreenshotCount: 0,
+    });
+
+    const usage = await getAccountPeriodUsages([account]).then((usages) =>
+      usages.get(account.id),
+    );
+
+    expect(usage?.billingPeriods).toHaveLength(1);
+    expect(getRunningCost(usage)).toBe(0);
+  });
+
+  it("leaves out the periods that predate the subscription", async () => {
+    // Boundaries are walked back from an anniversary, so they keep going past
+    // the day the subscription started. Pricing those as closed periods would
+    // report invoices that were never sent — and hide the running period, which
+    // is the only thing a team billed for the first time has.
+    const subscription = await createUsageBasedSubscription();
+    await subscription
+      .$query()
+      .patch({ createdAt: new Date(inPeriod.getTime() + 1000).toISOString() });
+    await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      createdAt: new Date(inPeriod.getTime() + 2000).toISOString(),
+      screenshotCount: 1200,
+      storybookScreenshotCount: 0,
+    });
+
+    const usage = await getAccountPeriodUsages([account]).then((usages) =>
+      usages.get(account.id),
+    );
+
+    expect(usage?.billingPeriods).toHaveLength(1);
+    expect(getRunningCost(usage)).toBe(100);
   });
 
   it("keeps accounts apart within one batch", async () => {
@@ -244,8 +333,8 @@ describe("getAccountPeriodUsages", () => {
       noSubscriptionAccount,
     ]);
 
-    expect(usages.get(account.id)?.additionalScreenshotCost).toBe(100);
-    expect(usages.get(otherAccount.id)?.additionalScreenshotCost).toBe(50);
+    expect(getRunningCost(usages.get(account.id))).toBe(100);
+    expect(getRunningCost(usages.get(otherAccount.id))).toBe(50);
     expect(usages.get(noSubscriptionAccount.id)).toBeNull();
   });
 });

--- a/apps/backend/src/database/services/period-usage.ts
+++ b/apps/backend/src/database/services/period-usage.ts
@@ -1,17 +1,30 @@
+import { invariant } from "@argos/util/invariant";
+
 import { knex } from "@/database";
 
-import { Account, Subscription } from "../models";
+import { Account, Plan, Subscription } from "../models";
 import { computeAdditionalScreenshots } from "./additional-screenshots";
+
+/** One billing period of an account, priced from the usage it accumulated. */
+type BillingPeriodUsage = {
+  from: Date;
+  /** End of the period, or the moment it was read while still running. */
+  to: Date;
+  /** False while the period is still accumulating usage. */
+  closed: boolean;
+  /**
+   * Cost of the screenshots consumed beyond the included quota over the
+   * period, in the subscription's currency.
+   */
+  additionalScreenshotCost: number;
+};
 
 /**
  * Billing usage for one account, as needed to explain what it is about to pay.
  */
 export type AccountPeriodUsage = {
-  /**
-   * Cost of the screenshots consumed beyond the included quota since the
-   * current period started, in the subscription's currency.
-   */
-  additionalScreenshotCost: number;
+  /** The plan the account is billed on. */
+  plan: Plan;
   /**
    * Share of Storybook screenshots in everything the account ever uploaded,
    * between 0 and 1. Null when it never uploaded a screenshot at all — an
@@ -20,62 +33,105 @@ export type AccountPeriodUsage = {
   storybookRatio: number | null;
   /** Storybook screenshots uploaded since the account was created. */
   storybookCount: number;
-};
-
-/** Usage of an account on a usage-based plan that has yet to upload anything. */
-const EMPTY_PERIOD_USAGE: AccountPeriodUsage = {
-  additionalScreenshotCost: 0,
-  storybookRatio: null,
-  storybookCount: 0,
+  /**
+   * Periods Stripe actually invoices, most recent first: the one still
+   * running, then the closed ones. Empty while the account is on its trial,
+   * whose usage is never billed.
+   */
+  billingPeriods: BillingPeriodUsage[];
 };
 
 /**
- * Screenshot totals for one account: over the current billing period, which is
- * what gets invoiced, and over its whole life, which is what describes its mix.
+ * Billing periods read per account: the one still running, and the one before
+ * it.
+ *
+ * One closed period is what pricing an account needs — it is the settled figure
+ * the trial pipeline reads — and every extra period multiplies the rows the
+ * aggregate below scans.
  */
-type ScreenshotTotals = {
-  periodAll: number;
-  periodStorybook: number;
-  allTimeAll: number;
-  allTimeStorybook: number;
+const READ_PERIOD_COUNT = 2;
+
+/**
+ * Slack allowed when placing a period against the moment billing began.
+ *
+ * Converting a trial opens a new Stripe period at the instant the trial ends,
+ * so the boundary between the two is one moment recorded twice: once as
+ * `trialEndDate`, once as `current_period_start`. Stripe rounds both to the
+ * second and Argos re-derives the period start from the anniversary offset, so
+ * the two can land a few seconds apart. Compared strictly, that is enough to
+ * read the first billed period as part of the trial. Periods are a month long,
+ * so an hour of slack cannot swallow a real one.
+ */
+const PERIOD_BOUNDARY_TOLERANCE = 60 * 60 * 1000;
+
+/** A window of one account's usage, as fed to the aggregate below. */
+type AccountPeriod = {
+  accountId: string;
+  index: number;
+  from: Date;
+  to: Date;
 };
+
+/** Screenshots uploaded over one window, split by the way they are billed. */
+type ScreenshotTotals = {
+  all: number;
+  storybook: number;
+};
+
+/** What one account uploaded, per period and over its whole life. */
+type AccountTotals = {
+  periods: Map<number, ScreenshotTotals>;
+  allTime: ScreenshotTotals;
+};
+
+const EMPTY_TOTALS: ScreenshotTotals = { all: 0, storybook: 0 };
 
 /** A bucket's Storybook count, never above the bucket's own total. */
 const CLAMPED_STORYBOOK_COUNT = `least(coalesce(sb."storybookScreenshotCount", 0), coalesce(sb."screenshotCount", 0))`;
 
+/** Rows of `(accountId, index, from, to)` to join the usage tables against. */
+function buildPeriodValues(periods: AccountPeriod[]) {
+  return {
+    sql: periods
+      .map(() => `(?::bigint, ?::int, ?::timestamptz, ?::timestamptz)`)
+      .join(", "),
+    bindings: periods.flatMap((period) => [
+      period.accountId,
+      period.index,
+      period.from.toISOString(),
+      period.to.toISOString(),
+    ]),
+  };
+}
+
 /**
- * Sum screenshots per account in a single pass.
+ * Sum screenshots per account and per period in a single pass.
  *
- * Every account has its own period start — it follows the subscription's
- * anniversary, not the calendar — so the boundaries travel with the rows as a
- * `VALUES` list and the period totals come out of a filtered aggregate. The
- * alternative is one query per account, which is what this exists to avoid.
+ * Every account has its own period boundaries — they follow the subscription's
+ * anniversary, not the calendar — so the windows travel with the rows as a
+ * `VALUES` list and each period's totals come out of a filtered aggregate. The
+ * alternative is one query per account and per period, which is what this
+ * exists to avoid.
  *
  * The joins are left joins throughout: an account whose projects never produced
  * a bucket still has to come back with zeros rather than vanish from the batch.
  */
 async function getScreenshotTotals(
-  periodStartByAccountId: Map<string, Date>,
-): Promise<Map<string, ScreenshotTotals>> {
-  const entries = [...periodStartByAccountId];
-
+  periods: AccountPeriod[],
+): Promise<Map<string, AccountTotals>> {
   // `accounts.id` is a bigint and the bindings arrive as strings, so the values
   // are cast explicitly — Postgres cannot infer the type of a bare parameter in
   // a `VALUES` list, and would refuse to join it against `projects."accountId"`.
-  const values = entries.map(() => `(?::bigint, ?::timestamptz)`).join(", ");
-  const bindings = entries.flatMap(([accountId, periodStart]) => [
-    accountId,
-    periodStart.toISOString(),
-  ]);
+  const values = buildPeriodValues(periods);
 
   const rows = (await knex
-    .select("v.accountId")
+    .select("v.accountId", "v.index")
     .select(
       // `screenshotCount` is null until a bucket completes, and the billing
       // aggregate it mirrors sums it as-is rather than filtering incomplete
       // buckets out. Coalescing here keeps both sides on the same number.
       knex.raw(
-        `coalesce(sum(sb."screenshotCount") filter (where sb."createdAt" >= v."periodStart"), 0) as "periodAll"`,
+        `coalesce(sum(sb."screenshotCount") filter (where sb."createdAt" >= v."from" and sb."createdAt" < v."to"), 0) as "periodAll"`,
       ),
       // A bucket's Storybook count is clamped to its total before being summed.
       // The two used to be counted by two separate queries, so buckets written
@@ -83,20 +139,26 @@ async function getScreenshotTotals(
       // would make the neutral count negative. Mirrors
       // `Account.$getScreenshotCountBetween`.
       knex.raw(
-        `coalesce(sum(${CLAMPED_STORYBOOK_COUNT}) filter (where sb."createdAt" >= v."periodStart"), 0) as "periodStorybook"`,
+        `coalesce(sum(${CLAMPED_STORYBOOK_COUNT}) filter (where sb."createdAt" >= v."from" and sb."createdAt" < v."to"), 0) as "periodStorybook"`,
       ),
+      // Unfiltered, so every period of an account repeats the same lifetime
+      // total. Read once per account below.
       knex.raw(`coalesce(sum(sb."screenshotCount"), 0) as "allTimeAll"`),
       knex.raw(
         `coalesce(sum(${CLAMPED_STORYBOOK_COUNT}), 0) as "allTimeStorybook"`,
       ),
     )
     .from(
-      knex.raw(`(values ${values}) as v("accountId", "periodStart")`, bindings),
+      knex.raw(
+        `(values ${values.sql}) as v("accountId", "index", "from", "to")`,
+        values.bindings,
+      ),
     )
     .leftJoin("projects as p", "p.accountId", "v.accountId")
     .leftJoin("screenshot_buckets as sb", "sb.projectId", "p.id")
-    .groupBy("v.accountId")) as unknown as {
+    .groupBy("v.accountId", "v.index")) as unknown as {
     accountId: string | number;
+    index: string | number;
     periodAll: string | number;
     periodStorybook: string | number;
     allTimeAll: string | number;
@@ -107,55 +169,54 @@ async function getScreenshotTotals(
   // join above: joining two independent one-to-many tables in a single pass
   // multiplies their rows against each other. It is aggregated separately and
   // added in.
-  const mediaUnitsByAccountId = await getMediaUnits(periodStartByAccountId);
+  const mediaUnits = await getMediaUnits(periods);
 
-  return new Map(
-    rows.map((row) => {
-      const accountId = String(row.accountId);
-      const media = mediaUnitsByAccountId.get(accountId);
-      return [
-        accountId,
-        {
-          // Media is never Storybook, so it lifts the totals without touching
-          // either Storybook count — the neutral half absorbs it.
-          periodAll: (Number(row.periodAll) || 0) + (media?.period ?? 0),
-          periodStorybook: Number(row.periodStorybook) || 0,
-          allTimeAll: (Number(row.allTimeAll) || 0) + (media?.allTime ?? 0),
-          allTimeStorybook: Number(row.allTimeStorybook) || 0,
-        },
-      ];
-    }),
-  );
+  const totalsByAccountId = new Map<string, AccountTotals>();
+  for (const row of rows) {
+    const accountId = String(row.accountId);
+    const index = Number(row.index);
+    const media = mediaUnits.get(accountId);
+    const totals = totalsByAccountId.get(accountId) ?? {
+      periods: new Map<number, ScreenshotTotals>(),
+      // Media is never Storybook, so it lifts the totals without touching
+      // either Storybook count — the neutral half absorbs it.
+      allTime: {
+        all: (Number(row.allTimeAll) || 0) + (media?.allTime ?? 0),
+        storybook: Number(row.allTimeStorybook) || 0,
+      },
+    };
+    totals.periods.set(index, {
+      all: (Number(row.periodAll) || 0) + (media?.periods.get(index) ?? 0),
+      storybook: Number(row.periodStorybook) || 0,
+    });
+    totalsByAccountId.set(accountId, totals);
+  }
+
+  return totalsByAccountId;
 }
 
 /**
- * Screenshot units charged by standalone media uploads, per account, over the
- * period and over all time.
- *
- * One query for the whole batch, same as the bucket totals: the period boundary
- * travels with the rows in a `VALUES` list because every account's period follows
- * its own subscription anniversary.
+ * Screenshot units charged by standalone media uploads, per account and per
+ * period, over the same windows as the bucket totals.
  */
 async function getMediaUnits(
-  periodStartByAccountId: Map<string, Date>,
-): Promise<Map<string, { period: number; allTime: number }>> {
-  const entries = [...periodStartByAccountId];
-  const values = entries.map(() => `(?::bigint, ?::timestamptz)`).join(", ");
-  const bindings = entries.flatMap(([accountId, periodStart]) => [
-    accountId,
-    periodStart.toISOString(),
-  ]);
+  periods: AccountPeriod[],
+): Promise<Map<string, { periods: Map<number, number>; allTime: number }>> {
+  const values = buildPeriodValues(periods);
 
   const rows = (await knex
-    .select("v.accountId")
+    .select("v.accountId", "v.index")
     .select(
       knex.raw(
-        `coalesce(sum(mv."billedUnits") filter (where mv."uploadedAt" >= v."periodStart"), 0) as "period"`,
+        `coalesce(sum(mv."billedUnits") filter (where mv."uploadedAt" >= v."from" and mv."uploadedAt" < v."to"), 0) as "period"`,
       ),
       knex.raw(`coalesce(sum(mv."billedUnits"), 0) as "allTime"`),
     )
     .from(
-      knex.raw(`(values ${values}) as v("accountId", "periodStart")`, bindings),
+      knex.raw(
+        `(values ${values.sql}) as v("accountId", "index", "from", "to")`,
+        values.bindings,
+      ),
     )
     // Media reaches the account through its project, exactly as a bucket does —
     // which is what makes a project transfer carry its billing with it.
@@ -167,21 +228,58 @@ async function getMediaUnits(
     .leftJoin("media_versions as mv", (join) => {
       join.on("mv.mediaId", "m.id").onNotNull("mv.uploadedAt");
     })
-    .groupBy("v.accountId")) as unknown as {
+    .groupBy("v.accountId", "v.index")) as unknown as {
     accountId: string | number;
+    index: string | number;
     period: string | number;
     allTime: string | number;
   }[];
 
-  return new Map(
-    rows.map((row) => [
-      String(row.accountId),
-      {
-        period: Number(row.period) || 0,
-        allTime: Number(row.allTime) || 0,
-      },
-    ]),
-  );
+  const unitsByAccountId = new Map<
+    string,
+    { periods: Map<number, number>; allTime: number }
+  >();
+  for (const row of rows) {
+    const accountId = String(row.accountId);
+    const units = unitsByAccountId.get(accountId) ?? {
+      periods: new Map<number, number>(),
+      allTime: Number(row.allTime) || 0,
+    };
+    units.periods.set(Number(row.index), Number(row.period) || 0);
+    unitsByAccountId.set(accountId, units);
+  }
+
+  return unitsByAccountId;
+}
+
+/** Whether a period is one Stripe invoices. */
+function checkIsBilledPeriod(
+  period: AccountPeriod,
+  subscription: Subscription,
+): boolean {
+  const from = period.from.getTime();
+
+  // Stripe never bills usage consumed during a trial, and converting one opens
+  // a fresh period at the instant it ends — so no period straddles that
+  // boundary, and every period before it is trial usage.
+  if (subscription.trialEndDate) {
+    const trialEnd = new Date(subscription.trialEndDate).getTime();
+    if (from < trialEnd - PERIOD_BOUNDARY_TOLERANCE) {
+      return false;
+    }
+  }
+
+  // The period still running is real whatever the rest says: it is the one
+  // usage is accruing into right now.
+  if (period.index === 0) {
+    return true;
+  }
+
+  // Boundaries are walked back from an anniversary, so they keep going past the
+  // point where the subscription itself begins. A closed period from before it
+  // existed is an invoice that was never sent.
+  const createdAt = new Date(subscription.createdAt).getTime();
+  return from >= createdAt - PERIOD_BOUNDARY_TOLERANCE;
 }
 
 /**
@@ -250,7 +348,7 @@ export async function getAccountPeriodUsages(
   );
 
   const now = new Date();
-  const periodStartByAccountId = new Map<string, Date>();
+  const periodsByAccountId = new Map<string, AccountPeriod[]>();
 
   for (const account of subscribedAccounts) {
     const subscription = subscriptionByAccountId.get(account.id);
@@ -258,35 +356,40 @@ export async function getAccountPeriodUsages(
       result.set(account.id, null);
       continue;
     }
-    periodStartByAccountId.set(
+    // Contiguous windows, newest first: each period runs until the next one
+    // opens, and the one still running until now.
+    const starts = subscription.getPeriodStarts(
+      now,
+      subscription.plan.interval,
+      READ_PERIOD_COUNT,
+    );
+    periodsByAccountId.set(
       account.id,
-      subscription.getLastResetDate(now, subscription.plan.interval),
+      starts.map((from, index) => ({
+        accountId: account.id,
+        index,
+        from,
+        to: starts[index - 1] ?? now,
+      })),
     );
   }
 
-  if (periodStartByAccountId.size === 0) {
+  const periods = [...periodsByAccountId.values()].flat();
+
+  if (periods.length === 0) {
     return result;
   }
 
-  const totalsByAccountId = await getScreenshotTotals(periodStartByAccountId);
+  const totalsByAccountId = await getScreenshotTotals(periods);
 
-  for (const accountId of periodStartByAccountId.keys()) {
+  for (const [accountId, accountPeriods] of periodsByAccountId) {
     const subscription = subscriptionByAccountId.get(accountId);
+    const plan = subscription?.plan;
     const totals = totalsByAccountId.get(accountId);
-
-    if (!subscription || !totals) {
-      result.set(accountId, EMPTY_PERIOD_USAGE);
-      continue;
-    }
-
-    const additional =
-      subscription.includedScreenshots === null
-        ? null
-        : computeAdditionalScreenshots({
-            neutral: totals.periodAll - totals.periodStorybook,
-            storybook: totals.periodStorybook,
-            included: subscription.includedScreenshots,
-          });
+    invariant(
+      subscription && plan && totals,
+      "every account with periods has a usage-based subscription and totals",
+    );
 
     // Storybook screenshots fall back to the neutral price when they have none
     // of their own, exactly as the per-account cost does.
@@ -299,15 +402,37 @@ export async function getAccountPeriodUsages(
     };
 
     result.set(accountId, {
-      additionalScreenshotCost: additional
-        ? additional.neutral * price.neutral +
-          additional.storybook * price.storybook
-        : 0,
+      plan,
       storybookRatio:
-        totals.allTimeAll > 0
-          ? totals.allTimeStorybook / totals.allTimeAll
+        totals.allTime.all > 0
+          ? totals.allTime.storybook / totals.allTime.all
           : null,
-      storybookCount: totals.allTimeStorybook,
+      storybookCount: totals.allTime.storybook,
+      billingPeriods: accountPeriods
+        .filter((period) => checkIsBilledPeriod(period, subscription))
+        .map((period) => {
+          const periodTotals = totals.periods.get(period.index) ?? EMPTY_TOTALS;
+          // The included quota resets at every period, so the overage is
+          // computed period by period rather than off a running total.
+          const additional =
+            subscription.includedScreenshots === null
+              ? null
+              : computeAdditionalScreenshots({
+                  neutral: periodTotals.all - periodTotals.storybook,
+                  storybook: periodTotals.storybook,
+                  included: subscription.includedScreenshots,
+                });
+
+          return {
+            from: period.from,
+            to: period.to,
+            closed: period.index > 0,
+            additionalScreenshotCost: additional
+              ? additional.neutral * price.neutral +
+                additional.storybook * price.storybook
+              : 0,
+          };
+        }),
     });
   }
 

--- a/apps/backend/src/database/services/period-usage.ts
+++ b/apps/backend/src/database/services/period-usage.ts
@@ -22,9 +22,7 @@ type BillingPeriodUsage = {
 /**
  * Billing usage for one account, as needed to explain what it is about to pay.
  */
-export type AccountPeriodUsage = {
-  /** The plan the account is billed on. */
-  plan: Plan;
+type AccountPeriodUsage = {
   /**
    * Share of Storybook screenshots in everything the account ever uploaded,
    * between 0 and 1. Null when it never uploaded a screenshot at all — an
@@ -39,6 +37,30 @@ export type AccountPeriodUsage = {
    * whose usage is never billed.
    */
   billingPeriods: BillingPeriodUsage[];
+};
+
+/**
+ * What an account is billed on, as needed to explain what it pays.
+ *
+ * The plan comes back even when there is nothing to price, because it is what
+ * explains the absence: an account on a flat plan or on a granted one has no
+ * overage of ours to quote, and saying which plan it is on is the difference
+ * between an empty cell and an answer.
+ */
+export type AccountBilling = {
+  /**
+   * The forced plan when the account has been granted one, the active
+   * subscription's plan otherwise, and null when it has neither. A personal
+   * account's implicit free plan is not resolved here — this serves team
+   * accounts.
+   */
+  plan: Plan | null;
+  /**
+   * Usage-based billing. Null when the plan is not usage-based: there is no
+   * overage to compute and no period to compute it over, which is a different
+   * answer from one that consumed nothing.
+   */
+  periodUsage: AccountPeriodUsage | null;
 };
 
 /**
@@ -283,17 +305,16 @@ function checkIsBilledPeriod(
 }
 
 /**
- * Billing usage for a batch of accounts, in two queries whatever the batch size.
+ * What a batch of accounts is billed on, in a handful of queries whatever the
+ * batch size.
  *
- * An account maps to `null` when it is not on a usage-based plan: it has no
- * overage to compute and no period to compute it over, which is a different
- * answer from one that consumed nothing. Callers that render money need to tell
- * the two apart, so the distinction is kept here rather than flattened to zero.
+ * Every requested account gets an entry, so a caller never has to tell a missing
+ * answer from an empty one.
  */
-export async function getAccountPeriodUsages(
+export async function getAccountBillings(
   accounts: Account[],
-): Promise<Map<string, AccountPeriodUsage | null>> {
-  const result = new Map<string, AccountPeriodUsage | null>();
+): Promise<Map<string, AccountBilling>> {
+  const result = new Map<string, AccountBilling>();
 
   if (accounts.length === 0) {
     return result;
@@ -303,13 +324,28 @@ export async function getAccountPeriodUsages(
   // carry — the subscription manager reports no active subscription at all for
   // it. These are the granted plans, open source above all: they read as
   // `active` everywhere while billing nothing, so a leftover subscription must
-  // not earn them a price here.
+  // not earn them a price here. The plan itself is still reported: it is what
+  // explains why the account is billed nothing.
   const subscribedAccounts: Account[] = [];
+  const forcedPlanIds = new Set<string>();
   for (const account of accounts) {
     if (account.forcedPlanId === null) {
       subscribedAccounts.push(account);
     } else {
-      result.set(account.id, null);
+      forcedPlanIds.add(account.forcedPlanId);
+    }
+  }
+
+  if (forcedPlanIds.size > 0) {
+    const forcedPlans = await Plan.query().findByIds([...forcedPlanIds]);
+    const forcedPlanById = new Map(forcedPlans.map((plan) => [plan.id, plan]));
+    for (const account of accounts) {
+      if (account.forcedPlanId !== null) {
+        result.set(account.id, {
+          plan: forcedPlanById.get(account.forcedPlanId) ?? null,
+          periodUsage: null,
+        });
+      }
     }
   }
 
@@ -353,7 +389,10 @@ export async function getAccountPeriodUsages(
   for (const account of subscribedAccounts) {
     const subscription = subscriptionByAccountId.get(account.id);
     if (!subscription?.plan?.usageBased) {
-      result.set(account.id, null);
+      result.set(account.id, {
+        plan: subscription?.plan ?? null,
+        periodUsage: null,
+      });
       continue;
     }
     // Contiguous windows, newest first: each period runs until the next one
@@ -403,36 +442,39 @@ export async function getAccountPeriodUsages(
 
     result.set(accountId, {
       plan,
-      storybookRatio:
-        totals.allTime.all > 0
-          ? totals.allTime.storybook / totals.allTime.all
-          : null,
-      storybookCount: totals.allTime.storybook,
-      billingPeriods: accountPeriods
-        .filter((period) => checkIsBilledPeriod(period, subscription))
-        .map((period) => {
-          const periodTotals = totals.periods.get(period.index) ?? EMPTY_TOTALS;
-          // The included quota resets at every period, so the overage is
-          // computed period by period rather than off a running total.
-          const additional =
-            subscription.includedScreenshots === null
-              ? null
-              : computeAdditionalScreenshots({
-                  neutral: periodTotals.all - periodTotals.storybook,
-                  storybook: periodTotals.storybook,
-                  included: subscription.includedScreenshots,
-                });
+      periodUsage: {
+        storybookRatio:
+          totals.allTime.all > 0
+            ? totals.allTime.storybook / totals.allTime.all
+            : null,
+        storybookCount: totals.allTime.storybook,
+        billingPeriods: accountPeriods
+          .filter((period) => checkIsBilledPeriod(period, subscription))
+          .map((period) => {
+            const periodTotals =
+              totals.periods.get(period.index) ?? EMPTY_TOTALS;
+            // The included quota resets at every period, so the overage is
+            // computed period by period rather than off a running total.
+            const additional =
+              subscription.includedScreenshots === null
+                ? null
+                : computeAdditionalScreenshots({
+                    neutral: periodTotals.all - periodTotals.storybook,
+                    storybook: periodTotals.storybook,
+                    included: subscription.includedScreenshots,
+                  });
 
-          return {
-            from: period.from,
-            to: period.to,
-            closed: period.index > 0,
-            additionalScreenshotCost: additional
-              ? additional.neutral * price.neutral +
-                additional.storybook * price.storybook
-              : 0,
-          };
-        }),
+            return {
+              from: period.from,
+              to: period.to,
+              closed: period.index > 0,
+              additionalScreenshotCost: additional
+                ? additional.neutral * price.neutral +
+                  additional.storybook * price.storybook
+                : 0,
+            };
+          }),
+      },
     });
   }
 

--- a/apps/backend/src/graphql/definitions/Plan.ts
+++ b/apps/backend/src/graphql/definitions/Plan.ts
@@ -10,6 +10,8 @@ export const typeDefs = gql`
 
   type Plan implements Node {
     id: ID!
+    "Internal name, stable across renames of the marketing label."
+    name: String!
     displayName: String!
     interval: PlanInterval!
     usageBased: Boolean!

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -84,8 +84,6 @@ export const typeDefs = gql`
     never billed.
     """
     billingPeriods: [TeamStaffBillingPeriod!]!
-    "The plan the team is billed on."
-    plan: Plan!
     """
     Share of Storybook screenshots in everything the team ever uploaded, between
     0 and 1. Null when it never uploaded a screenshot at all.
@@ -112,6 +110,11 @@ export const typeDefs = gql`
     owners: [TeamStaffOwner!]!
     "When a staff member reached out to the team, null if never"
     contact: TeamStaffContact
+    """
+    The plan the team is on, granted plans included. Null when it has no
+    subscription at all — which is most of a trial pipeline.
+    """
+    plan: Plan
     "Billing usage. Null when the team is not on a usage-based plan."
     periodUsage: TeamStaffPeriodUsage
   }
@@ -164,15 +167,19 @@ export const resolvers: IResolvers = {
       invariant(account.teamId, "not a team account");
       return ctx.loaders.StaffTeamContactByTeamId.load(account.teamId);
     },
-    periodUsage: async (account, _args, ctx) => {
-      const usage = await ctx.loaders.AccountPeriodUsageByAccountId.load(
+    plan: async (account, _args, ctx) => {
+      const billing = await ctx.loaders.AccountBillingByAccountId.load(
         account.id,
       );
+      return billing.plan;
+    },
+    periodUsage: async (account, _args, ctx) => {
+      const { periodUsage: usage } =
+        await ctx.loaders.AccountBillingByAccountId.load(account.id);
       if (!usage) {
         return null;
       }
       return {
-        plan: usage.plan,
         storybookRatio: usage.storybookRatio,
         storybookScreenshotsCount: usage.storybookCount,
         billingPeriods: usage.billingPeriods.map((period) => ({

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -65,10 +65,27 @@ export const typeDefs = gql`
     user: User!
   }
 
-  "What a team is consuming, as needed to explain what it is about to pay."
-  type TeamStaffPeriodUsage {
+  "One billing period of a team, priced from the usage it accumulated."
+  type TeamStaffBillingPeriod {
+    from: DateTime!
+    "End of the period, or now while it is still running."
+    to: DateTime!
+    "False while the period is still accumulating usage."
+    closed: Boolean!
     "Cost of the screenshots consumed beyond the included quota, this period."
     additionalScreenshotsCost: Float!
+  }
+
+  "What a team is consuming, as needed to explain what it is about to pay."
+  type TeamStaffPeriodUsage {
+    """
+    Periods Stripe actually invoices, most recent first: the one still running,
+    then the closed ones. Empty while the team is on its trial, whose usage is
+    never billed.
+    """
+    billingPeriods: [TeamStaffBillingPeriod!]!
+    "The plan the team is billed on."
+    plan: Plan!
     """
     Share of Storybook screenshots in everything the team ever uploaded, between
     0 and 1. Null when it never uploaded a screenshot at all.
@@ -155,9 +172,15 @@ export const resolvers: IResolvers = {
         return null;
       }
       return {
-        additionalScreenshotsCost: usage.additionalScreenshotCost,
+        plan: usage.plan,
         storybookRatio: usage.storybookRatio,
         storybookScreenshotsCount: usage.storybookCount,
+        billingPeriods: usage.billingPeriods.map((period) => ({
+          from: period.from,
+          to: period.to,
+          closed: period.closed,
+          additionalScreenshotsCost: period.additionalScreenshotCost,
+        })),
       };
     },
   },

--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -56,8 +56,8 @@ import {
 } from "@/database/models";
 import type { ProjectPermission } from "@/database/models/Project";
 import {
-  getAccountPeriodUsages,
-  type AccountPeriodUsage,
+  getAccountBillings,
+  type AccountBilling,
 } from "@/database/services/period-usage";
 import {
   getLatestReferenceBuildIds,
@@ -757,24 +757,25 @@ function createAccountActivationByAccountIdLoader() {
   });
 }
 
+/** An account that no longer exists, or was never billed anything. */
+const EMPTY_ACCOUNT_BILLING: AccountBilling = { plan: null, periodUsage: null };
+
 /**
- * Batches the billing usage that the staff trial pipeline reads per team.
+ * Batches the billing state that the staff trial pipeline reads per team.
  *
  * Without it, every row would resolve its own subscription and run its own
  * aggregate over `screenshot_buckets` — the exact N+1 the loaders around it
  * exist to prevent, on a list that has no upper bound on its row count.
  */
-function createAccountPeriodUsageByAccountIdLoader() {
-  return new DataLoader<string, AccountPeriodUsage | null>(
-    async (accountIds) => {
-      const uniqueAccountIds = [...new Set(accountIds as string[])];
-      const accounts = await Account.query().findByIds(uniqueAccountIds);
-      const usageByAccountId = await getAccountPeriodUsages(accounts);
-      return accountIds.map(
-        (accountId) => usageByAccountId.get(accountId) ?? null,
-      );
-    },
-  );
+function createAccountBillingByAccountIdLoader() {
+  return new DataLoader<string, AccountBilling>(async (accountIds) => {
+    const uniqueAccountIds = [...new Set(accountIds as string[])];
+    const accounts = await Account.query().findByIds(uniqueAccountIds);
+    const billingByAccountId = await getAccountBillings(accounts);
+    return accountIds.map(
+      (accountId) => billingByAccountId.get(accountId) ?? EMPTY_ACCOUNT_BILLING,
+    );
+  });
 }
 
 /** An owner of a team, as needed to write to them. */
@@ -1881,7 +1882,7 @@ export const createLoaders = () => ({
   AccountLastBuildDateByAccountId:
     createAccountLastBuildDateByAccountIdLoader(),
   AccountActivationByAccountId: createAccountActivationByAccountIdLoader(),
-  AccountPeriodUsageByAccountId: createAccountPeriodUsageByAccountIdLoader(),
+  AccountBillingByAccountId: createAccountBillingByAccountIdLoader(),
   TeamOwnersByTeamId: createTeamOwnersByTeamIdLoader(),
   StaffTeamContactByTeamId: createStaffTeamContactByTeamIdLoader(),
   AccountSubscriptionStatusByAccountId:

--- a/apps/backend/src/graphql/tests/staffTrialPipeline.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/staffTrialPipeline.e2e.test.ts
@@ -19,11 +19,11 @@ const TrialPipelineQuery = `
         buildsCount
         screenshotsCount
         firstComparisonAt
+        plan {
+          id
+          name
+        }
         periodUsage {
-          plan {
-            id
-            name
-          }
           billingPeriods {
             from
             to
@@ -165,8 +165,9 @@ describe("GraphQL staffTrialPipeline", () => {
     const res = await queryPipeline(viewer, 90);
 
     expectNoGraphQLError(res);
-    const { periodUsage } = findEntry(res, team.id).staff;
-    expect(periodUsage.plan.name).toBe("pro");
+    const { staff } = findEntry(res, team.id);
+    expect(staff.plan.name).toBe("pro");
+    const { periodUsage } = staff;
     // The period still running comes first, then the one that closed with 15k
     // screenshots past the 35k included, at $0.005.
     expect(periodUsage.billingPeriods).toMatchObject([

--- a/apps/backend/src/graphql/tests/staffTrialPipeline.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/staffTrialPipeline.e2e.test.ts
@@ -19,6 +19,18 @@ const TrialPipelineQuery = `
         buildsCount
         screenshotsCount
         firstComparisonAt
+        periodUsage {
+          plan {
+            id
+            name
+          }
+          billingPeriods {
+            from
+            to
+            closed
+            additionalScreenshotsCost
+          }
+        }
       }
     }
   }
@@ -108,6 +120,59 @@ describe("GraphQL staffTrialPipeline", () => {
     expect(
       res.body.data.staffTrialPipeline.map((team: any) => team.id),
     ).not.toContain(old.id);
+  });
+
+  it("prices the billing periods of a converted trial", async () => {
+    const viewer = await createViewer({ staff: true });
+    const team = await factory.TeamAccount.create({
+      createdAt: addDays(new Date(), -88).toISOString(),
+    });
+    const project = await factory.Project.create({ accountId: team.id });
+    const plan = await factory.Plan.create({
+      name: "pro",
+      usageBased: true,
+      interval: "month",
+    });
+    const subscriber = await factory.User.create();
+    const subscription = await factory.Subscription.create({
+      accountId: team.id,
+      planId: plan.id,
+      provider: "stripe",
+      stripeSubscriptionId: "sub_converted_trial",
+      subscriberId: subscriber.id,
+      createdAt: addDays(new Date(), -88).toISOString(),
+      startDate: addDays(new Date(), -14).toISOString(),
+      trialEndDate: addDays(new Date(), -85).toISOString(),
+      status: "active",
+      paymentMethodFilled: true,
+      includedScreenshots: 35_000,
+      additionalScreenshotPrice: 0.005,
+      currency: "usd",
+    });
+    const [, closedStart] = subscription.getPeriodStarts(
+      new Date(),
+      "month",
+      2,
+    );
+    invariant(closedStart, "the period before the running one");
+    await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      screenshotCount: 50_000,
+      storybookScreenshotCount: 0,
+      createdAt: new Date(closedStart.getTime() + 3_600_000).toISOString(),
+    });
+
+    const res = await queryPipeline(viewer, 90);
+
+    expectNoGraphQLError(res);
+    const { periodUsage } = findEntry(res, team.id).staff;
+    expect(periodUsage.plan.name).toBe("pro");
+    // The period still running comes first, then the one that closed with 15k
+    // screenshots past the 35k included, at $0.005.
+    expect(periodUsage.billingPeriods).toMatchObject([
+      { closed: false, additionalScreenshotsCost: 0 },
+      { closed: true, additionalScreenshotsCost: 75 },
+    ]);
   });
 
   it("reports a team that created a project but never built", async () => {

--- a/apps/backend/src/media/metering.e2e.test.ts
+++ b/apps/backend/src/media/metering.e2e.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
 import type { Account, Plan, Project } from "@/database/models";
-import { getAccountPeriodUsages } from "@/database/services/period-usage";
+import { getAccountBillings } from "@/database/services/period-usage";
 import { factory, setupDatabase } from "@/database/testing";
 
 /**
@@ -236,7 +236,7 @@ describe("media metering", () => {
     });
   });
 
-  describe("getAccountPeriodUsages", () => {
+  describe("getAccountBillings", () => {
     it("prices media overage on the same line as screenshots", async () => {
       await createSubscription();
       await factory.ScreenshotBucket.create({
@@ -252,10 +252,11 @@ describe("media metering", () => {
         uploadedAt: periodStart.toISOString(),
       });
 
-      const usages = await getAccountPeriodUsages([account]);
+      const usages = await getAccountBillings([account]);
 
       expect(
-        usages.get(account.id)?.billingPeriods[0]?.additionalScreenshotCost,
+        usages.get(account.id)?.periodUsage?.billingPeriods[0]
+          ?.additionalScreenshotCost,
       ).toBeCloseTo(25 * 0.004, 5);
     });
 
@@ -274,11 +275,12 @@ describe("media metering", () => {
         uploadedAt: periodStart.toISOString(),
       });
 
-      const usages = await getAccountPeriodUsages([account]);
+      const usages = await getAccountBillings([account]);
 
       // 25 units, under the 100 included: no overage, and crucially not 75.
       expect(
-        usages.get(account.id)?.billingPeriods[0]?.additionalScreenshotCost,
+        usages.get(account.id)?.periodUsage?.billingPeriods[0]
+          ?.additionalScreenshotCost,
       ).toBe(0);
 
       const count = await account.$getScreenshotCountBetween(

--- a/apps/backend/src/media/metering.e2e.test.ts
+++ b/apps/backend/src/media/metering.e2e.test.ts
@@ -254,10 +254,9 @@ describe("media metering", () => {
 
       const usages = await getAccountPeriodUsages([account]);
 
-      expect(usages.get(account.id)?.additionalScreenshotCost).toBeCloseTo(
-        25 * 0.004,
-        5,
-      );
+      expect(
+        usages.get(account.id)?.billingPeriods[0]?.additionalScreenshotCost,
+      ).toBeCloseTo(25 * 0.004, 5);
     });
 
     it("does not multiply media by the number of projects", async () => {
@@ -278,7 +277,9 @@ describe("media metering", () => {
       const usages = await getAccountPeriodUsages([account]);
 
       // 25 units, under the 100 included: no overage, and crucially not 75.
-      expect(usages.get(account.id)?.additionalScreenshotCost).toBe(0);
+      expect(
+        usages.get(account.id)?.billingPeriods[0]?.additionalScreenshotCost,
+      ).toBe(0);
 
       const count = await account.$getScreenshotCountBetween(
         periodStart,

--- a/apps/frontend/src/pages/Staff/Trials.tsx
+++ b/apps/frontend/src/pages/Staff/Trials.tsx
@@ -3,6 +3,7 @@ import { CombinedGraphQLErrors } from "@apollo/client";
 import { useMutation, useQuery } from "@apollo/client/react";
 import { checkIsTrialingSubscriptionStatus } from "@argos/schemas/subscription-status";
 import { addDays, startOfDay } from "@argos/util/date";
+import { invariant } from "@argos/util/invariant";
 import clsx from "clsx";
 import {
   CheckIcon,
@@ -27,7 +28,11 @@ import { AuthGuard } from "@/containers/AuthGuard";
 import { PeriodSelect, usePeriodState } from "@/containers/PeriodSelect";
 import type { DocumentType } from "@/gql";
 import { graphql } from "@/gql";
-import { AccountSubscriptionStatus, SignupSource } from "@/gql/graphql";
+import {
+  AccountSubscriptionStatus,
+  Currency,
+  SignupSource,
+} from "@/gql/graphql";
 import { Alert, AlertText, AlertTitle } from "@/ui/Alert";
 import { LinkButton } from "@/ui/Button";
 import {
@@ -68,9 +73,19 @@ const TrialPipelineQuery = graphql(`
         screenshotsCount
         firstComparisonAt
         periodUsage {
-          additionalScreenshotsCost
           storybookRatio
           storybookScreenshotsCount
+          plan {
+            id
+            name
+            displayName
+          }
+          billingPeriods {
+            from
+            to
+            closed
+            additionalScreenshotsCost
+          }
         }
         owners {
           id
@@ -92,6 +107,7 @@ const TrialPipelineQuery = graphql(`
         provider
         trialDaysRemaining
         paymentMethodFilled
+        currency
       }
     }
   }
@@ -175,37 +191,87 @@ type SortKey =
   | "estimatedPrice"
   | "contacted";
 
+const PRO_PLAN_NAME = "pro";
+
+/** Flat monthly price of the Pro plan, in dollars. Exact: it is public. */
+const PRO_FLAT_PRICE = 100;
+
 /**
- * Flat monthly price of the Pro plan, in dollars.
+ * Flat monthly price to quote per plan, in dollars.
  *
  * Hardcoded because the flat price is the one part of the pricing that is not
  * persisted: the Stripe sync keeps `includedScreenshots` and the per-screenshot
- * prices on the subscription, but not the plan's own amount. Pro is the only
- * usage-based plan a self-serve trial can land on, so the constant holds for
- * this page — it does not for a negotiated enterprise subscription, nor for a
- * customer billed in euros. Hence "estimated".
+ * prices on the subscription, but not the plan's own amount.
+ *
+ * Pro is the plan every self-serve trial lands on and its price is public, so
+ * that half of the estimate is exact. Enterprise is a stand-in — those
+ * contracts are negotiated one by one, so $1,000 is the order of magnitude
+ * rather than the invoice, which is why the plan is named under any row that is
+ * not on Pro.
  */
-const PRO_FLAT_PRICE = 100;
-
-const PRICE_FORMAT = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  maximumFractionDigits: 0,
-});
+const FLAT_PRICES: Record<string, number | undefined> = {
+  [PRO_PLAN_NAME]: PRO_FLAT_PRICE,
+  enterprise: 1000,
+};
 
 /**
- * What the team would be invoiced if its period closed right now, or null when
- * it would be invoiced nothing at all.
+ * A plan we have never priced falls back to Pro's: a new plan is far more
+ * likely to be another self-serve tier than a negotiated contract, and the row
+ * names it either way.
+ */
+function getFlatPrice(planName: string): number {
+  return FLAT_PRICES[planName] ?? PRO_FLAT_PRICE;
+}
+
+const PRICE_FORMATS = new Map<string, Intl.NumberFormat>();
+
+/**
+ * Prices are stored per subscription in the currency it is billed in, so the
+ * formatter follows the row rather than the page.
+ */
+function formatPrice(amount: number, currency: Currency) {
+  const format =
+    PRICE_FORMATS.get(currency) ??
+    new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 0,
+    });
+  PRICE_FORMATS.set(currency, format);
+  return format.format(amount);
+}
+
+type BillingPeriod = NonNullable<
+  PipelineTeam["staff"]["periodUsage"]
+>["billingPeriods"][number];
+
+/**
+ * The period a team's price is read from: the most recent one that closed.
+ *
+ * A settled period is the same figure whatever day it is read on, which is what
+ * makes the column comparable between rows and between window lengths — an
+ * account 3 days into its month would otherwise read as tiny next to one that
+ * is 3 days from its invoice. A team that converted less than a period ago has
+ * no closed period, so it falls back to the one still running: a floor, but the
+ * only thing that tells a big new account apart from a small one before its
+ * first invoice.
+ */
+function getBilledPeriod(periods: BillingPeriod[]): BillingPeriod | null {
+  return periods.find((period) => period.closed) ?? periods[0] ?? null;
+}
+
+/**
+ * What the team is billed per month, or null when it is billed nothing at all.
  *
  * What is owed depends on where the team sits in its lifecycle, not only on
  * what it consumed:
  *
- * - Active: billing has started, so the flat price plus the overage accrued
- *   since the period opened. The period opened when the subscription did, which
- *   for a converted trial is the conversion itself, so that overage is real.
+ * - Active: billing has started, so the flat price plus the overage of the
+ *   period above.
  * - Trialing with a card: Stripe never bills usage consumed during a trial, and
  *   a trial that goes over quota with a card on file is converted to active on
- *   the next build. Whatever it consumed, it owes the flat price and no more.
+ *   the next build. Whatever it consumed, it owes the flat price and no more —
+ *   which is also what an empty `billingPeriods` says.
  * - Trialing with no card: committed to nothing, and a build would be rejected
  *   before it could owe anything.
  * - Anything else: canceled, expired, or never subscribed.
@@ -220,12 +286,16 @@ function getEstimatedPrice(team: PipelineTeam): number | null {
     return null;
   }
 
+  const flatPrice = getFlatPrice(periodUsage.plan.name);
+
   switch (team.subscriptionStatus) {
-    case AccountSubscriptionStatus.Active:
-      return PRO_FLAT_PRICE + periodUsage.additionalScreenshotsCost;
+    case AccountSubscriptionStatus.Active: {
+      const period = getBilledPeriod(periodUsage.billingPeriods);
+      return flatPrice + (period?.additionalScreenshotsCost ?? 0);
+    }
 
     case AccountSubscriptionStatus.TrialingWithPaymentMethod:
-      return PRO_FLAT_PRICE;
+      return flatPrice;
 
     default:
       return null;
@@ -452,17 +522,52 @@ function ScreenshotsCell(props: { team: PipelineTeam }) {
   );
 }
 
+/**
+ * What the team is billed per month, with the plan named underneath when it is
+ * not Pro.
+ *
+ * Silent on Pro, which is nearly every row and the one plan whose flat price is
+ * public: the marker exists to say that the flat half of this number is a
+ * stand-in for a negotiated contract, so it belongs on the exceptions only. The
+ * overage half stays right whatever the plan — the per screenshot prices are
+ * stored on the subscription itself.
+ */
 function EstimatedPriceCell(props: { team: PipelineTeam }) {
-  const price = getEstimatedPrice(props.team);
+  const { team } = props;
+  const price = getEstimatedPrice(team);
 
   if (price === null) {
     return <span className="text-low">—</span>;
   }
 
+  const { periodUsage } = team.staff;
+  invariant(periodUsage, "a priced team is on a usage-based plan");
+  invariant(team.subscription, "a priced team has a subscription");
+
+  const period = getBilledPeriod(periodUsage.billingPeriods);
+  const { plan } = periodUsage;
+
   return (
-    <Tooltip content="Flat Pro plan, plus the overage accrued this period once billing has started. A running trial owes the flat price only: trial usage is never billed.">
-      <span className="font-medium">{PRICE_FORMAT.format(price)}</span>
-    </Tooltip>
+    <div className="inline-block text-right">
+      <Tooltip
+        content={
+          period?.closed
+            ? "The plan's flat price, plus the overage of the last month that closed — a settled figure, so it does not move with the day it is read on."
+            : "The plan's flat price, plus the overage accrued so far. No month has closed yet, so this is a floor. A running trial owes the flat price only: trial usage is never billed."
+        }
+      >
+        <span className="font-medium">
+          {formatPrice(price, team.subscription.currency)}
+        </span>
+      </Tooltip>
+      {plan.name === PRO_PLAN_NAME ? null : (
+        <Tooltip
+          content={`Billed on ${plan.displayName}, whose flat price is negotiated rather than published: the ${formatPrice(getFlatPrice(plan.name), team.subscription.currency)} half of this estimate is a stand-in. The overage half is read from the subscription and holds whatever the plan.`}
+        >
+          <div className="text-low text-xs">{plan.displayName}</div>
+        </Tooltip>
+      )}
+    </div>
   );
 }
 
@@ -827,8 +932,8 @@ function DecidedTrialsHint() {
  * and the column cannot drift into disagreeing, and the tile stays a figure a
  * reader can check by adding up what is on screen.
  *
- * The overage half is usage to date rather than a settled month, so the total
- * is a floor: it can only be revised upwards as the periods close.
+ * Teams still on their first, running period count what they have accrued so
+ * far, so the total is a floor: it can only be revised upwards as they close.
  */
 function getEstimatedMrr(teams: PipelineTeam[]): {
   total: number;
@@ -918,7 +1023,7 @@ function PipelineSummary(props: { teams: PipelineTeam[] }) {
         value={estimatedMrr.total}
         format="currency"
         hint={
-          <Tooltip content="The Est. price column added up. Active teams count their overage, running trials count the flat price only, and everything else counts nothing. Periods are still open, so this is a floor.">
+          <Tooltip content="The Est. price column added up. Active teams count their overage, running trials count the flat price only, and everything else counts nothing. Teams yet to close a month count what they have accrued, so this is a floor.">
             <span className="underline decoration-dotted underline-offset-2">
               from {estimatedMrr.billedTeams} billed
             </span>

--- a/apps/frontend/src/pages/Staff/Trials.tsx
+++ b/apps/frontend/src/pages/Staff/Trials.tsx
@@ -72,14 +72,14 @@ const TrialPipelineQuery = graphql(`
         buildsCount
         screenshotsCount
         firstComparisonAt
+        plan {
+          id
+          name
+          displayName
+        }
         periodUsage {
           storybookRatio
           storybookScreenshotsCount
-          plan {
-            id
-            name
-            displayName
-          }
           billingPeriods {
             from
             to
@@ -286,7 +286,11 @@ function getEstimatedPrice(team: PipelineTeam): number | null {
     return null;
   }
 
-  const flatPrice = getFlatPrice(periodUsage.plan.name);
+  // Usage to price means a usage-based plan was resolved to price it against.
+  const { plan } = team.staff;
+  invariant(plan, "a team billed by usage is on a plan");
+
+  const flatPrice = getFlatPrice(plan.name);
 
   switch (team.subscriptionStatus) {
     case AccountSubscriptionStatus.Active: {
@@ -523,32 +527,68 @@ function ScreenshotsCell(props: { team: PipelineTeam }) {
 }
 
 /**
- * What the team is billed per month, with the plan named underneath when it is
- * not Pro.
+ * The plan named under the amount, whenever it is not Pro.
  *
  * Silent on Pro, which is nearly every row and the one plan whose flat price is
- * public: the marker exists to say that the flat half of this number is a
- * stand-in for a negotiated contract, so it belongs on the exceptions only. The
- * overage half stays right whatever the plan — the per screenshot prices are
- * stored on the subscription itself.
+ * public. On the rows that carry a price it says the flat half of that number is
+ * a stand-in for a negotiated contract; on the rows that carry none it says why
+ * there is none — a flat or a granted plan has no overage of ours to quote, and
+ * a bare em dash next to an active team reads as missing data instead.
  */
+function PlanMarker(props: {
+  plan: NonNullable<PipelineTeam["staff"]["plan"]>;
+  priced: boolean;
+}) {
+  const { plan, priced } = props;
+
+  if (plan.name === PRO_PLAN_NAME) {
+    return null;
+  }
+
+  return (
+    <Tooltip
+      content={
+        priced
+          ? `Billed on ${plan.displayName}, whose flat price is negotiated rather than published: the ${formatPrice(getFlatPrice(plan.name), Currency.Usd)} half of this estimate is a stand-in. The overage half is read from the subscription and holds whatever the plan.`
+          : `On ${plan.displayName}, which Argos does not bill by usage — there is no overage of ours to put a figure on.`
+      }
+    >
+      {/* Plan names are free text and some are long enough to overrun the
+          column, which is narrow and fixed. Truncated rather than wrapped: the
+          tooltip already carries the whole name, and a second line would push
+          the amount off the row's centerline. */}
+      <div className="text-low truncate text-xs">{plan.displayName}</div>
+    </Tooltip>
+  );
+}
+
+/** What the team is billed per month, with the plan named under it. */
 function EstimatedPriceCell(props: { team: PipelineTeam }) {
   const { team } = props;
+  const { plan } = team.staff;
   const price = getEstimatedPrice(team);
 
   if (price === null) {
-    return <span className="text-low">—</span>;
+    return (
+      <div>
+        <span className="text-low">—</span>
+        {plan ? <PlanMarker plan={plan} priced={false} /> : null}
+      </div>
+    );
   }
 
   const { periodUsage } = team.staff;
   invariant(periodUsage, "a priced team is on a usage-based plan");
+  invariant(plan, "a priced team is on a plan");
   invariant(team.subscription, "a priced team has a subscription");
 
   const period = getBilledPeriod(periodUsage.billingPeriods);
-  const { plan } = periodUsage;
 
+  // A block rather than an inline box: the plan line below needs the width of
+  // the whole cell to know where to truncate. The column is already right
+  // aligned, so the amount does not move.
   return (
-    <div className="inline-block text-right">
+    <div>
       <Tooltip
         content={
           period?.closed
@@ -560,13 +600,7 @@ function EstimatedPriceCell(props: { team: PipelineTeam }) {
           {formatPrice(price, team.subscription.currency)}
         </span>
       </Tooltip>
-      {plan.name === PRO_PLAN_NAME ? null : (
-        <Tooltip
-          content={`Billed on ${plan.displayName}, whose flat price is negotiated rather than published: the ${formatPrice(getFlatPrice(plan.name), team.subscription.currency)} half of this estimate is a stand-in. The overage half is read from the subscription and holds whatever the plan.`}
-        >
-          <div className="text-low text-xs">{plan.displayName}</div>
-        </Tooltip>
-      )}
+      <PlanMarker plan={plan} priced />
     </div>
   );
 }

--- a/tests/seed-test.ts
+++ b/tests/seed-test.ts
@@ -42,7 +42,9 @@ export const seedTest = base.extend<TestFixtures, WorkerFixtures>({
   plan: [
     async ({}, use) => {
       const plan = await PlanModel.query().insertAndFetch({
-        name: "Pro",
+        // The name production uses, which the staff pipeline compares against
+        // to decide whether a row's plan is worth naming.
+        name: "pro",
         includedScreenshots: 15000,
         githubPlanId: null,
         stripeProductId: null,

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -5,6 +5,7 @@ import { expect, test } from "@playwright/test";
 import type { Account } from "../apps/backend/src/database/models";
 import {
   Build,
+  Plan as PlanModel,
   ScreenshotBucket,
   Subscription,
 } from "../apps/backend/src/database/models";
@@ -111,6 +112,112 @@ async function createPipelineTeam(input: {
   return account;
 }
 
+/**
+ * A team past its trial and billed by usage, with a screenshot volume placed
+ * inside each of the periods that have closed since.
+ *
+ * The period boundaries are read back off the subscription rather than guessed
+ * from day offsets: they follow the anniversary of `startDate`, so a fixed
+ * "45 days ago" would land in one period or the next depending on the length of
+ * the months the run happens to fall on.
+ */
+async function createBilledTeam(input: {
+  slug: string;
+  name: string;
+  planId: string;
+  subscriberId: string;
+  createdDaysAgo: number;
+  trialEndedDaysAgo: number;
+  /** Where the running period opened, which sets the billing anniversary. */
+  periodStartDaysAgo: number;
+  /** Screenshots uploaded during each closed period, most recent first. */
+  screenshotsByClosedPeriod: number[];
+}): Promise<Account> {
+  const { account } = await createTeamAccount({
+    slug: input.slug,
+    name: input.name,
+  });
+  await account
+    .$query()
+    .patch({ createdAt: daysFromNow(-input.createdDaysAgo) });
+
+  const subscription = await Subscription.query().insertAndFetch({
+    planId: input.planId,
+    accountId: account.id,
+    provider: "stripe",
+    stripeSubscriptionId: `sub_${input.slug}`,
+    subscriberId: input.subscriberId,
+    // The row is as old as the team: periods that predate it are not billed.
+    createdAt: daysFromNow(-input.createdDaysAgo),
+    startDate: daysFromNow(-input.periodStartDaysAgo),
+    endDate: null,
+    trialEndDate: daysFromNow(-input.trialEndedDaysAgo),
+    paymentMethodFilled: true,
+    status: "active",
+    includedScreenshots: 35_000,
+    additionalScreenshotPrice: 0.005,
+    additionalStorybookScreenshotPrice: 0.002,
+    currency: "usd",
+  });
+
+  const periodStarts = subscription.getPeriodStarts(
+    new Date(),
+    "month",
+    input.screenshotsByClosedPeriod.length + 1,
+  );
+  const project = await createProject({
+    accountId: account.id,
+    name: "usage",
+  });
+
+  // One build per closed period, rather than a bare bucket: the Screenshots
+  // column is summed off build stats while billing reads the buckets, and in
+  // real data every bucket comes from a build. Sequential because the build
+  // number is resolved with a `max(number) + 1` sub-query.
+  for (const [
+    index,
+    screenshotCount,
+  ] of input.screenshotsByClosedPeriod.entries()) {
+    // Index 0 is the period still running, so the closed ones start at 1.
+    const periodStart = periodStarts[index + 1];
+    if (!periodStart) {
+      throw new Error("missing closed period");
+    }
+    const createdAt = new Date(periodStart.getTime() + 3_600_000).toISOString();
+    const bucket = await ScreenshotBucket.query().insertAndFetch({
+      name: "default",
+      commit: "029b662f3ae57bae7a215301067262c1e95bbc95",
+      branch: "main",
+      projectId: project.id,
+      complete: true,
+      valid: true,
+      screenshotCount,
+      storybookScreenshotCount: 0,
+      createdAt,
+    });
+    await Build.query().insert({
+      projectId: project.id,
+      compareScreenshotBucketId: bucket.id,
+      jobStatus: "complete",
+      conclusion: "no-changes",
+      type: "check",
+      createdAt,
+      stats: {
+        total: screenshotCount,
+        failure: 0,
+        added: 0,
+        unchanged: screenshotCount,
+        changed: 0,
+        removed: 0,
+        retryFailure: 0,
+        ignored: 0,
+      },
+    });
+  }
+
+  return account;
+}
+
 type PipelineTeams = { prefix: string };
 
 const staffTest = loggedTest.extend<{ pipelineTeams: PipelineTeams }>({
@@ -134,7 +241,53 @@ const staffTest = loggedTest.extend<{ pipelineTeams: PipelineTeams }>({
   pipelineTeams: async ({ plan, user }, use, testInfo) => {
     const prefix = `pipeline-${getUniqueTestIdentifier(testInfo)}`;
     const common = { planId: plan.id, subscriberId: user.user.id };
+    // The shared plan is flat, so it has no usage to price. The billed teams
+    // below need usage-based ones: `pro`, which the price estimate is built
+    // for, and one that is not, to check that the row says so.
+    const [proPlan, enterprisePlan] = await Promise.all([
+      PlanModel.query().insertAndFetch({
+        name: "pro",
+        includedScreenshots: 35_000,
+        usageBased: true,
+        githubSsoIncluded: true,
+        fineGrainedAccessControlIncluded: true,
+        samlIncluded: true,
+        interval: "month",
+      }),
+      PlanModel.query().insertAndFetch({
+        name: "enterprise",
+        includedScreenshots: 35_000,
+        usageBased: true,
+        githubSsoIncluded: true,
+        fineGrainedAccessControlIncluded: true,
+        samlIncluded: true,
+        interval: "month",
+      }),
+    ]);
     await Promise.all([
+      // Converted almost three months ago, so two periods have closed since:
+      // 40k screenshots, then 50k. The row prices the most recent of the two.
+      createBilledTeam({
+        ...common,
+        planId: proPlan.id,
+        slug: `${prefix}-soylent`,
+        name: "Soylent",
+        createdDaysAgo: 88,
+        trialEndedDaysAgo: 85,
+        periodStartDaysAgo: 14,
+        screenshotsByClosedPeriod: [50_000, 40_000],
+      }),
+      // Same shape, on a plan the flat price is not taken from.
+      createBilledTeam({
+        ...common,
+        planId: enterprisePlan.id,
+        slug: `${prefix}-umbrella`,
+        name: "Umbrella",
+        createdDaysAgo: 80,
+        trialEndedDaysAgo: 77,
+        periodStartDaysAgo: 9,
+        screenshotsByClosedPeriod: [60_000],
+      }),
       createPipelineTeam({
         ...common,
         slug: `${prefix}-northwind`,
@@ -171,7 +324,7 @@ staffTest("staff all teams", async ({ page, pipelineTeams }) => {
   await page.goto("/staff/teams");
   await expect(page.getByRole("heading", { name: "All Teams" })).toBeVisible();
   await page.getByRole("searchbox").fill(pipelineTeams.prefix);
-  await expect(page.getByText("Showing 1-3 of 3 teams")).toBeVisible();
+  await expect(page.getByText("Showing 1-5 of 5 teams")).toBeVisible();
 
   await screenshot(page, "staff-all-teams");
 });
@@ -194,6 +347,30 @@ staffTest("staff trial pipeline", async ({ page, pipelineTeams }) => {
 
   await screenshot(page, "staff-trial-pipeline");
 });
+
+staffTest(
+  "staff trial pipeline over 90 days",
+  async ({ page, pipelineTeams }) => {
+    test.slow();
+    await page.goto("/staff/trials?period=last90Days");
+    await expect(
+      page.getByRole("heading", { name: "Trial pipeline" }),
+    ).toBeVisible();
+    await page.getByRole("searchbox").fill(pipelineTeams.prefix);
+    await expect(page.getByText(/^Showing 5 of \d+ teams$/)).toBeVisible();
+
+    // Soylent uploaded 50k screenshots over its last closed month: 15k past the
+    // 35k included, at $0.005, on top of the $100 flat plan. The month still
+    // running holds nothing, so reading that one instead would print $100.
+    await expect(page.getByText("$175")).toBeVisible();
+    // Umbrella is on Enterprise: same 60k over the same quota, but a flat price
+    // of its own, and the row names the plan under the amount.
+    await expect(page.getByText("$1,125")).toBeVisible();
+    await expect(page.getByText("Enterprise")).toBeVisible();
+
+    await screenshot(page, "staff-trial-pipeline-90-days");
+  },
+);
 
 loggedTest("staff pages are refused to regular users", async ({ page }) => {
   await page.goto("/staff/trials");

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -241,10 +241,11 @@ const staffTest = loggedTest.extend<{ pipelineTeams: PipelineTeams }>({
   pipelineTeams: async ({ plan, user }, use, testInfo) => {
     const prefix = `pipeline-${getUniqueTestIdentifier(testInfo)}`;
     const common = { planId: plan.id, subscriberId: user.user.id };
-    // The shared plan is flat, so it has no usage to price. The billed teams
-    // below need usage-based ones: `pro`, which the price estimate is built
-    // for, and one that is not, to check that the row says so.
-    const [proPlan, enterprisePlan] = await Promise.all([
+    // The shared plan is flat, so it has no usage to price. The teams below
+    // need three more: `pro`, which the price estimate is built for, one that
+    // is not, and a granted one that bills nothing at all — each row naming
+    // its plan when it is not Pro.
+    const [proPlan, enterprisePlan, grantedPlan] = await Promise.all([
       PlanModel.query().insertAndFetch({
         name: "pro",
         includedScreenshots: 35_000,
@@ -263,8 +264,26 @@ const staffTest = loggedTest.extend<{ pipelineTeams: PipelineTeams }>({
         samlIncluded: true,
         interval: "month",
       }),
+      PlanModel.query().insertAndFetch({
+        name: "open source",
+        includedScreenshots: 1_000_000,
+        usageBased: false,
+        githubSsoIncluded: true,
+        fineGrainedAccessControlIncluded: true,
+        samlIncluded: true,
+        interval: "month",
+      }),
     ]);
     await Promise.all([
+      // A granted plan reads as active everywhere while billing nothing, so
+      // its row carries no price — only the plan, which is what says why.
+      createTeamAccount({
+        slug: `${prefix}-hexagon`,
+        name: "Hexagon",
+        forcedPlanId: grantedPlan.id,
+      }).then(({ account }) =>
+        account.$query().patch({ createdAt: daysFromNow(-40) }),
+      ),
       // Converted almost three months ago, so two periods have closed since:
       // 40k screenshots, then 50k. The row prices the most recent of the two.
       createBilledTeam({
@@ -324,7 +343,7 @@ staffTest("staff all teams", async ({ page, pipelineTeams }) => {
   await page.goto("/staff/teams");
   await expect(page.getByRole("heading", { name: "All Teams" })).toBeVisible();
   await page.getByRole("searchbox").fill(pipelineTeams.prefix);
-  await expect(page.getByText("Showing 1-5 of 5 teams")).toBeVisible();
+  await expect(page.getByText("Showing 1-6 of 6 teams")).toBeVisible();
 
   await screenshot(page, "staff-all-teams");
 });
@@ -357,7 +376,7 @@ staffTest(
       page.getByRole("heading", { name: "Trial pipeline" }),
     ).toBeVisible();
     await page.getByRole("searchbox").fill(pipelineTeams.prefix);
-    await expect(page.getByText(/^Showing 5 of \d+ teams$/)).toBeVisible();
+    await expect(page.getByText(/^Showing 6 of \d+ teams$/)).toBeVisible();
 
     // Soylent uploaded 50k screenshots over its last closed month: 15k past the
     // 35k included, at $0.005, on top of the $100 flat plan. The month still
@@ -367,6 +386,9 @@ staffTest(
     // of its own, and the row names the plan under the amount.
     await expect(page.getByText("$1,125")).toBeVisible();
     await expect(page.getByText("Enterprise")).toBeVisible();
+    // Hexagon is billed nothing at all, and the plan is the only thing that
+    // says why — the price cell is an em dash.
+    await expect(page.getByText("Open source")).toBeVisible();
 
     await screenshot(page, "staff-trial-pipeline-90-days");
   },


### PR DESCRIPTION
The Est. price column read the overage accrued since the billing anniversary, so a team's price collapsed to the flat plan the day its month rolled over and climbed back until the next one. It now reads the last month that closed — a settled figure that does not depend on when the page is opened — and falls back to the period still running only for teams yet to be invoiced once.

Period starts are walked back from an anniversary, so they kept going past the end of the trial and past the creation of the subscription; those stretches were being priced as closed months.

Rows that are not on Pro name their plan under the amount, their flat price being negotiated rather than published, and Enterprise is quoted at $1,000. Amounts follow the subscription's own currency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)