### PR TITLE
feat(staff): read what a plan costs from Stripe

### DIFF
--- a/apps/backend/db/migrations/20260816090349_subscription-flat-price.js
+++ b/apps/backend/db/migrations/20260816090349_subscription-flat-price.js
@@ -1,0 +1,35 @@
+/**
+ * Record what the plan itself costs on a subscription.
+ *
+ * Everything else about the pricing is already synced from Stripe — the
+ * included screenshots, the price of an additional one — but the recurring
+ * amount of the plan was not, so the only way to quote it was to hardcode it.
+ * That works for the self-serve plans, whose price is published, and is wrong
+ * by construction for a negotiated contract.
+ *
+ * Held per subscription rather than per plan for the same reason
+ * `includedScreenshots` is: every enterprise contract shares one `plans` row
+ * while each carries its own amount.
+ *
+ * The amount is per billing period and in the subscription's own currency, read
+ * exactly as Stripe states it — the same convention as `includedScreenshots`,
+ * which readers already interpret through `plans.interval`. `NULL` means the
+ * sync has not seen this subscription since the column existed, or that it has
+ * no Stripe price to read at all, as a GitHub subscription does.
+ *
+ * @param {import('knex').Knex} knex
+ */
+export const up = async (knex) => {
+  await knex.schema.alterTable("subscriptions", (table) => {
+    table.float("flatPrice");
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+export const down = async (knex) => {
+  await knex.schema.alterTable("subscriptions", (table) => {
+    table.dropColumn("flatPrice");
+  });
+};

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -2,10 +2,10 @@
 -- PostgreSQL database dump
 --
 
-\restrict BP0mq72amFd2hqhwLdkTacMXSNGJyX9xkoDpE3W9d4mo17sxB6E4dvy4pxodiih
+\restrict I3c71ozcUc6qIxshE9FEt2xxcp0iTprj3I7DbqFDTBMY5k3xcGbjx5vlNVrhV8O
 
 -- Dumped from database version 18.4
--- Dumped by pg_dump version 18.4 (Homebrew)
+-- Dumped by pg_dump version 18.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -1463,7 +1463,7 @@ CREATE TABLE public.media (
     visibility character varying(255) DEFAULT 'team'::character varying NOT NULL,
     "shareToken" character varying(255) NOT NULL,
     branch character varying(255),
-    CONSTRAINT media_state_check CHECK (((state IS NULL) OR ((state)::text = ANY (ARRAY[('before'::character varying)::text, ('after'::character varying)::text]))))
+    CONSTRAINT media_state_check CHECK (((state IS NULL) OR ((state)::text = ANY ((ARRAY['before'::character varying, 'after'::character varying])::text[]))))
 );
 
 
@@ -2423,6 +2423,7 @@ CREATE TABLE public.subscriptions (
     currency character varying(255),
     "usageUpdatedAt" timestamp with time zone,
     "additionalStorybookScreenshotPrice" real,
+    "flatPrice" real,
     CONSTRAINT check_stripe_fields CHECK (((provider <> 'stripe'::text) OR (("stripeSubscriptionId" IS NOT NULL) AND ("subscriberId" IS NOT NULL)))),
     CONSTRAINT subscriptions_provider_check CHECK ((provider = ANY (ARRAY['stripe'::text, 'github'::text])))
 );
@@ -6236,7 +6237,7 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-\unrestrict BP0mq72amFd2hqhwLdkTacMXSNGJyX9xkoDpE3W9d4mo17sxB6E4dvy4pxodiih
+\unrestrict I3c71ozcUc6qIxshE9FEt2xxcp0iTprj3I7DbqFDTBMY5k3xcGbjx5vlNVrhV8O
 
 -- Knex migrations
 
@@ -6482,3 +6483,4 @@ INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('2026080
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260811133709_media-diffs.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260813191611_comment-agent.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260814161900_build-review-agent.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260816090349_subscription-flat-price.js', 1, NOW());

--- a/apps/backend/src/database/models/Subscription.ts
+++ b/apps/backend/src/database/models/Subscription.ts
@@ -47,6 +47,9 @@ export class Subscription extends Model {
           includedScreenshots: {
             anyOf: [{ type: "null" }, { type: "integer", minimum: 0 }],
           },
+          flatPrice: {
+            anyOf: [{ type: "null" }, { type: "number", minimum: 0 }],
+          },
           additionalScreenshotPrice: {
             anyOf: [{ type: "null" }, { type: "number", minimum: 0 }],
           },
@@ -81,6 +84,14 @@ export class Subscription extends Model {
     | "incomplete_expired"
     | "paused";
   includedScreenshots!: number | null;
+  /**
+   * Recurring amount of the plan itself, per billing period and in `currency`.
+   *
+   * Null when the subscription has not been synced since the column existed, or
+   * when there is no Stripe price to read it from — a GitHub subscription, or a
+   * plan priced by tiers, which has no single unit amount.
+   */
+  flatPrice!: number | null;
   additionalScreenshotPrice!: number | null;
   additionalStorybookScreenshotPrice!: number | null;
   usageUpdatedAt!: string | null;

--- a/apps/backend/src/database/services/period-usage.e2e.test.ts
+++ b/apps/backend/src/database/services/period-usage.e2e.test.ts
@@ -58,7 +58,11 @@ describe("getAccountPeriodUsages", () => {
 
   it("reports no plan and no usage for an account without a subscription", async () => {
     const usages = await getAccountBillings([account]);
-    expect(usages.get(account.id)).toEqual({ plan: null, periodUsage: null });
+    expect(usages.get(account.id)).toEqual({
+      plan: null,
+      flatPrice: null,
+      periodUsage: null,
+    });
   });
 
   it("reports a granted plan, and no usage under it", async () => {
@@ -79,6 +83,7 @@ describe("getAccountPeriodUsages", () => {
     // The plan still comes back: it is what explains why nothing is billed.
     expect(usages.get(grantedAccount.id)).toEqual({
       plan: expect.objectContaining({ id: usageBasedPlan.id }),
+      flatPrice: null,
       periodUsage: null,
     });
   });
@@ -116,6 +121,7 @@ describe("getAccountPeriodUsages", () => {
 
     expect(usages.get(account.id)).toEqual({
       plan: expect.objectContaining({ id: flatPlan.id }),
+      flatPrice: null,
       periodUsage: null,
     });
   });
@@ -347,6 +353,7 @@ describe("getAccountPeriodUsages", () => {
     expect(getRunningCost(usages.get(otherAccount.id))).toBe(50);
     expect(usages.get(noSubscriptionAccount.id)).toEqual({
       plan: null,
+      flatPrice: null,
       periodUsage: null,
     });
   });

--- a/apps/backend/src/database/services/period-usage.ts
+++ b/apps/backend/src/database/services/period-usage.ts
@@ -56,6 +56,13 @@ export type AccountBilling = {
    */
   plan: Plan | null;
   /**
+   * What the plan costs per billing period on this account's subscription, in
+   * that subscription's currency — the negotiated amount for a contract, the
+   * published one otherwise. Null when Stripe has never been asked for it, or
+   * has nothing to answer: see `Subscription.flatPrice`.
+   */
+  flatPrice: number | null;
+  /**
    * Usage-based billing. Null when the plan is not usage-based: there is no
    * overage to compute and no period to compute it over, which is a different
    * answer from one that consumed nothing.
@@ -343,6 +350,9 @@ export async function getAccountBillings(
       if (account.forcedPlanId !== null) {
         result.set(account.id, {
           plan: forcedPlanById.get(account.forcedPlanId) ?? null,
+          // A granted plan is not paid for, so there is no amount to report
+          // even when a leftover subscription still carries one.
+          flatPrice: null,
           periodUsage: null,
         });
       }
@@ -391,6 +401,7 @@ export async function getAccountBillings(
     if (!subscription?.plan?.usageBased) {
       result.set(account.id, {
         plan: subscription?.plan ?? null,
+        flatPrice: subscription?.flatPrice ?? null,
         periodUsage: null,
       });
       continue;
@@ -442,6 +453,7 @@ export async function getAccountBillings(
 
     result.set(accountId, {
       plan,
+      flatPrice: subscription.flatPrice,
       periodUsage: {
         storybookRatio:
           totals.allTime.all > 0

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -115,6 +115,13 @@ export const typeDefs = gql`
     subscription at all — which is most of a trial pipeline.
     """
     plan: Plan
+    """
+    What the plan costs per billing period, in the subscription's currency, as
+    Stripe states it. Null when Stripe has nothing to state: a granted plan, a
+    GitHub subscription, or a subscription not synced since Argos started
+    reading the amount.
+    """
+    flatPrice: Float
     "Billing usage. Null when the team is not on a usage-based plan."
     periodUsage: TeamStaffPeriodUsage
   }
@@ -172,6 +179,12 @@ export const resolvers: IResolvers = {
         account.id,
       );
       return billing.plan;
+    },
+    flatPrice: async (account, _args, ctx) => {
+      const billing = await ctx.loaders.AccountBillingByAccountId.load(
+        account.id,
+      );
+      return billing.flatPrice;
     },
     periodUsage: async (account, _args, ctx) => {
       const { periodUsage: usage } =

--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -758,7 +758,11 @@ function createAccountActivationByAccountIdLoader() {
 }
 
 /** An account that no longer exists, or was never billed anything. */
-const EMPTY_ACCOUNT_BILLING: AccountBilling = { plan: null, periodUsage: null };
+const EMPTY_ACCOUNT_BILLING: AccountBilling = {
+  plan: null,
+  flatPrice: null,
+  periodUsage: null,
+};
 
 /**
  * Batches the billing state that the staff trial pipeline reads per team.

--- a/apps/backend/src/graphql/tests/staffTrialPipeline.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/staffTrialPipeline.e2e.test.ts
@@ -23,6 +23,7 @@ const TrialPipelineQuery = `
           id
           name
         }
+        flatPrice
         periodUsage {
           billingPeriods {
             from
@@ -147,6 +148,7 @@ describe("GraphQL staffTrialPipeline", () => {
       paymentMethodFilled: true,
       includedScreenshots: 35_000,
       additionalScreenshotPrice: 0.005,
+      flatPrice: 100,
       currency: "usd",
     });
     const [, closedStart] = subscription.getPeriodStarts(
@@ -167,6 +169,7 @@ describe("GraphQL staffTrialPipeline", () => {
     expectNoGraphQLError(res);
     const { staff } = findEntry(res, team.id);
     expect(staff.plan.name).toBe("pro");
+    expect(staff.flatPrice).toBe(100);
     const { periodUsage } = staff;
     // The period still running comes first, then the one that closed with 15k
     // screenshots past the 35k included, at $0.005.

--- a/apps/backend/src/stripe/fixtures/trial-subscription.ts
+++ b/apps/backend/src/stripe/fixtures/trial-subscription.ts
@@ -3,6 +3,8 @@ import Stripe from "stripe";
 export const TRIAL_STRIPE_PRODUCT_ID = "prod_trial_test";
 export const TRIAL_STRIPE_SUBSCRIPTION_ID = "sub_trial_test";
 export const TRIAL_INCLUDED_SCREENSHOTS = 15000;
+/** Monthly price of the plan, in dollars. */
+export const TRIAL_FLAT_PRICE = 250;
 /** Moment the trial started. */
 const TRIAL_START_TIMESTAMP = 1751760000;
 /**
@@ -22,6 +24,9 @@ function createPlanItem(currentPeriodStart: number) {
       billing_scheme: "per_unit",
       currency: "usd",
       metadata: { includedScreenshots: String(TRIAL_INCLUDED_SCREENSHOTS) },
+      // Stripe states amounts in the smallest currency unit, behind a decimal
+      // wrapper — mirrored here so the sync reads it the way it does in prod.
+      unit_amount_decimal: { toNumber: () => TRIAL_FLAT_PRICE * 100 },
       product: TRIAL_STRIPE_PRODUCT_ID,
       tiers_mode: null,
     },

--- a/apps/backend/src/stripe/index.ts
+++ b/apps/backend/src/stripe/index.ts
@@ -254,9 +254,9 @@ async function getPriceInfosFromStripeSubscription(
   const { price } = planItem;
   const startDate = timestampToISOString(planItem.current_period_start);
   const currency = CurrencySchema.parse(price.currency);
-  // Read outside the branches below: unlike the included screenshots, the
-  // amount does not depend on any metadata we declare, so a plan we could not
-  // interpret still has a price we can report.
+  // Read once, above the branches: both ways out of `per_unit` report it, and
+  // unlike the included screenshots it depends on no metadata of ours, so a
+  // plan whose metadata we cannot interpret still has a price we can state.
   const flatPrice = getFlatPriceFromPlanItem(planItem);
 
   switch (price.billing_scheme) {
@@ -330,12 +330,22 @@ async function getPriceInfosFromStripeSubscription(
 function getFlatPriceFromPlanItem(
   planItem: Stripe.SubscriptionItem,
 ): number | null {
-  const unitAmount = planItem.price.unit_amount_decimal;
+  const { price } = planItem;
+
+  // A metered price states what one unit costs, not what the plan costs, and
+  // Stripe carries no quantity on it. Reading it here would record a fraction
+  // of a cent as the price of the plan.
+  if (price.recurring?.usage_type === "metered") {
+    return null;
+  }
+
+  const unitAmount = price.unit_amount_decimal;
   // Absent as well as null: a price by tiers carries no unit amount, and Stripe
   // leaves the field out entirely on some price shapes rather than nulling it.
   if (!unitAmount) {
     return null;
   }
+
   // Every Argos plan line sits at a quantity of 1, but it is read rather than
   // assumed: a contract billed per seat would otherwise report one seat.
   return (unitAmount.toNumber() / 100) * (planItem.quantity ?? 1);
@@ -673,6 +683,13 @@ export async function getDefaultTeamPlanItems(
 /**
  * Check if a usage-based subscription is incomplete.
  * Meaning some information are missing to be able to use it.
+ *
+ * This is what backfills a column added after the fact: usage is reported on
+ * every build, so a row missing anything re-syncs itself the next time the
+ * account uploads, without a script to run. A subscription whose price Stripe
+ * cannot state — one billed by tiers — stays incomplete and re-syncs on every
+ * build, which is already true of one whose metadata we cannot read, and costs
+ * a patch on a subscription Stripe was going to be asked about anyway.
  */
 function checkIsUsageBasedSubscriptionIncomplete(
   subscription: Subscription,
@@ -680,7 +697,8 @@ function checkIsUsageBasedSubscriptionIncomplete(
   return (
     subscription.includedScreenshots === null ||
     subscription.additionalScreenshotPrice === null ||
-    subscription.currency === null
+    subscription.currency === null ||
+    subscription.flatPrice === null
   );
 }
 

--- a/apps/backend/src/stripe/index.ts
+++ b/apps/backend/src/stripe/index.ts
@@ -244,6 +244,7 @@ async function getPriceInfosFromStripeSubscription(
     Subscription,
     | "includedScreenshots"
     | "currency"
+    | "flatPrice"
     | "additionalScreenshotPrice"
     | "additionalStorybookScreenshotPrice"
     | "startDate"
@@ -253,6 +254,10 @@ async function getPriceInfosFromStripeSubscription(
   const { price } = planItem;
   const startDate = timestampToISOString(planItem.current_period_start);
   const currency = CurrencySchema.parse(price.currency);
+  // Read outside the branches below: unlike the included screenshots, the
+  // amount does not depend on any metadata we declare, so a plan we could not
+  // interpret still has a price we can report.
+  const flatPrice = getFlatPriceFromPlanItem(planItem);
 
   switch (price.billing_scheme) {
     case "tiered": {
@@ -283,6 +288,7 @@ async function getPriceInfosFromStripeSubscription(
             return {
               startDate,
               currency,
+              flatPrice,
               includedScreenshots: includedScreenshots,
               additionalScreenshotPrice: screenshotItem
                 ? getUnitAmountFromPrice(screenshotItem.price)
@@ -297,6 +303,7 @@ async function getPriceInfosFromStripeSubscription(
       return {
         startDate,
         currency,
+        flatPrice,
         includedScreenshots: null,
         additionalScreenshotPrice: null,
         additionalStorybookScreenshotPrice: null,
@@ -305,6 +312,33 @@ async function getPriceInfosFromStripeSubscription(
     default:
       assertNever(price.billing_scheme);
   }
+}
+
+/**
+ * What the plan itself costs on this subscription, per billing period.
+ *
+ * Unlike the included screenshots, this needs no metadata of ours: the
+ * recurring amount is a first-class Stripe field, so it cannot be left out when
+ * a contract is set up the way a metadata key can. Stored as Stripe states it —
+ * in the subscription's currency, for its own interval — which is the same
+ * convention `includedScreenshots` follows.
+ *
+ * Null when the plan is priced by tiers rather than by a unit amount: there is
+ * no single figure to store, and failing the whole sync over it would take a
+ * subscription offline for the sake of a display detail.
+ */
+function getFlatPriceFromPlanItem(
+  planItem: Stripe.SubscriptionItem,
+): number | null {
+  const unitAmount = planItem.price.unit_amount_decimal;
+  // Absent as well as null: a price by tiers carries no unit amount, and Stripe
+  // leaves the field out entirely on some price shapes rather than nulling it.
+  if (!unitAmount) {
+    return null;
+  }
+  // Every Argos plan line sits at a quantity of 1, but it is read rather than
+  // assumed: a contract billed per seat would otherwise report one seat.
+  return (unitAmount.toNumber() / 100) * (planItem.quantity ?? 1);
 }
 
 /**

--- a/apps/backend/src/stripe/trial.e2e.test.ts
+++ b/apps/backend/src/stripe/trial.e2e.test.ts
@@ -10,6 +10,7 @@ import { redisLock } from "@/util/redis";
 import {
   ENDED_TRIAL_STRIPE_SUBSCRIPTION,
   TRIAL_CONVERSION_TIMESTAMP,
+  TRIAL_FLAT_PRICE,
   TRIAL_INCLUDED_SCREENSHOTS,
   TRIAL_STRIPE_PRODUCT_ID,
   TRIAL_STRIPE_SUBSCRIPTION_ID,
@@ -99,6 +100,9 @@ describe("endTrialToUnlockUsage", () => {
     expect(new Date(updated.startDate).getTime()).toBe(
       TRIAL_CONVERSION_TIMESTAMP * 1000,
     );
+    // The plan's own amount is synced along with the rest of the pricing, so
+    // nothing downstream has to guess what the subscription costs.
+    expect(updated.flatPrice).toBe(TRIAL_FLAT_PRICE);
     expect(send).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "trial_ended",

--- a/apps/frontend/src/pages/Staff/Trials.tsx
+++ b/apps/frontend/src/pages/Staff/Trials.tsx
@@ -29,7 +29,6 @@ import type { DocumentType } from "@/gql";
 import { graphql } from "@/gql";
 import {
   AccountSubscriptionStatus,
-  Currency,
   PlanInterval,
   SignupSource,
 } from "@/gql/graphql";
@@ -111,7 +110,6 @@ const TrialPipelineQuery = graphql(`
         provider
         trialDaysRemaining
         paymentMethodFilled
-        currency
       }
     }
   }
@@ -197,59 +195,72 @@ type SortKey =
 
 const PRO_PLAN_NAME = "pro";
 
-/**
- * Published monthly price of the Pro plan, in dollars.
- *
- * The fallback for a subscription whose own amount is not on file — one that
- * has not been synced since Argos started reading it from Stripe, or that has
- * no Stripe price at all. Pro is what a self-serve trial lands on, so it is the
- * right guess for the rows that need one; a contract on another plan is priced
- * far too low by it, which is what the plan named under the amount warns about.
- */
-const PRO_FLAT_PRICE = 100;
+type StaffPlan = NonNullable<PipelineTeam["staff"]["plan"]>;
 
 /**
- * What the plan costs for one billing period, in the subscription's currency.
+ * Monthly price to assume for a plan when the subscription carries no amount of
+ * its own — one Stripe has not been asked about since Argos started reading the
+ * amount, or that has none to give.
+ *
+ * These are guesses, and they are the reason the plan is named under any amount
+ * that is not Pro's. Enterprise is here because the alternative is worse: with
+ * no entry at all a negotiated contract would fall back to the cheapest plan we
+ * sell, and understate itself tenfold in a total that carries no warning.
+ */
+const FALLBACK_MONTHLY_PRICES: Record<string, number | undefined> = {
+  [PRO_PLAN_NAME]: 100,
+  enterprise: 1000,
+};
+
+/** What a plan a trial can land on costs, for the rows that need a guess. */
+const DEFAULT_FALLBACK_MONTHLY_PRICE = 100;
+
+function getFallbackMonthlyPrice(plan: StaffPlan): number {
+  return FALLBACK_MONTHLY_PRICES[plan.name] ?? DEFAULT_FALLBACK_MONTHLY_PRICE;
+}
+
+/**
+ * An amount stated for one billing period, read as a monthly one.
+ *
+ * Stripe states every amount per period — the plan's price and the overage
+ * alike — and a yearly subscription's period is a year. The column compares
+ * teams against each other, so it holds one unit: the month.
+ */
+function toMonthlyAmount(amount: number, plan: StaffPlan): number {
+  return plan.interval === PlanInterval.Year ? amount / 12 : amount;
+}
+
+/**
+ * What the plan costs per month.
  *
  * Read from Stripe and stored on the subscription, so a negotiated contract
- * quotes its own amount rather than a constant of ours.
+ * quotes its own amount rather than a constant of ours. The fallbacks are
+ * already monthly figures, which is why only the stored amount is converted.
  */
-function getPeriodFlatPrice(staff: PipelineTeam["staff"]): number {
-  // Pro is billed monthly, so its published price is already one period's
-  // worth — which is why the fallback needs no conversion.
-  return staff.flatPrice ?? PRO_FLAT_PRICE;
-}
-
-/**
- * A period's amount read as a monthly one.
- *
- * Everything in this column is per billing period — the plan's price and the
- * overage alike — and a yearly subscription's period is a year. The column
- * compares teams against each other, so it holds one unit: the month.
- */
-function toMonthlyAmount(
-  amount: number,
-  plan: PipelineTeam["staff"]["plan"],
+function getMonthlyFlatPrice(
+  staff: PipelineTeam["staff"],
+  plan: StaffPlan,
 ): number {
-  return plan?.interval === PlanInterval.Year ? amount / 12 : amount;
+  return staff.flatPrice === null
+    ? getFallbackMonthlyPrice(plan)
+    : toMonthlyAmount(staff.flatPrice, plan);
 }
 
-const PRICE_FORMATS = new Map<string, Intl.NumberFormat>();
-
 /**
- * Prices are stored per subscription in the currency it is billed in, so the
- * formatter follows the row rather than the page.
+ * Every amount on this page is printed in dollars, whatever the subscription is
+ * billed in — the currency Argos reports revenue in, and the one the summary
+ * tiles already add up. A euro contract is therefore read at parity rather than
+ * converted, which is close enough for a pipeline view and far clearer than a
+ * column mixing two currencies it cannot total.
  */
-function formatPrice(amount: number, currency: Currency) {
-  const format =
-    PRICE_FORMATS.get(currency) ??
-    new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency,
-      maximumFractionDigits: 0,
-    });
-  PRICE_FORMATS.set(currency, format);
-  return format.format(amount);
+const PRICE_FORMAT = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+
+function formatPrice(amount: number) {
+  return PRICE_FORMAT.format(amount);
 }
 
 type BillingPeriod = NonNullable<
@@ -301,19 +312,19 @@ function getEstimatedPrice(team: PipelineTeam): number | null {
   const { plan } = team.staff;
   invariant(plan, "a team billed by usage is on a plan");
 
-  const flatPrice = getPeriodFlatPrice(team.staff);
+  const monthlyFlatPrice = getMonthlyFlatPrice(team.staff, plan);
 
   switch (team.subscriptionStatus) {
     case AccountSubscriptionStatus.Active: {
       const period = getBilledPeriod(periodUsage.billingPeriods);
-      return toMonthlyAmount(
-        flatPrice + (period?.additionalScreenshotsCost ?? 0),
-        plan,
+      return (
+        monthlyFlatPrice +
+        toMonthlyAmount(period?.additionalScreenshotsCost ?? 0, plan)
       );
     }
 
     case AccountSubscriptionStatus.TrialingWithPaymentMethod:
-      return toMonthlyAmount(flatPrice, plan);
+      return monthlyFlatPrice;
 
     default:
       return null;
@@ -549,7 +560,7 @@ function ScreenshotsCell(props: { team: PipelineTeam }) {
  */
 function getPlanHint(input: {
   staff: PipelineTeam["staff"];
-  plan: NonNullable<PipelineTeam["staff"]["plan"]>;
+  plan: StaffPlan;
   priced: boolean;
 }): string {
   const { staff, plan, priced } = input;
@@ -559,10 +570,10 @@ function getPlanHint(input: {
   }
 
   if (staff.flatPrice === null) {
-    return `Billed on ${plan.displayName}, whose own amount is not on file — the subscription has not been synced since Argos started reading it from Stripe, so the flat half of this estimate falls back to Pro's ${formatPrice(PRO_FLAT_PRICE, Currency.Usd)} and is almost certainly too low.`;
+    return `Billed on ${plan.displayName}, whose own amount is not on file, so the flat half of this estimate is a ${formatPrice(getFallbackMonthlyPrice(plan))} guess rather than the contract.`;
   }
 
-  return `Billed on ${plan.displayName}. The flat half is the amount Stripe holds for this subscription, not a price of ours.`;
+  return `Billed on ${plan.displayName}. The flat half is the amount held on the subscription in Stripe, not a price of ours.`;
 }
 
 /**
@@ -577,7 +588,7 @@ function getPlanHint(input: {
  */
 function PlanMarker(props: {
   staff: PipelineTeam["staff"];
-  plan: NonNullable<PipelineTeam["staff"]["plan"]>;
+  plan: StaffPlan;
   priced: boolean;
 }) {
   const { plan } = props;
@@ -617,7 +628,6 @@ function EstimatedPriceCell(props: { team: PipelineTeam }) {
   const { periodUsage } = team.staff;
   invariant(periodUsage, "a priced team is on a usage-based plan");
   invariant(plan, "a priced team is on a plan");
-  invariant(team.subscription, "a priced team has a subscription");
 
   const period = getBilledPeriod(periodUsage.billingPeriods);
 
@@ -629,13 +639,11 @@ function EstimatedPriceCell(props: { team: PipelineTeam }) {
       <Tooltip
         content={
           period?.closed
-            ? "The plan's flat price, plus the overage of the last month that closed — a settled figure, so it does not move with the day it is read on."
-            : "The plan's flat price, plus the overage accrued so far. No month has closed yet, so this is a floor. A running trial owes the flat price only: trial usage is never billed."
+            ? "The plan's price, plus the overage of the last billing period that closed — a settled figure, so it does not move with the day it is read on. Read per month, whatever the subscription is billed in."
+            : "The plan's price, plus the overage accrued so far. No period has closed yet, so this is a floor. A running trial owes the plan's price only: trial usage is never billed."
         }
       >
-        <span className="font-medium">
-          {formatPrice(price, team.subscription.currency)}
-        </span>
+        <span className="font-medium">{formatPrice(price)}</span>
       </Tooltip>
       <PlanMarker staff={team.staff} plan={plan} priced />
     </div>

--- a/apps/frontend/src/pages/Staff/Trials.tsx
+++ b/apps/frontend/src/pages/Staff/Trials.tsx
@@ -30,6 +30,7 @@ import { graphql } from "@/gql";
 import {
   AccountSubscriptionStatus,
   Currency,
+  PlanInterval,
   SignupSource,
 } from "@/gql/graphql";
 import { Alert, AlertText, AlertTitle } from "@/ui/Alert";
@@ -77,7 +78,9 @@ const TrialPipelineQuery = graphql(`
           id
           name
           displayName
+          interval
         }
+        flatPrice
         periodUsage {
           storybookRatio
           storybookScreenshotsCount
@@ -194,34 +197,41 @@ type SortKey =
 
 const PRO_PLAN_NAME = "pro";
 
-/** Flat monthly price of the Pro plan, in dollars. Exact: it is public. */
+/**
+ * Published monthly price of the Pro plan, in dollars.
+ *
+ * The fallback for a subscription whose own amount is not on file — one that
+ * has not been synced since Argos started reading it from Stripe, or that has
+ * no Stripe price at all. Pro is what a self-serve trial lands on, so it is the
+ * right guess for the rows that need one; a contract on another plan is priced
+ * far too low by it, which is what the plan named under the amount warns about.
+ */
 const PRO_FLAT_PRICE = 100;
 
 /**
- * Flat monthly price to quote per plan, in dollars.
+ * What the plan costs for one billing period, in the subscription's currency.
  *
- * Hardcoded because the flat price is the one part of the pricing that is not
- * persisted: the Stripe sync keeps `includedScreenshots` and the per-screenshot
- * prices on the subscription, but not the plan's own amount.
- *
- * Pro is the plan every self-serve trial lands on and its price is public, so
- * that half of the estimate is exact. Enterprise is a stand-in — those
- * contracts are negotiated one by one, so $1,000 is the order of magnitude
- * rather than the invoice, which is why the plan is named under any row that is
- * not on Pro.
+ * Read from Stripe and stored on the subscription, so a negotiated contract
+ * quotes its own amount rather than a constant of ours.
  */
-const FLAT_PRICES: Record<string, number | undefined> = {
-  [PRO_PLAN_NAME]: PRO_FLAT_PRICE,
-  enterprise: 1000,
-};
+function getPeriodFlatPrice(staff: PipelineTeam["staff"]): number {
+  // Pro is billed monthly, so its published price is already one period's
+  // worth — which is why the fallback needs no conversion.
+  return staff.flatPrice ?? PRO_FLAT_PRICE;
+}
 
 /**
- * A plan we have never priced falls back to Pro's: a new plan is far more
- * likely to be another self-serve tier than a negotiated contract, and the row
- * names it either way.
+ * A period's amount read as a monthly one.
+ *
+ * Everything in this column is per billing period — the plan's price and the
+ * overage alike — and a yearly subscription's period is a year. The column
+ * compares teams against each other, so it holds one unit: the month.
  */
-function getFlatPrice(planName: string): number {
-  return FLAT_PRICES[planName] ?? PRO_FLAT_PRICE;
+function toMonthlyAmount(
+  amount: number,
+  plan: PipelineTeam["staff"]["plan"],
+): number {
+  return plan?.interval === PlanInterval.Year ? amount / 12 : amount;
 }
 
 const PRICE_FORMATS = new Map<string, Intl.NumberFormat>();
@@ -291,16 +301,19 @@ function getEstimatedPrice(team: PipelineTeam): number | null {
   const { plan } = team.staff;
   invariant(plan, "a team billed by usage is on a plan");
 
-  const flatPrice = getFlatPrice(plan.name);
+  const flatPrice = getPeriodFlatPrice(team.staff);
 
   switch (team.subscriptionStatus) {
     case AccountSubscriptionStatus.Active: {
       const period = getBilledPeriod(periodUsage.billingPeriods);
-      return flatPrice + (period?.additionalScreenshotsCost ?? 0);
+      return toMonthlyAmount(
+        flatPrice + (period?.additionalScreenshotsCost ?? 0),
+        plan,
+      );
     }
 
     case AccountSubscriptionStatus.TrialingWithPaymentMethod:
-      return flatPrice;
+      return toMonthlyAmount(flatPrice, plan);
 
     default:
       return null;
@@ -528,32 +541,53 @@ function ScreenshotsCell(props: { team: PipelineTeam }) {
 }
 
 /**
+ * What to say about a plan that is not Pro, under the amount.
+ *
+ * Three different things, because the row means three different things: an
+ * amount read from the contract, an amount guessed because the contract's is
+ * not on file, and no amount at all.
+ */
+function getPlanHint(input: {
+  staff: PipelineTeam["staff"];
+  plan: NonNullable<PipelineTeam["staff"]["plan"]>;
+  priced: boolean;
+}): string {
+  const { staff, plan, priced } = input;
+
+  if (!priced) {
+    return `On ${plan.displayName}, which Argos does not bill by usage — there is no overage of ours to put a figure on.`;
+  }
+
+  if (staff.flatPrice === null) {
+    return `Billed on ${plan.displayName}, whose own amount is not on file — the subscription has not been synced since Argos started reading it from Stripe, so the flat half of this estimate falls back to Pro's ${formatPrice(PRO_FLAT_PRICE, Currency.Usd)} and is almost certainly too low.`;
+  }
+
+  return `Billed on ${plan.displayName}. The flat half is the amount Stripe holds for this subscription, not a price of ours.`;
+}
+
+/**
  * The plan named under the amount, whenever it is not Pro.
  *
- * Silent on Pro, which is nearly every row and the one plan whose flat price is
- * public. On the rows that carry a price it says the flat half of that number is
- * a stand-in for a negotiated contract; on the rows that carry none it says why
- * there is none — a flat or a granted plan has no overage of ours to quote, and
- * a bare em dash next to an active team reads as missing data instead.
+ * Silent on Pro, which is nearly every row: naming it would put a word under
+ * every amount to say the ordinary thing. On the rows that carry a price it
+ * says the amount was negotiated rather than published; on the rows that carry
+ * none it says why there is none — a flat or a granted plan has no overage of
+ * ours to quote, and a bare em dash next to an active team reads as missing
+ * data instead.
  */
 function PlanMarker(props: {
+  staff: PipelineTeam["staff"];
   plan: NonNullable<PipelineTeam["staff"]["plan"]>;
   priced: boolean;
 }) {
-  const { plan, priced } = props;
+  const { plan } = props;
 
   if (plan.name === PRO_PLAN_NAME) {
     return null;
   }
 
   return (
-    <Tooltip
-      content={
-        priced
-          ? `Billed on ${plan.displayName}, whose flat price is negotiated rather than published: the ${formatPrice(getFlatPrice(plan.name), Currency.Usd)} half of this estimate is a stand-in. The overage half is read from the subscription and holds whatever the plan.`
-          : `On ${plan.displayName}, which Argos does not bill by usage — there is no overage of ours to put a figure on.`
-      }
-    >
+    <Tooltip content={getPlanHint(props)}>
       {/* Plan names are free text and some are long enough to overrun the
           column, which is narrow and fixed. Truncated rather than wrapped: the
           tooltip already carries the whole name, and a second line would push
@@ -573,7 +607,9 @@ function EstimatedPriceCell(props: { team: PipelineTeam }) {
     return (
       <div>
         <span className="text-low">—</span>
-        {plan ? <PlanMarker plan={plan} priced={false} /> : null}
+        {plan ? (
+          <PlanMarker staff={team.staff} plan={plan} priced={false} />
+        ) : null}
       </div>
     );
   }
@@ -601,7 +637,7 @@ function EstimatedPriceCell(props: { team: PipelineTeam }) {
           {formatPrice(price, team.subscription.currency)}
         </span>
       </Tooltip>
-      <PlanMarker plan={plan} priced />
+      <PlanMarker staff={team.staff} plan={plan} priced />
     </div>
   );
 }

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -130,8 +130,9 @@ async function createBilledTeam(input: {
   trialEndedDaysAgo: number;
   /** Where the running period opened, which sets the billing anniversary. */
   periodStartDaysAgo: number;
-  /** What the plan costs per month, as Stripe holds it. */
-  flatPrice: number;
+  /** What the plan costs per month, as Stripe holds it — null when Argos has
+   * not read it yet, which every subscription is until its next sync. */
+  flatPrice: number | null;
   /** Screenshots uploaded during each closed period, most recent first. */
   screenshotsByClosedPeriod: number[];
 }): Promise<Account> {
@@ -300,6 +301,19 @@ const staffTest = loggedTest.extend<{ pipelineTeams: PipelineTeams }>({
         flatPrice: 100,
         screenshotsByClosedPeriod: [50_000, 40_000],
       }),
+      // A contract whose amount Argos has not read yet: the row falls back to
+      // the guess for its plan rather than to the cheapest plan we sell.
+      createBilledTeam({
+        ...common,
+        planId: enterprisePlan.id,
+        slug: `${prefix}-vandelay`,
+        name: "Vandelay",
+        createdDaysAgo: 70,
+        trialEndedDaysAgo: 67,
+        periodStartDaysAgo: 6,
+        flatPrice: null,
+        screenshotsByClosedPeriod: [20_000],
+      }),
       // Same shape, on a contract with a negotiated amount of its own — the
       // row has to quote that rather than a constant.
       createBilledTeam({
@@ -349,7 +363,7 @@ staffTest("staff all teams", async ({ page, pipelineTeams }) => {
   await page.goto("/staff/teams");
   await expect(page.getByRole("heading", { name: "All Teams" })).toBeVisible();
   await page.getByRole("searchbox").fill(pipelineTeams.prefix);
-  await expect(page.getByText("Showing 1-6 of 6 teams")).toBeVisible();
+  await expect(page.getByText("Showing 1-7 of 7 teams")).toBeVisible();
 
   await screenshot(page, "staff-all-teams");
 });
@@ -382,7 +396,7 @@ staffTest(
       page.getByRole("heading", { name: "Trial pipeline" }),
     ).toBeVisible();
     await page.getByRole("searchbox").fill(pipelineTeams.prefix);
-    await expect(page.getByText(/^Showing 6 of \d+ teams$/)).toBeVisible();
+    await expect(page.getByText(/^Showing 7 of \d+ teams$/)).toBeVisible();
 
     // Soylent uploaded 50k screenshots over its last closed month: 15k past the
     // 35k included, at $0.005, on top of the $100 flat plan. The month still
@@ -392,10 +406,15 @@ staffTest(
     // contract is $750, read from the subscription rather than assumed. The row
     // names the plan under the amount to say so.
     await expect(page.getByText("$875")).toBeVisible();
-    await expect(page.getByText("Enterprise")).toBeVisible();
+    // Both Enterprise rows name their plan: the one quoting its contract and
+    // the one falling back to a guess.
+    await expect(page.getByText("Enterprise")).toHaveCount(2);
     // Hexagon is billed nothing at all, and the plan is the only thing that
     // says why — the price cell is an em dash.
     await expect(page.getByText("Open source")).toBeVisible();
+    // Vandelay stayed inside its quota, and its own amount is unknown, so the
+    // row shows the guess for an Enterprise contract rather than Pro's $100.
+    await expect(page.getByText("$1,000")).toBeVisible();
 
     await screenshot(page, "staff-trial-pipeline-90-days");
   },

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -130,6 +130,8 @@ async function createBilledTeam(input: {
   trialEndedDaysAgo: number;
   /** Where the running period opened, which sets the billing anniversary. */
   periodStartDaysAgo: number;
+  /** What the plan costs per month, as Stripe holds it. */
+  flatPrice: number;
   /** Screenshots uploaded during each closed period, most recent first. */
   screenshotsByClosedPeriod: number[];
 }): Promise<Account> {
@@ -154,6 +156,7 @@ async function createBilledTeam(input: {
     trialEndDate: daysFromNow(-input.trialEndedDaysAgo),
     paymentMethodFilled: true,
     status: "active",
+    flatPrice: input.flatPrice,
     includedScreenshots: 35_000,
     additionalScreenshotPrice: 0.005,
     additionalStorybookScreenshotPrice: 0.002,
@@ -294,9 +297,11 @@ const staffTest = loggedTest.extend<{ pipelineTeams: PipelineTeams }>({
         createdDaysAgo: 88,
         trialEndedDaysAgo: 85,
         periodStartDaysAgo: 14,
+        flatPrice: 100,
         screenshotsByClosedPeriod: [50_000, 40_000],
       }),
-      // Same shape, on a plan the flat price is not taken from.
+      // Same shape, on a contract with a negotiated amount of its own — the
+      // row has to quote that rather than a constant.
       createBilledTeam({
         ...common,
         planId: enterprisePlan.id,
@@ -304,6 +309,7 @@ const staffTest = loggedTest.extend<{ pipelineTeams: PipelineTeams }>({
         name: "Umbrella",
         createdDaysAgo: 80,
         trialEndedDaysAgo: 77,
+        flatPrice: 750,
         periodStartDaysAgo: 9,
         screenshotsByClosedPeriod: [60_000],
       }),
@@ -382,9 +388,10 @@ staffTest(
     // 35k included, at $0.005, on top of the $100 flat plan. The month still
     // running holds nothing, so reading that one instead would print $100.
     await expect(page.getByText("$175")).toBeVisible();
-    // Umbrella is on Enterprise: same 60k over the same quota, but a flat price
-    // of its own, and the row names the plan under the amount.
-    await expect(page.getByText("$1,125")).toBeVisible();
+    // Umbrella is on Enterprise: same 60k over the same quota, but its
+    // contract is $750, read from the subscription rather than assumed. The row
+    // names the plan under the amount to say so.
+    await expect(page.getByText("$875")).toBeVisible();
     await expect(page.getByText("Enterprise")).toBeVisible();
     // Hexagon is billed nothing at all, and the plan is the only thing that
     // says why — the price cell is an em dash.


### PR DESCRIPTION
The trial pipeline quoted a constant for the flat half of its price estimate — $100, or $1,000 for Enterprise. A negotiated contract is exactly what a constant cannot fit, and the two Enterprise accounts on the page are also its largest consumers.

The recurring amount is a first-class Stripe field, so unlike the included screenshots it needs no metadata of ours and cannot be forgotten when a contract is set up. It lands on the subscription rather than the plan, for the same reason `includedScreenshots` does: every contract shares one plan row while each carries its own amount.

Rows fill in as Stripe touches their subscription; those that have not yet fall back to Pro's published price, with the plan named under the amount to say so. A yearly subscription states a yearly amount, so the column brings it back to the month.

🤖 Generated with [Claude Code](https://claude.com/claude-code)