### PR TITLE
feat(ui): move the overlays onto Base UI

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "storybook",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@argos/frontend", "storybook"],
+      "port": 6006
+    }
+  ]
+}

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -86,7 +86,6 @@
     "react-helmet": "^6.1.0",
     "react-hook-form": "^7.84.0",
     "react-router": "catalog:",
-    "react-stately": "^3.49.0",
     "react-twc": "^1.5.1",
     "recharts": "^3.10.1",
     "rxjs": "^7.8.2",

--- a/apps/frontend/src/containers/AccountSelector.tsx
+++ b/apps/frontend/src/containers/AccountSelector.tsx
@@ -1,5 +1,5 @@
 import { ListBox, ListBoxItem } from "@/ui/ListBox";
-import { Popover } from "@/ui/Popover";
+import { SelectPopover } from "@/ui/Popover";
 import { Select, SelectButton } from "@/ui/Select";
 
 import { AccountItem, AccountItemProps } from "./AccountItem";
@@ -39,7 +39,7 @@ export function AccountSelector(props: {
         )}
       </SelectButton>
 
-      <Popover>
+      <SelectPopover>
         <ListBox>
           {props.accounts.map((account) => {
             const disabledReason = props.disabledReasons?.[account.id];
@@ -62,7 +62,7 @@ export function AccountSelector(props: {
             );
           })}
         </ListBox>
-      </Popover>
+      </SelectPopover>
     </Select>
   );
 }

