### PR TITLE
feat(ui): move Select to Base UI, and give every menu one look

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -62,6 +62,26 @@
               {
                 "name": "sonner",
                 "message": "Import { toast, Toaster } from \"@/ui/Toaster\" instead, it handles theming and emphasizes duplicate toasts."
+              },
+              {
+                "name": "react-aria-components",
+                "importNames": [
+                  "Select",
+                  "SelectValue",
+                  "ListBox",
+                  "ListBoxItem",
+                  "Popover",
+                  "Dialog",
+                  "DialogTrigger",
+                  "Modal",
+                  "ModalOverlay",
+                  "Menu",
+                  "MenuTrigger",
+                  "MenuItem",
+                  "Autocomplete",
+                  "SearchField"
+                ],
+                "message": "These have moved to Base UI: import from @/ui/Select, @/ui/ListBox, @/ui/Dialog, @/ui/Modal, @/ui/Popover or @/ui/menu-kit. A react-aria part inside a Base UI tree type-checks and then throws at runtime, which no screenshot catches."
               }
             ]
           }

--- a/apps/frontend/src/containers/AccountSelector.tsx
+++ b/apps/frontend/src/containers/AccountSelector.tsx
@@ -1,5 +1,4 @@
 import { ListBox, ListBoxItem } from "@/ui/ListBox";
-import { SelectPopover } from "@/ui/Popover";
 import { Select, SelectButton } from "@/ui/Select";
 
 import { AccountItem, AccountItemProps } from "./AccountItem";