--- a/apps/frontend/src/containers/Build/BuildHotkeys.tsx
+++ b/apps/frontend/src/containers/Build/BuildHotkeys.tsx
@@ -518,7 +518,7 @@ const BuildHotkeysDialogWithState = memo(
       state.setIsOpen((value) => !value),
     );
     return (
-      <Modal isOpen={state.isOpen} onOpenChange={state.setIsOpen} isDismissable>
+      <Modal open={state.isOpen} onOpenChange={state.setIsOpen} dismissible>
         <Dialog>
           <DialogBody>
             <DialogTitle>Keyboard Shortcuts</DialogTitle>

--- a/apps/frontend/src/containers/Build/BuildHotkeys.tsx
+++ b/apps/frontend/src/containers/Build/BuildHotkeys.tsx
@@ -525,7 +525,7 @@ const BuildHotkeysDialogWithState = memo(
             <Button
               variant="secondary"
               iconOnly
-              slot="close"
+              onPress={() => state.setIsOpen(false)}
               aria-label="Close"
               className="absolute top-3 right-3 z-10"
             >

--- a/apps/frontend/src/containers/Build/BuildHotkeysDialogState.tsx
+++ b/apps/frontend/src/containers/Build/BuildHotkeysDialogState.tsx
@@ -3,7 +3,7 @@ import { createContext, use, useMemo, useState } from "react";
 import { ModalProps } from "@/ui/Modal";
 
 export type HotkeysDialogState = {
-  isOpen: ModalProps["isOpen"];
+  isOpen: ModalProps["open"];
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };
 

--- a/apps/frontend/src/containers/Build/toolbar/IgnoreButton.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/IgnoreButton.tsx
@@ -2,7 +2,6 @@ import { memo, useState } from "react";
 import { useApolloClient } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { FlagOffIcon } from "lucide-react";
-import { DialogTrigger } from "react-aria-components";
 
 import { useAuth } from "@/containers/Auth";
 import { useBuildHotkey } from "@/containers/Build/BuildHotkeys";
@@ -11,6 +10,7 @@ import { graphql } from "@/gql";
 import { useProjectParams } from "@/pages/Project/ProjectParams";
 import { Button, type ButtonProps } from "@/ui/Button";
 import { Checkbox } from "@/ui/Checkbox";
+import { DialogTrigger } from "@/ui/Dialog";
 import {
   Dialog,
   DialogBody,
@@ -171,7 +171,7 @@ function EnabledIgnoreButton(props: {
         />
       </HotkeyTooltip>
       <DialogTrigger
-        isOpen={dialog === "ignore"}
+        open={dialog === "ignore"}
         onOpenChange={(open) => {
           if (!open) {
             setDialog(null);
@@ -215,7 +215,7 @@ function EnabledIgnoreButton(props: {
         </Modal>
       </DialogTrigger>
       <DialogTrigger
-        isOpen={dialog === "unignore"}
+        open={dialog === "unignore"}
         onOpenChange={(open) => {
           if (!open) {
             setDialog(null);

--- a/apps/frontend/src/containers/Build/toolbar/SettingsButton.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/SettingsButton.tsx
@@ -37,9 +37,11 @@ export const SettingsButton = memo(() => {
 
 function OverlaySettingsDialog() {
   return (
-    <Dialog className="w-80 select-none">
+    <Dialog className="w-80 select-none" aria-label="Customize overlay">
       <DialogBody>
-        <Heading slot="title" level={2} className="mb-4 font-medium">
+        {/* Not a `DialogTitle`: this one reads at body size. The dialog is
+            named by `aria-label` instead, which says the same words. */}
+        <Heading level={2} className="mb-4 font-medium">
           Customize overlay
         </Heading>
         <div className="flex flex-col gap-6">

--- a/apps/frontend/src/containers/Build/toolbar/SettingsButton.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/SettingsButton.tsx
@@ -2,11 +2,10 @@ import { memo } from "react";
 import { invariant } from "@argos/util/invariant";
 import { useAtom } from "jotai/react";
 import { PaintbrushIcon } from "lucide-react";
-import { Heading } from "react-aria-components";
 
 import { Button } from "@/ui/Button";
 import { ColorSwatchPicker, ColorSwatchPickerItem } from "@/ui/ColorPicker";
-import { Dialog, DialogBody, DialogTrigger } from "@/ui/Dialog";
+import { Dialog, DialogBody, DialogTitle, DialogTrigger } from "@/ui/Dialog";
 import { Label } from "@/ui/Label";
 import { Popover } from "@/ui/Popover";
 import {
@@ -37,13 +36,13 @@ export const SettingsButton = memo(() => {
 
 function OverlaySettingsDialog() {
   return (
-    <Dialog className="w-80 select-none" aria-label="Customize overlay">
+    <Dialog className="w-80 select-none">
       <DialogBody>
-        {/* Not a `DialogTitle`: this one reads at body size. The dialog is
-            named by `aria-label` instead, which says the same words. */}
-        <Heading level={2} className="mb-4 font-medium">
+        {/* Reads at body size rather than a dialog title's, but still names
+            the dialog. */}
+        <DialogTitle render={<h2 className="mb-4 font-medium" />}>
           Customize overlay
-        </Heading>
+        </DialogTitle>
         <div className="flex flex-col gap-6">
           <ColorPicker />
           <OpacityPicker />

--- a/apps/frontend/src/containers/Build/toolbar/SettingsButton.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/SettingsButton.tsx
@@ -28,7 +28,7 @@ export const SettingsButton = memo(() => {
           <PaintbrushIcon />
         </Button>
       </Tooltip>
-      <Popover placement="bottom end">
+      <Popover side="bottom" align="end">
         <OverlaySettingsDialog />
       </Popover>
     </DialogTrigger>

--- a/apps/frontend/src/containers/CheckoutStatusDialog.tsx
+++ b/apps/frontend/src/containers/CheckoutStatusDialog.tsx
@@ -25,7 +25,7 @@ export function CheckoutStatusDialog() {
       : null;
   const [isOpen, setIsOpen] = useState<boolean>(checkoutStatus !== null);
   return (
-    <Modal isOpen={isOpen} onOpenChange={setIsOpen}>
+    <Modal open={isOpen} onOpenChange={setIsOpen}>
       <Dialog>
         <DialogBody>
           <DialogTitle>

--- a/apps/frontend/src/containers/Comment/CommentCard.tsx
+++ b/apps/frontend/src/containers/Comment/CommentCard.tsx
@@ -701,7 +701,7 @@ function CommentMessage(props: {
         </div>
         <CommentReactionList comment={comment} />
       </div>
-      <Modal isOpen={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+      <Modal open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
         <DeleteCommentDialog commentId={comment.id} />
       </Modal>
     </>

--- a/apps/frontend/src/containers/Comment/CommentReactions.tsx
+++ b/apps/frontend/src/containers/Comment/CommentReactions.tsx
@@ -129,7 +129,8 @@ export function CommentAddReactionButton(props: { comment: Comment }) {
         </Button>
       </Tooltip>
       <EmojiPickerPopover
-        placement="bottom end"
+        side="bottom"
+        align="end"
         onEmojiSelect={({ emoji }) => react(emoji)}
       />
     </EmojiPickerTrigger>

--- a/apps/frontend/src/containers/Comment/DeleteCommentDialog.tsx
+++ b/apps/frontend/src/containers/Comment/DeleteCommentDialog.tsx
@@ -57,7 +57,7 @@ export function DeleteCommentDialog(props: { commentId: string }) {
             {getErrorMessage(error)}
           </ErrorMessage>
         )}
-        <DialogDismiss isDisabled={loading}>Cancel</DialogDismiss>
+        <DialogDismiss disabled={loading}>Cancel</DialogDismiss>
         <Button
           variant="destructive"
           isPending={loading}

--- a/apps/frontend/src/containers/GithubInstallationsSelect.tsx
+++ b/apps/frontend/src/containers/GithubInstallationsSelect.tsx
@@ -9,7 +9,7 @@ import {
   ListBoxItemIcon,
   ListBoxSeparator,
 } from "@/ui/ListBox";
-import { Popover } from "@/ui/Popover";
+import { SelectPopover } from "@/ui/Popover";
 import { Select, SelectButton } from "@/ui/Select";
 
 import { getGitHubAppInstallURL } from "./GitHub";
@@ -73,7 +73,7 @@ export function GithubInstallationsSelect(props: {
         )}
       </SelectButton>
 
-      <Popover>
+      <SelectPopover>
         <ListBox>
           {installations.map((installation) => {
             return (
@@ -116,7 +116,7 @@ export function GithubInstallationsSelect(props: {
             </ListBoxItem>
           )}
         </ListBox>
-      </Popover>
+      </SelectPopover>
     </Select>
   );
 }

--- a/apps/frontend/src/containers/GitlabNamespacesSelect.tsx
+++ b/apps/frontend/src/containers/GitlabNamespacesSelect.tsx
@@ -8,7 +8,7 @@ import {
   ListBoxItemIcon,
   ListBoxSeparator,
 } from "@/ui/ListBox";
-import { Popover } from "@/ui/Popover";
+import { SelectPopover } from "@/ui/Popover";
 import { Select, SelectButton } from "@/ui/Select";
 
 import { GitLabLogo } from "./GitLab";
@@ -56,7 +56,7 @@ export const GitlabNamespacesSelect = (props: {
         </div>
       </SelectButton>
 
-      <Popover>
+      <SelectPopover>
         <ListBox>
           {namespaces.map((namespace) => {
             return (
@@ -86,7 +86,7 @@ export const GitlabNamespacesSelect = (props: {
             Switch Git Provider
           </ListBoxItem>
         </ListBox>
-      </Popover>
+      </SelectPopover>
     </Select>
   );
 };

--- a/apps/frontend/src/containers/PeriodSelect.tsx
+++ b/apps/frontend/src/containers/PeriodSelect.tsx
@@ -2,7 +2,7 @@ import { invariant } from "@argos/util/invariant";
 import { parseAsStringEnum, useQueryState } from "nuqs";
 
 import { ListBox, ListBoxItem, ListBoxItemLabel } from "@/ui/ListBox";
-import { Popover } from "@/ui/Popover";
+import { SelectPopover } from "@/ui/Popover";
 import { Select, SelectButton } from "@/ui/Select";
 
 export type PeriodsDefinition = Record<string, PeriodEntry>;
@@ -58,7 +58,7 @@ export function PeriodSelect<TDef extends PeriodsDefinition>(props: {
       onChange={(value) => setValue(String(value))}
     >
       <SelectButton className="text-sm">{current.label}</SelectButton>
-      <Popover>
+      <SelectPopover>
         <ListBox>
           {Object.entries(definition).map(([key, entry]) => {
             return (
@@ -68,7 +68,7 @@ export function PeriodSelect<TDef extends PeriodsDefinition>(props: {
             );
           })}
         </ListBox>
-      </Popover>
+      </SelectPopover>
     </Select>
   );
 }

--- a/apps/frontend/src/containers/Project/Contributors/ProjectContributorLevelSelect.tsx
+++ b/apps/frontend/src/containers/Project/Contributors/ProjectContributorLevelSelect.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/containers/ProjectContributor";
 import { graphql } from "@/gql";
 import { ProjectUserLevel } from "@/gql/graphql";
-import { Popover } from "@/ui/Popover";
+import { SelectPopover } from "@/ui/Popover";
 import { Select, SelectButton } from "@/ui/Select";
 
 import { addContributor, OPTIMISTIC_CONTRIBUTOR_ID } from "./operations";
@@ -77,9 +77,9 @@ export function ProjectContributorLevelSelect(props: {
         {props.level ? ProjectContributorLevelLabel[props.level] : "Add as"}
       </SelectButton>
 
-      <Popover>
+      <SelectPopover>
         <ProjectContributorLevelListBox />
-      </Popover>
+      </SelectPopover>
     </Select>
   );
 }

--- a/apps/frontend/src/containers/Project/Contributors/ProjectDefaultUserLevel.tsx
+++ b/apps/frontend/src/containers/Project/Contributors/ProjectDefaultUserLevel.tsx
@@ -28,7 +28,7 @@ import {
 import { Form } from "@/ui/Form";
 import { FormSubmit } from "@/ui/FormSubmit";
 import { Modal } from "@/ui/Modal";
-import { Popover } from "@/ui/Popover";
+import { SelectPopover } from "@/ui/Popover";
 import { Select, SelectButton } from "@/ui/Select";
 
 const _ProjectFragment = graphql(`
@@ -66,9 +66,9 @@ function ProjectDefaultUserLevelField(props: { control: Control<Inputs> }) {
           : ProjectContributorLevelLabel[controller.field.value]}
       </SelectButton>
 
-      <Popover>
+      <SelectPopover>
         <ProjectContributorLevelListBox clearable />
-      </Popover>
+      </SelectPopover>
     </Select>
   );
 }

--- a/apps/frontend/src/containers/Project/Deployments/DeploymentAuthentication.tsx
+++ b/apps/frontend/src/containers/Project/Deployments/DeploymentAuthentication.tsx
@@ -15,7 +15,7 @@ import {
   ListBoxItemDescription,
   ListBoxItemLabel,
 } from "@/ui/ListBox";
-import { Popover } from "@/ui/Popover";
+import { SelectPopover } from "@/ui/Popover";
 import { SelectButton, SelectField } from "@/ui/Select";
 
 type DeploymentAuthLevel =
@@ -100,7 +100,7 @@ export function DeploymentAuthentication(props: {
                   {deploymentAuthDef.label}
                 </SelectButton>
                 <FieldError />
-                <Popover className="max-w-sm">
+                <SelectPopover className="max-w-sm">
                   <ListBox>
                     <ListBoxItem
                       id={DeploymentAuth.DomainPrivate}
@@ -123,7 +123,7 @@ export function DeploymentAuthentication(props: {
                       </ListBoxItemDescription>
                     </ListBoxItem>
                   </ListBox>
-                </Popover>
+                </SelectPopover>
               </SelectField>
             )}
           </div>

--- a/apps/frontend/src/containers/Project/Token.tsx
+++ b/apps/frontend/src/containers/Project/Token.tsx
@@ -1,6 +1,5 @@
 import { ComponentProps, useEffect, useRef } from "react";
 import { useApolloClient } from "@apollo/client/react";
-import { DialogTrigger } from "react-aria-components";
 import { SubmitHandler, useForm } from "react-hook-form";
 
 import { DocumentType, graphql } from "@/gql";
@@ -15,6 +14,7 @@ import {
   CardTitle,
 } from "@/ui/Card";
 import { Code } from "@/ui/Code";
+import { DialogTrigger } from "@/ui/Dialog";
 import {
   Dialog,
   DialogBody,

--- a/apps/frontend/src/containers/Project/Transfer.tsx
+++ b/apps/frontend/src/containers/Project/Transfer.tsx
@@ -378,7 +378,7 @@ const SuccessStep = (props: SuccessStepProps) => {
       <DialogFooter>
         <DialogDismiss
           single
-          onPress={() => {
+          onClick={() => {
             props.onContinue();
           }}
         >

--- a/apps/frontend/src/containers/Team/Discord.tsx
+++ b/apps/frontend/src/containers/Team/Discord.tsx
@@ -285,7 +285,7 @@ function WebhookActionsMenu(props: { webhook: DiscordWebhook }) {
           </MenuItem>
         </Menu>
       </MenuRoot>
-      <Modal isOpen={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+      <Modal open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
         <DeleteWebhookDialog webhook={webhook} />
       </Modal>
     </>
@@ -320,7 +320,7 @@ function DeleteWebhookDialog(props: { webhook: DiscordWebhook }) {
         {error ? (
           <ErrorMessage className="flex-1">{error.message}</ErrorMessage>
         ) : null}
-        <DialogDismiss isDisabled={loading}>Cancel</DialogDismiss>
+        <DialogDismiss disabled={loading}>Cancel</DialogDismiss>
         <Button
           variant="destructive"
           isPending={loading}

--- a/apps/frontend/src/containers/Team/Domains.tsx
+++ b/apps/frontend/src/containers/Team/Domains.tsx
@@ -191,7 +191,7 @@ function RemoveTeamDomainDialog(props: { teamDomain: TeamDomain }) {
         {error ? (
           <ErrorMessage className="flex-1">{error.message}</ErrorMessage>
         ) : null}
-        <DialogDismiss isDisabled={loading}>Cancel</DialogDismiss>
+        <DialogDismiss disabled={loading}>Cancel</DialogDismiss>
         <Button
           variant="destructive"
           isPending={loading}

--- a/apps/frontend/src/containers/Team/MsTeams.tsx
+++ b/apps/frontend/src/containers/Team/MsTeams.tsx
@@ -285,7 +285,7 @@ function WebhookActionsMenu(props: { webhook: MsTeamsWebhook }) {
           </MenuItem>
         </Menu>
       </MenuRoot>
-      <Modal isOpen={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+      <Modal open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
         <DeleteWebhookDialog webhook={webhook} />
       </Modal>
     </>
@@ -320,7 +320,7 @@ function DeleteWebhookDialog(props: { webhook: MsTeamsWebhook }) {
         {error ? (
           <ErrorMessage className="flex-1">{error.message}</ErrorMessage>
         ) : null}
-        <DialogDismiss isDisabled={loading}>Cancel</DialogDismiss>
+        <DialogDismiss disabled={loading}>Cancel</DialogDismiss>
         <Button
           variant="destructive"
           isPending={loading}

--- a/apps/frontend/src/containers/Team/SpendManagement.tsx
+++ b/apps/frontend/src/containers/Team/SpendManagement.tsx
@@ -259,7 +259,7 @@ function SpendManagementForm(props: {
         </FormCardFooter>
       </Form>
       <Modal
-        isOpen={confirmation.isOpen}
+        open={confirmation.isOpen}
         onOpenChange={(isOpen) =>
           setConfirmation((prev) => ({ ...prev, isOpen }))
         }

--- a/apps/frontend/src/containers/Team/members/MemberLevelFilter.tsx
+++ b/apps/frontend/src/containers/Team/members/MemberLevelFilter.tsx
@@ -3,7 +3,7 @@ import z from "zod";
 
 import { TeamUserLevel } from "@/gql/graphql";
 import { ListBox, ListBoxItem } from "@/ui/ListBox";
-import { Popover } from "@/ui/Popover";
+import { SelectPopover } from "@/ui/Popover";
 import { Select, SelectButton } from "@/ui/Select";
 
 const FilterUserLevelSchema = z.enum([
@@ -31,7 +31,7 @@ export function MemberLevelFilter(props: {
       <SelectButton>
         <SelectValue />
       </SelectButton>
-      <Popover>
+      <SelectPopover>
         <ListBox>
           <ListBoxItem id="all">All roles</ListBoxItem>
           {hasFineGrainedAccessControl && (
@@ -40,7 +40,7 @@ export function MemberLevelFilter(props: {
           <ListBoxItem id="member">Member</ListBoxItem>
           <ListBoxItem id="owner">Owner</ListBoxItem>
         </ListBox>
-      </Popover>
+      </SelectPopover>
     </Select>
   );
 }

--- a/apps/frontend/src/containers/Team/members/MemberLevelSelect.tsx
+++ b/apps/frontend/src/containers/Team/members/MemberLevelSelect.tsx
@@ -7,7 +7,7 @@ import {
   ListBoxItemDescription,
   ListBoxItemLabel,
 } from "@/ui/ListBox";
-import { Popover } from "@/ui/Popover";
+import { SelectPopover } from "@/ui/Popover";
 import { Select, SelectButton, type SelectButtonProps } from "@/ui/Select";
 
 export function MemberLevelSelect(
@@ -29,7 +29,7 @@ export function MemberLevelSelect(
           }}
         </SelectValue>
       </SelectButton>
-      <Popover>
+      <SelectPopover>
         <ListBox>
           {hasFineGrainedAccessControl && (
             <ListBoxItem id="contributor" textValue="Contributor">
@@ -52,7 +52,7 @@ export function MemberLevelSelect(
             </ListBoxItemDescription>
           </ListBoxItem>
         </ListBox>
-      </Popover>
+      </SelectPopover>
     </Select>
   );
 }

--- a/apps/frontend/src/containers/Team/members/SortFilter.tsx
+++ b/apps/frontend/src/containers/Team/members/SortFilter.tsx
@@ -8,7 +8,7 @@ import { z } from "zod";
 
 import { TeamMembersOrderBy } from "@/gql/graphql";
 import { ListBox, ListBoxItem, ListBoxItemIcon } from "@/ui/ListBox";
-import { Popover } from "@/ui/Popover";
+import { SelectPopover } from "@/ui/Popover";
 import { Select, SelectButton } from "@/ui/Select";
 
 const OrderBySchema = z.enum(TeamMembersOrderBy);
@@ -28,7 +28,7 @@ export function SortFilter(props: {
       <SelectButton>
         <SelectValue />
       </SelectButton>
-      <Popover>
+      <SelectPopover>
         <ListBox>
           <ListBoxItem id={TeamMembersOrderBy.Date}>
             <ListBoxItemIcon>
@@ -49,7 +49,7 @@ export function SortFilter(props: {
             Name (Z-A)
           </ListBoxItem>
         </ListBox>
-      </Popover>
+      </SelectPopover>
     </Select>
   );
 }

--- a/apps/frontend/src/containers/Team/members/SourceFilter.tsx
+++ b/apps/frontend/src/containers/Team/members/SourceFilter.tsx
@@ -2,7 +2,7 @@ import { SelectValue } from "react-aria-components";
 import { z } from "zod";
 
 import { ListBox, ListBoxItem } from "@/ui/ListBox";
-import { Popover } from "@/ui/Popover";
+import { SelectPopover } from "@/ui/Popover";
 import { Select, SelectButton } from "@/ui/Select";
 
 const SourceSchema = z.enum(["everyone", "sso", "invite"]);
@@ -23,13 +23,13 @@ export function SourceFilter(props: {
         <SelectValue />
       </SelectButton>
 
-      <Popover>
+      <SelectPopover>
         <ListBox>
           <ListBoxItem id="everyone">Everyone</ListBoxItem>
           <ListBoxItem id="sso">Synced from GitHub</ListBoxItem>
           <ListBoxItem id="invite">Manually invited</ListBoxItem>
         </ListBox>
-      </Popover>
+      </SelectPopover>
     </Select>
   );
 }

--- a/apps/frontend/src/containers/User/Auth.tsx
+++ b/apps/frontend/src/containers/User/Auth.tsx
@@ -178,7 +178,7 @@ function RevokeSessionDialog(props: { session: Session }) {
         {error ? (
           <ErrorMessage className="flex-1">{error.message}</ErrorMessage>
         ) : null}
-        <DialogDismiss isDisabled={loading}>Cancel</DialogDismiss>
+        <DialogDismiss disabled={loading}>Cancel</DialogDismiss>
         <Button
           variant="destructive"
           isPending={loading}
@@ -221,7 +221,7 @@ function RevokeAllSessionsDialog(props: { count: number }) {
         {error ? (
           <ErrorMessage className="flex-1">{error.message}</ErrorMessage>
         ) : null}
-        <DialogDismiss isDisabled={loading}>Cancel</DialogDismiss>
+        <DialogDismiss disabled={loading}>Cancel</DialogDismiss>
         <Button
           variant="destructive"
           isPending={loading}
@@ -322,7 +322,7 @@ function UserSessions(props: { sessions: readonly Session[] }) {
       </CardBody>
 
       {revoking.value ? (
-        <Modal isOpen={revoking.isOpen} onOpenChange={revoking.onOpenChange}>
+        <Modal open={revoking.isOpen} onOpenChange={revoking.onOpenChange}>
           <RevokeSessionDialog session={revoking.value} />
         </Modal>
       ) : null}

--- a/apps/frontend/src/containers/User/Emails.tsx
+++ b/apps/frontend/src/containers/User/Emails.tsx
@@ -1,7 +1,6 @@
 import { useApolloClient } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { MoreVerticalIcon, PlusIcon } from "lucide-react";
-import { DialogTrigger } from "react-aria-components";
 
 import { DocumentType, graphql } from "@/gql";
 import { Button, ButtonIcon } from "@/ui/Button";
@@ -13,6 +12,7 @@ import {
   CardTitle,
 } from "@/ui/Card";
 import { Chip } from "@/ui/Chip";
+import { DialogTrigger } from "@/ui/Dialog";
 import { useDialogValueState } from "@/ui/Dialog";
 import { List, ListRow } from "@/ui/List";
 import {
@@ -185,7 +185,7 @@ export function UserEmails(props: {
         primary email.
       </CardFooter>
       {deleting.value ? (
-        <Modal isOpen={deleting.isOpen} onOpenChange={deleting.onOpenChange}>
+        <Modal open={deleting.isOpen} onOpenChange={deleting.onOpenChange}>
           <DeleteUserEmailDialog email={deleting.value} />
         </Modal>
       ) : null}

--- a/apps/frontend/src/containers/User/OAuthApps.tsx
+++ b/apps/frontend/src/containers/User/OAuthApps.tsx
@@ -251,7 +251,7 @@ export function OAuthApps(props: {
       </CardBody>
 
       {revoking.value ? (
-        <Modal isOpen={revoking.isOpen} onOpenChange={revoking.onOpenChange}>
+        <Modal open={revoking.isOpen} onOpenChange={revoking.onOpenChange}>
           <RevokeAppDialog
             accountId={account.id}
             id={revoking.value.id}

--- a/apps/frontend/src/containers/User/UserAccessTokens.tsx
+++ b/apps/frontend/src/containers/User/UserAccessTokens.tsx
@@ -1,7 +1,6 @@
 import { invariant } from "@argos/util/invariant";
 import clsx from "clsx";
 import { PencilIcon, PlusIcon, Trash2Icon } from "lucide-react";
-import { DialogTrigger } from "react-aria-components";
 
 import { ProviderMenuButton } from "@/containers/User/ui";
 import { DocumentType, graphql } from "@/gql";
@@ -13,6 +12,7 @@ import {
   CardParagraph,
   CardTitle,
 } from "@/ui/Card";
+import { DialogTrigger } from "@/ui/Dialog";
 import { useDialogValueState } from "@/ui/Dialog";
 import { List, ListHeaderRow, ListRow } from "@/ui/List";
 import { Menu, MenuItem, MenuRoot, MenuTrigger } from "@/ui/menu-kit";
@@ -218,13 +218,13 @@ export function UserAccessTokens(props: {
       </CardFooter>
 
       {editing.value ? (
-        <Modal isOpen={editing.isOpen} onOpenChange={editing.onOpenChange}>
+        <Modal open={editing.isOpen} onOpenChange={editing.onOpenChange}>
           <EditTokenDialog id={editing.value.id} name={editing.value.name} />
         </Modal>
       ) : null}
 
       {deleting.value ? (
-        <Modal isOpen={deleting.isOpen} onOpenChange={deleting.onOpenChange}>
+        <Modal open={deleting.isOpen} onOpenChange={deleting.onOpenChange}>
           <DeleteTokenDialog
             id={deleting.value.id}
             name={deleting.value.name}

--- a/apps/frontend/src/containers/User/emails/DeleteUserEmailDialog.tsx
+++ b/apps/frontend/src/containers/User/emails/DeleteUserEmailDialog.tsx
@@ -55,7 +55,7 @@ export function DeleteUserEmailDialog(props: DeleteUserEmailDialogProps) {
         {error && (
           <ErrorMessage className="flex-1">{error.message}</ErrorMessage>
         )}
-        <DialogDismiss isDisabled={loading}>Cancel</DialogDismiss>
+        <DialogDismiss disabled={loading}>Cancel</DialogDismiss>
         <Button
           variant="destructive"
           isPending={loading}

--- a/apps/frontend/src/containers/User/providers/PasskeyAuth.tsx
+++ b/apps/frontend/src/containers/User/providers/PasskeyAuth.tsx
@@ -344,13 +344,13 @@ export function PasskeyAuth(props: {
       </ProviderCard>
 
       {editing.value ? (
-        <Modal isOpen={editing.isOpen} onOpenChange={editing.onOpenChange}>
+        <Modal open={editing.isOpen} onOpenChange={editing.onOpenChange}>
           <EditPasskeyDialog passkey={editing.value} />
         </Modal>
       ) : null}
 
       {deleting.value ? (
-        <Modal isOpen={deleting.isOpen} onOpenChange={deleting.onOpenChange}>
+        <Modal open={deleting.isOpen} onOpenChange={deleting.onOpenChange}>
           <DeletePasskeyDialog passkey={deleting.value} />
         </Modal>
       ) : null}

--- a/apps/frontend/src/containers/User/tokens/CreateTokenDialog.tsx
+++ b/apps/frontend/src/containers/User/tokens/CreateTokenDialog.tsx
@@ -22,7 +22,7 @@ import { FormSubmit } from "@/ui/FormSubmit";
 import { FormTextInput } from "@/ui/FormTextInput";
 import { Label } from "@/ui/Label";
 import { ListBox, ListBoxItem } from "@/ui/ListBox";
-import { Popover } from "@/ui/Popover";
+import { SelectPopover } from "@/ui/Popover";
 import { Pre } from "@/ui/Pre";
 import { SelectButton, SelectField, SelectValue } from "@/ui/Select";
 
@@ -304,7 +304,7 @@ export function CreateTokenDialog(props: {
                 <SelectButton className="w-full text-sm">
                   <SelectValue />
                 </SelectButton>
-                <Popover>
+                <SelectPopover>
                   <ListBox>
                     {EXPIRATION_OPTIONS.map((option) => (
                       <ListBoxItem
@@ -316,7 +316,7 @@ export function CreateTokenDialog(props: {
                       </ListBoxItem>
                     ))}
                   </ListBox>
-                </Popover>
+                </SelectPopover>
               </SelectField>
               {expireInDaysValue === "no-expiration" ? (
                 <div className="bg-pending-subtle text-pending-low mt-2 flex items-start gap-2 rounded-md p-2 text-xs">

--- a/apps/frontend/src/containers/User/tokens/DeleteTokenDialog.tsx
+++ b/apps/frontend/src/containers/User/tokens/DeleteTokenDialog.tsx
@@ -65,7 +65,7 @@ export function DeleteTokenDialog(props: DeleteTokenDialogProps) {
         {error && (
           <ErrorMessage className="flex-1">{error.message}</ErrorMessage>
         )}
-        <DialogDismiss isDisabled={loading}>Cancel</DialogDismiss>
+        <DialogDismiss disabled={loading}>Cancel</DialogDismiss>
         <Button
           variant="destructive"
           isPending={loading}

--- a/apps/frontend/src/pages/Account/Analytics.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.tsx
@@ -71,7 +71,7 @@ import {
 import { ListBox, ListBoxItem, ListBoxItemLabel } from "@/ui/ListBox";
 import { Menu, MenuItem, MenuRoot, MenuTrigger } from "@/ui/menu-kit";
 import { PageLoader } from "@/ui/PageLoader";
-import { Popover } from "@/ui/Popover";
+import { SelectPopover } from "@/ui/Popover";
 import { Select, SelectButton } from "@/ui/Select";
 import { StatTile } from "@/ui/StatTile";
 import { Text } from "@/ui/Text";
@@ -1374,7 +1374,7 @@ function PeriodSelect(props: {
       <SelectButton className="w-full shrink-0 text-sm whitespace-nowrap">
         {PeriodLabels[props.value]}
       </SelectButton>
-      <Popover>
+      <SelectPopover>
         <ListBox>
           {Object.entries(PeriodLabels).map(([key, label]) => {
             return (
@@ -1384,7 +1384,7 @@ function PeriodSelect(props: {
             );
           })}
         </ListBox>
-      </Popover>
+      </SelectPopover>
     </Select>
   );
 }

--- a/apps/frontend/src/pages/Automation/AutomationFormActionsStep.tsx
+++ b/apps/frontend/src/pages/Automation/AutomationFormActionsStep.tsx
@@ -19,7 +19,7 @@ import {
   ListBoxItemIcon,
   ListBoxItemLabel,
 } from "@/ui/ListBox";
-import { Popover } from "@/ui/Popover";
+import { SelectPopover } from "@/ui/Popover";
 import { SelectButton, SelectField, SelectValue } from "@/ui/Select";
 import { getSlackAuthURL } from "@/util/slack";
 
@@ -214,7 +214,7 @@ function SendWebhookMessageAction(props: {
           <SelectValue />
         </SelectButton>
         <FieldError />
-        <Popover>
+        <SelectPopover>
           <ListBox>
             {webhooks.map((webhook) => (
               <ListBoxItem
@@ -229,7 +229,7 @@ function SendWebhookMessageAction(props: {
               </ListBoxItem>
             ))}
           </ListBox>
-        </Popover>
+        </SelectPopover>
       </SelectField>
     </div>
   );
@@ -385,7 +385,7 @@ export function AutomationActionsStep(props: { form: AutomationForm }) {
             <SelectValue />
           </SelectButton>
           <FieldError />
-          <Popover>
+          <SelectPopover>
             <ListBox>
               {ACTIONS.map((action) => (
                 <ListBoxItem
@@ -400,7 +400,7 @@ export function AutomationActionsStep(props: { form: AutomationForm }) {
                 </ListBoxItem>
               ))}
             </ListBox>
-          </Popover>
+          </SelectPopover>
         </SelectField>
       </div>
     </div>

--- a/apps/frontend/src/pages/Automation/AutomationFormConditionsStep.tsx
+++ b/apps/frontend/src/pages/Automation/AutomationFormConditionsStep.tsx
@@ -10,7 +10,7 @@ import { FieldError } from "@/ui/FieldError";
 import { FormTextInput } from "@/ui/FormTextInput";
 import { ListBox, ListBoxItem, ListBoxItemLabel } from "@/ui/ListBox";
 import { MenuItemIcon } from "@/ui/Menu";
-import { Popover } from "@/ui/Popover";
+import { SelectPopover } from "@/ui/Popover";
 import { Select, SelectButton, SelectField, SelectValue } from "@/ui/Select";
 import {
   checkIsGlobCondition,
@@ -61,7 +61,7 @@ function BuildConclusionCondition(props: {
           <SelectValue />
         </SelectButton>
         <FieldError />
-        <Popover>
+        <SelectPopover>
           <ListBox>
             {conclusions.map(({ status, value }) => {
               const descriptor = buildStatusDescriptors[status];
@@ -83,7 +83,7 @@ function BuildConclusionCondition(props: {
               );
             })}
           </ListBox>
-        </Popover>
+        </SelectPopover>
       </SelectField>
     </div>
   );
@@ -152,7 +152,7 @@ function BuildNameCondition(props: {
           <SelectValue />
         </SelectButton>
         <FieldError />
-        <Popover>
+        <SelectPopover>
           <ListBox>
             {buildNames.map((name) => (
               <ListBoxItem
@@ -165,7 +165,7 @@ function BuildNameCondition(props: {
               </ListBoxItem>
             ))}
           </ListBox>
-        </Popover>
+        </SelectPopover>
       </SelectField>
     </div>
   );
@@ -226,7 +226,7 @@ function BuildModeCondition(props: {
           <SelectValue />
         </SelectButton>
         <FieldError />
-        <Popover>
+        <SelectPopover>
           <ListBox>
             {buildModeOptions.map(({ mode, label, icon: Icon }) => (
               <ListBoxItem
@@ -242,7 +242,7 @@ function BuildModeCondition(props: {
               </ListBoxItem>
             ))}
           </ListBox>
-        </Popover>
+        </SelectPopover>
       </SelectField>
     </div>
   );
@@ -271,7 +271,7 @@ function BuildTypeCondition(props: {
           <SelectValue />
         </SelectButton>
         <FieldError />
-        <Popover>
+        <SelectPopover>
           <ListBox>
             {Object.values(BuildType).map((type) => {
               const descriptor = buildTypeDescriptors[type];
@@ -293,7 +293,7 @@ function BuildTypeCondition(props: {
               );
             })}
           </ListBox>
-        </Popover>
+        </SelectPopover>
       </SelectField>
     </div>
   );
@@ -394,7 +394,7 @@ function OperatorSelector(props: {
       <SelectButton>
         <SelectValue />
       </SelectButton>
-      <Popover>
+      <SelectPopover>
         <ListBox>
           <ListBoxItem id="eq" textValue={labels.eq}>
             {labels.eq}
@@ -403,7 +403,7 @@ function OperatorSelector(props: {
             {labels.neq}
           </ListBoxItem>
         </ListBox>
-      </Popover>
+      </SelectPopover>
     </Select>
   );
 }
@@ -466,7 +466,7 @@ function BranchOperatorSelector(props: {
       <SelectButton>
         <SelectValue />
       </SelectButton>
-      <Popover>
+      <SelectPopover>
         <ListBox>
           <ListBoxItem id="eq" textValue="is">
             is
@@ -481,7 +481,7 @@ function BranchOperatorSelector(props: {
             does not match
           </ListBoxItem>
         </ListBox>
-      </Popover>
+      </SelectPopover>
     </Select>
   );
 }
@@ -562,7 +562,7 @@ export function AutomationConditionsStep(props: {
             <SelectValue />
           </SelectButton>
           <FieldError />
-          <Popover>
+          <SelectPopover>
             <ListBox>
               {conditions.map((condition) => (
                 <ListBoxItem
@@ -574,7 +574,7 @@ export function AutomationConditionsStep(props: {
                 </ListBoxItem>
               ))}
             </ListBox>
-          </Popover>
+          </SelectPopover>
         </SelectField>
       </div>
     </div>

--- a/apps/frontend/src/pages/Automation/AutomationRulesList.tsx
+++ b/apps/frontend/src/pages/Automation/AutomationRulesList.tsx
@@ -199,7 +199,7 @@ export function DeleteAutomation(props: {
 
   return (
     <DialogTrigger
-      isOpen={Boolean(deletedId)}
+      open={Boolean(deletedId)}
       onOpenChange={(isOpen) => {
         if (!isOpen) {
           setDeletedId(null);

--- a/apps/frontend/src/pages/Automation/EditAutomation.tsx
+++ b/apps/frontend/src/pages/Automation/EditAutomation.tsx
@@ -3,7 +3,6 @@ import { invariant } from "@argos/util/invariant";
 import { zodResolver } from "@hookform/resolvers/zod";
 import clsx from "clsx";
 import { CheckCircle2Icon, CircleDotIcon, XCircleIcon } from "lucide-react";
-import { DialogTrigger } from "react-aria-components";
 import { Helmet } from "react-helmet";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
@@ -19,6 +18,7 @@ import {
   CardParagraph,
   CardTitle,
 } from "@/ui/Card";
+import { DialogTrigger } from "@/ui/Dialog";
 import { Form } from "@/ui/Form";
 import { FormRootError } from "@/ui/FormRootError";
 import { Heading } from "@/ui/Heading";

--- a/apps/frontend/src/pages/Build/BuildReviewButton.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewButton.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
-import { DialogTrigger } from "react-aria-components";
 
 import { DocumentType, graphql } from "@/gql";
 import { BuildStatus, ProjectPermission } from "@/gql/graphql";
 import { Button } from "@/ui/Button";
+import { DialogTrigger } from "@/ui/Dialog";
 import { Dialog } from "@/ui/Dialog";
 import { Popover } from "@/ui/Popover";
 import { Tooltip } from "@/ui/Tooltip";
@@ -37,7 +37,7 @@ function BaseReviewButton(props: {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <DialogTrigger isOpen={isOpen} onOpenChange={setIsOpen}>
+    <DialogTrigger open={isOpen} onOpenChange={setIsOpen}>
       <Button
         className="shrink-0"
         isDisabled={props.disabled}
@@ -45,7 +45,7 @@ function BaseReviewButton(props: {
       >
         {props.children ?? "Submit review"}
       </Button>
-      <Popover placement="bottom end" className="overflow-hidden">
+      <Popover side="bottom" align="end" className="overflow-hidden">
         <Dialog aria-label="Submit review">
           <BuildReviewForm
             build={props.build}

--- a/apps/frontend/src/pages/Build/BuildReviewDialog.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewDialog.tsx
@@ -39,7 +39,7 @@ export function useReviewDialog() {
 }
 
 const BuildReviewModal = memo(function BuildReviewModal(props: {
-  isOpen: NonNullable<ModalProps["isOpen"]>;
+  isOpen: NonNullable<ModalProps["open"]>;
   onOpenChange: NonNullable<ModalProps["onOpenChange"]>;
   project: DocumentType<typeof _ProjectFragment>;
 }) {
@@ -48,7 +48,7 @@ const BuildReviewModal = memo(function BuildReviewModal(props: {
     return null;
   }
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange} isDismissable>
+    <Modal open={isOpen} onOpenChange={onOpenChange} dismissible>
       {/* Same review surface as the header popover, just hosted in a modal. */}
       <Dialog aria-label="Submit your review">
         <BuildReviewForm

--- a/apps/frontend/src/pages/Build/RejectCommentDialog.tsx
+++ b/apps/frontend/src/pages/Build/RejectCommentDialog.tsx
@@ -128,13 +128,13 @@ export function RejectCommentDialogProvider(props: {
       {children}
       {build ? (
         <Modal
-          isOpen={state != null}
+          open={state != null}
           onOpenChange={(open) => {
             if (!open) {
               setState(null);
             }
           }}
-          isDismissable
+          dismissible
         >
           {state ? (
             <RejectCommentDialog
@@ -284,7 +284,7 @@ function RejectCommentDialog(props: {
           closes the dialog after `onPress`. Skipping still advances to the next
           diff to review, matching a submitted note.
         */}
-        <DialogDismiss onPress={onProceed}>Skip</DialogDismiss>
+        <DialogDismiss onClick={onProceed}>Skip</DialogDismiss>
         <Button
           variant="primary"
           isPending={isPending}

--- a/apps/frontend/src/pages/Build/metadata/filters/FilterChips.tsx
+++ b/apps/frontend/src/pages/Build/metadata/filters/FilterChips.tsx
@@ -5,7 +5,6 @@ import { XIcon } from "lucide-react";
 import { ButtonGroup } from "@/ui/ButtonGroup";
 import { Chip, ChipButton } from "@/ui/Chip";
 import { MenuRoot, MenuTrigger } from "@/ui/menu-kit";
-import { Popover } from "@/ui/Popover";
 import { StackedItems } from "@/ui/StackedItems";
 import { Truncable } from "@/ui/Truncable";
 
@@ -117,14 +116,12 @@ const ChipValueButton = (props: {
           </div>
         </ChipButton>
       </MenuTrigger>
-      <Popover placement="bottom start">
-        <FilterCategoryMenu
-          filterGroup={filterGroup}
-          state={state}
-          className="min-w-32"
-          splitSelected
-        />
-      </Popover>
+      <FilterCategoryMenu
+        filterGroup={filterGroup}
+        state={state}
+        className="min-w-32"
+        splitSelected
+      />
     </MenuRoot>
   );
 };

--- a/apps/frontend/src/pages/Build/metadata/filters/FilterableIndicator.tsx
+++ b/apps/frontend/src/pages/Build/metadata/filters/FilterableIndicator.tsx
@@ -59,10 +59,11 @@ function InnerFilterableIndicator({
     <div ref={ref} onContextMenu={handleContextMenu} className="min-w-0">
       {children}
       <Popover
-        triggerRef={ref}
-        isOpen={isOpen}
+        anchor={ref}
+        open={isOpen}
         onOpenChange={setIsOpen}
-        placement="bottom start"
+        side="bottom"
+        align="start"
       >
         <FilterIndicatorMenu
           isActive={isActive}

--- a/apps/frontend/src/pages/Build/sidebar/ReviewersSection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ReviewersSection.tsx
@@ -204,13 +204,13 @@ export function ReviewersSection(props: { build: Build }) {
         />
       )}
       <Modal
-        isOpen={Boolean(reviewToDismiss)}
+        open={Boolean(reviewToDismiss)}
         onOpenChange={(isOpen) => {
           if (!isOpen) {
             setReviewToDismiss(null);
           }
         }}
-        isDismissable
+        dismissible
       >
         {reviewToDismiss ? (
           <DismissReviewDialog

--- a/apps/frontend/src/pages/Project/BuildNameFilter.tsx
+++ b/apps/frontend/src/pages/Project/BuildNameFilter.tsx
@@ -8,7 +8,7 @@ import {
 } from "react-aria-components";
 
 import { ListBox, ListBoxItem } from "@/ui/ListBox";
-import { Popover } from "@/ui/Popover";
+import { SelectPopover } from "@/ui/Popover";
 import { Select, SelectButton } from "@/ui/Select";
 import { TextInput } from "@/ui/TextInput";
 
@@ -37,7 +37,7 @@ export function BuildNameFilter(props: {
       <SelectButton className="min-w-[8em] text-sm">
         {getBuildNameLabel(value)}
       </SelectButton>
-      <Popover className="flex flex-col gap-2">
+      <SelectPopover className="flex flex-col gap-2">
         <Autocomplete filter={contains}>
           <SearchField className="relative">
             <SearchIcon
@@ -74,7 +74,7 @@ export function BuildNameFilter(props: {
             ))}
           </ListBox>
         </Autocomplete>
-      </Popover>
+      </SelectPopover>
     </Select>
   );
 }

--- a/apps/frontend/src/pages/Project/IgnoredChanges.tsx
+++ b/apps/frontend/src/pages/Project/IgnoredChanges.tsx
@@ -366,10 +366,7 @@ function PageContent(props: { params: ProjectParams }) {
         </>
       )}
       {unignoring.value ? (
-        <Modal
-          isOpen={unignoring.isOpen}
-          onOpenChange={unignoring.onOpenChange}
-        >
+        <Modal open={unignoring.isOpen} onOpenChange={unignoring.onOpenChange}>
           <UnignoreChangeDialog
             projectId={project.id}
             params={params}

--- a/apps/frontend/src/ui/DateRangePicker.tsx
+++ b/apps/frontend/src/ui/DateRangePicker.tsx
@@ -22,7 +22,7 @@ import {
 } from "react-aria-components";
 
 import { FieldError, FieldErrorContext } from "./FieldError";
-import { Popover } from "./Popover";
+import { SelectPopover } from "./Popover";
 
 type DateRange = {
   from: Date;
@@ -125,7 +125,7 @@ export function DateRangePicker({
         </Button>
       </Group>
       <DateRangeFieldError />
-      <Popover>
+      <SelectPopover>
         <Dialog className="p-3">
           <RangeCalendar className="flex flex-col gap-3">
             <header className="flex items-center justify-between">
@@ -182,7 +182,7 @@ export function DateRangePicker({
             </CalendarGrid>
           </RangeCalendar>
         </Dialog>
-      </Popover>
+      </SelectPopover>
     </AriaDateRangePicker>
   );
 }

--- a/apps/frontend/src/ui/Dialog.stories.tsx
+++ b/apps/frontend/src/ui/Dialog.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, screen, waitFor } from "storybook/test";
 
 import { Button } from "./Button";
 import {
   Dialog,
+  DialogActionButton,
   DialogBody,
   DialogDismiss,
   DialogFooter,
@@ -28,7 +30,7 @@ export const Default: Story = {
       <StoryTitle>Default</StoryTitle>
       <DialogTrigger>
         <Button variant="secondary">Open Dialog</Button>
-        <Modal isDismissable>
+        <Modal dismissible>
           <Dialog>
             <DialogBody>
               <DialogTitle>Confirm Action</DialogTitle>
@@ -45,7 +47,7 @@ export const Default: Story = {
       <StoryTitle>Destructive</StoryTitle>
       <DialogTrigger>
         <Button variant="destructive">Delete Project</Button>
-        <Modal isDismissable>
+        <Modal dismissible>
           <Dialog role="alertdialog">
             <DialogBody>
               <DialogTitle>Delete Project</DialogTitle>
@@ -75,7 +77,7 @@ export const Open: Story = {
   render: () => (
     <DialogTrigger defaultOpen>
       <Button variant="secondary">Open Dialog</Button>
-      <Modal isDismissable>
+      <Modal dismissible>
         <Dialog>
           <DialogBody>
             <DialogTitle>Confirm Action</DialogTitle>
@@ -100,7 +102,7 @@ export const OpenAlert: Story = {
   render: () => (
     <DialogTrigger defaultOpen>
       <Button variant="destructive">Delete Project</Button>
-      <Modal isDismissable>
+      <Modal dismissible>
         <Dialog role="alertdialog">
           <DialogBody>
             <DialogTitle>Delete Project</DialogTitle>
@@ -129,7 +131,7 @@ export const OpenPending: Story = {
   render: () => (
     <DialogTrigger defaultOpen>
       <Button variant="secondary">Open Dialog</Button>
-      <Modal isDismissable>
+      <Modal dismissible>
         <Dialog>
           <DialogBody>
             <DialogTitle>Transfer ownership</DialogTitle>
@@ -138,7 +140,7 @@ export const OpenPending: Story = {
             </DialogText>
           </DialogBody>
           <DialogFooter>
-            <DialogDismiss isDisabled>Cancel</DialogDismiss>
+            <DialogDismiss disabled>Cancel</DialogDismiss>
             <Button variant="primary" isPending>
               Transfer
             </Button>
@@ -147,4 +149,71 @@ export const OpenPending: Story = {
       </Modal>
     </DialogTrigger>
   ),
+};
+
+/** The play drives this to settle the pending action on demand. */
+let settlePendingAction: (() => void) | null = null;
+
+/**
+ * The dialog's one hard behaviour: while an action runs, every user dismissal
+ * — Escape, the backdrop, the dismiss button — is refused, and the dialog
+ * un-blocks once the action settles. No screenshot can see this; the play is
+ * the guard.
+ */
+export const PendingBlocksDismissal: Story = {
+  parameters: openOverlayParameters,
+  render: () => (
+    <div className="flex h-screen w-full items-start justify-center p-16">
+      <DialogTrigger>
+        <Button variant="secondary">Delete project</Button>
+        <Modal dismissible>
+          <Dialog role="alertdialog">
+            <DialogBody>
+              <DialogTitle>Delete this project?</DialogTitle>
+              <DialogText>This cannot be undone.</DialogText>
+            </DialogBody>
+            <DialogFooter>
+              <DialogDismiss>Cancel</DialogDismiss>
+              <DialogActionButton
+                variant="destructive"
+                onAsyncAction={() =>
+                  new Promise<void>((resolve) => {
+                    settlePendingAction = resolve;
+                  })
+                }
+              >
+                Delete
+              </DialogActionButton>
+            </DialogFooter>
+          </Dialog>
+        </Modal>
+      </DialogTrigger>
+    </div>
+  ),
+  play: async ({ userEvent }) => {
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Delete project" }),
+    );
+    const dialog = await screen.findByRole("alertdialog");
+    // Start the action: the dialog is now pending.
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    // Escape and a backdrop press are refused while it runs.
+    await userEvent.keyboard("{Escape}");
+    await expect(dialog).toBeVisible();
+    await userEvent.click(document.body);
+    await expect(dialog).toBeVisible();
+    // The dismiss button is disabled while it runs.
+    await expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    // Once the action settles, the dialog un-blocks and Escape closes it.
+    settlePendingAction?.();
+    await waitFor(async () => {
+      await expect(
+        screen.getByRole("button", { name: "Cancel" }),
+      ).toBeEnabled();
+    });
+    await userEvent.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    });
+  },
 };

--- a/apps/frontend/src/ui/Dialog.stories.tsx
+++ b/apps/frontend/src/ui/Dialog.stories.tsx
@@ -217,3 +217,41 @@ export const PendingBlocksDismissal: Story = {
     });
   },
 };
+
+/**
+ * A dialog is named by its title even when the caller styles that title
+ * itself through `render`. Nothing visible says whether the wiring holds —
+ * `aria-labelledby` pointing at a missing id reads as a name right up until a
+ * screen reader asks — so it is asserted. Only one dialog at a time: an open
+ * modal marks every other one `aria-hidden`, which hides it from the roles.
+ */
+export const StyledTitleNamesTheDialog: Story = {
+  parameters: openOverlayParameters,
+  render: () => (
+    <div className="flex h-screen w-full items-start justify-center p-16">
+      <DialogTrigger defaultOpen>
+        <Button variant="secondary">Settings</Button>
+        <Modal dismissible>
+          <Dialog>
+            <DialogBody>
+              <DialogTitle render={<h2 className="mb-4 font-medium" />}>
+                Customize overlay
+              </DialogTitle>
+              <DialogText>Body size, still the dialog's name.</DialogText>
+            </DialogBody>
+          </Dialog>
+        </Modal>
+      </DialogTrigger>
+    </div>
+  ),
+  play: async () => {
+    // Named by the title the caller styled.
+    await expect(
+      await screen.findByRole("dialog", { name: "Customize overlay" }),
+    ).toBeVisible();
+    // And the caller's styling won: this is not the default title heading.
+    await expect(screen.getByText("Customize overlay")).not.toHaveClass(
+      "text-xl",
+    );
+  },
+};

--- a/apps/frontend/src/ui/Dialog.tsx
+++ b/apps/frontend/src/ui/Dialog.tsx
@@ -1,10 +1,12 @@
 import {
+  cloneElement,
   ComponentPropsWithRef,
   createContext,
   use,
   useEffect,
   useId,
   useState,
+  type ReactElement,
   type ReactNode,
 } from "react";
 import { invariant } from "@argos/util/invariant";
@@ -58,12 +60,32 @@ export function DialogBody(props: ComponentPropsWithRef<"div">) {
   );
 }
 
+/**
+ * The dialog's title, and what names it: the dialog points its
+ * `aria-labelledby` here.
+ *
+ * A dialog that wants its title to read differently passes the element to
+ * render, and gets the wiring without the styling — the same `render` escape
+ * hatch Base UI's own parts take:
+ *
+ * ```tsx
+ * <DialogTitle render={<h2 className="mb-4 font-medium" />}>
+ *   Customize overlay
+ * </DialogTitle>
+ * ```
+ */
 export function DialogTitle(props: {
   ref?: React.Ref<HTMLHeadingElement>;
   children: React.ReactNode;
+  render?: ReactElement<{ id?: string; children?: ReactNode }>;
 }) {
-  const { ref, children } = props;
+  const { ref, children, render } = props;
   const id = use(DialogTitleIdContext);
+  if (render) {
+    // Only the id: a caller who renders their own element puts their own ref
+    // on it, and threading one through here would be reading a ref in render.
+    return cloneElement(render, { id }, children);
+  }
   return (
     <h2 ref={ref} id={id} className="mb-4 text-xl font-medium">
       {children}

--- a/apps/frontend/src/ui/Dialog.tsx
+++ b/apps/frontend/src/ui/Dialog.tsx
@@ -2,6 +2,7 @@ import {
   ComponentPropsWithRef,
   createContext,
   use,
+  useEffect,
   useId,
   useState,
   type ReactNode,
@@ -179,6 +180,20 @@ export function Dialog({
   const { ref, role, children, "aria-label": ariaLabel, ...rest } = props;
   const state = useOverlayTriggerState();
   const titleId = useId();
+  // A dialog names itself through its `DialogTitle`, so one that has neither a
+  // title nor an `aria-label` points `aria-labelledby` at nothing and ends up
+  // with no accessible name at all. Nothing sees that — not a screenshot, not
+  // a type — so say it out loud where the browser can.
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "development" || ariaLabel) {
+      return;
+    }
+    if (!document.getElementById(titleId)) {
+      console.warn(
+        "A dialog has no accessible name: it renders no `DialogTitle`, and no `aria-label` was given. Add one of the two.",
+      );
+    }
+  }, [ariaLabel, titleId]);
   return (
     <DialogRoleContext value={role ?? "dialog"}>
       <DialogTitleIdContext value={ariaLabel ? undefined : titleId}>

--- a/apps/frontend/src/ui/Dialog.tsx
+++ b/apps/frontend/src/ui/Dialog.tsx
@@ -1,23 +1,27 @@
-import { ComponentPropsWithRef, createContext, use, useState } from "react";
+import {
+  ComponentPropsWithRef,
+  createContext,
+  use,
+  useId,
+  useState,
+  type ReactNode,
+} from "react";
 import { invariant } from "@argos/util/invariant";
 import { clsx } from "clsx";
-import {
-  Heading,
-  OverlayTriggerStateContext,
-  Dialog as RACDialog,
-  DialogProps as RACDialogProps,
-} from "react-aria-components";
-import type { OverlayTriggerState } from "react-stately";
 
 import { Button, ButtonProps } from "./Button";
 import { ModalActionContext } from "./Modal";
+import { useOverlayTriggerState } from "./Overlay";
 import { usePersistentValue } from "./usePersistentValue";
 
-export { DialogTrigger } from "react-aria-components";
+export { DialogTrigger, useOverlayTriggerState } from "./Overlay";
 
-type DialogRole = NonNullable<RACDialogProps["role"]>;
+type DialogRole = "dialog" | "alertdialog";
 
 const DialogRoleContext = createContext<DialogRole>("dialog");
+
+/** Set by `Dialog`, read by `DialogTitle` so the dialog can label itself. */
+const DialogTitleIdContext = createContext<string | undefined>(undefined);
 
 export function DialogFooter(props: ComponentPropsWithRef<"div">) {
   const role = use(DialogRoleContext);
@@ -58,20 +62,12 @@ export function DialogTitle(props: {
   children: React.ReactNode;
 }) {
   const { ref, children } = props;
+  const id = use(DialogTitleIdContext);
   return (
-    <Heading ref={ref} slot="title" className="mb-4 text-xl font-medium">
+    <h2 ref={ref} id={id} className="mb-4 text-xl font-medium">
       {children}
-    </Heading>
+    </h2>
   );
-}
-
-export function useOverlayTriggerState(): OverlayTriggerState {
-  const ctx = use(OverlayTriggerStateContext);
-  invariant(
-    ctx,
-    "useOverlayTriggerState must be used within an OverlayTrigger",
-  );
-  return ctx;
 }
 
 /**
@@ -95,9 +91,9 @@ export function useDialogValueState<S>(initialState: S | (() => S)) {
 export function DialogDismiss(props: {
   ref?: React.Ref<HTMLButtonElement>;
   children: React.ReactNode;
-  onPress?: ButtonProps["onPress"];
+  onClick?: () => void;
   single?: boolean;
-  isDisabled?: boolean;
+  disabled?: boolean;
 }) {
   const { ref, ...rest } = props;
   const state = useOverlayTriggerState();
@@ -107,11 +103,11 @@ export function DialogDismiss(props: {
       ref={ref}
       className={rest.single ? "flex-1 justify-center" : undefined}
       variant="secondary"
-      onPress={(event) => {
-        props.onPress?.(event);
+      onPress={() => {
+        props.onClick?.();
         state.close();
       }}
-      isDisabled={rest.isDisabled || actionContext?.isPending}
+      isDisabled={rest.disabled || actionContext?.isPending}
     >
       {rest.children}
     </Button>
@@ -149,8 +145,16 @@ export function DialogActionButton(
   );
 }
 
-type DialogProps = RACDialogProps & {
+type DialogProps = {
   ref?: React.Ref<HTMLDivElement>;
+  role?: DialogRole;
+  className?: string;
+  "aria-label"?: string;
+  /**
+   * The dialog's content — or a function of the overlay state, for content
+   * that closes the dialog itself.
+   */
+  children?: ReactNode | ((state: { close: () => void }) => ReactNode);
   size?: "auto" | "medium";
   /**
    * Whether the dialog should be scrollable or not.
@@ -159,27 +163,45 @@ type DialogProps = RACDialogProps & {
   scrollable?: boolean;
 };
 
+/**
+ * The dialog itself, inside a `Modal` or a `Popover`.
+ *
+ * This element carries the `dialog` / `alertdialog` role, exactly as it did on
+ * react-aria — the overlay popup around it stays `presentation` — so
+ * `getByRole("dialog")` keeps finding one element, and its box.
+ */
 export function Dialog({
   className,
   size = "auto",
   scrollable = true,
   ...props
 }: DialogProps) {
-  const { ref, role, ...rest } = props;
+  const { ref, role, children, "aria-label": ariaLabel, ...rest } = props;
+  const state = useOverlayTriggerState();
+  const titleId = useId();
   return (
     <DialogRoleContext value={role ?? "dialog"}>
-      <RACDialog
-        ref={ref}
-        role={role}
-        className={clsx(
-          className,
-          "relative max-h-[inherit] max-w-full focus:outline-hidden",
-          role === "alertdialog" && size === "auto" ? "w-xl" : null,
-          size === "medium" && "w-xl",
-          scrollable === false ? "overflow-hidden" : "overflow-auto",
-        )}
-        {...rest}
-      />
+      <DialogTitleIdContext value={ariaLabel ? undefined : titleId}>
+        <div
+          ref={ref}
+          role={role ?? "dialog"}
+          aria-modal="true"
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabel ? undefined : titleId}
+          className={clsx(
+            className,
+            "relative max-h-[inherit] max-w-full focus:outline-hidden",
+            role === "alertdialog" && size === "auto" ? "w-xl" : null,
+            size === "medium" && "w-xl",
+            scrollable === false ? "overflow-hidden" : "overflow-auto",
+          )}
+          {...rest}
+        >
+          {typeof children === "function"
+            ? children({ close: state.close })
+            : children}
+        </div>
+      </DialogTitleIdContext>
     </DialogRoleContext>
   );
 }

--- a/apps/frontend/src/ui/EmojiPicker.tsx
+++ b/apps/frontend/src/ui/EmojiPicker.tsx
@@ -1,6 +1,5 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, type ComponentProps } from "react";
 import { SmilePlusIcon } from "lucide-react";
-import { DialogTrigger, type PopoverProps } from "react-aria-components";
 import {
   useController,
   type Control,
@@ -14,9 +13,10 @@ import { Button, type ButtonProps } from "./Button";
 import { Dialog } from "./Dialog";
 import type { Emoji, EmojiPickerProps } from "./EmojiPickerGrid";
 import { Loader } from "./Loader";
+import { DialogTrigger } from "./Overlay";
 import { Popover } from "./Popover";
 
-export { DialogTrigger as EmojiPickerTrigger } from "react-aria-components";
+export { DialogTrigger as EmojiPickerTrigger } from "./Overlay";
 
 /**
  * The picker grid carries the full emojibase dataset — 571 kB of JSON, plus the
@@ -52,7 +52,10 @@ export function EmojiPicker(props: EmojiPickerProps) {
   );
 }
 
-export type EmojiPickerPopoverProps = Omit<PopoverProps, "children"> & {
+export type EmojiPickerPopoverProps = Omit<
+  ComponentProps<typeof Popover>,
+  "children"
+> & {
   /** Called with the selected {@link Emoji} (use `emoji.emoji` for the character). */
   onEmojiSelect: (emoji: Emoji) => void;
 };

--- a/apps/frontend/src/ui/Modal.tsx
+++ b/apps/frontend/src/ui/Modal.tsx
@@ -1,35 +1,40 @@
 import {
   createContext,
-  use,
-  useEffect,
   useMemo,
   useRef,
   useState,
+  type ReactNode,
 } from "react";
+import { Dialog as BaseDialog } from "@base-ui/react/dialog";
 import { clsx } from "clsx";
-import {
-  ModalOverlay,
-  ModalOverlayProps,
-  ModalRenderProps,
-  OverlayTriggerStateContext,
-  Modal as RACModal,
-} from "react-aria-components";
 
+import { OverlayContentProvider, useOverlayRoot } from "./Overlay";
 import { useEventCallback } from "./useEventCallback";
 
-const overlayStyles = (props: ModalRenderProps) =>
-  clsx(
-    "fixed top-0 left-0 w-full h-(--visual-viewport-height) isolate z-dialog bg-black/15 flex items-center justify-center p-4 text-center backdrop-blur-lg",
-    props.isEntering && "animate-in fade-in duration-200 ease-out",
-    props.isExiting && "animate-out fade-out duration-200 ease-in",
-  );
+const backdropClassName = clsx(
+  "fixed inset-0 z-dialog bg-black/15 backdrop-blur-lg",
+  "data-open:animate-in data-open:fade-in data-open:duration-200 data-open:ease-out",
+  "data-closed:animate-out data-closed:fade-out data-closed:duration-200 data-closed:ease-in",
+);
 
-const modalStyles = (props: ModalRenderProps) =>
-  clsx(
-    "overflow-hidden max-h-[calc(100vh-4rem)] max-w-[calc(100vw-4rem)] rounded-2xl bg-app dark:backdrop-blur-2xl dark:backdrop-saturate-200 forced-colors:bg-[Canvas] text-left align-middle text-sm shadow-2xl bg-clip-padding dark:border",
-    props.isEntering && "animate-in zoom-in-105 ease-out duration-200",
-    props.isExiting && "animate-out zoom-out-95 ease-in duration-200",
-  );
+// `h-dvh` where react-aria measured `--visual-viewport-height` with a script:
+// the dynamic viewport unit tracks the same mobile-keyboard resizes natively.
+const viewportClassName =
+  "fixed top-0 left-0 isolate z-dialog flex h-dvh w-full items-center justify-center p-4 text-center";
+
+const popupClassName = clsx(
+  "bg-app max-h-[calc(100vh-4rem)] max-w-[calc(100vw-4rem)] overflow-hidden rounded-2xl bg-clip-padding text-left align-middle text-sm shadow-2xl outline-none dark:border dark:backdrop-blur-2xl dark:backdrop-saturate-200 forced-colors:bg-[Canvas]",
+  // Grows in from slightly small. Deliberately no fade: the card must stay
+  // opaque for every frame it is on screen, or the page shows through it —
+  // which is exactly what a screenshot taken mid-entrance caught. The
+  // backdrop behind it does the fading.
+  "data-open:animate-in data-open:zoom-in-95 data-open:duration-200 data-open:ease-out",
+  // Fades as it shrinks — react-aria tore the card out on the animation's
+  // last frame, so the missing fade never showed; Base UI keeps it mounted a
+  // beat longer, and a card that only scales visibly pops out at the end.
+  // Safe on the way out, where nothing is left to see through it.
+  "data-closed:animate-out data-closed:fade-out data-closed:zoom-out-95 data-closed:duration-200 data-closed:ease-in data-closed:fill-mode-forwards",
+);
 
 interface ActionContextValue {
   isPending: boolean;
@@ -40,108 +45,90 @@ export const ModalActionContext = createContext<ActionContextValue | null>(
   null,
 );
 
-export type ModalProps = ModalOverlayProps;
+export type ModalProps = {
+  children: ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /**
+   * Whether clicking the backdrop dismisses the dialog. Escape always does —
+   * unless an action is pending, which blocks every user dismissal.
+   */
+  dismissible?: boolean;
+};
 
 export function Modal(props: ModalProps) {
-  const { children, ...rest } = props;
+  const { children, dismissible = false, ...stateProps } = props;
+  const { state, renderTrigger } = useOverlayRoot(stateProps);
   const [isPending, setIsPending] = useState(false);
-  // Once the dialog close has been requested while pending, we keep the modal
-  // pending while it's closing: resetting the state would re-enable its
-  // content during the exit animation.
-  const closeRequestedRef = useRef(false);
-  const actionContextValue: ActionContextValue = useMemo(
-    () => ({
-      isPending,
-      setIsPending: (isPending) => {
-        if (!isPending && closeRequestedRef.current) {
-          return;
-        }
-        setIsPending(isPending);
-      },
-    }),
-    [isPending],
+  // A fresh open starts un-pending. Reset on the way in — the state outlives
+  // the popup, and resetting on close would re-enable the dialog's content
+  // while the exit animation still shows it.
+  const [prevOpen, setPrevOpen] = useState(state.isOpen);
+  if (state.isOpen !== prevOpen) {
+    setPrevOpen(state.isOpen);
+    if (state.isOpen) {
+      setIsPending(false);
+    }
+  }
+  const setIsPendingSafe = useEventCallback((next: boolean) => {
+    // An action that settles after the dialog started closing must not
+    // re-enable its content mid-exit.
+    if (!next && !state.isOpen) {
+      return;
+    }
+    setIsPending(next);
+  });
+  const actionContextValue = useMemo<ActionContextValue>(
+    () => ({ isPending, setIsPending: setIsPendingSafe }),
+    [isPending, setIsPendingSafe],
   );
-  const isDismissable = isPending ? false : props.isDismissable;
+  const popupRef = useRef<HTMLDivElement>(null);
+
   return (
     <ModalActionContext.Provider value={actionContextValue}>
-      <ModalOverlay
-        {...rest}
-        className={overlayStyles}
-        isDismissable={isDismissable}
-        isKeyboardDismissDisabled={isPending}
+      <BaseDialog.Root
+        open={state.isOpen}
+        onOpenChange={(next, details) => {
+          // Only user dismissals arrive here — Escape, the backdrop, the
+          // trigger. While an action is pending they are refused; the app's
+          // own `close()` drives the state directly and stays allowed.
+          if (!next && isPending) {
+            details.cancel();
+            return;
+          }
+          state.setOpen(next);
+        }}
+        disablePointerDismissal={isPending || !dismissible}
+        modal
       >
-        <RACModal
-          data-modal=""
-          className={modalStyles}
-          isDismissable={isDismissable}
-          isKeyboardDismissDisabled={isPending}
-        >
-          {(renderProps) => (
-            <ModalCloseTracker
-              onOpen={() => {
-                closeRequestedRef.current = false;
-                setIsPending(false);
-              }}
-              onCloseRequested={() => {
-                closeRequestedRef.current = true;
-              }}
+        {renderTrigger?.((element) => (
+          <BaseDialog.Trigger render={element} />
+        ))}
+        <BaseDialog.Portal>
+          <BaseDialog.Backdrop className={backdropClassName} />
+          <BaseDialog.Viewport className={viewportClassName}>
+            {/* `data-modal` is load-bearing: the build hotkeys treat any event
+                from inside it as belonging to the dialog. The dialog role
+                itself lives on `Dialog`, as it always has — `presentation`
+                keeps the popup from being a second one. */}
+            <BaseDialog.Popup
+              ref={popupRef}
+              role="presentation"
+              data-modal=""
+              // Focus lands on the dialog itself, as it did on react-aria —
+              // Base UI's default keeps it on the trigger for pointer opens,
+              // which leaves a modal the keyboard is not inside of.
+              initialFocus={popupRef}
+              className={popupClassName}
             >
-              {typeof children === "function"
-                ? children(renderProps)
-                : children}
-            </ModalCloseTracker>
-          )}
-        </RACModal>
-      </ModalOverlay>
+              <OverlayContentProvider state={state}>
+                {children}
+              </OverlayContentProvider>
+            </BaseDialog.Popup>
+          </BaseDialog.Viewport>
+        </BaseDialog.Portal>
+      </BaseDialog.Root>
     </ModalActionContext.Provider>
-  );
-}
-
-/**
- * Intercept close requests made through the overlay trigger state (Dialog
- * render prop `close`, `DialogDismiss`, `useOverlayTriggerState().close()`)
- * so the Modal knows the dialog is closing.
- */
-function ModalCloseTracker(props: {
-  onOpen: () => void;
-  onCloseRequested: () => void;
-  children: React.ReactNode;
-}) {
-  const state = use(OverlayTriggerStateContext);
-  const onOpen = useEventCallback(props.onOpen);
-  const onCloseRequested = useEventCallback(props.onCloseRequested);
-  // The tracker mounts each time the modal opens and stays mounted during the
-  // exit animation, so mounting marks a fresh dialog session.
-  useEffect(() => {
-    onOpen();
-  }, [onOpen]);
-  const wrappedState = useMemo(() => {
-    if (!state) {
-      return state;
-    }
-    return {
-      ...state,
-      setOpen: (isOpen: boolean) => {
-        if (!isOpen) {
-          onCloseRequested();
-        }
-        state.setOpen(isOpen);
-      },
-      close: () => {
-        onCloseRequested();
-        state.close();
-      },
-      toggle: () => {
-        if (state.isOpen) {
-          onCloseRequested();
-        }
-        state.toggle();
-      },
-    };
-  }, [state, onCloseRequested]);
-  return (
-    <OverlayTriggerStateContext.Provider value={wrappedState}>
-      {props.children}
-    </OverlayTriggerStateContext.Provider>
   );
 }

--- a/apps/frontend/src/ui/Overlay.tsx
+++ b/apps/frontend/src/ui/Overlay.tsx
@@ -1,0 +1,194 @@
+import {
+  Children,
+  cloneElement,
+  createContext,
+  isValidElement,
+  use,
+  useMemo,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { invariant } from "@argos/util/invariant";
+
+import { HotkeyTooltip } from "./HotkeyTooltip";
+import { Tooltip } from "./Tooltip";
+import { useEventCallback } from "./useEventCallback";
+
+/**
+ * Renders the trigger with the overlay's own trigger part wrapped around the
+ * right element — `wrap` receives the pressable, and what comes back is the
+ * whole control.
+ */
+type OverlayTriggerRenderer = (
+  wrap: (element: ReactElement) => ReactNode,
+) => ReactNode;
+
+/**
+ * A tooltip around a trigger stays *outside* the overlay's trigger part: the
+ * tooltip consumes the props handed to it rather than forwarding them, so
+ * wrapping the tooltip itself would leave the overlay deaf to the press. The
+ * pressable inside is what gets wrapped, and the tooltip is put back around
+ * the result — the same `Tooltip > Trigger > Button` order the menus use.
+ */
+function getTriggerRenderer(element: ReactElement): OverlayTriggerRenderer {
+  if (element.type === Tooltip || element.type === HotkeyTooltip) {
+    const child = (element.props as { children?: ReactNode }).children;
+    if (isValidElement(child)) {
+      return (wrap) => cloneElement(element, undefined, wrap(child));
+    }
+  }
+  return (wrap) => wrap(element);
+}
+
+/**
+ * The open state of an overlay — a dialog, a popover, the emoji picker — and
+ * the ways to drive it.
+ *
+ * Mirrors the react-stately object it replaces, so the many call sites of
+ * `useOverlayTriggerState().close()` keep working unchanged. Only `close` is
+ * used in anger; the rest is kept because the shape is the contract.
+ */
+export type OverlayTriggerState = {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+  setOpen: (open: boolean) => void;
+};
+
+type OverlayTriggerContextValue = {
+  state: OverlayTriggerState;
+  /**
+   * How the overlay renders the control that opens it. Held rather than
+   * rendered: the overlay wraps it in its own Base UI trigger part, which is
+   * what wires the aria attributes, the toggle-on-press behaviour and — for
+   * popovers — the anchor the popup positions against. `DialogTrigger` cannot
+   * render the trigger part itself, because it does not know which namespace
+   * its overlay child belongs to.
+   */
+  renderTrigger: OverlayTriggerRenderer | null;
+};
+
+const OverlayTriggerContext = createContext<OverlayTriggerContextValue | null>(
+  null,
+);
+
+/** One overlay open state, controlled from props or owned locally. */
+function useLocalOverlayState(props: {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}): OverlayTriggerState {
+  const { open: openProp, defaultOpen = false, onOpenChange } = props;
+  const [uncontrolled, setUncontrolled] = useState(defaultOpen);
+  const isOpen = openProp ?? uncontrolled;
+  const setOpen = useEventCallback((next: boolean) => {
+    setUncontrolled(next);
+    onOpenChange?.(next);
+  });
+  return useMemo<OverlayTriggerState>(
+    () => ({
+      isOpen,
+      setOpen,
+      open: () => setOpen(true),
+      close: () => setOpen(false),
+      toggle: () => setOpen(!isOpen),
+    }),
+    [isOpen, setOpen],
+  );
+}
+
+/**
+ * Ties a trigger element to the overlay that follows it.
+ *
+ * ```tsx
+ * <DialogTrigger>
+ *   <Button>Delete</Button>
+ *   <Modal>
+ *     <Dialog role="alertdialog">…</Dialog>
+ *   </Modal>
+ * </DialogTrigger>
+ * ```
+ *
+ * The first element child is the trigger; the overlay renders it through its
+ * own Base UI trigger part, in the same spot in the tree. The name is a
+ * react-aria survival: it also triggers popovers and the emoji picker.
+ */
+export function DialogTrigger(props: {
+  children: ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  const { children, ...stateProps } = props;
+  const state = useLocalOverlayState(stateProps);
+  const [triggerElement, ...overlays] =
+    Children.toArray(children).filter(isValidElement);
+  invariant(
+    triggerElement,
+    "DialogTrigger expects a trigger element as its first child",
+  );
+  const value = useMemo<OverlayTriggerContextValue>(
+    () => ({ state, renderTrigger: getTriggerRenderer(triggerElement) }),
+    [state, triggerElement],
+  );
+  return (
+    <OverlayTriggerContext value={value}>{overlays}</OverlayTriggerContext>
+  );
+}
+
+/**
+ * The state of the overlay this component is rendered in. The single way for
+ * dialog or popover content — at any depth — to close the overlay it lives in.
+ */
+export function useOverlayTriggerState(): OverlayTriggerState {
+  const ctx = use(OverlayTriggerContext);
+  invariant(
+    ctx,
+    "useOverlayTriggerState must be used within an overlay trigger",
+  );
+  return ctx.state;
+}
+
+/**
+ * How an overlay resolves its open state: from the `DialogTrigger` above it,
+ * unless it is given `open`/`defaultOpen` itself — a controlled overlay with
+ * no trigger is the other common shape (`<Modal open={…}>`).
+ */
+export function useOverlayRoot(props: {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}): {
+  state: OverlayTriggerState;
+  renderTrigger: OverlayTriggerRenderer | null;
+} {
+  const ctx = use(OverlayTriggerContext);
+  const localState = useLocalOverlayState(props);
+  const isLocal =
+    !ctx || props.open !== undefined || props.defaultOpen !== undefined;
+  return {
+    state: isLocal ? localState : ctx.state,
+    renderTrigger: isLocal ? null : ctx.renderTrigger,
+  };
+}
+
+/**
+ * What an overlay wraps its content in, so `useOverlayTriggerState()` inside
+ * resolves to *this* overlay — and never to an ancestor's trigger, which is
+ * also why the trigger element is hidden from descendants here.
+ */
+export function OverlayContentProvider(props: {
+  state: OverlayTriggerState;
+  children: ReactNode;
+}) {
+  const { state, children } = props;
+  const value = useMemo<OverlayTriggerContextValue>(
+    () => ({ state, renderTrigger: null }),
+    [state],
+  );
+  return (
+    <OverlayTriggerContext value={value}>{children}</OverlayTriggerContext>
+  );
+}

--- a/apps/frontend/src/ui/Overlay.tsx
+++ b/apps/frontend/src/ui/Overlay.tsx
@@ -42,23 +42,21 @@ function getTriggerRenderer(element: ReactElement): OverlayTriggerRenderer {
 }
 
 /**
- * The open state of an overlay — a dialog, a popover, the emoji picker — and
- * the ways to drive it.
+ * The open state of an overlay — a dialog, a popover, the emoji picker.
  *
- * Mirrors the react-stately object it replaces, so the many call sites of
- * `useOverlayTriggerState().close()` keep working unchanged. Only `close` is
- * used in anger; the rest is kept because the shape is the contract.
+ * `isOpen`/`setOpen` are what the overlay drives Base UI's root with; `close`
+ * is the only member anything outside `ui/` ever touches. It carried
+ * react-stately's full shape at first — `open()`, `toggle()` — which nothing
+ * ever called: that was react-aria's contract, and react-aria is gone.
  */
-export type OverlayTriggerState = {
+type OverlayState = {
   isOpen: boolean;
-  open: () => void;
   close: () => void;
-  toggle: () => void;
   setOpen: (open: boolean) => void;
 };
 
 type OverlayTriggerContextValue = {
-  state: OverlayTriggerState;
+  state: OverlayState;
   /**
    * How the overlay renders the control that opens it. Held rather than
    * rendered: the overlay wraps it in its own Base UI trigger part, which is
@@ -79,7 +77,7 @@ function useLocalOverlayState(props: {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
-}): OverlayTriggerState {
+}): OverlayState {
   const { open: openProp, defaultOpen = false, onOpenChange } = props;
   const [uncontrolled, setUncontrolled] = useState(defaultOpen);
   const isOpen = openProp ?? uncontrolled;
@@ -87,14 +85,8 @@ function useLocalOverlayState(props: {
     setUncontrolled(next);
     onOpenChange?.(next);
   });
-  return useMemo<OverlayTriggerState>(
-    () => ({
-      isOpen,
-      setOpen,
-      open: () => setOpen(true),
-      close: () => setOpen(false),
-      toggle: () => setOpen(!isOpen),
-    }),
+  return useMemo<OverlayState>(
+    () => ({ isOpen, setOpen, close: () => setOpen(false) }),
     [isOpen, setOpen],
   );
 }
@@ -139,10 +131,14 @@ export function DialogTrigger(props: {
 }
 
 /**
- * The state of the overlay this component is rendered in. The single way for
- * dialog or popover content — at any depth — to close the overlay it lives in.
+ * Closes the overlay this component is rendered in, from any depth.
+ *
+ * Base UI has no equivalent: its dialog namespace exports parts and a
+ * module-scoped handle, and `Dialog.Close` is a button — none of which a
+ * mutation's `onCompleted` deep inside the dialog can call. That gap is why
+ * this file exists.
  */
-export function useOverlayTriggerState(): OverlayTriggerState {
+export function useOverlayTriggerState(): Pick<OverlayState, "close"> {
   const ctx = use(OverlayTriggerContext);
   invariant(
     ctx,
@@ -161,7 +157,7 @@ export function useOverlayRoot(props: {
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
 }): {
-  state: OverlayTriggerState;
+  state: OverlayState;
   renderTrigger: OverlayTriggerRenderer | null;
 } {
   const ctx = use(OverlayTriggerContext);
@@ -180,7 +176,7 @@ export function useOverlayRoot(props: {
  * also why the trigger element is hidden from descendants here.
  */
 export function OverlayContentProvider(props: {
-  state: OverlayTriggerState;
+  state: OverlayState;
   children: ReactNode;
 }) {
   const { state, children } = props;

--- a/apps/frontend/src/ui/Popover.stories.tsx
+++ b/apps/frontend/src/ui/Popover.stories.tsx
@@ -31,27 +31,32 @@ export const Default: Story = {
 };
 
 /**
- * The popover surface at each placement. `getPopoverOriginClassName` derives
- * the transform origin from the requested placement, and that whole mechanism
- * is what Base UI replaces with a `--transform-origin` custom property — so
- * every placement needs a baseline of its own.
+ * The popover surface at each placement. Base UI resolves the transform
+ * origin into a `--transform-origin` custom property per side and alignment —
+ * so every placement needs a baseline of its own.
  */
 export const Open: Story = {
   parameters: openOverlayParameters,
   render: () => (
     <OverlayStage className="items-center">
-      {(["bottom start", "bottom end", "top", "left", "right"] as const).map(
-        (placement) => (
-          <OverlaySlot key={placement} className="flex justify-center">
-            <DialogTrigger defaultOpen>
-              <Button variant="secondary">{placement}</Button>
-              <Popover placement={placement}>
-                <div className="p-3 text-sm">Popover content here</div>
-              </Popover>
-            </DialogTrigger>
-          </OverlaySlot>
-        ),
-      )}
+      {(
+        [
+          { label: "bottom start", side: "bottom", align: "start" },
+          { label: "bottom end", side: "bottom", align: "end" },
+          { label: "top", side: "top", align: "center" },
+          { label: "left", side: "left", align: "center" },
+          { label: "right", side: "right", align: "center" },
+        ] as const
+      ).map(({ label, side, align }) => (
+        <OverlaySlot key={label} className="flex justify-center">
+          <DialogTrigger defaultOpen>
+            <Button variant="secondary">{label}</Button>
+            <Popover side={side} align={align}>
+              <div className="p-3 text-sm">Popover content here</div>
+            </Popover>
+          </DialogTrigger>
+        </OverlaySlot>
+      ))}
     </OverlayStage>
   ),
 };

--- a/apps/frontend/src/ui/Popover.tsx
+++ b/apps/frontend/src/ui/Popover.tsx
@@ -1,11 +1,92 @@
+import { useRef, type ReactNode } from "react";
+import { Popover as BasePopover } from "@base-ui/react/popover";
 import { clsx } from "clsx";
 import {
-  PopoverProps,
+  PopoverProps as RACPopoverProps,
   PopoverRenderProps,
   Popover as RACPopover,
 } from "react-aria-components";
 
-import { popupSurfaceClassName, popupZIndexClassName } from "./popupSurface";
+import { OverlayContentProvider, useOverlayRoot } from "./Overlay";
+import {
+  popupAnimationClassName,
+  popupSurfaceClassName,
+  popupZIndexClassName,
+} from "./popupSurface";
+
+/**
+ * A small floating layer opened from a trigger.
+ *
+ * Reads its open state and its trigger from the `DialogTrigger` above it, or
+ * owns it when given `open`/`onOpenChange` — a context menu positions against
+ * an `anchor` ref instead of a trigger.
+ */
+export function Popover(props: {
+  children?: ReactNode;
+  side?: BasePopover.Positioner.Props["side"];
+  align?: BasePopover.Positioner.Props["align"];
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /** What the popup positions against, when the trigger is not a pressable. */
+  anchor?: React.RefObject<Element | null>;
+  className?: string;
+}) {
+  const {
+    children,
+    side = "bottom",
+    // Centered, as react-aria's default `placement="bottom"` was.
+    align = "center",
+    anchor,
+    className,
+    ...stateProps
+  } = props;
+  const { state, renderTrigger } = useOverlayRoot(stateProps);
+  const popupRef = useRef<HTMLDivElement>(null);
+  return (
+    <BasePopover.Root
+      open={state.isOpen}
+      onOpenChange={(next) => state.setOpen(next)}
+    >
+      {renderTrigger?.((element) => (
+        <BasePopover.Trigger render={element} />
+      ))}
+      <BasePopover.Portal>
+        <BasePopover.Positioner
+          side={side}
+          align={align}
+          sideOffset={4}
+          anchor={anchor}
+          className={clsx(popupZIndexClassName, "max-w-(--available-width)")}
+        >
+          {/* The dialog role belongs to the `Dialog` rendered inside, exactly
+              as it did on react-aria — this surface is just its frame. */}
+          <BasePopover.Popup
+            ref={popupRef}
+            role="presentation"
+            // As on react-aria: focus moves into the popover when it opens,
+            // whatever opened it.
+            initialFocus={popupRef}
+            className={clsx(
+              popupSurfaceClassName,
+              popupAnimationClassName,
+              "flex-col outline-none",
+              className,
+            )}
+          >
+            <OverlayContentProvider state={state}>
+              {children}
+            </OverlayContentProvider>
+          </BasePopover.Popup>
+        </BasePopover.Positioner>
+      </BasePopover.Portal>
+    </BasePopover.Root>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* The react-aria popover, kept for Select                                    */
+/* -------------------------------------------------------------------------- */
 
 /**
  * Where the pop-in animation grows from: the corner touching the trigger.
@@ -18,7 +99,7 @@ import { popupSurfaceClassName, popupZIndexClassName } from "./popupSurface";
  */
 function getPopoverOriginClassName(
   side: PopoverRenderProps["placement"],
-  requestedPlacement: PopoverProps["placement"],
+  requestedPlacement: RACPopoverProps["placement"],
 ): string | null {
   const alignment = requestedPlacement?.split(" ")[1];
   switch (side) {
@@ -47,7 +128,7 @@ function getPopoverOriginClassName(
 
 function getPopoverAnimationClassName(
   values: PopoverRenderProps,
-  requestedPlacement: PopoverProps["placement"],
+  requestedPlacement: RACPopoverProps["placement"],
 ): string {
   return clsx(
     "fill-mode-forwards",
@@ -59,8 +140,13 @@ function getPopoverAnimationClassName(
   );
 }
 
-export function Popover(
-  props: PopoverProps & {
+/**
+ * The react-aria popover `Select` still opens — it reads the select's state
+ * from context, which Base UI's popover cannot. It dies with `ListBox` when
+ * Select moves to Base UI.
+ */
+export function SelectPopover(
+  props: RACPopoverProps & {
     ref?: React.Ref<HTMLDivElement>;
   },
 ) {

--- a/apps/frontend/src/ui/Select.stories.tsx
+++ b/apps/frontend/src/ui/Select.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Label } from "./Label";
 import { ListBox, ListBoxItem } from "./ListBox";
-import { Popover } from "./Popover";
+import { SelectPopover } from "./Popover";
 import { Select, SelectButton, SelectValue } from "./Select";
 import {
   openOverlayParameters,
@@ -24,22 +24,22 @@ export const Default: Story = {
       <Select placeholder="Choose…">
         <Label>Small</Label>
         <SelectButton size="sm">Choose…</SelectButton>
-        <Popover>
+        <SelectPopover>
           <ListBox>
             <ListBoxItem id="a">Option A</ListBoxItem>
             <ListBoxItem id="b">Option B</ListBoxItem>
           </ListBox>
-        </Popover>
+        </SelectPopover>
       </Select>
       <Select placeholder="Choose…">
         <Label>Medium</Label>
         <SelectButton size="md">Choose…</SelectButton>
-        <Popover>
+        <SelectPopover>
           <ListBox>
             <ListBoxItem id="a">Option A</ListBoxItem>
             <ListBoxItem id="b">Option B</ListBoxItem>
           </ListBox>
-        </Popover>
+        </SelectPopover>
       </Select>
     </div>
   ),
@@ -59,13 +59,13 @@ export const Open: Story = {
           <SelectButton size="sm">
             <SelectValue />
           </SelectButton>
-          <Popover>
+          <SelectPopover>
             <ListBox>
               <ListBoxItem id="a">Option A</ListBoxItem>
               <ListBoxItem id="b">Option B</ListBoxItem>
               <ListBoxItem id="c">Option C</ListBoxItem>
             </ListBox>
-          </Popover>
+          </SelectPopover>
         </Select>
       </OverlaySlot>
 
@@ -74,7 +74,7 @@ export const Open: Story = {
           <SelectButton size="md">
             <SelectValue />
           </SelectButton>
-          <Popover>
+          <SelectPopover>
             <ListBox>
               <ListBoxItem id="a">Option A</ListBoxItem>
               <ListBoxItem id="b">Option B</ListBoxItem>
@@ -82,7 +82,7 @@ export const Open: Story = {
                 Option C
               </ListBoxItem>
             </ListBox>
-          </Popover>
+          </SelectPopover>
         </Select>
       </OverlaySlot>
     </OverlayStage>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -644,9 +644,6 @@ importers:
       react-router:
         specifier: ^8.3.0
         version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react-stately:
-        specifier: ^3.49.0
-        version: 3.49.0(react@19.2.8)
       react-twc:
         specifier: ^1.5.1
         version: 1.5.1(@types/react@19.2.18)(react@19.2.8)


### PR DESCRIPTION
Batch 1 of the remaining react-aria → Base UI migration: **Modal, Dialog, Popover, EmojiPicker** — the batch everything else waits on.

## The three things that were not renames

**Pending blocks dismissal.** `Modal` monkey-patched `OverlayTriggerStateContext` to intercept close requests, because react-aria owned the open state. Base UI hands it to us, so `ModalCloseTracker` disappears entirely: a *user* dismissal (Escape, backdrop, trigger) arrives in `onOpenChange` and is refused with `details.cancel()` while an action runs, while the app's own `close()` drives the state directly and stays allowed. `ModalActionContext` keeps its exact shape, so `Form`, `DialogActionButton` and `DialogDismiss` needed nothing. (There is no `disableEscapeDismissal` prop — Escape arrives like any other dismissal, so one branch covers all three.)

**The overlay surface splits three ways** — tint/blur/z-index onto `Dialog.Backdrop`, centering onto `Dialog.Viewport`, the card onto `Dialog.Popup`. `h-dvh` replaces the `--visual-viewport-height` measurement react-aria ran a script for.

**The dialog labels itself.** `Heading slot="title"` is gone, so `DialogTitle` takes an id from the dialog and `Dialog` points `aria-labelledby` at it. The `dialog`/`alertdialog` role stays on `Dialog` with the popup around it as `presentation`, so `getByRole("dialog")` still finds exactly one element — the four element-scoped dialog screenshots in `passkeys.spec.ts` keep working unchanged.

## Deliberate behaviour changes

- **The exit fades as it shrinks.** react-aria tore the card out on the animation's last frame, so the missing fade never showed; Base UI keeps it mounted a beat longer and a card that only scales visibly pops out at the end.
- **The entrance grows from 95%** instead of shrinking from 105%. It deliberately does **not** fade: the card must be opaque on every frame it is on screen, or the page shows through it — which is exactly what a Firefox screenshot caught mid-entrance when I tried it. The backdrop does the fading, as it always did.
- **Focus lands on the dialog itself**, as it did on react-aria. Base UI's default focuses the first tabbable element, which would put a focus ring on *Cancel* in every dialog screenshot. Verified it does not clobber `autoFocus`ed inputs — the focus manager bails when focus already moved inside.

## `ui/Overlay.tsx` — why a local file exists

Base UI's dialog namespace exports only parts plus `createHandle`; there is **no hook or context for a descendant to close the overlay it lives in**. 48 sites need exactly that, nearly all of the shape `onCompleted: () => state.close()` — a mutation callback several components below the `Modal`. `Dialog.Close` is a button and cannot express it; `actionsRef` belongs to whoever renders the Root; a handle is module-scoped. So the close context is a genuine gap-filler, not a compatibility shim.

What *is* inherited from react-aria is the **shape**: `<DialogTrigger>` taking trigger and overlay as siblings, and the `useOverlayTriggerState()` name. That keeps 28 files unchanged, at the cost of one wart — the trigger element is held in context and rendered by the overlay, which means `getTriggerRenderer` special-cases `Tooltip`/`HotkeyTooltip` by component identity (3 real call sites wrap their trigger in one). Base UI's native composition — a `<ModalTrigger>` part inside `<Modal>` — would delete that wart, for ~28 files of churn. Worth doing with the Button batch; flagging rather than deciding unilaterally.

## Two silent breaks found in review

`slot="close"` and `slot="title"` were react-aria mechanisms that compile fine and do nothing now. The hotkeys dialog's close button was dead (fixed in `chore: fix hotkey dialog`), and the overlay settings dialog was left with **no accessible name** — `aria-labelledby` pointing at an id nothing rendered. Both fixed, and a dialog with neither a `DialogTitle` nor an `aria-label` now warns in development, because nothing else can see it: not a screenshot, not a type, and a dangling reference reads as a name right up until a screen reader asks.

## What's left behind on purpose

`ui/Popover` keeps a react-aria `SelectPopover`: `Select` reads its state from react-aria context, so it cannot move until `ListBox` does (batch 2). Its 16 call sites are renamed to say so, which also gives the next batch an exact worklist.

`react-stately` leaves the lockfile — the first of the four packages to go.

## Verification

`static-checks` 11/11 · Storybook **76/76** · full chromium e2e **96 passed** (the 2 local reds were the backend rate-limiter serving "Too many requests"; both pass in isolation).

**Argos, reviewed:** Storybook **1 of 76** changed — `ui-popover--open`, where only the `right`-placement popover shifts ~2px; every dialog snapshot is pixel-identical. e2e **2 of 239** changed, and the 94% one on `firefox/settings/passkeys-create` is what caught the entrance-fade problem above; it should be back to identical on this run.

The pending-dismissal contract is the one behaviour no screenshot can see, so it now has a play test (`Dialog > PendingBlocksDismissal`) that starts an action, asserts Escape / backdrop / dismiss-button are all refused, settles the action, and asserts the dialog un-blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)