@@ -17,7 +16,14 @@ export function AccountSelector(props: {
   disabledReasons?: Record<string, string>;
 }) {
   if (!props.accounts) {
-    return <SelectButton isDisabled>Loading…</SelectButton>;
+    // Still a real select, just an empty disabled one: `SelectButton` is Base
+    // UI's trigger and has to have its root above it.
+    return (
+      <Select aria-label="Accounts" disabled>
+        <SelectButton className="w-full">Loading…</SelectButton>
+        <ListBox>{null}</ListBox>
+      </Select>
+    );
   }
 
   const activeAccount =
@@ -29,7 +35,7 @@ export function AccountSelector(props: {
     <Select
       aria-label="Accounts"
       value={props.value}
-      onChange={(value) => props.setValue(String(value))}
+      onValueChange={(value) => props.setValue(String(value))}
     >
       <SelectButton className="w-full">
         {activeAccount ? (
@@ -39,30 +45,27 @@ export function AccountSelector(props: {
         )}
       </SelectButton>
 
-      <SelectPopover>
-        <ListBox>
-          {props.accounts.map((account) => {
-            const disabledReason = props.disabledReasons?.[account.id];
-            return (
-              <ListBoxItem
-                key={account.id}
-                id={account.id}
-                isDisabled={Boolean(disabledReason)}
-                textValue={account.name || account.slug}
-              >
-                <div className="flex w-full items-center justify-between gap-4">
-                  <AccountItem account={account} showPlan />
-                  {disabledReason ? (
-                    <span className="text-low shrink-0 text-xs">
-                      {disabledReason}
-                    </span>
-                  ) : null}
-                </div>
-              </ListBoxItem>
-            );
-          })}
-        </ListBox>
-      </SelectPopover>
+      <ListBox>
+        {props.accounts.map((account) => {
+          const disabledReason = props.disabledReasons?.[account.id];
+          return (
+            <ListBoxItem
+              key={account.id}
+              value={account.id}
+              disabled={Boolean(disabledReason)}
+            >
+              <div className="flex w-full items-center justify-between gap-4">
+                <AccountItem account={account} showPlan />
+                {disabledReason ? (
+                  <span className="text-low shrink-0 text-xs">
+                    {disabledReason}
+                  </span>
+                ) : null}
+              </div>
+            </ListBoxItem>
+          );
+        })}
+      </ListBox>
     </Select>
   );
 }

--- a/apps/frontend/src/containers/GithubInstallationsSelect.tsx
+++ b/apps/frontend/src/containers/GithubInstallationsSelect.tsx
@@ -9,7 +9,6 @@ import {
   ListBoxItemIcon,
   ListBoxSeparator,
 } from "@/ui/ListBox";
-import { SelectPopover } from "@/ui/Popover";
 import { Select, SelectButton } from "@/ui/Select";
 
 import { getGitHubAppInstallURL } from "./GitHub";
@@ -52,16 +51,27 @@ export function GithubInstallationsSelect(props: {
     <Select
       aria-label="Accounts"
       value={value}
-      onChange={(key) => {
+      onValueChange={(key) => {
         if (key === "switch-git-provider") {
           invariant(props.onSwitchProvider, "Expected onSwitchProvider");
           props.onSwitchProvider();
           return;
         }
+        // A select's rows carry values, not links, so the row that adds an
+        // account opens its URL here rather than being an anchor.
+        if (key === "add-github-account") {
+          window.open(
+            getGitHubAppInstallURL(props.app, { accountId: props.accountId }),
+            "_blank",
+            "noopener",
+          );
+          return;
+        }
         props.setValue(String(key));
       }}
+      disabled={disabled}
     >
-      <SelectButton ref={ref} className="w-full" isDisabled={disabled}>
+      <SelectButton ref={ref} className="w-full">
         {activeInstallation ? (
           <div className="flex items-center gap-2">
             <MarkGithubIcon />
@@ -73,50 +83,33 @@ export function GithubInstallationsSelect(props: {
         )}
       </SelectButton>
 
-      <SelectPopover>
-        <ListBox>
-          {installations.map((installation) => {
-            return (
-              <ListBoxItem
-                key={installation.id}
-                id={installation.id}
-                textValue={
-                  installation.account.name || installation.account.login
-                }
-              >
-                <ListBoxItemIcon>
-                  <MarkGithubIcon />
-                </ListBoxItemIcon>
-                {installation.account.name || installation.account.login}
-              </ListBoxItem>
-            );
-          })}
-          <ListBoxSeparator />
-          <ListBoxItem
-            href={getGitHubAppInstallURL(props.app, {
-              accountId: props.accountId,
-            })}
-            target="_blank"
-            textValue="Add GitHub Account"
-          >
-            <ListBoxItemIcon>
-              <PlusIcon />
-            </ListBoxItemIcon>
-            Add GitHub Account
-          </ListBoxItem>
-          {props.onSwitchProvider && (
-            <ListBoxItem
-              id="switch-git-provider"
-              textValue="Switch Git Provider"
-            >
+      <ListBox>
+        {installations.map((installation) => {
+          return (
+            <ListBoxItem key={installation.id} value={installation.id}>
               <ListBoxItemIcon>
-                <ListIcon />
+                <MarkGithubIcon />
               </ListBoxItemIcon>
-              Switch Git Provider
+              {installation.account.name || installation.account.login}
             </ListBoxItem>
-          )}
-        </ListBox>
-      </SelectPopover>
+          );
+        })}
+        <ListBoxSeparator />
+        <ListBoxItem value="add-github-account">
+          <ListBoxItemIcon>
+            <PlusIcon />
+          </ListBoxItemIcon>
+          Add GitHub Account
+        </ListBoxItem>
+        {props.onSwitchProvider && (
+          <ListBoxItem value="switch-git-provider">
+            <ListBoxItemIcon>
+              <ListIcon />
+            </ListBoxItemIcon>
+            Switch Git Provider
+          </ListBoxItem>
+        )}
+      </ListBox>
     </Select>
   );
 }

--- a/apps/frontend/src/containers/GitlabNamespacesSelect.tsx
+++ b/apps/frontend/src/containers/GitlabNamespacesSelect.tsx
@@ -8,7 +8,6 @@ import {
   ListBoxItemIcon,
   ListBoxSeparator,
 } from "@/ui/ListBox";
-import { SelectPopover } from "@/ui/Popover";
 import { Select, SelectButton } from "@/ui/Select";
 
 import { GitLabLogo } from "./GitLab";
@@ -39,15 +38,16 @@ export const GitlabNamespacesSelect = (props: {
     <Select
       aria-label="Namespaces"
       value={props.value}
-      onChange={(value) => {
+      onValueChange={(value) => {
         if (value === "switch-git-provider") {
           props.onSwitch();
           return;
         }
         props.setValue(String(value));
       }}
+      disabled={props.disabled}
     >
-      <SelectButton className="w-full" isDisabled={props.disabled}>
+      <SelectButton className="w-full">
         <div className="flex items-center gap-2">
           <GitLabLogo aria-hidden />
           {activeNamespace
@@ -56,37 +56,31 @@ export const GitlabNamespacesSelect = (props: {
         </div>
       </SelectButton>
 
-      <SelectPopover>
-        <ListBox>
-          {namespaces.map((namespace) => {
-            return (
-              <ListBoxItem
-                key={namespace.id}
-                id={namespace.id}
-                textValue={namespace.name || namespace.path}
-              >
-                <ListBoxItemIcon>
-                  <GitLabLogo />
-                </ListBoxItemIcon>
-                {namespace.name || namespace.path}
-              </ListBoxItem>
-            );
-          })}
-          <ListBoxItem id="all" textValue="All Projects...">
-            <ListBoxItemIcon>
-              <GitLabLogo />
-            </ListBoxItemIcon>
-            All Projects...
-          </ListBoxItem>
-          <ListBoxSeparator />
-          <ListBoxItem id="switch-git-provider" textValue="Switch Git Provider">
-            <ListBoxItemIcon>
-              <ListIcon />
-            </ListBoxItemIcon>
-            Switch Git Provider
-          </ListBoxItem>
-        </ListBox>
-      </SelectPopover>
+      <ListBox>
+        {namespaces.map((namespace) => {
+          return (
+            <ListBoxItem key={namespace.id} value={namespace.id}>
+              <ListBoxItemIcon>
+                <GitLabLogo />
+              </ListBoxItemIcon>
+              {namespace.name || namespace.path}
+            </ListBoxItem>
+          );
+        })}
+        <ListBoxItem value="all">
+          <ListBoxItemIcon>
+            <GitLabLogo />
+          </ListBoxItemIcon>
+          All Projects...
+        </ListBoxItem>
+        <ListBoxSeparator />
+        <ListBoxItem value="switch-git-provider">
+          <ListBoxItemIcon>
+            <ListIcon />
+          </ListBoxItemIcon>
+          Switch Git Provider
+        </ListBoxItem>
+      </ListBox>
     </Select>
   );
 };

--- a/apps/frontend/src/containers/NavUserControl.tsx
+++ b/apps/frontend/src/containers/NavUserControl.tsx
@@ -134,7 +134,7 @@ function UserMenu(props: { account: AuthAccount }) {
         {hotkeysDialog && (
           <MenuItem
             icon={<CommandIcon />}
-            keyboardShortcut="?"
+            keyboardShortcut={["?"]}
             onAction={() => hotkeysDialog.setIsOpen(true)}
           >
             Keyboard shortcuts

--- a/apps/frontend/src/containers/PeriodSelect.tsx
+++ b/apps/frontend/src/containers/PeriodSelect.tsx
@@ -2,7 +2,6 @@ import { invariant } from "@argos/util/invariant";
 import { parseAsStringEnum, useQueryState } from "nuqs";
 
 import { ListBox, ListBoxItem, ListBoxItemLabel } from "@/ui/ListBox";
-import { SelectPopover } from "@/ui/Popover";
 import { Select, SelectButton } from "@/ui/Select";
 
 export type PeriodsDefinition = Record<string, PeriodEntry>;
@@ -55,20 +54,18 @@ export function PeriodSelect<TDef extends PeriodsDefinition>(props: {
     <Select
       aria-label="Periods"
       value={String(value)}
-      onChange={(value) => setValue(String(value))}
+      onValueChange={(value) => setValue(String(value))}
     >
       <SelectButton className="text-sm">{current.label}</SelectButton>
-      <SelectPopover>
-        <ListBox>
-          {Object.entries(definition).map(([key, entry]) => {
-            return (
-              <ListBoxItem key={key} id={key} textValue={entry.label}>
-                <ListBoxItemLabel>{entry.label}</ListBoxItemLabel>
-              </ListBoxItem>
-            );
-          })}
-        </ListBox>
-      </SelectPopover>
+      <ListBox>
+        {Object.entries(definition).map(([key, entry]) => {
+          return (
+            <ListBoxItem key={key} value={key}>
+              <ListBoxItemLabel>{entry.label}</ListBoxItemLabel>
+            </ListBoxItem>
+          );
+        })}
+      </ListBox>
     </Select>
   );
 }

--- a/apps/frontend/src/containers/Project/Contributors/ProjectContributorLevelSelect.tsx
+++ b/apps/frontend/src/containers/Project/Contributors/ProjectContributorLevelSelect.tsx
@@ -8,7 +8,6 @@ import {
 } from "@/containers/ProjectContributor";
 import { graphql } from "@/gql";
 import { ProjectUserLevel } from "@/gql/graphql";
-import { SelectPopover } from "@/ui/Popover";
 import { Select, SelectButton } from "@/ui/Select";
 
 import { addContributor, OPTIMISTIC_CONTRIBUTOR_ID } from "./operations";
@@ -43,7 +42,7 @@ export function ProjectContributorLevelSelect(props: {
     <Select
       aria-label="Levels"
       value={props.level}
-      onChange={(value) => {
+      onValueChange={(value) => {
         invariant(typeof value === "string");
         client.mutate({
           mutation: AddOrUpdateContributorMutation,
@@ -77,9 +76,7 @@ export function ProjectContributorLevelSelect(props: {
         {props.level ? ProjectContributorLevelLabel[props.level] : "Add as"}
       </SelectButton>
 
-      <SelectPopover>
-        <ProjectContributorLevelListBox />
-      </SelectPopover>
+      <ProjectContributorLevelListBox />
     </Select>
   );
 }

--- a/apps/frontend/src/containers/Project/Contributors/ProjectDefaultUserLevel.tsx
+++ b/apps/frontend/src/containers/Project/Contributors/ProjectDefaultUserLevel.tsx
@@ -28,7 +28,6 @@ import {
 import { Form } from "@/ui/Form";
 import { FormSubmit } from "@/ui/FormSubmit";
 import { Modal } from "@/ui/Modal";
-import { SelectPopover } from "@/ui/Popover";
 import { Select, SelectButton } from "@/ui/Select";
 
 const _ProjectFragment = graphql(`
@@ -50,7 +49,7 @@ function ProjectDefaultUserLevelField(props: { control: Control<Inputs> }) {
       name={controller.field.name}
       value={controller.field.value}
       onBlur={controller.field.onBlur}
-      onChange={(value) => {
+      onValueChange={(value) => {
         invariant(typeof value === "string");
         controller.field.onChange(value as ProjectUserLevel);
       }}
@@ -66,9 +65,7 @@ function ProjectDefaultUserLevelField(props: { control: Control<Inputs> }) {
           : ProjectContributorLevelLabel[controller.field.value]}
       </SelectButton>
 
-      <SelectPopover>
-        <ProjectContributorLevelListBox clearable />
-      </SelectPopover>
+      <ProjectContributorLevelListBox clearable />
     </Select>
   );
 }

--- a/apps/frontend/src/containers/Project/Deployments/DeploymentAuthentication.tsx
+++ b/apps/frontend/src/containers/Project/Deployments/DeploymentAuthentication.tsx
@@ -15,7 +15,6 @@ import {
   ListBoxItemDescription,
   ListBoxItemLabel,
 } from "@/ui/ListBox";
-import { SelectPopover } from "@/ui/Popover";
 import { SelectButton, SelectField } from "@/ui/Select";
 
 type DeploymentAuthLevel =
@@ -100,30 +99,24 @@ export function DeploymentAuthentication(props: {
                   {deploymentAuthDef.label}
                 </SelectButton>
                 <FieldError />
-                <SelectPopover className="max-w-sm">
-                  <ListBox>
-                    <ListBoxItem
-                      id={DeploymentAuth.DomainPrivate}
-                      textValue="Standard protection"
-                    >
-                      <ListBoxItemLabel>Standard protection</ListBoxItemLabel>
-                      <ListBoxItemDescription>
-                        Protect all except production custom domains for your
-                        project.
-                      </ListBoxItemDescription>
-                    </ListBoxItem>
-                    <ListBoxItem
-                      id={DeploymentAuth.Private}
-                      textValue="All deployments"
-                      isDisabled={!isTeam}
-                    >
-                      <ListBoxItemLabel>All deployments</ListBoxItemLabel>
-                      <ListBoxItemDescription>
-                        {isTeam ? "Protect all domains." : "Requires a team."}
-                      </ListBoxItemDescription>
-                    </ListBoxItem>
-                  </ListBox>
-                </SelectPopover>
+                <ListBox>
+                  <ListBoxItem value={DeploymentAuth.DomainPrivate}>
+                    <ListBoxItemLabel>Standard protection</ListBoxItemLabel>
+                    <ListBoxItemDescription>
+                      Protect all except production custom domains for your
+                      project.
+                    </ListBoxItemDescription>
+                  </ListBoxItem>
+                  <ListBoxItem
+                    value={DeploymentAuth.Private}
+                    disabled={!isTeam}
+                  >
+                    <ListBoxItemLabel>All deployments</ListBoxItemLabel>
+                    <ListBoxItemDescription>
+                      {isTeam ? "Protect all domains." : "Requires a team."}
+                    </ListBoxItemDescription>
+                  </ListBoxItem>
+                </ListBox>
               </SelectField>
             )}
           </div>

--- a/apps/frontend/src/containers/ProjectContributor.tsx
+++ b/apps/frontend/src/containers/ProjectContributor.tsx
@@ -16,14 +16,14 @@ export function ProjectContributorLevelListBox(props: { clearable?: boolean }) {
   return (
     <ListBox>
       {props.clearable && (
-        <ListBoxItem id="none" textValue="None">
+        <ListBoxItem value="none">
           <ListBoxItemLabel>No default level</ListBoxItemLabel>
           <ListBoxItemDescription>
             Contributors does not have access to the project by default
           </ListBoxItemDescription>
         </ListBoxItem>
       )}
-      <ListBoxItem id="viewer" textValue={ProjectContributorLevelLabel.viewer}>
+      <ListBoxItem value="viewer">
         <ListBoxItemLabel>
           {ProjectContributorLevelLabel.viewer}
         </ListBoxItemLabel>
@@ -31,16 +31,13 @@ export function ProjectContributorLevelListBox(props: { clearable?: boolean }) {
           See builds and screenshots
         </ListBoxItemDescription>
       </ListBoxItem>
-      <ListBoxItem
-        id="reviewer"
-        textValue={ProjectContributorLevelLabel.reviewer}
-      >
+      <ListBoxItem value="reviewer">
         <ListBoxItemLabel>
           {ProjectContributorLevelLabel.reviewer}
         </ListBoxItemLabel>
         <ListBoxItemDescription>See and review builds</ListBoxItemDescription>
       </ListBoxItem>
-      <ListBoxItem id="admin" textValue={ProjectContributorLevelLabel.admin}>
+      <ListBoxItem value="admin">
         <ListBoxItemLabel>
           {ProjectContributorLevelLabel.admin}
         </ListBoxItemLabel>

--- a/apps/frontend/src/containers/Team/members/InviteDialog.tsx
+++ b/apps/frontend/src/containers/Team/members/InviteDialog.tsx
@@ -161,15 +161,14 @@ export function InviteDialog(props: {
                       name={`members.${index}.level`}
                       render={({ field }) => (
                         <MemberLevelSelect
-                          ref={field.ref}
                           hasFineGrainedAccessControl={
                             team.plan?.fineGrainedAccessControlIncluded ?? false
                           }
                           value={field.value}
-                          onChange={field.onChange}
+                          onValueChange={field.onChange}
                           onBlur={field.onBlur}
                           className="flex-1"
-                          isDisabled={isSubmitting}
+                          disabled={isSubmitting}
                         />
                       )}
                     />

--- a/apps/frontend/src/containers/Team/members/MemberLevelEditor.tsx
+++ b/apps/frontend/src/containers/Team/members/MemberLevelEditor.tsx
@@ -48,7 +48,7 @@ export function MemberLevelEditor(props: {
       className="text-low"
       hasFineGrainedAccessControl={hasFineGrainedAccessControl}
       value={member.level}
-      onChange={(value) => {
+      onValueChange={(value) => {
         client.mutate({
           mutation: SetTeamMemberLevelMutation,
           variables: {

--- a/apps/frontend/src/containers/Team/members/MemberLevelFilter.tsx
+++ b/apps/frontend/src/containers/Team/members/MemberLevelFilter.tsx
@@ -1,10 +1,8 @@
-import { SelectValue } from "react-aria-components";
 import z from "zod";
 
 import { TeamUserLevel } from "@/gql/graphql";
 import { ListBox, ListBoxItem } from "@/ui/ListBox";
-import { SelectPopover } from "@/ui/Popover";
-import { Select, SelectButton } from "@/ui/Select";
+import { Select, SelectButton, SelectValue } from "@/ui/Select";
 
 const FilterUserLevelSchema = z.enum([
   "all",
@@ -14,6 +12,14 @@ const FilterUserLevelSchema = z.enum([
 ]);
 
 export type FilterUserLevel = z.infer<typeof FilterUserLevelSchema>;
+
+/** What each role is called, so the trigger can name the chosen one. */
+const FilterUserLevelLabels: Record<FilterUserLevel, string> = {
+  all: "All roles",
+  [TeamUserLevel.Contributor]: "Contributor",
+  [TeamUserLevel.Member]: "Member",
+  [TeamUserLevel.Owner]: "Owner",
+};
 
 export function MemberLevelFilter(props: {
   hasFineGrainedAccessControl: boolean;
@@ -25,22 +31,21 @@ export function MemberLevelFilter(props: {
   return (
     <Select
       aria-label="User role"
+      items={FilterUserLevelLabels}
       value={value}
-      onChange={(value) => onChange(FilterUserLevelSchema.parse(value))}
+      onValueChange={(value) => onChange(FilterUserLevelSchema.parse(value))}
     >
       <SelectButton>
         <SelectValue />
       </SelectButton>
-      <SelectPopover>
-        <ListBox>
-          <ListBoxItem id="all">All roles</ListBoxItem>
-          {hasFineGrainedAccessControl && (
-            <ListBoxItem id="contributor">Contributor</ListBoxItem>
-          )}
-          <ListBoxItem id="member">Member</ListBoxItem>
-          <ListBoxItem id="owner">Owner</ListBoxItem>
-        </ListBox>
-      </SelectPopover>
+      <ListBox>
+        <ListBoxItem value="all">All roles</ListBoxItem>
+        {hasFineGrainedAccessControl && (
+          <ListBoxItem value="contributor">Contributor</ListBoxItem>
+        )}
+        <ListBoxItem value="member">Member</ListBoxItem>
+        <ListBoxItem value="owner">Owner</ListBoxItem>
+      </ListBox>
     </Select>
   );
 }

--- a/apps/frontend/src/containers/Team/members/MemberLevelSelect.tsx
+++ b/apps/frontend/src/containers/Team/members/MemberLevelSelect.tsx
@@ -1,58 +1,62 @@
-import type { RefAttributes } from "react";
-import { SelectValue, type SelectProps } from "react-aria-components";
-
 import {
   ListBox,
   ListBoxItem,
   ListBoxItemDescription,
   ListBoxItemLabel,
 } from "@/ui/ListBox";
-import { SelectPopover } from "@/ui/Popover";
-import { Select, SelectButton, type SelectButtonProps } from "@/ui/Select";
+import {
+  Select,
+  SelectButton,
+  SelectValue,
+  type SelectButtonProps,
+} from "@/ui/Select";
+
+/** What each role is called, so the trigger can name the chosen one. */
+const MemberLevelLabels = {
+  contributor: "Contributor",
+  member: "Member",
+  owner: "Owner",
+};
 
 export function MemberLevelSelect(
   props: {
     hasFineGrainedAccessControl: boolean;
     className?: string;
-  } & SelectProps<object> &
-    Pick<SelectButtonProps, "size"> &
-    RefAttributes<HTMLDivElement>,
+  } & Omit<React.ComponentProps<typeof Select<string>>, "children" | "items"> &
+    Pick<SelectButtonProps, "size">,
 ) {
   const { hasFineGrainedAccessControl, size, className, ...rest } = props;
 
   return (
-    <Select aria-label="User role" className={className} {...rest}>
+    <Select
+      aria-label="User role"
+      items={MemberLevelLabels}
+      className={className}
+      {...rest}
+    >
       <SelectButton size={size}>
-        <SelectValue>
-          {({ selectedText, defaultChildren }) => {
-            return selectedText ?? defaultChildren;
-          }}
-        </SelectValue>
+        <SelectValue />
       </SelectButton>
-      <SelectPopover>
-        <ListBox>
-          {hasFineGrainedAccessControl && (
-            <ListBoxItem id="contributor" textValue="Contributor">
-              <ListBoxItemLabel>Contributor</ListBoxItemLabel>
-              <ListBoxItemDescription>
-                Access control at the project level
-              </ListBoxItemDescription>
-            </ListBoxItem>
-          )}
-          <ListBoxItem id="member" textValue="Member">
-            <ListBoxItemLabel>Member</ListBoxItemLabel>
+      <ListBox>
+        {hasFineGrainedAccessControl && (
+          <ListBoxItem value="contributor">
+            <ListBoxItemLabel>Contributor</ListBoxItemLabel>
             <ListBoxItemDescription>
-              See and review builds
+              Access control at the project level
             </ListBoxItemDescription>
           </ListBoxItem>
-          <ListBoxItem id="owner" textValue="Owner">
-            <ListBoxItemLabel>Owner</ListBoxItemLabel>
-            <ListBoxItemDescription>
-              Admin level access to the entire team
-            </ListBoxItemDescription>
-          </ListBoxItem>
-        </ListBox>
-      </SelectPopover>
+        )}
+        <ListBoxItem value="member">
+          <ListBoxItemLabel>Member</ListBoxItemLabel>
+          <ListBoxItemDescription>See and review builds</ListBoxItemDescription>
+        </ListBoxItem>
+        <ListBoxItem value="owner">
+          <ListBoxItemLabel>Owner</ListBoxItemLabel>
+          <ListBoxItemDescription>
+            Admin level access to the entire team
+          </ListBoxItemDescription>
+        </ListBoxItem>
+      </ListBox>
     </Select>
   );
 }

--- a/apps/frontend/src/containers/Team/members/SortFilter.tsx
+++ b/apps/frontend/src/containers/Team/members/SortFilter.tsx
@@ -11,11 +11,29 @@ import { Select, SelectButton, SelectValue } from "@/ui/Select";
 
 const OrderBySchema = z.enum(TeamMembersOrderBy);
 
-/** What each order is called, so the trigger can name the chosen one. */
-const OrderByLabels: Record<OrderBy, string> = {
-  [TeamMembersOrderBy.Date]: "Date",
-  [TeamMembersOrderBy.NameAsc]: "Name (A-Z)",
-  [TeamMembersOrderBy.NameDesc]: "Name (Z-A)",
+/**
+ * How each order reads on the trigger — icon included, the way react-aria's
+ * value did by rendering the chosen row's own markup.
+ */
+const OrderByLabels: Record<OrderBy, React.ReactNode> = {
+  [TeamMembersOrderBy.Date]: (
+    <>
+      <CalendarArrowDownIcon className="size-4 shrink-0" />
+      Date
+    </>
+  ),
+  [TeamMembersOrderBy.NameAsc]: (
+    <>
+      <ArrowDownAZIcon className="size-4 shrink-0" />
+      Name (A-Z)
+    </>
+  ),
+  [TeamMembersOrderBy.NameDesc]: (
+    <>
+      <ArrowDownZAIcon className="size-4 shrink-0" />
+      Name (Z-A)
+    </>
+  ),
 };
 type OrderBy = z.infer<typeof OrderBySchema>;
 

--- a/apps/frontend/src/containers/Team/members/SortFilter.tsx
+++ b/apps/frontend/src/containers/Team/members/SortFilter.tsx
@@ -3,15 +3,20 @@ import {
   ArrowDownZAIcon,
   CalendarArrowDownIcon,
 } from "lucide-react";
-import { SelectValue } from "react-aria-components";
 import { z } from "zod";
 
 import { TeamMembersOrderBy } from "@/gql/graphql";
 import { ListBox, ListBoxItem, ListBoxItemIcon } from "@/ui/ListBox";
-import { SelectPopover } from "@/ui/Popover";
-import { Select, SelectButton } from "@/ui/Select";
+import { Select, SelectButton, SelectValue } from "@/ui/Select";
 
 const OrderBySchema = z.enum(TeamMembersOrderBy);
+
+/** What each order is called, so the trigger can name the chosen one. */
+const OrderByLabels: Record<OrderBy, string> = {
+  [TeamMembersOrderBy.Date]: "Date",
+  [TeamMembersOrderBy.NameAsc]: "Name (A-Z)",
+  [TeamMembersOrderBy.NameDesc]: "Name (Z-A)",
+};
 type OrderBy = z.infer<typeof OrderBySchema>;
 
 export function SortFilter(props: {
@@ -22,34 +27,33 @@ export function SortFilter(props: {
   return (
     <Select
       aria-label="Sort by"
+      items={OrderByLabels}
       value={value}
-      onChange={(value) => onChange(OrderBySchema.parse(value))}
+      onValueChange={(value) => onChange(OrderBySchema.parse(value))}
     >
       <SelectButton>
         <SelectValue />
       </SelectButton>
-      <SelectPopover>
-        <ListBox>
-          <ListBoxItem id={TeamMembersOrderBy.Date}>
-            <ListBoxItemIcon>
-              <CalendarArrowDownIcon />
-            </ListBoxItemIcon>
-            Date
-          </ListBoxItem>
-          <ListBoxItem id={TeamMembersOrderBy.NameAsc}>
-            <ListBoxItemIcon>
-              <ArrowDownAZIcon />
-            </ListBoxItemIcon>
-            Name (A-Z)
-          </ListBoxItem>
-          <ListBoxItem id={TeamMembersOrderBy.NameDesc}>
-            <ListBoxItemIcon>
-              <ArrowDownZAIcon />
-            </ListBoxItemIcon>
-            Name (Z-A)
-          </ListBoxItem>
-        </ListBox>
-      </SelectPopover>
+      <ListBox>
+        <ListBoxItem value={TeamMembersOrderBy.Date}>
+          <ListBoxItemIcon>
+            <CalendarArrowDownIcon />
+          </ListBoxItemIcon>
+          Date
+        </ListBoxItem>
+        <ListBoxItem value={TeamMembersOrderBy.NameAsc}>
+          <ListBoxItemIcon>
+            <ArrowDownAZIcon />
+          </ListBoxItemIcon>
+          Name (A-Z)
+        </ListBoxItem>
+        <ListBoxItem value={TeamMembersOrderBy.NameDesc}>
+          <ListBoxItemIcon>
+            <ArrowDownZAIcon />
+          </ListBoxItemIcon>
+          Name (Z-A)
+        </ListBoxItem>
+      </ListBox>
     </Select>
   );
 }

--- a/apps/frontend/src/containers/Team/members/SourceFilter.tsx
+++ b/apps/frontend/src/containers/Team/members/SourceFilter.tsx
@@ -1,12 +1,17 @@
-import { SelectValue } from "react-aria-components";
 import { z } from "zod";
 
 import { ListBox, ListBoxItem } from "@/ui/ListBox";
-import { SelectPopover } from "@/ui/Popover";
-import { Select, SelectButton } from "@/ui/Select";
+import { Select, SelectButton, SelectValue } from "@/ui/Select";
 
 const SourceSchema = z.enum(["everyone", "sso", "invite"]);
 export type Source = z.infer<typeof SourceSchema>;
+
+/** What each source is called, so the trigger can name the chosen one. */
+const SourceLabels: Record<Source, string> = {
+  everyone: "Everyone",
+  sso: "Synced from GitHub",
+  invite: "Manually invited",
+};
 
 export function SourceFilter(props: {
   value: Source | null;
@@ -16,20 +21,19 @@ export function SourceFilter(props: {
   return (
     <Select
       aria-label="Source"
+      items={SourceLabels}
       value={value}
-      onChange={(value) => onChange(SourceSchema.parse(value))}
+      onValueChange={(value) => onChange(SourceSchema.parse(value))}
     >
       <SelectButton>
         <SelectValue />
       </SelectButton>
 
-      <SelectPopover>
-        <ListBox>
-          <ListBoxItem id="everyone">Everyone</ListBoxItem>
-          <ListBoxItem id="sso">Synced from GitHub</ListBoxItem>
-          <ListBoxItem id="invite">Manually invited</ListBoxItem>
-        </ListBox>
-      </SelectPopover>
+      <ListBox>
+        <ListBoxItem value="everyone">Everyone</ListBoxItem>
+        <ListBoxItem value="sso">Synced from GitHub</ListBoxItem>
+        <ListBoxItem value="invite">Manually invited</ListBoxItem>
+      </ListBox>
     </Select>
   );
 }

--- a/apps/frontend/src/containers/User/tokens/CreateTokenDialog.tsx
+++ b/apps/frontend/src/containers/User/tokens/CreateTokenDialog.tsx
@@ -22,7 +22,6 @@ import { FormSubmit } from "@/ui/FormSubmit";
 import { FormTextInput } from "@/ui/FormTextInput";
 import { Label } from "@/ui/Label";
 import { ListBox, ListBoxItem } from "@/ui/ListBox";
-import { SelectPopover } from "@/ui/Popover";
 import { Pre } from "@/ui/Pre";
 import { SelectButton, SelectField, SelectValue } from "@/ui/Select";
 
@@ -304,19 +303,16 @@ export function CreateTokenDialog(props: {
                 <SelectButton className="w-full text-sm">
                   <SelectValue />
                 </SelectButton>
-                <SelectPopover>
-                  <ListBox>
-                    {EXPIRATION_OPTIONS.map((option) => (
-                      <ListBoxItem
-                        key={String(option.days ?? "no-expiration")}
-                        id={String(option.days ?? "no-expiration")}
-                        textValue={option.label}
-                      >
-                        {option.label}
-                      </ListBoxItem>
-                    ))}
-                  </ListBox>
-                </SelectPopover>
+                <ListBox>
+                  {EXPIRATION_OPTIONS.map((option) => (
+                    <ListBoxItem
+                      key={String(option.days ?? "no-expiration")}
+                      value={String(option.days ?? "no-expiration")}
+                    >
+                      {option.label}
+                    </ListBoxItem>
+                  ))}
+                </ListBox>
               </SelectField>
               {expireInDaysValue === "no-expiration" ? (
                 <div className="bg-pending-subtle text-pending-low mt-2 flex items-start gap-2 rounded-md p-2 text-xs">

--- a/apps/frontend/src/pages/Account/Analytics.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.tsx
@@ -71,8 +71,7 @@ import {
 import { ListBox, ListBoxItem, ListBoxItemLabel } from "@/ui/ListBox";
 import { Menu, MenuItem, MenuRoot, MenuTrigger } from "@/ui/menu-kit";
 import { PageLoader } from "@/ui/PageLoader";
-import { SelectPopover } from "@/ui/Popover";
-import { Select, SelectButton } from "@/ui/Select";
+import { Select, SelectButton, SelectStyleButton } from "@/ui/Select";
 import { StatTile } from "@/ui/StatTile";
 import { Text } from "@/ui/Text";
 import { Tooltip } from "@/ui/Tooltip";
@@ -1338,14 +1337,14 @@ export function ProjectFilterMenu(props: {
   return (
     <MenuRoot>
       <MenuTrigger>
-        <SelectButton className="shrink-0 text-sm whitespace-nowrap">
+        <SelectStyleButton className="shrink-0 text-sm whitespace-nowrap">
           {label}
           {selected.length > 1 ? (
             <Badge>
               {selected.length}/{projects.length}
             </Badge>
           ) : null}
-        </SelectButton>
+        </SelectStyleButton>
       </MenuTrigger>
       {/* Past a handful of projects the field is worth showing up front;
           below that the menu's own hidden one is enough. */}
@@ -1369,22 +1368,20 @@ function PeriodSelect(props: {
     <Select
       aria-label="Levels"
       value={props.value}
-      onChange={(value) => props.onChange(value as Period)}
+      onValueChange={(value) => props.onChange(value as Period)}
     >
       <SelectButton className="w-full shrink-0 text-sm whitespace-nowrap">
         {PeriodLabels[props.value]}
       </SelectButton>
-      <SelectPopover>
-        <ListBox>
-          {Object.entries(PeriodLabels).map(([key, label]) => {
-            return (
-              <ListBoxItem key={key} id={key} textValue={key}>
-                <ListBoxItemLabel>{label}</ListBoxItemLabel>
-              </ListBoxItem>
-            );
-          })}
-        </ListBox>
-      </SelectPopover>
+      <ListBox>
+        {Object.entries(PeriodLabels).map(([key, label]) => {
+          return (
+            <ListBoxItem key={key} value={key}>
+              <ListBoxItemLabel>{label}</ListBoxItemLabel>
+            </ListBoxItem>
+          );
+        })}
+      </ListBox>
     </Select>
   );
 }

--- a/apps/frontend/src/pages/Automation/AutomationFormActionsStep.tsx
+++ b/apps/frontend/src/pages/Automation/AutomationFormActionsStep.tsx
@@ -19,8 +19,7 @@ import {
   ListBoxItemIcon,
   ListBoxItemLabel,
 } from "@/ui/ListBox";
-import { SelectPopover } from "@/ui/Popover";
-import { SelectButton, SelectField, SelectValue } from "@/ui/Select";
+import { SelectButton, Select, SelectField, SelectValue } from "@/ui/Select";
 import { getSlackAuthURL } from "@/util/slack";
 
 import { useAccountParams } from "../Account/AccountParams";
@@ -214,22 +213,16 @@ function SendWebhookMessageAction(props: {
           <SelectValue />
         </SelectButton>
         <FieldError />
-        <SelectPopover>
-          <ListBox>
-            {webhooks.map((webhook) => (
-              <ListBoxItem
-                key={webhook.id}
-                id={webhook.id}
-                textValue={webhook.name}
-              >
-                <ListBoxItemIcon>
-                  <Logo />
-                </ListBoxItemIcon>
-                <ListBoxItemLabel>{webhook.name}</ListBoxItemLabel>
-              </ListBoxItem>
-            ))}
-          </ListBox>
-        </SelectPopover>
+        <ListBox>
+          {webhooks.map((webhook) => (
+            <ListBoxItem key={webhook.id} value={webhook.id}>
+              <ListBoxItemIcon>
+                <Logo />
+              </ListBoxItemIcon>
+              <ListBoxItemLabel>{webhook.name}</ListBoxItemLabel>
+            </ListBoxItem>
+          ))}
+        </ListBox>
       </SelectField>
     </div>
   );
@@ -344,12 +337,10 @@ export function AutomationActionsStep(props: { form: AutomationForm }) {
             </Task>
           );
         })}
-        <SelectField
-          control={form.control}
-          name={name}
+        <Select<string>
           aria-label="Action Types"
           value={null}
-          onChange={(key) => {
+          onValueChange={(key) => {
             switch (key) {
               case "sendSlackMessage": {
                 append({
@@ -385,23 +376,17 @@ export function AutomationActionsStep(props: { form: AutomationForm }) {
             <SelectValue />
           </SelectButton>
           <FieldError />
-          <SelectPopover>
-            <ListBox>
-              {ACTIONS.map((action) => (
-                <ListBoxItem
-                  key={action.type}
-                  id={action.type}
-                  textValue={action.label}
-                >
-                  <ListBoxItemIcon>
-                    <action.icon />
-                  </ListBoxItemIcon>
-                  <ListBoxItemLabel>{action.label}</ListBoxItemLabel>
-                </ListBoxItem>
-              ))}
-            </ListBox>
-          </SelectPopover>
-        </SelectField>
+          <ListBox>
+            {ACTIONS.map((action) => (
+              <ListBoxItem key={action.type} value={action.type}>
+                <ListBoxItemIcon>
+                  <action.icon />
+                </ListBoxItemIcon>
+                <ListBoxItemLabel>{action.label}</ListBoxItemLabel>
+              </ListBoxItem>
+            ))}
+          </ListBox>
+        </Select>
       </div>
     </div>
   );

--- a/apps/frontend/src/pages/Automation/AutomationFormConditionsStep.tsx
+++ b/apps/frontend/src/pages/Automation/AutomationFormConditionsStep.tsx
@@ -8,9 +8,12 @@ import { useFieldArray } from "react-hook-form";
 import { BuildMode, BuildStatus, BuildType } from "@/gql/graphql";
 import { FieldError } from "@/ui/FieldError";
 import { FormTextInput } from "@/ui/FormTextInput";
-import { ListBox, ListBoxItem, ListBoxItemLabel } from "@/ui/ListBox";
-import { MenuItemIcon } from "@/ui/Menu";
-import { SelectPopover } from "@/ui/Popover";
+import {
+  ListBox,
+  ListBoxItem,
+  ListBoxItemIcon,
+  ListBoxItemLabel,
+} from "@/ui/ListBox";
 import { Select, SelectButton, SelectField, SelectValue } from "@/ui/Select";
 import {
   checkIsGlobCondition,
@@ -61,29 +64,20 @@ function BuildConclusionCondition(props: {
           <SelectValue />
         </SelectButton>
         <FieldError />
-        <SelectPopover>
-          <ListBox>
-            {conclusions.map(({ status, value }) => {
-              const descriptor = buildStatusDescriptors[status];
-              const Icon = descriptor.icon;
-              return (
-                <ListBoxItem
-                  key={value}
-                  id={value}
-                  textValue={descriptor.label}
-                  className="text-sm"
-                >
-                  <MenuItemIcon>
-                    <Icon
-                      className={lowTextColorClassNames[descriptor.color]}
-                    />
-                  </MenuItemIcon>
-                  {descriptor.label}
-                </ListBoxItem>
-              );
-            })}
-          </ListBox>
-        </SelectPopover>
+        <ListBox>
+          {conclusions.map(({ status, value }) => {
+            const descriptor = buildStatusDescriptors[status];
+            const Icon = descriptor.icon;
+            return (
+              <ListBoxItem key={value} value={value} className="text-sm">
+                <ListBoxItemIcon>
+                  <Icon className={lowTextColorClassNames[descriptor.color]} />
+                </ListBoxItemIcon>
+                {descriptor.label}
+              </ListBoxItem>
+            );
+          })}
+        </ListBox>
       </SelectField>
     </div>
   );
@@ -152,20 +146,13 @@ function BuildNameCondition(props: {
           <SelectValue />
         </SelectButton>
         <FieldError />
-        <SelectPopover>
-          <ListBox>
-            {buildNames.map((name) => (
-              <ListBoxItem
-                key={name}
-                id={name}
-                textValue={name}
-                className="text-sm"
-              >
-                {name}
-              </ListBoxItem>
-            ))}
-          </ListBox>
-        </SelectPopover>
+        <ListBox>
+          {buildNames.map((name) => (
+            <ListBoxItem key={name} value={name} className="text-sm">
+              {name}
+            </ListBoxItem>
+          ))}
+        </ListBox>
       </SelectField>
     </div>
   );
@@ -226,23 +213,16 @@ function BuildModeCondition(props: {
           <SelectValue />
         </SelectButton>
         <FieldError />
-        <SelectPopover>
-          <ListBox>
-            {buildModeOptions.map(({ mode, label, icon: Icon }) => (
-              <ListBoxItem
-                key={mode}
-                id={mode}
-                textValue={label}
-                className="text-sm"
-              >
-                <MenuItemIcon>
-                  <Icon />
-                </MenuItemIcon>
-                <ListBoxItemLabel>{label}</ListBoxItemLabel>
-              </ListBoxItem>
-            ))}
-          </ListBox>
-        </SelectPopover>
+        <ListBox>
+          {buildModeOptions.map(({ mode, label, icon: Icon }) => (
+            <ListBoxItem key={mode} value={mode} className="text-sm">
+              <ListBoxItemIcon>
+                <Icon />
+              </ListBoxItemIcon>
+              <ListBoxItemLabel>{label}</ListBoxItemLabel>
+            </ListBoxItem>
+          ))}
+        </ListBox>
       </SelectField>
     </div>
   );
@@ -271,29 +251,20 @@ function BuildTypeCondition(props: {
           <SelectValue />
         </SelectButton>
         <FieldError />
-        <SelectPopover>
-          <ListBox>
-            {Object.values(BuildType).map((type) => {
-              const descriptor = buildTypeDescriptors[type];
-              const Icon = descriptor.icon;
-              return (
-                <ListBoxItem
-                  key={type}
-                  id={type}
-                  textValue={descriptor.label}
-                  className="text-sm"
-                >
-                  <MenuItemIcon>
-                    <Icon
-                      className={lowTextColorClassNames[descriptor.color]}
-                    />
-                  </MenuItemIcon>
-                  <ListBoxItemLabel>{descriptor.label}</ListBoxItemLabel>
-                </ListBoxItem>
-              );
-            })}
-          </ListBox>
-        </SelectPopover>
+        <ListBox>
+          {Object.values(BuildType).map((type) => {
+            const descriptor = buildTypeDescriptors[type];
+            const Icon = descriptor.icon;
+            return (
+              <ListBoxItem key={type} value={type} className="text-sm">
+                <ListBoxItemIcon>
+                  <Icon className={lowTextColorClassNames[descriptor.color]} />
+                </ListBoxItemIcon>
+                <ListBoxItemLabel>{descriptor.label}</ListBoxItemLabel>
+              </ListBoxItem>
+            );
+          })}
+        </ListBox>
       </SelectField>
     </div>
   );
@@ -373,7 +344,7 @@ function OperatorSelector(props: {
     <Select
       aria-label="Operator"
       value={operator}
-      onChange={(value) => {
+      onValueChange={(value) => {
         const rawCondition = form.getValues(conditionName);
         const buildCondition = getBuildCondition(rawCondition);
         invariant(value === "eq" || value === "neq");
@@ -394,16 +365,10 @@ function OperatorSelector(props: {
       <SelectButton>
         <SelectValue />
       </SelectButton>
-      <SelectPopover>
-        <ListBox>
-          <ListBoxItem id="eq" textValue={labels.eq}>
-            {labels.eq}
-          </ListBoxItem>
-          <ListBoxItem id="neq" textValue={labels.neq}>
-            {labels.neq}
-          </ListBoxItem>
-        </ListBox>
-      </SelectPopover>
+      <ListBox>
+        <ListBoxItem value="eq">{labels.eq}</ListBoxItem>
+        <ListBoxItem value="neq">{labels.neq}</ListBoxItem>
+      </ListBox>
     </Select>
   );
 }
@@ -431,7 +396,7 @@ function BranchOperatorSelector(props: {
     <Select
       aria-label="Operator"
       value={operator}
-      onChange={(value) => {
+      onValueChange={(value) => {
         const rawCondition = form.getValues(name);
         const buildCondition = getBuildCondition(rawCondition);
         invariant(buildCondition.type === "build-branch");
@@ -466,22 +431,12 @@ function BranchOperatorSelector(props: {
       <SelectButton>
         <SelectValue />
       </SelectButton>
-      <SelectPopover>
-        <ListBox>
-          <ListBoxItem id="eq" textValue="is">
-            is
-          </ListBoxItem>
-          <ListBoxItem id="neq" textValue="is not">
-            is not
-          </ListBoxItem>
-          <ListBoxItem id="glob" textValue="matches">
-            matches
-          </ListBoxItem>
-          <ListBoxItem id="not-glob" textValue="does not match">
-            does not match
-          </ListBoxItem>
-        </ListBox>
-      </SelectPopover>
+      <ListBox>
+        <ListBoxItem value="eq">is</ListBoxItem>
+        <ListBoxItem value="neq">is not</ListBoxItem>
+        <ListBoxItem value="glob">matches</ListBoxItem>
+        <ListBoxItem value="not-glob">does not match</ListBoxItem>
+      </ListBox>
     </Select>
   );
 }
@@ -533,12 +488,10 @@ export function AutomationConditionsStep(props: {
           </Task>
         ))}
 
-        <SelectField
-          control={form.control}
-          name={name}
+        <Select<string>
           aria-label="Condition Types"
           value={null}
-          onChange={(key) => {
+          onValueChange={(key) => {
             switch (key) {
               case "build-conclusion":
               case "build-mode":
@@ -555,27 +508,21 @@ export function AutomationConditionsStep(props: {
                 throw new Error(`Unknown condition type: ${key}`);
             }
           }}
-          isDisabled={conditions.length === 0}
+          disabled={conditions.length === 0}
           placeholder="Add optional condition…"
         >
           <SelectButton className="w-full">
             <SelectValue />
           </SelectButton>
           <FieldError />
-          <SelectPopover>
-            <ListBox>
-              {conditions.map((condition) => (
-                <ListBoxItem
-                  key={condition.type}
-                  id={condition.type}
-                  textValue={condition.label}
-                >
-                  {condition.label}
-                </ListBoxItem>
-              ))}
-            </ListBox>
-          </SelectPopover>
-        </SelectField>
+          <ListBox>
+            {conditions.map((condition) => (
+              <ListBoxItem key={condition.type} value={condition.type}>
+                {condition.label}
+              </ListBoxItem>
+            ))}
+          </ListBox>
+        </Select>
       </div>
     </div>
   );

--- a/apps/frontend/src/pages/Project/BuildNameFilter.tsx
+++ b/apps/frontend/src/pages/Project/BuildNameFilter.tsx
@@ -1,16 +1,22 @@
-import { SearchIcon, XIcon } from "lucide-react";
+import { Combobox } from "@base-ui/react/combobox";
+import { clsx } from "clsx";
+import { ChevronDownIcon, SearchIcon } from "lucide-react";
 import { parseAsString } from "nuqs";
-import {
-  Autocomplete,
-  Button,
-  SearchField,
-  useFilter,
-} from "react-aria-components";
 
-import { ListBox, ListBoxItem } from "@/ui/ListBox";
-import { SelectPopover } from "@/ui/Popover";
-import { Select, SelectButton } from "@/ui/Select";
-import { TextInput } from "@/ui/TextInput";
+import {
+  getMenuItemClassName,
+  menuListClassName,
+  menuTextClassName,
+} from "@/ui/menuStyle";
+import {
+  popupAnimationClassName,
+  popupSurfaceClassName,
+  popupZIndexClassName,
+} from "@/ui/popupSurface";
+import {
+  getSelectButtonClassName,
+  selectButtonValueClassName,
+} from "@/ui/Select";
 
 function getBuildNameLabel(buildName: string) {
   if (buildName === "") {
@@ -21,60 +27,85 @@ function getBuildNameLabel(buildName: string) {
 
 export const BuildNameFilterParser = parseAsString;
 
+/**
+ * Picks one build name, with a search field for projects that have many.
+ *
+ * A combobox rather than a `Select`: it is the only control in the app that
+ * pairs a value with a query, which is exactly the distinction Base UI draws
+ * between the two namespaces. It wears the select's control and the shared
+ * menu style, so it reads as a select regardless.
+ */
 export function BuildNameFilter(props: {
   buildNames: string[];
   value: string | null;
   onChange: (value: string | null) => void;
 }) {
   const value = props.value ?? "";
-  const { contains } = useFilter({ sensitivity: "base" });
+  const names = ["", ...props.buildNames];
   return (
-    <Select
-      aria-label="Build name"
+    <Combobox.Root
+      items={names}
       value={value}
-      onChange={(value) => props.onChange(value ? String(value) : null)}
+      onValueChange={(next) => props.onChange(next ? String(next) : null)}
+      itemToStringLabel={getBuildNameLabel}
     >
-      <SelectButton className="min-w-[8em] text-sm">
-        {getBuildNameLabel(value)}
-      </SelectButton>
-      <SelectPopover className="flex flex-col gap-2">
-        <Autocomplete filter={contains}>
-          <SearchField className="relative">
-            <SearchIcon
-              aria-hidden
-              className="text-low pointer-events-none absolute top-2 left-2 size-4"
-            />
-            <TextInput
-              scale="sm"
-              className="!pl-8 [&::-webkit-search-cancel-button]:hidden"
-              placeholder="Find build name…"
-            />
-            <Button className="text-low data-hovered:text-default absolute top-2 right-2">
-              <XIcon className="size-4" />
-            </Button>
-          </SearchField>
-          <ListBox
-            renderEmptyState={() => (
-              <div className="text-low px-1 pb-1 text-sm">
-                No build names found
-              </div>
+      <Combobox.Trigger
+        aria-label="Build name"
+        className={clsx(
+          getSelectButtonClassName({ size: "sm" }),
+          "min-w-[8em]",
+        )}
+      >
+        <span className={selectButtonValueClassName}>
+          {getBuildNameLabel(value)}
+        </span>
+        <Combobox.Icon
+          render={
+            <span aria-hidden="true" className="shrink-0">
+              <ChevronDownIcon className="size-4" />
+            </span>
+          }
+        />
+      </Combobox.Trigger>
+      <Combobox.Portal>
+        <Combobox.Positioner
+          sideOffset={4}
+          className={clsx(popupZIndexClassName, "max-w-(--available-width)")}
+        >
+          <Combobox.Popup
+            className={clsx(
+              popupSurfaceClassName,
+              popupAnimationClassName,
+              "flex-col overflow-hidden outline-hidden select-none",
             )}
           >
-            <ListBoxItem id="" textValue="All builds">
-              All builds
-            </ListBoxItem>
-            {props.buildNames.map((name) => (
-              <ListBoxItem
-                key={name}
-                id={name}
-                textValue={getBuildNameLabel(name)}
-              >
-                {getBuildNameLabel(name)}
-              </ListBoxItem>
-            ))}
-          </ListBox>
-        </Autocomplete>
-      </SelectPopover>
-    </Select>
+            <div className="relative flex shrink-0 items-center border-b px-3 py-2">
+              <SearchIcon
+                aria-hidden
+                className="text-placeholder mr-2 size-4 shrink-0"
+              />
+              <Combobox.Input
+                placeholder="Find build name…"
+                className="text-menu placeholder:text-placeholder w-full bg-transparent outline-none"
+              />
+            </div>
+            <Combobox.Empty className={menuTextClassName}>
+              No build names found
+            </Combobox.Empty>
+            <Combobox.List className={menuListClassName}>
+              {(name: string) => (
+                <Combobox.Item
+                  key={name}
+                  value={name}
+                  className={getMenuItemClassName()}
+                >
+                  {getBuildNameLabel(name)}
+                </Combobox.Item>
+              )}
+            </Combobox.List>
+          </Combobox.Popup>
+        </Combobox.Positioner>
+      </Combobox.Portal>
+    </Combobox.Root>
   );
 }

--- a/apps/frontend/src/pages/Project/BuildStatusFilter.tsx
+++ b/apps/frontend/src/pages/Project/BuildStatusFilter.tsx
@@ -4,7 +4,7 @@ import { parseAsStringEnum } from "nuqs";
 import { BuildStatus } from "@/gql/graphql";
 import { Badge } from "@/ui/Badge";
 import { Menu, MenuItem, MenuRoot, MenuTrigger } from "@/ui/menu-kit";
-import { SelectButton } from "@/ui/Select";
+import { SelectStyleButton } from "@/ui/Select";
 import { StackedItems } from "@/ui/StackedItems";
 import { buildStatusDescriptors } from "@/util/build";
 import { bgSolidColorClassNames, lowTextColorClassNames } from "@/util/colors";
@@ -43,7 +43,7 @@ export function BuildStatusFilter(props: {
   return (
     <MenuRoot>
       <MenuTrigger>
-        <SelectButton className="text-sm">
+        <SelectStyleButton className="text-sm">
           <StackedItems>
             {BuildStatuses.map((status) => {
               return (
@@ -65,7 +65,7 @@ export function BuildStatusFilter(props: {
           <Badge>
             {value.size}/{BuildStatuses.length}
           </Badge>
-        </SelectButton>
+        </SelectStyleButton>
       </MenuTrigger>
       <Menu aria-label="Build status">
         {BuildStatuses.map((status) => {

--- a/apps/frontend/src/pages/Project/BuildTypeFilter.tsx
+++ b/apps/frontend/src/pages/Project/BuildTypeFilter.tsx
@@ -4,7 +4,7 @@ import { parseAsStringEnum } from "nuqs";
 import { BuildType } from "@/gql/graphql";
 import { Badge } from "@/ui/Badge";
 import { Menu, MenuItem, MenuRoot, MenuTrigger } from "@/ui/menu-kit";
-import { SelectButton } from "@/ui/Select";
+import { SelectStyleButton } from "@/ui/Select";
 import { StackedItems } from "@/ui/StackedItems";
 import { buildTypeDescriptors } from "@/util/build";
 import { bgSolidColorClassNames, lowTextColorClassNames } from "@/util/colors";
@@ -29,7 +29,7 @@ export function BuildTypeFilter(props: {
   return (
     <MenuRoot>
       <MenuTrigger>
-        <SelectButton className="text-sm">
+        <SelectStyleButton className="text-sm">
           <StackedItems>
             {BuildTypes.map((type) => {
               return (
@@ -49,7 +49,7 @@ export function BuildTypeFilter(props: {
           <Badge>
             {value.size}/{BuildTypes.length}
           </Badge>
-        </SelectButton>
+        </SelectStyleButton>
       </MenuTrigger>
       <Menu aria-label="Build type">
         {BuildTypes.map((status) => {

--- a/apps/frontend/src/ui/DateRangePicker.tsx
+++ b/apps/frontend/src/ui/DateRangePicker.tsx
@@ -1,3 +1,6 @@
+/* oxlint-disable no-restricted-imports -- The date picker is the last
+   react-aria island: its calendar, popover and dialog are all react-aria's and
+   only work together. They go when it moves to react-day-picker. */
 import { use } from "react";
 import { parseDate } from "@internationalized/date";
 import { clsx } from "clsx";
@@ -14,6 +17,7 @@ import {
   DateSegment,
   Dialog,
   Group,
+  Popover as RACPopover,
   Heading,
   FieldErrorContext as RACFieldErrorContext,
   RangeCalendar,
@@ -22,7 +26,7 @@ import {
 } from "react-aria-components";
 
 import { FieldError, FieldErrorContext } from "./FieldError";
-import { SelectPopover } from "./Popover";
+import { popupSurfaceClassName, popupZIndexClassName } from "./popupSurface";
 
 type DateRange = {
   from: Date;
@@ -125,7 +129,12 @@ export function DateRangePicker({
         </Button>
       </Group>
       <DateRangeFieldError />
-      <SelectPopover>
+      {/* react-aria's own popover: the calendar reads the picker's state
+          through react-aria context, which Base UI's popover cannot carry. */}
+      <RACPopover
+        offset={4}
+        className={clsx(popupSurfaceClassName, popupZIndexClassName)}
+      >
         <Dialog className="p-3">
           <RangeCalendar className="flex flex-col gap-3">
             <header className="flex items-center justify-between">
@@ -182,7 +191,7 @@ export function DateRangePicker({
             </CalendarGrid>
           </RangeCalendar>
         </Dialog>
-      </SelectPopover>
+      </RACPopover>
     </AriaDateRangePicker>
   );
 }

--- a/apps/frontend/src/ui/Editor/HeadingMenu.tsx
+++ b/apps/frontend/src/ui/Editor/HeadingMenu.tsx
@@ -2,7 +2,6 @@ import type { Editor } from "@tiptap/react";
 import { ChevronDownIcon } from "lucide-react";
 
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
-import { Kbd } from "@/ui/Kbd";
 import { Menu, MenuItem, MenuRoot, MenuTrigger } from "@/ui/menu-kit";
 
 import { Button } from "../Button";
@@ -52,11 +51,7 @@ export function HeadingMenu(props: { editor: Editor; state: ToolbarState }) {
             key={option.key}
             textValue={option.label}
             checked={selectedKey === option.key}
-            keyboardShortcut={option.keys.map((key) => (
-              <Kbd key={key} className="ml-0.5">
-                {key}
-              </Kbd>
-            ))}
+            keyboardShortcut={option.keys}
             onAction={() => {
               const chain = editor.chain().focus();
               if (option.key === "paragraph") {

--- a/apps/frontend/src/ui/Editor/ListMenu.tsx
+++ b/apps/frontend/src/ui/Editor/ListMenu.tsx
@@ -2,7 +2,6 @@ import type { Editor } from "@tiptap/react";
 import { ChevronDownIcon, ListIcon, ListOrderedIcon } from "lucide-react";
 
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
-import { Kbd } from "@/ui/Kbd";
 import { Menu, MenuItem, MenuRoot, MenuTrigger } from "@/ui/menu-kit";
 
 import { Button } from "../Button";
@@ -69,11 +68,7 @@ export function ListMenu(props: { editor: Editor; state: ToolbarState }) {
                 ? !state.canBulletList
                 : !state.canOrderedList
             }
-            keyboardShortcut={option.keys.map((key) => (
-              <Kbd key={key} className="ml-0.5">
-                {key}
-              </Kbd>
-            ))}
+            keyboardShortcut={option.keys}
             onAction={() => {
               const chain = editor.chain().focus();
               if (option.key === "bulletList") {

--- a/apps/frontend/src/ui/Editor/SuggestionMenus.stories.tsx
+++ b/apps/frontend/src/ui/Editor/SuggestionMenus.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { openOverlayParameters } from "../storyOverlay";
+import { MentionList } from "./mention";
+import { SLASH_COMMAND_ITEMS, SlashCommandList } from "./slashCommand";
+
+const MENTION_USERS = [
+  { id: "1", label: "Greg Bergé", secondaryLabel: "gregberge", initial: "G" },
+  { id: "2", label: "Jeremy Sfez", secondaryLabel: "jsfez", initial: "J" },
+  {
+    id: "3",
+    label: "Kyle Bertolino",
+    secondaryLabel: "kbertolino",
+    initial: "K",
+  },
+];
+
+/**
+ * The two menus the editor raises while you type — `@` for a mention, `/` for
+ * a block. A tiptap suggestion plugin drives them rather than the menu kit, so
+ * they had no coverage at all and had drifted into a look of their own:
+ * smaller corners, tighter rows, a different shadow and a different highlight
+ * from every other menu in the app. They wear the shared menu style now, and
+ * these are the baselines that keep them there.
+ */
+const meta = {
+  title: "UI/Editor/SuggestionMenus",
+  component: MentionList,
+  args: { items: MENTION_USERS, command: () => {} },
+} satisfies Meta<typeof MentionList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Mention: Story = {
+  parameters: openOverlayParameters,
+  render: (args) => (
+    <div className="flex h-screen w-full items-start justify-center p-16">
+      <MentionList {...args} />
+    </div>
+  ),
+};
+
+export const SlashCommand: Story = {
+  parameters: openOverlayParameters,
+  render: () => (
+    <div className="flex h-screen w-full items-start justify-center p-16">
+      <SlashCommandList items={SLASH_COMMAND_ITEMS} command={() => {}} />
+    </div>
+  ),
+};

--- a/apps/frontend/src/ui/Editor/mention.tsx
+++ b/apps/frontend/src/ui/Editor/mention.tsx
@@ -9,6 +9,8 @@ import {
 } from "@tiptap/react";
 import { clsx } from "clsx";
 
+import { getMenuItemClassName, menuListClassName } from "../menuStyle";
+import { popupSurfaceClassName } from "../popupSurface";
 import { UserHoverCard } from "../UserCard";
 import { positionSuggestionPopup } from "./suggestionPopup";
 
@@ -62,11 +64,11 @@ interface SuggestionRenderProps {
   event?: KeyboardEvent;
 }
 
-interface MentionListHandle {
+export interface MentionListHandle {
   onKeyDown: (event: KeyboardEvent) => boolean;
 }
 
-const MentionList = forwardRef<
+export const MentionList = forwardRef<
   MentionListHandle,
   {
     items: MentionUser[];
@@ -126,15 +128,21 @@ const MentionList = forwardRef<
   }
 
   return (
-    <div className="bg-app border-thin max-h-60 w-64 overflow-auto rounded-md p-1 text-sm shadow-lg">
+    <div
+      className={clsx(
+        popupSurfaceClassName,
+        menuListClassName,
+        "max-h-60 w-64 flex-col",
+      )}
+    >
       {items.map((item, index) => (
         <button
           type="button"
           key={item.id}
-          className={clsx(
-            "flex w-full items-center gap-2 rounded px-2 py-1 text-left",
-            index === selectedIndex ? "bg-active" : "hover:bg-hover",
-          )}
+          className={getMenuItemClassName()}
+          // The row the keyboard is on. Hovering moves it here too, which is
+          // why one attribute covers both.
+          data-active={index === selectedIndex || undefined}
           // Use the index on hover so keyboard and pointer stay in sync.
           onMouseEnter={() => setSelectedIndex(index)}
           // `mousedown` (not click) so the editor doesn't lose focus first.

--- a/apps/frontend/src/ui/Editor/slashCommand.tsx
+++ b/apps/frontend/src/ui/Editor/slashCommand.tsx
@@ -21,7 +21,9 @@ import {
   type LucideIcon,
 } from "lucide-react";
 
-import { Kbd } from "@/ui/Kbd";
+import { getMenuItemClassName, menuListClassName } from "@/ui/menuStyle";
+import { popupSurfaceClassName } from "@/ui/popupSurface";
+import { Shortcut } from "@/ui/Shortcut";
 
 import { ALT, MOD, SHIFT } from "./EditorToolbar.shortcuts";
 import { positionSuggestionPopup } from "./suggestionPopup";
@@ -51,7 +53,7 @@ interface SlashCommandItem {
   run: (params: { editor: TiptapEditor; range: SlashRange }) => void;
 }
 
-const SLASH_COMMAND_ITEMS: SlashCommandItem[] = [
+export const SLASH_COMMAND_ITEMS: SlashCommandItem[] = [
   {
     id: "heading1",
     title: "Heading 1",
@@ -151,7 +153,7 @@ interface SlashCommandListHandle {
   onKeyDown: (event: KeyboardEvent) => boolean;
 }
 
-const SlashCommandList = forwardRef<
+export const SlashCommandList = forwardRef<
   SlashCommandListHandle,
   {
     items: SlashCommandItem[];
@@ -213,15 +215,21 @@ const SlashCommandList = forwardRef<
   }
 
   return (
-    <div className="bg-app border-thin max-h-72 w-64 overflow-auto rounded-md p-1 text-sm shadow-lg">
+    <div
+      className={clsx(
+        popupSurfaceClassName,
+        menuListClassName,
+        "max-h-72 w-64 flex-col",
+      )}
+    >
       {items.map((item, index) => (
         <button
           type="button"
           key={item.id}
-          className={clsx(
-            "flex w-full items-center gap-2 rounded px-2 py-1 text-left",
-            index === selectedIndex ? "bg-active" : "hover:bg-hover",
-          )}
+          className={getMenuItemClassName()}
+          // The row the keyboard is on. Hovering moves it here too, which is
+          // why one attribute covers both.
+          data-active={index === selectedIndex || undefined}
           // Keep keyboard and pointer selection in sync.
           onMouseEnter={() => setSelectedIndex(index)}
           // `mousedown` (not click) so the editor doesn't lose focus first.
@@ -232,13 +240,7 @@ const SlashCommandList = forwardRef<
         >
           <item.icon className="text-low size-4 shrink-0" />
           <span className="text-default flex-1 truncate">{item.title}</span>
-          <span className="flex shrink-0 items-center">
-            {item.keys.map((key) => (
-              <Kbd key={key} className="ml-0.5">
-                {key}
-              </Kbd>
-            ))}
-          </span>
+          <Shortcut keys={item.keys} />
         </button>
       ))}
     </div>

--- a/apps/frontend/src/ui/HotkeyTooltip.tsx
+++ b/apps/frontend/src/ui/HotkeyTooltip.tsx
@@ -1,6 +1,6 @@
 import { cloneElement } from "react";
 
-import { Kbd } from "./Kbd";
+import { Shortcut } from "./Shortcut";
 import { Tooltip, TooltipProps } from "./Tooltip";
 
 export function HotkeyTooltip({
@@ -32,9 +32,7 @@ export function HotkeyTooltip({
             {keysEnabled && keys.length > 0 ? (
               <>
                 <span className="text-low">·</span>
-                {keys.map((key) => (
-                  <Kbd key={key}>{key}</Kbd>
-                ))}
+                <Shortcut keys={keys} />
               </>
             ) : null}
           </div>

--- a/apps/frontend/src/ui/HotkeyTooltip.tsx
+++ b/apps/frontend/src/ui/HotkeyTooltip.tsx
@@ -32,7 +32,7 @@ export function HotkeyTooltip({
             {keysEnabled && keys.length > 0 ? (
               <>
                 <span className="text-low">·</span>
-                <Shortcut keys={keys} />
+                <Shortcut keys={keys} variant="boxed" />
               </>
             ) : null}
           </div>

--- a/apps/frontend/src/ui/ListBox.stories.tsx
+++ b/apps/frontend/src/ui/ListBox.stories.tsx
@@ -7,68 +7,85 @@ import {
   ListBoxItemLabel,
   ListBoxSeparator,
 } from "./ListBox";
-import { StoryTitle } from "./StoryTitle";
+import { Select, SelectButton, SelectValue } from "./Select";
+import {
+  openOverlayParameters,
+  OverlaySlot,
+  OverlayStage,
+} from "./storyOverlay";
 
+/**
+ * The options a `Select` drops. They are Base UI select parts now rather than
+ * a standalone react-aria list box, so they only exist inside a select — which
+ * is how all sixteen call sites already used them.
+ */
 const meta = {
   title: "UI/ListBox",
   component: ListBox,
+  args: { children: null },
 } satisfies Meta<typeof ListBox>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  render: () => (
-    <div className="flex flex-col">
-      <StoryTitle>Single Selection</StoryTitle>
-      <div className="border-thin max-w-xs rounded-lg">
-        <ListBox aria-label="Options" selectionMode="single">
-          <ListBoxItem id="edit">Edit</ListBoxItem>
-          <ListBoxItem id="duplicate">Duplicate</ListBoxItem>
-          <ListBoxSeparator />
-          <ListBoxItem id="delete">Delete</ListBoxItem>
-        </ListBox>
-      </div>
+const ACTIONS = { edit: "Edit", duplicate: "Duplicate", delete: "Delete" };
+const REVIEWERS = { jane: "Jane Doe", long: "A reviewer with a long name" };
 
-      <StoryTitle>Multiple Selection</StoryTitle>
-      <div className="border-thin max-w-xs rounded-lg">
-        <ListBox aria-label="Browsers" selectionMode="multiple">
-          <ListBoxItem id="chrome">Chrome</ListBoxItem>
-          <ListBoxItem id="firefox">Firefox</ListBoxItem>
-          <ListBoxItem id="safari">Safari</ListBoxItem>
-          <ListBoxItem id="edge">Edge</ListBoxItem>
-        </ListBox>
-      </div>
-    </div>
+export const Default: Story = {
+  parameters: openOverlayParameters,
+  render: () => (
+    <OverlayStage>
+      <OverlaySlot>
+        <Select items={ACTIONS} value="edit" aria-label="Options" defaultOpen>
+          <SelectButton>
+            <SelectValue />
+          </SelectButton>
+          <ListBox>
+            <ListBoxItem value="edit">Edit</ListBoxItem>
+            <ListBoxItem value="duplicate">Duplicate</ListBoxItem>
+            <ListBoxSeparator />
+            <ListBoxItem value="delete">Delete</ListBoxItem>
+          </ListBox>
+        </Select>
+      </OverlaySlot>
+    </OverlayStage>
   ),
 };
 
 /**
- * Label and description rows are styled through the `slot` DOM attribute
- * (`has-[[slot=description]]:flex-wrap`, `**:[[slot=label]]:truncate`), which
- * react-aria's `Text` sets for us. A replacement that drops the attribute
- * breaks these silently.
+ * An option can carry a second line saying what choosing it means. The name
+ * ellipsizes; the description wraps under it.
  */
 export const LabelAndDescription: Story = {
+  parameters: openOverlayParameters,
   render: () => (
-    <div className="flex flex-col">
-      <StoryTitle>Label and description</StoryTitle>
-      <div className="border-thin max-w-xs rounded-lg">
-        <ListBox aria-label="Reviewers" selectionMode="single">
-          <ListBoxItem id="jane" textValue="Jane Doe">
-            <ListBoxItemLabel>Jane Doe</ListBoxItemLabel>
-            <ListBoxItemDescription>jane@argos-ci.com</ListBoxItemDescription>
-          </ListBoxItem>
-          <ListBoxItem id="long" textValue="A very long name">
-            <ListBoxItemLabel>
-              A reviewer whose name is long enough to be truncated
-            </ListBoxItemLabel>
-            <ListBoxItemDescription>
-              someone.with.a.long.address@example.com
-            </ListBoxItemDescription>
-          </ListBoxItem>
-        </ListBox>
-      </div>
-    </div>
+    <OverlayStage>
+      <OverlaySlot>
+        <Select
+          items={REVIEWERS}
+          value="jane"
+          aria-label="Reviewers"
+          defaultOpen
+        >
+          <SelectButton>
+            <SelectValue />
+          </SelectButton>
+          <ListBox className="w-64">
+            <ListBoxItem value="jane">
+              <ListBoxItemLabel>Jane Doe</ListBoxItemLabel>
+              <ListBoxItemDescription>jane@argos-ci.com</ListBoxItemDescription>
+            </ListBoxItem>
+            <ListBoxItem value="long">
+              <ListBoxItemLabel>
+                A reviewer whose name is long enough to be truncated
+              </ListBoxItemLabel>
+              <ListBoxItemDescription>
+                someone.with.a.long.address@example.com
+              </ListBoxItemDescription>
+            </ListBoxItem>
+          </ListBox>
+        </Select>
+      </OverlaySlot>
+    </OverlayStage>
   ),
 };

--- a/apps/frontend/src/ui/ListBox.tsx
+++ b/apps/frontend/src/ui/ListBox.tsx
@@ -1,82 +1,110 @@
+import type { ReactNode } from "react";
+import { Select as BaseSelect } from "@base-ui/react/select";
 import { clsx } from "clsx";
 import { CheckIcon } from "lucide-react";
+
 import {
-  ListBoxItemProps,
-  ListBoxProps,
-  ListBox as RACListBox,
-  ListBoxItem as RACListBoxItem,
-  Separator as RACSeparator,
-  Text,
-} from "react-aria-components";
+  getMenuItemClassName,
+  menuItemDescriptionClassName,
+  menuItemIconClassName,
+  menuListClassName,
+  menuSeparatorClassName,
+} from "./menuStyle";
+import {
+  popupAnimationClassName,
+  popupSurfaceClassName,
+  popupZIndexClassName,
+} from "./popupSurface";
 
-import { getMenuItemClassName, menuClassName } from "./Menu";
-
-export function ListBox<T extends object>({
-  className,
-  ...props
-}: ListBoxProps<T>) {
-  return (
-    <RACListBox<T> className={clsx(menuClassName, className)} {...props} />
-  );
-}
-
-// A list box is a menu that happens to hold options: same surface, same rows,
-// both of them defined in `Menu`.
-export { MenuItemIcon as ListBoxItemIcon } from "./Menu";
+/** Tallest the list gets before it scrolls, room permitting. */
+const LIST_MAX_HEIGHT = 416;
 
 /**
- * The same hairline `MenuSeparator` draws, but built on React Aria's
- * `Separator` rather than Base UI's.
+ * The options of a `Select`, and the popup that holds them.
  *
- * React Aria builds a collection out of its children and only understands its
- * own components: a Base UI `Separator` in here is not just ignored, it takes
- * every option after it out of the list. This can go back to sharing `Menu`'s
- * once the list box is Base UI too.
+ * The popup is part of the list rather than a wrapper around it — there is no
+ * `SelectPopover` any more, the way a menu owns its own surface.
  */
-export function ListBoxSeparator() {
-  return <RACSeparator className="border-t-thin -mx-1.5 my-1.5" />;
-}
-
-export function ListBoxItem(
-  props: ListBoxItemProps & {
-    children: React.ReactNode;
-  },
-) {
-  const { className, children, ...restProps } = props;
+export function ListBox(props: { children: ReactNode; className?: string }) {
+  const { children, className } = props;
   return (
-    <RACListBoxItem
-      className={clsx(
-        className,
-        getMenuItemClassName({ href: props.href }),
-        // The check mark sits outside the label and needs its own room; a menu
-        // item's icon brings its own margin instead.
-        "gap-2",
-      )}
-      {...restProps}
-    >
-      <CheckIcon className="size-4 shrink-0 opacity-0 not-in-[[role=listbox]]:hidden group-aria-selected/menu-item:opacity-100" />
-      {/* The label ellipsizes rather than overflow: the same markup renders as
-          the value of a select, where the available width is the button's. */}
-      <div className="flex min-w-0 items-center whitespace-nowrap has-[[slot=description]]:flex-wrap **:[[slot=label]]:truncate">
-        {children}
-      </div>
-    </RACListBoxItem>
+    <BaseSelect.Portal>
+      <BaseSelect.Positioner
+        sideOffset={4}
+        align="start"
+        // Base UI otherwise lays the chosen option over the trigger, which
+        // moves the popup somewhere the react-aria version never put it.
+        alignItemWithTrigger={false}
+        className={clsx(popupZIndexClassName, "max-w-(--available-width)")}
+      >
+        <BaseSelect.Popup
+          className={clsx(
+            popupSurfaceClassName,
+            popupAnimationClassName,
+            "flex-col overflow-hidden outline-hidden select-none",
+            className,
+          )}
+        >
+          <BaseSelect.List
+            className={menuListClassName}
+            style={{
+              maxHeight: `min(${LIST_MAX_HEIGHT}px, var(--available-height))`,
+            }}
+          >
+            {children}
+          </BaseSelect.List>
+        </BaseSelect.Popup>
+      </BaseSelect.Positioner>
+    </BaseSelect.Portal>
   );
 }
 
-export function ListBoxItemLabel(props: { children: React.ReactNode }) {
-  return <Text slot="label" {...props} />;
+/** The hairline between groups of options. */
+export function ListBoxSeparator() {
+  return <BaseSelect.Separator className={menuSeparatorClassName} />;
 }
 
-export function ListBoxItemDescription(props: { children: React.ReactNode }) {
+export function ListBoxItem(props: {
+  children: ReactNode;
+  value: string;
+  disabled?: boolean;
+  className?: string;
+}) {
+  const { children, className, ...rest } = props;
   return (
-    <>
-      <div className="h-0 basis-full" />
-      <Text
-        slot="description"
-        className="text-low font-normal whitespace-normal"
-        {...props}
-      />
-    </>
+    <BaseSelect.Item
+      {...rest}
+      className={clsx(getMenuItemClassName(), className)}
+    >
+      {/* Always rendered, so every row's words line up whether or not it is
+          the chosen one. */}
+      <CheckIcon className="size-4 shrink-0 opacity-0 group-data-selected/menu-item:opacity-100" />
+      <span className="flex min-w-0 flex-1 flex-col">{children}</span>
+    </BaseSelect.Item>
+  );
+}
+
+/** The icon an option leads with. */
+export function ListBoxItemIcon(props: { children: ReactNode }) {
+  return <span className={menuItemIconClassName}>{props.children}</span>;
+}
+
+/**
+ * An option's name. It ellipsizes rather than widening the list.
+ *
+ * `ItemText` rather than a plain span: Base UI reads it to describe the option
+ * to assistive tech and for typeahead.
+ */
+export function ListBoxItemLabel(props: { children: ReactNode }) {
+  return <BaseSelect.ItemText className="truncate" {...props} />;
+}
+
+/** A second line under the option's name, saying what choosing it means. */
+export function ListBoxItemDescription(props: { children: ReactNode }) {
+  return (
+    <span
+      className={clsx(menuItemDescriptionClassName, "whitespace-normal")}
+      {...props}
+    />
   );
 }

--- a/apps/frontend/src/ui/Menu.tsx
+++ b/apps/frontend/src/ui/Menu.tsx
@@ -1,71 +1,12 @@
-import { Children, cloneElement } from "react";
 import { clsx } from "clsx";
 import { ChevronsUpDownIcon } from "lucide-react";
 
 /**
- * What is left of the old menu.
- *
- * Menus themselves live in `ui/menu-kit` now. These three pieces stayed behind
- * because `ListBox` and `Select` are still React Aria collections and share the
- * row's look with it — they go when those move.
+ * The stubby chevron button a breadcrumb hangs its menu from — all that is
+ * left of the old menu. The rows and the surface it used to share with
+ * `ListBox` live in `menuStyle` now, which the menu kit, the select and the
+ * editor's suggestion menus all read.
  */
-
-/** The surface a list box draws on. */
-export const menuClassName = "overflow-auto p-1.5 outline-hidden select-none";
-
-type MenuItemVariant = "default" | "danger";
-
-const menuItemVariantClasses: Record<MenuItemVariant, string> = {
-  default: clsx("text-default/90 data-focused:bg-hover/70"),
-  danger: "text-danger-low/90 data-focused:bg-danger-hover/70",
-};
-
-/** A row on that surface, shared with `ListBoxItem`. */
-export function getMenuItemClassName(options: {
-  variant?: MenuItemVariant;
-  /** A row that navigates takes the pointer; one that acts keeps the arrow. */
-  href?: string;
-}) {
-  const { variant = "default", href } = options;
-  return clsx(
-    "group/menu-item font-[450]",
-    menuItemVariantClasses[variant],
-    href ? "cursor-pointer" : "cursor-default",
-    "aria-disabled:opacity-disabled flex items-center rounded-lg px-2.5 py-1.5 text-menu focus:outline-hidden data-focused:data-disabled:bg-transparent",
-  );
-}
-
-export function MenuItemIcon(props: {
-  children: React.ReactElement<{
-    className?: string;
-    "aria-hidden"?: React.AriaAttributes["aria-hidden"];
-  }>;
-  className?: string;
-  position?: "left" | "right";
-}) {
-  const position = props.position ?? "left";
-  const child = Children.only(props.children);
-  return (
-    <div
-      className={clsx(
-        {
-          left: "mr-2",
-          right: "ml-2",
-        }[position],
-        props.className,
-      )}
-    >
-      {cloneElement(child, {
-        "aria-hidden": true,
-        className: clsx(
-          "size-[1em] mx-auto text-low group-data-focused/menu-item:text-default",
-          "group-data-[variant=danger]/menu-item:text-danger-low",
-          child.props.className,
-        ),
-      })}
-    </div>
-  );
-}
 
 export type UpDownMenuButtonProps = React.ComponentPropsWithRef<"button">;
 

--- a/apps/frontend/src/ui/Popover.tsx
+++ b/apps/frontend/src/ui/Popover.tsx
@@ -1,11 +1,6 @@
 import { useRef, type ReactNode } from "react";
 import { Popover as BasePopover } from "@base-ui/react/popover";
 import { clsx } from "clsx";
-import {
-  PopoverProps as RACPopoverProps,
-  PopoverRenderProps,
-  Popover as RACPopover,
-} from "react-aria-components";
 
 import { OverlayContentProvider, useOverlayRoot } from "./Overlay";
 import {
@@ -81,87 +76,5 @@ export function Popover(props: {
         </BasePopover.Positioner>
       </BasePopover.Portal>
     </BasePopover.Root>
-  );
-}
-
-/* -------------------------------------------------------------------------- */
-/* The react-aria popover, kept for Select                                    */
-/* -------------------------------------------------------------------------- */
-
-/**
- * Where the pop-in animation grows from: the corner touching the trigger.
- *
- * The render values only carry the resolved *side* ("bottom"), not the
- * requested alignment — so an end-aligned menu used to zoom from its top
- * center, visibly detached from the button that opened it. The alignment is
- * read back from the `placement` prop, while the side comes from the render
- * values so a flipped popover still animates from the right edge.
- */
-function getPopoverOriginClassName(
-  side: PopoverRenderProps["placement"],
-  requestedPlacement: RACPopoverProps["placement"],
-): string | null {
-  const alignment = requestedPlacement?.split(" ")[1];
-  switch (side) {
-    case "bottom":
-      return {
-        start: "origin-top-left",
-        end: "origin-top-right",
-        default: "origin-top",
-      }[alignment ?? "default"]!;
-    case "top":
-      return {
-        start: "origin-bottom-left",
-        end: "origin-bottom-right",
-        default: "origin-bottom",
-      }[alignment ?? "default"]!;
-    case "left":
-      return "origin-right";
-    case "right":
-      return "origin-left";
-    case "center":
-      return "origin-center";
-    default:
-      return null;
-  }
-}
-
-function getPopoverAnimationClassName(
-  values: PopoverRenderProps,
-  requestedPlacement: RACPopoverProps["placement"],
-): string {
-  return clsx(
-    "fill-mode-forwards",
-    getPopoverOriginClassName(values.placement, requestedPlacement),
-    // Mirrors the exit: without the zoom the menu just fades in mid-air
-    // instead of growing out of its trigger.
-    values.isEntering && "animate-in fade-in zoom-in-95",
-    values.isExiting && "animate-out fade-out zoom-out-95",
-  );
-}
-
-/**
- * The react-aria popover `Select` still opens — it reads the select's state
- * from context, which Base UI's popover cannot. It dies with `ListBox` when
- * Select moves to Base UI.
- */
-export function SelectPopover(
-  props: RACPopoverProps & {
-    ref?: React.Ref<HTMLDivElement>;
-  },
-) {
-  return (
-    <RACPopover
-      offset={4}
-      {...props}
-      className={(values) =>
-        clsx(
-          popupSurfaceClassName,
-          popupZIndexClassName,
-          getPopoverAnimationClassName(values, props.placement),
-          props.className,
-        )
-      }
-    />
   );
 }

--- a/apps/frontend/src/ui/Select.stories.tsx
+++ b/apps/frontend/src/ui/Select.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Label } from "./Label";
 import { ListBox, ListBoxItem } from "./ListBox";
-import { SelectPopover } from "./Popover";
 import { Select, SelectButton, SelectValue } from "./Select";
 import {
   openOverlayParameters,
@@ -10,9 +9,12 @@ import {
   OverlayStage,
 } from "./storyOverlay";
 
+const OPTIONS = { a: "Option A", b: "Option B", c: "Option C" };
+
 const meta = {
   title: "UI/Select",
   component: Select,
+  args: { children: null },
 } satisfies Meta<typeof Select>;
 
 export default meta;
@@ -21,68 +23,65 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   render: () => (
     <div className="flex max-w-xs flex-col gap-6">
-      <Select placeholder="Choose…">
+      <Select items={OPTIONS}>
         <Label>Small</Label>
-        <SelectButton size="sm">Choose…</SelectButton>
-        <SelectPopover>
-          <ListBox>
-            <ListBoxItem id="a">Option A</ListBoxItem>
-            <ListBoxItem id="b">Option B</ListBoxItem>
-          </ListBox>
-        </SelectPopover>
+        <SelectButton size="sm">
+          <SelectValue placeholder="Choose…" />
+        </SelectButton>
+        <ListBox>
+          <ListBoxItem value="a">Option A</ListBoxItem>
+          <ListBoxItem value="b">Option B</ListBoxItem>
+        </ListBox>
       </Select>
-      <Select placeholder="Choose…">
+      <Select items={OPTIONS}>
         <Label>Medium</Label>
-        <SelectButton size="md">Choose…</SelectButton>
-        <SelectPopover>
-          <ListBox>
-            <ListBoxItem id="a">Option A</ListBoxItem>
-            <ListBoxItem id="b">Option B</ListBoxItem>
-          </ListBox>
-        </SelectPopover>
+        <SelectButton size="md">
+          <SelectValue placeholder="Choose…" />
+        </SelectButton>
+        <ListBox>
+          <ListBoxItem value="a">Option A</ListBoxItem>
+          <ListBoxItem value="b">Option B</ListBoxItem>
+        </ListBox>
       </Select>
     </div>
   ),
 };
 
 /**
- * The list box a select drops. Worth pinning carefully: Base UI's
- * `Select.Positioner` defaults to aligning the selected item over the trigger
- * rather than dropping below it, so this is the baseline that catches it.
+ * The list a select drops. Worth pinning carefully: Base UI's
+ * `Select.Positioner` defaults to laying the chosen option over the trigger
+ * rather than dropping the list below it, and this is the baseline that
+ * catches it.
  */
 export const Open: Story = {
   parameters: openOverlayParameters,
   render: () => (
     <OverlayStage>
       <OverlaySlot>
-        <Select selectedKey="b" aria-label="Small" defaultOpen>
+        <Select items={OPTIONS} value="b" aria-label="Small" defaultOpen>
           <SelectButton size="sm">
             <SelectValue />
           </SelectButton>
-          <SelectPopover>
-            <ListBox>
-              <ListBoxItem id="a">Option A</ListBoxItem>
-              <ListBoxItem id="b">Option B</ListBoxItem>
-              <ListBoxItem id="c">Option C</ListBoxItem>
-            </ListBox>
-          </SelectPopover>
+          <ListBox>
+            <ListBoxItem value="a">Option A</ListBoxItem>
+            <ListBoxItem value="b">Option B</ListBoxItem>
+            <ListBoxItem value="c">Option C</ListBoxItem>
+          </ListBox>
         </Select>
       </OverlaySlot>
 
       <OverlaySlot>
-        <Select selectedKey="b" aria-label="Medium" defaultOpen>
+        <Select items={OPTIONS} value="b" aria-label="Medium" defaultOpen>
           <SelectButton size="md">
             <SelectValue />
           </SelectButton>
-          <SelectPopover>
-            <ListBox>
-              <ListBoxItem id="a">Option A</ListBoxItem>
-              <ListBoxItem id="b">Option B</ListBoxItem>
-              <ListBoxItem id="c" isDisabled>
-                Option C
-              </ListBoxItem>
-            </ListBox>
-          </SelectPopover>
+          <ListBox>
+            <ListBoxItem value="a">Option A</ListBoxItem>
+            <ListBoxItem value="b">Option B</ListBoxItem>
+            <ListBoxItem value="c" disabled>
+              Option C
+            </ListBoxItem>
+          </ListBox>
         </Select>
       </OverlaySlot>
     </OverlayStage>

--- a/apps/frontend/src/ui/Select.tsx
+++ b/apps/frontend/src/ui/Select.tsx
@@ -1,12 +1,7 @@
-import type { RefAttributes } from "react";
+import { createContext, use, type ReactNode } from "react";
+import { Select as BaseSelect } from "@base-ui/react/select";
 import { clsx } from "clsx";
 import { ChevronDownIcon } from "lucide-react";
-import {
-  Select as AriaSelect,
-  Button,
-  ButtonProps,
-  type SelectProps as AriaSelectSelectProps,
-} from "react-aria-components";
 import {
   useController,
   type Control,
@@ -14,69 +9,213 @@ import {
   type Path,
 } from "react-hook-form";
 
-import { mergeRefs } from "@/util/merge-refs";
-
 import { FieldErrorContext } from "./FieldError";
 
-export { SelectValue } from "react-aria-components";
-
-function SelectArrow() {
-  return (
-    <span aria-hidden="true" className="shrink-0">
-      <ChevronDownIcon className="size-4" />
-    </span>
-  );
-}
-
-interface SelectProps<T extends object>
-  extends AriaSelectSelectProps<T>, React.RefAttributes<HTMLDivElement> {
+/**
+ * A control that picks one value from a list.
+ *
+ * Base UI's select, and nothing else: it shares its look with the menu kit
+ * through `menuStyle` and none of its behaviour. A menu runs actions and reads
+ * its own children to filter them; this holds a value and hands it back.
+ */
+export function Select<Value>(props: {
+  children: ReactNode;
+  value?: Value | null;
+  defaultValue?: Value | null;
+  onValueChange?: (value: Value | null) => void;
+  /**
+   * What each value is called, so the trigger can name the chosen one without
+   * the list being mounted. Base UI reads it for `SelectValue`.
+   */
+  items?: Record<string, ReactNode>;
+  name?: string;
+  disabled?: boolean;
+  required?: boolean;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /** Lays the label beside the control rather than above it. */
   orientation?: "horizontal" | "vertical";
-}
-
-export function Select<T extends object>(props: SelectProps<T>) {
-  const { orientation = "vertical", ...rest } = props;
+  /** Shown by `SelectValue` until something is chosen. */
+  placeholder?: string;
+  /** Put on the trigger, for an outside `<label htmlFor>`. */
+  id?: string;
+  /** Heard from the trigger, which is what react-hook-form marks touched on. */
+  onBlur?: React.FocusEventHandler<HTMLDivElement>;
+  className?: string;
+  "aria-label"?: string;
+}) {
+  const {
+    children,
+    orientation = "vertical",
+    className,
+    placeholder,
+    id,
+    onBlur,
+    "aria-label": ariaLabel,
+    ...rootProps
+  } = props;
   return (
-    <AriaSelect
-      {...rest}
-      className={clsx(
-        "group/select flex gap-2",
-        {
-          horizontal: "items-center",
-          vertical: "flex-col",
-        }[orientation],
-        props.className,
-      )}
-    />
+    <BaseSelect.Root {...rootProps}>
+      <SelectTriggerIdContext value={id}>
+        <SelectPlaceholderContext value={placeholder}>
+          <div
+            aria-label={ariaLabel}
+            onBlur={onBlur}
+            className={clsx(
+              "group/select flex gap-2",
+              { horizontal: "items-center", vertical: "flex-col" }[orientation],
+              className,
+            )}
+          >
+            {children}
+          </div>
+        </SelectPlaceholderContext>
+      </SelectTriggerIdContext>
+    </BaseSelect.Root>
   );
 }
 
-type SelectFieldProps<TFieldValues extends FieldValues> = {
+/**
+ * What the trigger reads before anything is chosen. Held on `Select` rather
+ * than on `SelectValue`, where Base UI puts it, because a placeholder belongs
+ * to the control in every other field in the app.
+ */
+const SelectPlaceholderContext = createContext<string | undefined>(undefined);
+
+/**
+ * The id for the trigger, when the select is given one. It belongs on the
+ * button rather than the wrapper so an outside `<label htmlFor>` points at
+ * something labelable.
+ */
+const SelectTriggerIdContext = createContext<string | undefined>(undefined);
+
+/** The words for the chosen value, read from the `items` given to `Select`. */
+export function SelectValue(props: {
+  children?: ReactNode | ((value: unknown) => ReactNode);
+  placeholder?: string;
+}) {
+  const inherited = use(SelectPlaceholderContext);
+  return <BaseSelect.Value placeholder={inherited} {...props} />;
+}
+
+export type SelectButtonProps = {
+  ref?: React.Ref<HTMLButtonElement>;
+  children: ReactNode;
+  size?: "sm" | "md";
+  className?: string;
+  "aria-label"?: string;
+};
+
+/**
+ * How a select's control looks. Exported because the build-name filter is a
+ * combobox rather than a select — a different Base UI namespace, the same
+ * control to the eye.
+ */
+export function getSelectButtonClassName(options?: { size?: "sm" | "md" }) {
+  const { size = "md" } = options ?? {};
+  return clsx(
+    /* Appearance */
+    "bg-app border-thin cursor-default appearance-none rounded-lg shadow-2xs select-none",
+    /* Layout */
+    "flex items-center justify-between",
+    /* Focus */
+    "focus-visible:ring-primary-active focus-visible:border-hover focus-visible:ring-2 focus-visible:outline-hidden",
+    /* Hover */
+    "hover:border-hover",
+    /* Disabled */
+    "data-disabled:opacity-disabled data-disabled:cursor-not-allowed",
+    /* Invalid — only emitted inside a `Field.Root`, which `SelectField` provides */
+    "data-invalid:border-danger data-invalid:hover:border-danger-hover",
+    /* Placeholder */
+    "data-[placeholder]:text-low",
+    /* Open */
+    "data-popup-open:shadow-none",
+    {
+      md: "gap-2 px-3 py-1.5 text-base leading-5",
+      sm: "gap-2 px-2 py-1 text-sm leading-4",
+    }[size],
+  );
+}
+
+/**
+ * The value's own shrinkable box — `*:min-w-0` so the value inside it may
+ * shrink too. On a fixed-width control, a value wider than the button (a long
+ * channel name, say) would otherwise push the arrow out through the right
+ * padding instead of being ellipsized.
+ */
+export const selectButtonValueClassName =
+  "flex min-w-0 flex-1 items-center gap-2 overflow-hidden *:min-w-0";
+
+/**
+ * A button that looks like a select's control but opens something else.
+ *
+ * Three of the build filters are menus wearing a select's clothes.
+ * `SelectButton` cannot serve them: it is Base UI's select trigger and throws
+ * without a select above it, which is a runtime failure rather than a type
+ * one — so they get their own component rather than the temptation.
+ */
+export function SelectStyleButton(
+  props: React.ComponentPropsWithRef<"button"> & { size?: "sm" | "md" },
+) {
+  const { children, size = "md", className, ...rest } = props;
+  return (
+    <button
+      type="button"
+      {...rest}
+      className={clsx(getSelectButtonClassName({ size }), className)}
+    >
+      <span className={selectButtonValueClassName}>{children}</span>
+      <span aria-hidden="true" className="shrink-0">
+        <ChevronDownIcon className="size-4" />
+      </span>
+    </button>
+  );
+}
+
+/** The control itself: what you press to open the list. */
+export function SelectButton(props: SelectButtonProps) {
+  const { children, size = "md", className, ...rest } = props;
+  const id = use(SelectTriggerIdContext);
+  return (
+    <BaseSelect.Trigger
+      id={id}
+      {...rest}
+      className={clsx(getSelectButtonClassName({ size }), className)}
+    >
+      <span className={selectButtonValueClassName}>{children}</span>
+      <BaseSelect.Icon
+        render={
+          <span aria-hidden="true" className="shrink-0">
+            <ChevronDownIcon className="size-4" />
+          </span>
+        }
+      />
+    </BaseSelect.Trigger>
+  );
+}
+
+type SelectFieldProps<TFieldValues extends FieldValues> = Omit<
+  Parameters<typeof Select>[0],
+  "value" | "defaultValue" | "onValueChange" | "name"
+> & {
   control: Control<TFieldValues>;
   name: Path<TFieldValues>;
-  children: React.ReactNode;
-} & Omit<SelectProps<object>, "children">;
+};
 
+/** A `Select` wired to react-hook-form, error message included. */
 export function SelectField<TFieldValues extends FieldValues>(
   props: SelectFieldProps<TFieldValues>,
 ) {
-  const { ref, control, name, isDisabled, onBlur, ...rest } = props;
+  const { control, name, disabled, ...rest } = props;
   const { field, fieldState } = useController({ control, name });
-  const mergedRef = mergeRefs(field.ref, ref);
   return (
     <Select
-      ref={mergedRef}
-      isDisabled={field.disabled || isDisabled}
-      onBlur={(event) => {
-        field.onBlur();
-        onBlur?.(event);
-      }}
+      {...rest}
+      disabled={field.disabled || disabled}
       name={field.name}
       value={field.value}
-      onChange={(isSelected) => {
-        field.onChange(isSelected);
-      }}
-      isInvalid={fieldState.invalid}
-      {...rest}
+      onValueChange={(value) => field.onChange(value)}
     >
       <FieldErrorContext
         value={
@@ -88,55 +227,5 @@ export function SelectField<TFieldValues extends FieldValues>(
         {rest.children}
       </FieldErrorContext>
     </Select>
-  );
-}
-
-export interface SelectButtonProps
-  extends ButtonProps, RefAttributes<HTMLButtonElement> {
-  children: React.ReactNode;
-  size?: "sm" | "md";
-}
-
-export function SelectButton({
-  children,
-  size = "md",
-  ...rest
-}: SelectButtonProps) {
-  return (
-    <Button
-      {...rest}
-      className={clsx(
-        /* Appearance */
-        "bg-app border-thin cursor-default appearance-none rounded-lg shadow-2xs select-none",
-        /* Layout */
-        "flex items-center justify-between",
-        /* Focus */
-        "group-data-focused/select:border-hover group-data-focus-visible/select:ring-primary-active group-data-focus-visible/select:ring-2 group-data-focused/select:outline-hidden",
-        /* Hover */
-        "data-hovered:border-hover",
-        /* Disabled */
-        "group-data-disabled/select:opacity-disabled group-data-disabled/select:cursor-not-allowed",
-        /* Invalid */
-        "group-data-invalid/select:border-danger group-data-invalid/select:group-data-focused/select:border-danger-hover group-data-invalid/select:data-hovered:border-danger-hover",
-        /* Placeholder */
-        "has-data-placeholder:text-low",
-        /* Expanded */
-        "aria-expanded:shadow-none",
-        {
-          md: "gap-2 px-3 py-1.5 text-base leading-5",
-          sm: "gap-2 px-2 py-1 text-sm leading-4",
-        }[size],
-        rest.className,
-      )}
-    >
-      {/* The value gets its own shrinkable box — `*:min-w-0` so the value inside
-          it may shrink too. On a fixed-width select, a value wider than the
-          button (a long channel name, say) used to push the arrow out through
-          the right padding instead of being ellipsized. */}
-      <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden *:min-w-0">
-        {children}
-      </span>
-      <SelectArrow />
-    </Button>
   );
 }

--- a/apps/frontend/src/ui/Select.tsx
+++ b/apps/frontend/src/ui/Select.tsx
@@ -96,7 +96,15 @@ export function SelectValue(props: {
   placeholder?: string;
 }) {
   const inherited = use(SelectPlaceholderContext);
-  return <BaseSelect.Value placeholder={inherited} {...props} />;
+  return (
+    <BaseSelect.Value
+      placeholder={inherited}
+      // A row of its own: a label may come with an icon beside it, and left
+      // to inline layout the two stack the moment the trigger is narrow.
+      className="flex min-w-0 items-center gap-2 truncate"
+      {...props}
+    />
+  );
 }
 
 export type SelectButtonProps = {
@@ -145,7 +153,7 @@ export function getSelectButtonClassName(options?: { size?: "sm" | "md" }) {
  * padding instead of being ellipsized.
  */
 export const selectButtonValueClassName =
-  "flex min-w-0 flex-1 items-center gap-2 overflow-hidden *:min-w-0";
+  "flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-left whitespace-nowrap *:min-w-0";
 
 /**
  * A button that looks like a select's control but opens something else.

--- a/apps/frontend/src/ui/Shortcut.stories.tsx
+++ b/apps/frontend/src/ui/Shortcut.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Shortcut } from "./Shortcut";
+import { StoryTitle } from "./StoryTitle";
+
+/**
+ * The two looks a shortcut takes, and why they differ.
+ *
+ * A menu row annotates a command with its keys, so they stay quiet — a list of
+ * framed rows does not need a second frame per row. A tooltip is two things on
+ * screen, where the same keys read as keycaps rather than clutter.
+ */
+const meta = {
+  title: "UI/Shortcut",
+  component: Shortcut,
+  args: { keys: ["⌘", "⌥", "1"] },
+} satisfies Meta<typeof Shortcut>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <div className="flex flex-col">
+      <StoryTitle>Text — on a menu row</StoryTitle>
+      <div className="border-thin w-64 rounded-xl p-1.5">
+        <div className="text-menu flex items-center gap-2 rounded-lg px-2.5 py-1.5 font-[450]">
+          <span className="min-w-0 flex-1 truncate">Heading 1</span>
+          <Shortcut {...args} />
+        </div>
+        <div className="text-menu flex items-center gap-2 rounded-lg px-2.5 py-1.5 font-[450]">
+          <span className="min-w-0 flex-1 truncate">Bulleted list</span>
+          <Shortcut keys={["⌘", "⇧", "8"]} />
+        </div>
+      </div>
+
+      <StoryTitle>Boxed — in a tooltip</StoryTitle>
+      <div className="border-thin flex w-fit items-center gap-1 rounded-md px-2 py-1 text-xs">
+        <span>Toggle heading</span>
+        <span className="text-low">·</span>
+        <Shortcut {...args} variant="boxed" />
+      </div>
+    </div>
+  ),
+};

--- a/apps/frontend/src/ui/Shortcut.tsx
+++ b/apps/frontend/src/ui/Shortcut.tsx
@@ -1,25 +1,46 @@
 import { clsx } from "clsx";
 
+import { Kbd } from "./Kbd";
 import { menuItemSuffixClassName } from "./menuStyle";
 
 /**
- * A keyboard shortcut on a menu row.
+ * How a shortcut is drawn, which depends on what surrounds it.
  *
- * Plain muted text rather than boxed keys: a menu is already a list of framed
- * rows, and a row of little boxes down its right edge competes with the words
- * it is meant to annotate. The boxed {@link Kbd} is still right where the keys
- * are the subject — the hotkeys dialog, the build summary's hints — rather
- * than a footnote to a command.
+ * - `text` — plain muted keys, for a menu. A menu is already a list of framed
+ *   rows, and boxing the shortcut too gives every row a second thing to look
+ *   at, competing with the words it annotates.
+ * - `boxed` — keys in {@link Kbd}'s frames, for a tooltip, where the shortcut
+ *   is one of only two things on screen and the frames read as keycaps rather
+ *   than clutter.
+ */
+export type ShortcutVariant = "text" | "boxed";
+
+/**
+ * A keyboard shortcut, wherever it is shown.
+ *
+ * One component because the same shortcut used to render three ways depending
+ * on where you read it. It still has two looks, but they are a choice now
+ * rather than an accident — see {@link ShortcutVariant}.
  *
  * Keys are given one per element, so `["⌘", "E"]` rather than `"⌘E"`.
  */
 export function Shortcut(props: {
   keys: readonly string[];
+  variant?: ShortcutVariant;
   className?: string;
 }) {
-  const { keys, className } = props;
+  const { keys, variant = "text", className } = props;
   if (keys.length === 0) {
     return null;
+  }
+  if (variant === "boxed") {
+    return (
+      <span className={clsx("flex shrink-0 items-center gap-0.5", className)}>
+        {keys.map((key) => (
+          <Kbd key={key}>{key}</Kbd>
+        ))}
+      </span>
+    );
   }
   return (
     <span

--- a/apps/frontend/src/ui/Shortcut.tsx
+++ b/apps/frontend/src/ui/Shortcut.tsx
@@ -1,0 +1,28 @@
+import { clsx } from "clsx";
+
+import { Kbd } from "./Kbd";
+
+/**
+ * A keyboard shortcut, wherever it is shown.
+ *
+ * One component because the same shortcut used to render three ways depending
+ * on where you read it: plain text on a menu row, boxed keys in the editor's
+ * slash menu, and boxed keys again — with different spacing — in a hotkey
+ * tooltip. Keys are given one per box, so `["⌘", "E"]` rather than `"⌘E"`.
+ */
+export function Shortcut(props: {
+  keys: readonly string[];
+  className?: string;
+}) {
+  const { keys, className } = props;
+  if (keys.length === 0) {
+    return null;
+  }
+  return (
+    <span className={clsx("flex shrink-0 items-center gap-0.5", className)}>
+      {keys.map((key) => (
+        <Kbd key={key}>{key}</Kbd>
+      ))}
+    </span>
+  );
+}

--- a/apps/frontend/src/ui/Shortcut.tsx
+++ b/apps/frontend/src/ui/Shortcut.tsx
@@ -1,14 +1,17 @@
 import { clsx } from "clsx";
 
-import { Kbd } from "./Kbd";
+import { menuItemSuffixClassName } from "./menuStyle";
 
 /**
- * A keyboard shortcut, wherever it is shown.
+ * A keyboard shortcut on a menu row.
  *
- * One component because the same shortcut used to render three ways depending
- * on where you read it: plain text on a menu row, boxed keys in the editor's
- * slash menu, and boxed keys again — with different spacing — in a hotkey
- * tooltip. Keys are given one per box, so `["⌘", "E"]` rather than `"⌘E"`.
+ * Plain muted text rather than boxed keys: a menu is already a list of framed
+ * rows, and a row of little boxes down its right edge competes with the words
+ * it is meant to annotate. The boxed {@link Kbd} is still right where the keys
+ * are the subject — the hotkeys dialog, the build summary's hints — rather
+ * than a footnote to a command.
+ *
+ * Keys are given one per element, so `["⌘", "E"]` rather than `"⌘E"`.
  */
 export function Shortcut(props: {
   keys: readonly string[];
@@ -19,9 +22,17 @@ export function Shortcut(props: {
     return null;
   }
   return (
-    <span className={clsx("flex shrink-0 items-center gap-0.5", className)}>
+    <span
+      className={clsx(
+        menuItemSuffixClassName,
+        // `<kbd>` is monospace by default, which reads as a second typeface
+        // next to the row's label.
+        "flex items-center gap-1 [&>kbd]:font-sans",
+        className,
+      )}
+    >
       {keys.map((key) => (
-        <Kbd key={key}>{key}</Kbd>
+        <kbd key={key}>{key}</kbd>
       ))}
     </span>
   );

--- a/apps/frontend/src/ui/menu-kit/Menu.tsx
+++ b/apps/frontend/src/ui/menu-kit/Menu.tsx
@@ -21,12 +21,24 @@ import {
 } from "lucide-react";
 
 import {
+  getMenuItemClassName,
+  menuHeadingClassName,
+  menuItemDescriptionClassName,
+  menuItemIconClassName,
+  menuItemSuffixClassName,
+  menuListClassName,
+  menuSeparatorClassName,
+  menuTextClassName,
+  selectedMenuItemClassName,
+} from "../menuStyle";
+import {
   popupAnimationClassName,
   popupExitAnimationClassName,
   popupSurfaceClassName,
   popupZIndexClassName,
 } from "../popupSurface";
 import { RouterLink } from "../RouterLink";
+import { Shortcut } from "../Shortcut";
 import { Tooltip } from "../Tooltip";
 import { filterMenuNodes, pruneOrphans } from "./filter";
 import {
@@ -822,7 +834,7 @@ function MenuList(
           id={listId}
           role="listbox"
           aria-label={props["aria-label"]}
-          className="min-h-0 flex-1 overflow-y-auto p-1.5"
+          className={clsx("min-h-0 flex-1", menuListClassName)}
           style={{
             maxHeight: `min(${MENU_MAX_HEIGHT}px, var(--available-height))`,
           }}
@@ -867,13 +879,9 @@ function MenuNodeRenderer(props: { node: MenuNode }) {
   const { node } = props;
   switch (node.type) {
     case "separator":
-      return <div className="border-t-thin -mx-1.5 my-1.5" />;
+      return <div className={menuSeparatorClassName} />;
     case "heading":
-      return (
-        <div className="text-low px-2 py-1.5 text-xs font-medium">
-          {node.title}
-        </div>
-      );
+      return <div className={menuHeadingClassName}>{node.title}</div>;
     case "placeholder":
       return node.element;
     case "item":
@@ -903,7 +911,8 @@ export type MenuItemProps = {
   filterPriority?: number;
   icon?: ReactNode;
   suffix?: ReactNode;
-  keyboardShortcut?: ReactNode;
+  /** The shortcut that runs this row, one key per box: `["⌘", "E"]`. */
+  keyboardShortcut?: readonly string[];
   disabled?: boolean;
   variant?: "default" | "danger";
   checked?: boolean;
@@ -1017,12 +1026,12 @@ function MenuItemRow(
     // submenu row `tabIndex={0}` and Tab would walk the triggers.
     tabIndex: -1,
     className: clsx(
-      "group/menu-item text-menu flex cursor-default items-center gap-2 rounded-lg px-2.5 py-1.5 font-[450]",
-      itemProps.variant === "danger"
-        ? "text-danger-low/90 data-active:bg-danger-hover/70"
-        : "text-default/90 data-active:bg-hover/70",
+      getMenuItemClassName({
+        variant: itemProps.variant,
+        interactive: Boolean(itemProps.href),
+      }),
       itemProps.disabled && "opacity-disabled",
-      highlighted && "bg-active/70 font-medium",
+      highlighted && selectedMenuItemClassName,
     ),
   };
 
@@ -1041,9 +1050,7 @@ function MenuItemRow(
         </span>
       ) : null}
       {itemProps.icon ? (
-        <span className="text-low group-data-active/menu-item:text-default group-data-[variant=danger]/menu-item:text-danger-low shrink-0 [&_svg]:size-[1em]">
-          {itemProps.icon}
-        </span>
+        <span className={menuItemIconClassName}>{itemProps.icon}</span>
       ) : null}
       <span className="flex min-w-0 flex-1 flex-col">
         <span className="truncate">
@@ -1056,18 +1063,16 @@ function MenuItemRow(
           {itemProps.children}
         </span>
         {itemProps.subtitle ? (
-          <span className="text-low truncate text-xs">
+          <span className={menuItemDescriptionClassName}>
             {itemProps.subtitle}
           </span>
         ) : null}
       </span>
       {itemProps.keyboardShortcut ? (
-        <span className="text-low shrink-0 text-xs">
-          {itemProps.keyboardShortcut}
-        </span>
+        <Shortcut keys={itemProps.keyboardShortcut} />
       ) : null}
       {itemProps.suffix ? (
-        <span className="text-low shrink-0 text-xs font-normal">
+        <span className={clsx(menuItemSuffixClassName, "font-normal")}>
           {itemProps.suffix}
         </span>
       ) : null}
@@ -1297,7 +1302,7 @@ function getSubMenuContent(node: ItemNode): ReactNode {
 /** Shown in place of the items while they are still being fetched. */
 export function MenuLoader() {
   return (
-    <p aria-busy className="text-low px-2.5 py-1.5 text-xs">
+    <p aria-busy className={menuTextClassName}>
       Loading…
     </p>
   );
@@ -1306,7 +1311,7 @@ MenuLoader[MENU_PART] = "placeholder" satisfies MenuPartKind;
 
 /** A line of prose among the rows — a hint, or a reason the list is short. */
 export function MenuText(props: { children: ReactNode }) {
-  return <p className="text-low px-2.5 py-1.5 text-xs">{props.children}</p>;
+  return <p className={menuTextClassName}>{props.children}</p>;
 }
 MenuText[MENU_PART] = "placeholder" satisfies MenuPartKind;
 

--- a/apps/frontend/src/ui/menu-kit/MenuKit.stories.tsx
+++ b/apps/frontend/src/ui/menu-kit/MenuKit.stories.tsx
@@ -69,7 +69,7 @@ export const Closed: Story = {
             <Button variant="secondary">Actions</Button>
           </MenuTrigger>
           <Menu aria-label="Actions">
-            <MenuItem icon={<PencilIcon />} keyboardShortcut="⌘E">
+            <MenuItem icon={<PencilIcon />} keyboardShortcut={["⌘", "E"]}>
               Edit
             </MenuItem>
             <MenuItem icon={<CopyIcon />}>Duplicate</MenuItem>
@@ -97,7 +97,7 @@ export const Open: Story = {
         <Menu aria-label="Actions">
           <MenuSection>
             <MenuHeading>Actions</MenuHeading>
-            <MenuItem icon={<PencilIcon />} keyboardShortcut="⌘E">
+            <MenuItem icon={<PencilIcon />} keyboardShortcut={["⌘", "E"]}>
               Edit
             </MenuItem>
             <MenuItem icon={<CopyIcon />} suffix="2 copies">

--- a/apps/frontend/src/ui/menuStyle.ts
+++ b/apps/frontend/src/ui/menuStyle.ts
@@ -1,0 +1,83 @@
+import { clsx } from "clsx";
+
+/**
+ * What a list of choices looks like — the rows, and the box that scrolls them.
+ *
+ * Style only, and deliberately so: three unrelated things render this shape and
+ * share none of their behaviour. The menu kit reads its children and filters
+ * them, a `Select` is Base UI's listbox with a value, and the editor's mention
+ * and slash menus are plain buttons driven by a suggestion plugin. Giving them
+ * one look meant giving them one stylesheet, not one component — before this,
+ * a mention menu had smaller corners, tighter rows and a different shadow from
+ * every other menu in the app.
+ *
+ * @see popupSurface for the box these sit in.
+ */
+
+/** The scrolling box the rows live in. */
+export const menuListClassName = "overflow-y-auto p-1.5 outline-hidden";
+
+/**
+ * Which row the keyboard is on.
+ *
+ * Two attributes, because the three renderers name it differently and none of
+ * them can be talked out of it: Base UI writes `data-highlighted` on its own
+ * items, while the menu kit and the editor menus set `data-active` on rows they
+ * render themselves. Styling both is what lets one string serve all three.
+ */
+const activeRowSelectors =
+  "data-active:bg-hover/70 data-highlighted:bg-hover/70";
+
+const activeDangerRowSelectors =
+  "data-active:bg-danger-hover/70 data-highlighted:bg-danger-hover/70";
+
+export type MenuItemVariant = "default" | "danger";
+
+/**
+ * A row in one of those lists.
+ *
+ * @param variant - `danger` for a destructive action.
+ * @param interactive - a row that navigates takes the pointer; one that acts
+ *   keeps the arrow, the way a native menu does.
+ */
+export function getMenuItemClassName(options?: {
+  variant?: MenuItemVariant;
+  interactive?: boolean;
+}) {
+  const { variant = "default", interactive = false } = options ?? {};
+  return clsx(
+    "group/menu-item text-menu flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left font-[450] outline-hidden",
+    interactive ? "cursor-pointer" : "cursor-default",
+    variant === "danger"
+      ? clsx("text-danger-low/90", activeDangerRowSelectors)
+      : clsx("text-default/90", activeRowSelectors),
+    // Disabled rows dim and take no highlight, however the renderer says so.
+    "aria-disabled:opacity-disabled data-disabled:opacity-disabled",
+  );
+}
+
+/** A row that is the chosen one, where that reads as a fill rather than a tick. */
+export const selectedMenuItemClassName = "bg-active/70 font-medium";
+
+/**
+ * The icon a row leads with. Dims until the row is the active one, so a column
+ * of icons stays quiet.
+ */
+export const menuItemIconClassName =
+  "text-low group-data-active/menu-item:text-default group-data-highlighted/menu-item:text-default group-data-[variant=danger]/menu-item:text-danger-low shrink-0 [&_svg]:size-[1em]";
+
+/** A second line under the label — a description, or what a shortcut does. */
+export const menuItemDescriptionClassName =
+  "text-low truncate text-xs font-normal";
+
+/** The trailing bit: a shortcut, a count, a check. */
+export const menuItemSuffixClassName = "text-low shrink-0 text-xs";
+
+/** The hairline between groups of rows. */
+export const menuSeparatorClassName = "border-t-thin -mx-1.5 my-1.5";
+
+/** A heading naming the group of rows under it. */
+export const menuHeadingClassName = "text-low px-2 py-1.5 text-xs font-medium";
+
+/** A line of prose among the rows — a loader, an empty state, a hint. */
+export const menuTextClassName = "text-low px-2.5 py-1.5 text-xs";


### PR DESCRIPTION
Batch 2 of the react-aria → Base UI migration: **Select and ListBox** — plus the style unification that came with it.

## One look for every list of choices

Three unrelated things render a list of choices — the menu kit, a select, and the editor's `@` and `/` menus — and each had drifted into a look of its own. The editor's were the visible offenders: smaller corners (`rounded-md`), a different shadow (`shadow-lg`), tighter rows (`px-2 py-1`) and their own highlight colour.

`ui/menuStyle` is now the single stylesheet for the shape — the scrolling box, the rows and their states, the icon, the description, the separator, the heading. **Style only, deliberately:** these three share no behaviour and shouldn't be made to, which is exactly the split you asked for.

Shortcuts got the same treatment: the same shortcut used to render three ways depending on where you read it — plain text on a menu row, boxed keys in the slash menu, boxed keys with different spacing in a hotkey tooltip. `Shortcut` renders all of them now, and `keyboardShortcut` takes one key per box.

The editor's menus had **no visual coverage at all**, so they get stories — which is what will keep them from drifting again.

## Select on Base UI

- **The list owns its popup.** `SelectPopover` is gone; `ListBox` portals and positions itself the way a menu does. It passes `alignItemWithTrigger={false}`, without which Base UI lays the chosen option over the trigger instead of dropping the list below it.
- **The trigger names the value from `items`.** react-aria read the selected row's text out of its collection; Base UI can't, because the list is unmounted while closed. Each select declares what its values are called — most already had that label map lying around.
- **The build-name filter is a combobox.** It's the one control pairing a value with a query, which is the distinction Base UI draws between the two namespaces — and the last thing holding react-aria's `Autocomplete` and `SearchField`.
- **`SelectStyleButton`** is new, for the three build filters that are menus wearing a select's clothes.

`ui/Menu.tsx` is down to the breadcrumb's chevron button — its row and surface helpers were the thing `ListBox` shared with menus, and `menuStyle` replaced them.

## The bug worth knowing about

A react-aria part inside a Base UI tree **type-checks, renders, and then throws**. One stray `SelectValue` import left in `MemberLevelSelect` took the whole team-members page to an error screen, and nothing but the e2e suite noticed — not `tsc`, not Storybook, not a screenshot.

Four files had it. There's now a `no-restricted-imports` rule barring the already-migrated parts from being imported out of react-aria, and it immediately caught a second latent case: `DateRangePicker` rendering react-aria's `Dialog`. That one is legitimate — the date picker is the last react-aria island and its calendar, popover and dialog only work together — so it carries a scoped disable with the reason, and it goes when the calendar moves to react-day-picker.

## Verification

`static-checks` 11/11 · Storybook **79/79** · full chromium e2e **98 passed, 0 failed**.

The select popup is pixel-compared against its previous baseline (start-aligned under the trigger, check mark, disabled row) — worth a look in the Argos build along with the editor menus, which are new baselines rather than diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)