### PR TITLE
refactor(ui): move Button and LinkButton off react-aria

### DIFF
--- a/apps/frontend/src/containers/Project/ConnectRepository.tsx
+++ b/apps/frontend/src/containers/Project/ConnectRepository.tsx
@@ -13,13 +13,7 @@ import { GitlabNamespacesSelect } from "@/containers/GitlabNamespacesSelect";
 import { DocumentType, graphql } from "@/gql";
 import { AccountPermission, GitHubAppType } from "@/gql/graphql";
 import { Alert, AlertText, AlertTitle } from "@/ui/Alert";
-import {
-  Button,
-  ButtonIcon,
-  ButtonProps,
-  LinkButton,
-  LinkButtonProps,
-} from "@/ui/Button";
+import { Button, ButtonIcon, ButtonProps, LinkButton } from "@/ui/Button";
 import { Link } from "@/ui/Link";
 import { TextInput } from "@/ui/TextInput";
 import * as storage from "@/util/storage";
@@ -220,7 +214,7 @@ enum GitProvider {
 }
 
 function GitHubButton(props: {
-  onPress: LinkButtonProps["onPress"];
+  onPress: ButtonProps["onPress"];
   hasInstallations: boolean;
   hasValidGitHubToken: boolean;
   children?: React.ReactNode;
@@ -253,7 +247,7 @@ function GitHubButton(props: {
 }
 
 function GitHubBaseButton(props: {
-  onPress: LinkButtonProps["onPress"];
+  onPress: ButtonProps["onPress"];
   children?: React.ReactNode;
   size?: ButtonProps["size"];
 }) {

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -324,22 +324,26 @@
 @custom-variant search-cancel (&::-webkit-search-cancel-button);
 
 /**
- * Hover and press, but only on a control they can lead somewhere.
+ * Hover, but only where it can lead somewhere.
  *
- * react-aria set `data-hovered` / `data-pressed` only while the control was
- * enabled, so a disabled button never took a hover fill. Native `:hover` has
- * no such scruples — it matches a disabled button too — and `aria-disabled`,
- * which a pending button wears so it keeps its focus and its tooltip, is
- * invisible to `:disabled`.
+ * Hovering promises that pressing will do something. Three kinds of control
+ * cannot keep that promise, and none of them should light up:
  *
- * A selected tab is left out of the hover for the same reason rather than a
- * different one: it is already the chosen one, so lighting it up would promise
- * something that pressing it cannot deliver. Its fill, its edge and its shadow
- * all stay exactly where they are. A pressed *toggle* is not the same thing —
- * pressing it again turns it off — so it keeps its hover.
+ * - **Disabled.** react-aria set `data-hovered` only while the control was
+ *   enabled; native `:hover` matches a disabled button happily, and
+ *   `aria-disabled` — which a pending button wears so it keeps its focus and
+ *   its tooltip — is invisible to `:disabled`.
+ * - **The chosen tab.** It is already the one you are on.
+ * - **The open trigger.** Its menu is already showing; the fill it wears says
+ *   so, and moving it under the pointer reads as the menu about to change.
+ *
+ * A pressed *toggle* is none of these — pressing it again turns it off — so it
+ * keeps its hover.
  */
 @custom-variant enabled-hover (
-  &:not(:disabled):not([aria-disabled="true"]):not([aria-selected="true"]):hover
+  &:not(:disabled):not([aria-disabled="true"]):not([aria-selected="true"]):not(
+      [aria-expanded="true"]
+    ):not([data-popup-open]):hover
 );
 @custom-variant enabled-active (
   &:not(:disabled):not([aria-disabled="true"]):active

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -339,6 +339,18 @@
   &:not(:disabled):not([aria-disabled="true"]):active
 );
 
+/**
+ * A control that is currently on.
+ *
+ * Two attributes for one idea: a toggle button says so with `aria-pressed`,
+ * while a tab or an option says it with `aria-selected`. The button surface is
+ * worn by both — `PillTab` is a tab in a button's clothes — so the "on" look
+ * has to answer to either, or a selected pill sits there looking untouched.
+ *
+ * `="true"` matters: `aria-selected="false"` is on every unselected tab.
+ */
+@custom-variant on (&:is([aria-pressed="true"], [aria-selected="true"]));
+
 @utility rac-focus {
   &[data-focused]:not([data-focus-visible]) {
     @apply outline-none;

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -352,14 +352,22 @@
 /**
  * A control that is currently on.
  *
- * Two attributes for one idea: a toggle button says so with `aria-pressed`,
- * while a tab or an option says it with `aria-selected`. The button surface is
- * worn by both — `PillTab` is a tab in a button's clothes — so the "on" look
- * has to answer to either, or a selected pill sits there looking untouched.
+ * Four attributes for one idea, because each kind of control spells it its own
+ * way: a toggle says `aria-pressed`, a tab says `aria-selected`, and a trigger
+ * whose menu is showing says `aria-expanded` — plus Base UI's own
+ * `data-popup-open`, which its triggers set alongside it. The button surface
+ * is worn by all of them, so the "on" look has to answer to any of them.
  *
  * `="true"` matters: `aria-selected="false"` is on every unselected tab.
  */
-@custom-variant on (&:is([aria-pressed="true"], [aria-selected="true"]));
+@custom-variant on (
+  &:is(
+      [aria-pressed="true"],
+      [aria-selected="true"],
+      [aria-expanded="true"],
+      [data-popup-open]
+    )
+);
 
 @utility rac-focus {
   &[data-focused]:not([data-focus-visible]) {

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -324,16 +324,22 @@
 @custom-variant search-cancel (&::-webkit-search-cancel-button);
 
 /**
- * Hover and press, but only on a control that can actually act.
+ * Hover and press, but only on a control they can lead somewhere.
  *
  * react-aria set `data-hovered` / `data-pressed` only while the control was
  * enabled, so a disabled button never took a hover fill. Native `:hover` has
  * no such scruples — it matches a disabled button too — and `aria-disabled`,
  * which a pending button wears so it keeps its focus and its tooltip, is
- * invisible to `:disabled`. These restore the old behaviour for both.
+ * invisible to `:disabled`.
+ *
+ * A selected tab is left out of the hover for the same reason rather than a
+ * different one: it is already the chosen one, so lighting it up would promise
+ * something that pressing it cannot deliver. Its fill, its edge and its shadow
+ * all stay exactly where they are. A pressed *toggle* is not the same thing —
+ * pressing it again turns it off — so it keeps its hover.
  */
 @custom-variant enabled-hover (
-  &:not(:disabled):not([aria-disabled="true"]):hover
+  &:not(:disabled):not([aria-disabled="true"]):not([aria-selected="true"]):hover
 );
 @custom-variant enabled-active (
   &:not(:disabled):not([aria-disabled="true"]):active

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -323,6 +323,22 @@
 @custom-variant dark (&:where(.dark, .dark *));
 @custom-variant search-cancel (&::-webkit-search-cancel-button);
 
+/**
+ * Hover and press, but only on a control that can actually act.
+ *
+ * react-aria set `data-hovered` / `data-pressed` only while the control was
+ * enabled, so a disabled button never took a hover fill. Native `:hover` has
+ * no such scruples — it matches a disabled button too — and `aria-disabled`,
+ * which a pending button wears so it keeps its focus and its tooltip, is
+ * invisible to `:disabled`. These restore the old behaviour for both.
+ */
+@custom-variant enabled-hover (
+  &:not(:disabled):not([aria-disabled="true"]):hover
+);
+@custom-variant enabled-active (
+  &:not(:disabled):not([aria-disabled="true"]):active
+);
+
 @utility rac-focus {
   &[data-focused]:not([data-focus-visible]) {
     @apply outline-none;

--- a/apps/frontend/src/pages/Automation/AutomationForm.tsx
+++ b/apps/frontend/src/pages/Automation/AutomationForm.tsx
@@ -1,12 +1,11 @@
 import { AutomationConditionSchema } from "@argos/schemas/automation-condition";
 import { AutomationEventSchema } from "@argos/schemas/automation-event";
 import { Trash2Icon } from "lucide-react";
-import type { PressEvent } from "react-aria";
 import type { UseFormReturn } from "react-hook-form";
 import { twc } from "react-twc";
 import { z } from "zod/v4";
 
-import { Button } from "@/ui/Button";
+import { Button, type ButtonProps } from "@/ui/Button";
 import { FormTextInput } from "@/ui/FormTextInput";
 import { Tooltip } from "@/ui/Tooltip";
 import { AutomationActionSchema } from "@/util/automation";
@@ -50,7 +49,7 @@ export function Task(props: { children: React.ReactNode }) {
   );
 }
 
-export function RemoveButton(props: { onPress: (e: PressEvent) => void }) {
+export function RemoveButton(props: { onPress: ButtonProps["onPress"] }) {
   return (
     <Tooltip content="Remove">
       <Button

--- a/apps/frontend/src/ui/Button.tsx
+++ b/apps/frontend/src/ui/Button.tsx
@@ -1,16 +1,18 @@
-import { Children, cloneElement, useState } from "react";
-import { clsx } from "clsx";
 import {
-  Button as RACButton,
-  ButtonProps as RACButtonProps,
-  Link as RACLink,
-  LinkProps as RACLinkProps,
-} from "react-aria-components";
+  Children,
+  cloneElement,
+  useState,
+  type ComponentPropsWithRef,
+  type MouseEvent,
+} from "react";
+import { Button as BaseButton } from "@base-ui/react/button";
+import { clsx } from "clsx";
 
 import { toast } from "@/ui/Toaster";
 import { getErrorMessage } from "@/util/error";
 
 import { Loader } from "./Loader";
+import { RouterLink } from "./RouterLink";
 
 export type ButtonVariant =
   | "primary"
@@ -47,7 +49,7 @@ type ButtonOptions = {
  * button's icon is its only child.
  */
 const ICON_STEPS_BACK = clsx(
-  "*:not-data-colored-icon:text-low data-hovered:*:not-data-colored-icon:text-default",
+  "*:not-data-colored-icon:text-low enabled-hover:*:not-data-colored-icon:text-default",
 );
 
 /**
@@ -59,64 +61,64 @@ const ICON_STEPS_BACK = clsx(
  */
 const EDGE = clsx(
   "edge-default",
-  "data-hovered:edge-hover",
-  "group-[*]/button-group:data-hovered:edge-default",
+  "enabled-hover:edge-hover",
+  "group-[*]/button-group:enabled-hover:edge-default",
 );
 
 const variantClassNames: Record<ButtonVariant, string> = {
   primary:
-    "text-white bg-primary-solid data-hovered:bg-primary-solid-hover data-pressed:bg-primary-solid-active active:bg-primary-solid-active aria-expanded:bg-primary-solid-active",
+    "text-white bg-primary-solid enabled-hover:bg-primary-solid-hover enabled-active:bg-primary-solid-active aria-expanded:bg-primary-solid-active",
   // A wash rather than a fill: `bg-ui` at half opacity lifts the button off
   // whatever it sits on — the app background, a panel, an image — without
   // reading as a filled button next to `primary`. Icons sit one step back from
   // the label and come forward on hover, so a row of icon buttons stays quiet
   // until it is pointed at.
   secondary: clsx(
-    "text-default bg-raised data-hovered:bg-raised-hover data-pressed:bg-raised-active active:bg-raised-active",
+    "text-default bg-raised enabled-hover:bg-raised-hover enabled-active:bg-raised-active",
     EDGE,
     ICON_STEPS_BACK,
     // Pressed, the fill stays put and only the icon brightens on hover: moving
     // the fill as well made a control that is already on look like it was
     // about to change.
-    "aria-pressed:bg-raised-active aria-pressed:data-hovered:bg-raised-active aria-pressed:text-default",
+    "aria-pressed:bg-raised-active aria-pressed:enabled-hover:bg-raised-active aria-pressed:text-default",
     "aria-expanded:bg-raised-active data-popup-open:bg-raised-active",
   ),
   // No fill at rest, and the same "on" fill as `secondary` once it has one, so
   // a toolbar mixing the two never shows the state two shades apart.
   ghost: clsx(
-    "text-default bg-transparent data-hovered:bg-hover data-pressed:bg-raised-active active:bg-raised-active",
+    "text-default bg-transparent enabled-hover:bg-hover enabled-active:bg-raised-active",
     ICON_STEPS_BACK,
     // Pressed, the fill stays put and only the icon brightens on hover: moving
     // the fill as well made a control that is already on look like it was
     // about to change.
-    "aria-pressed:bg-raised-active aria-pressed:data-hovered:bg-raised-active aria-pressed:text-default",
+    "aria-pressed:bg-raised-active aria-pressed:enabled-hover:bg-raised-active aria-pressed:text-default",
     "aria-expanded:bg-raised-active",
   ),
   // The quiet colored actions — approve, reject, delete — as opposed to
   // `destructive`, which is a solid call to action. The color is in the icon and
   // the label, and only fills in on hover.
   danger: clsx(
-    "text-danger-low bg-raised data-hovered:bg-danger-hover/50 data-pressed:bg-danger-active active:bg-danger-active",
-    "edge-default data-hovered:edge-danger-hover group-[*]/button-group:data-hovered:edge-default",
-    "aria-pressed:bg-danger-active aria-pressed:edge-danger aria-pressed:data-hovered:bg-danger-active aria-pressed:data-hovered:text-danger",
+    "text-danger-low bg-raised enabled-hover:bg-danger-hover/50 enabled-active:bg-danger-active",
+    "edge-default enabled-hover:edge-danger-hover group-[*]/button-group:enabled-hover:edge-default",
+    "aria-pressed:bg-danger-active aria-pressed:edge-danger aria-pressed:enabled-hover:bg-danger-active aria-pressed:enabled-hover:text-danger",
   ),
   success: clsx(
-    "text-success-low bg-raised data-hovered:bg-success-hover/50 data-pressed:bg-success-active active:bg-success-active",
-    "edge-default data-hovered:edge-success-hover group-[*]/button-group:data-hovered:edge-default",
-    "aria-pressed:bg-success-active aria-pressed:data-hovered:bg-success-active aria-pressed:data-hovered:text-success",
+    "text-success-low bg-raised enabled-hover:bg-success-hover/50 enabled-active:bg-success-active",
+    "edge-default enabled-hover:edge-success-hover group-[*]/button-group:enabled-hover:edge-default",
+    "aria-pressed:bg-success-active aria-pressed:enabled-hover:bg-success-active aria-pressed:enabled-hover:text-success",
   ),
   destructive:
-    "text-white bg-danger-solid data-hovered:bg-danger-solid-hover data-pressed:bg-danger-solid-active active:bg-danger-solid-active aria-expanded:bg-danger-solid-active",
+    "text-white bg-danger-solid enabled-hover:bg-danger-solid-hover enabled-active:bg-danger-solid-active aria-expanded:bg-danger-solid-active",
   github:
-    "text-white bg-github data-hovered:bg-github-hover data-pressed:bg-github-active active:bg-github-active aria-expanded:bg-github-active",
+    "text-white bg-github enabled-hover:bg-github-hover enabled-active:bg-github-active aria-expanded:bg-github-active",
   gitlab:
-    "text-white bg-gitlab data-hovered:bg-gitlab-hover data-pressed:bg-gitlab-active active:bg-gitlab-active aria-expanded:bg-gitlab-active",
+    "text-white bg-gitlab enabled-hover:bg-gitlab-hover enabled-active:bg-gitlab-active aria-expanded:bg-gitlab-active",
   // The only fill that is the page color itself, so the hairline is the whole
   // of the button's shape — it takes the same gray as a quiet button rather
   // than the near-black the solid fills sit behind. It used to be a `ring-1`,
   // which the focus ring then had to fight with.
   google:
-    "text-default edge-default bg-google data-hovered:bg-google-hover data-pressed:bg-google-active active:bg-google-active aria-expanded:bg-google-active",
+    "text-default edge-default bg-google enabled-hover:bg-google-hover enabled-active:bg-google-active aria-expanded:bg-google-active",
 };
 
 // With the edge out of the layout, the line box and the padding are the whole
@@ -142,8 +144,8 @@ const iconOnlySizeClassNames: Record<ButtonSize, string> = {
 };
 
 // Ring color per variant, the single source of truth for both the
-// keyboard-focus ring (`data-focus-visible`) and the always-on ring drawn by
-// `showFocusRing` (`data-focused`, e.g. an autofocused default action). Keeping
+// keyboard-focus ring (`:focus-visible`) and the always-on ring drawn by
+// `showFocusRing` (`:focus`, e.g. an autofocused default action). Keeping
 // the two states side by side stops them from drifting apart; the values are
 // full literals so Tailwind keeps generating the classes.
 const ringClassNames: Record<
@@ -151,40 +153,40 @@ const ringClassNames: Record<
   { focusVisible: string; focused: string }
 > = {
   primary: {
-    focusVisible: "data-focus-visible:ring-primary",
-    focused: "data-focused:ring-primary",
+    focusVisible: "focus-visible:ring-primary",
+    focused: "focus:ring-primary",
   },
   secondary: {
-    focusVisible: "data-focus-visible:ring-default",
-    focused: "data-focused:ring-default",
+    focusVisible: "focus-visible:ring-default",
+    focused: "focus:ring-default",
   },
   ghost: {
-    focusVisible: "data-focus-visible:ring-default",
-    focused: "data-focused:ring-default",
+    focusVisible: "focus-visible:ring-default",
+    focused: "focus:ring-default",
   },
   danger: {
-    focusVisible: "data-focus-visible:ring-danger",
-    focused: "data-focused:ring-danger",
+    focusVisible: "focus-visible:ring-danger",
+    focused: "focus:ring-danger",
   },
   success: {
-    focusVisible: "data-focus-visible:ring-success",
-    focused: "data-focused:ring-success",
+    focusVisible: "focus-visible:ring-success",
+    focused: "focus:ring-success",
   },
   destructive: {
-    focusVisible: "data-focus-visible:ring-danger",
-    focused: "data-focused:ring-danger",
+    focusVisible: "focus-visible:ring-danger",
+    focused: "focus:ring-danger",
   },
   github: {
-    focusVisible: "data-focus-visible:ring-default",
-    focused: "data-focused:ring-default",
+    focusVisible: "focus-visible:ring-default",
+    focused: "focus:ring-default",
   },
   gitlab: {
-    focusVisible: "data-focus-visible:ring-default",
-    focused: "data-focused:ring-default",
+    focusVisible: "focus-visible:ring-default",
+    focused: "focus:ring-default",
   },
   google: {
-    focusVisible: "data-focus-visible:ring-default",
-    focused: "data-focused:ring-default",
+    focusVisible: "focus-visible:ring-default",
+    focused: "focus:ring-default",
   },
 };
 
@@ -222,7 +224,7 @@ export function getButtonClassName(options: {
     variantClassName,
     sizeClassName,
     ring.focusVisible,
-    showFocusRing && ["data-focused:ring-4", ring.focused],
+    showFocusRing && ["focus:ring-4", ring.focused],
     "rounded-full",
     // ButtonGroup integration: drop the inner rounded ends so the segments butt
     // together, and where they meet each one's hairline draws the seam.
@@ -234,7 +236,7 @@ export function getButtonClassName(options: {
     "group-[*]/button-group:[:is(button,a)~&]:rounded-l-none",
     "group-[*]/button-group:[&:has(~:is(button,a))]:rounded-r-none",
     iconOnly && "justify-center",
-    "focus:outline-hidden data-focus-visible:ring-4",
+    "focus:outline-hidden focus-visible:ring-4",
     "items-center inline-flex select-none whitespace-nowrap font-sans font-medium",
     "aria-disabled:opacity-disabled aria-disabled:cursor-not-allowed",
     "disabled:opacity-disabled disabled:cursor-not-allowed",
@@ -261,10 +263,20 @@ function getButtonProps(options: ButtonOptions) {
 }
 
 export interface ButtonProps
-  extends
-    RACButtonProps,
-    ButtonOptions,
-    React.RefAttributes<HTMLButtonElement> {
+  extends Omit<ComponentPropsWithRef<"button">, "disabled">, ButtonOptions {
+  /**
+   * Kept from react-aria for now, and mapped to a click: renaming it at ~150
+   * call sites is its own change, so that a visual diff here can only be the
+   * new internals.
+   */
+  onPress?: (event: MouseEvent<HTMLElement>) => void;
+  isDisabled?: boolean;
+  /**
+   * Holds the button in flight: it keeps its focus and its tooltip — hence
+   * `aria-disabled` rather than `disabled` — swallows presses, and shows a
+   * spinner. react-aria's button had this built in; Base UI's does not.
+   */
+  isPending?: boolean;
   /**
    * Run an asynchronous action when the button is pressed.
    * Automatically set the button in pending mode and
@@ -297,6 +309,10 @@ export function Button({
   children,
   onAsyncAction,
   onPress,
+  onClick,
+  isDisabled,
+  isPending,
+  type = "button",
   ...props
 }: ButtonProps) {
   const buttonProps = getButtonProps({
@@ -305,60 +321,81 @@ export function Button({
     iconOnly,
     showFocusRing,
   });
-  const [isPending, setIsPending] = useState(false);
+  const [isRunning, setIsRunning] = useState(false);
+  const pending = isPending ?? isRunning;
   return (
-    <RACButton
+    <BaseButton
       {...buttonProps}
       className={clsx(buttonProps.className, "cursor-default", className)}
-      isPending={props.isPending ?? isPending}
-      onPress={(event) => {
+      disabled={isDisabled}
+      // Pending is not disabled: the button stays focusable, so it keeps its
+      // place in the tab order and its tooltip stays reachable.
+      aria-disabled={pending || undefined}
+      type={type}
+      onClick={(event) => {
+        if (pending) {
+          event.preventDefault();
+          return;
+        }
         onPress?.(event);
+        onClick?.(event);
         const promise = onAsyncAction?.();
         if (promise) {
-          setIsPending(true);
+          setIsRunning(true);
           promise
             .catch((error) => {
               toast.error(getErrorMessage(error));
             })
             .finally(() => {
-              setIsPending(false);
+              setIsRunning(false);
             });
         }
       }}
       {...props}
     >
-      {(renderProps) => {
-        const childrenRes =
-          typeof children === "function" ? children(renderProps) : children;
-        if (renderProps.isPending) {
-          if (iconOnly) {
-            return <Loader delay={0} />;
-          }
-          return (
-            <>
-              <ButtonIcon>
-                <Loader delay={0} />
-              </ButtonIcon>
-              {childrenRes}
-            </>
-          );
-        }
-        return childrenRes;
-      }}
-    </RACButton>
+      {pending ? (
+        iconOnly ? (
+          <Loader delay={0} />
+        ) : (
+          <>
+            <ButtonIcon>
+              <Loader delay={0} />
+            </ButtonIcon>
+            {children}
+          </>
+        )
+      ) : (
+        children
+      )}
+    </BaseButton>
   );
 }
 
 export interface LinkButtonProps
-  extends RACLinkProps, ButtonOptions, React.RefAttributes<HTMLAnchorElement> {}
+  extends ComponentPropsWithRef<"a">, ButtonOptions {
+  /** Mapped to a click, like `Button`'s — renamed in its own change. */
+  onPress?: (event: MouseEvent<HTMLElement>) => void;
+  /**
+   * A link cannot be `disabled`, so it says so and refuses the navigation —
+   * which is what react-aria's `Link` did with the same prop.
+   */
+  isDisabled?: boolean;
+}
 
+/**
+ * A link wearing the button's clothes. `RouterLink` keeps an in-app path on
+ * the client router and leaves a scheme like `codex://` a plain anchor —
+ * which is what react-aria's `RouterProvider` used to do for every link.
+ */
 export function LinkButton({
-  ref,
   className,
   variant,
   size,
   iconOnly,
   showFocusRing,
+  onPress,
+  onClick,
+  isDisabled,
   ...props
 }: LinkButtonProps) {
   const buttonProps = getButtonProps({
@@ -368,10 +405,18 @@ export function LinkButton({
     showFocusRing,
   });
   return (
-    <RACLink
-      ref={ref}
+    <RouterLink
       {...buttonProps}
       className={clsx(buttonProps.className, className)}
+      aria-disabled={isDisabled || undefined}
+      onClick={(event) => {
+        if (isDisabled) {
+          event.preventDefault();
+          return;
+        }
+        onPress?.(event);
+        onClick?.(event);
+      }}
       {...props}
     />
   );

--- a/apps/frontend/src/ui/Button.tsx
+++ b/apps/frontend/src/ui/Button.tsx
@@ -44,12 +44,15 @@ type ButtonOptions = {
 };
 
 /**
- * Icons a step back from the label, forward again on hover. `*:` reaches the
- * icon because `ButtonIcon` clones it as a direct child, and an `iconOnly`
- * button's icon is its only child.
+ * Icons a step back from the label, forward again on hover — or for good, once
+ * the control is on. Hover alone is not enough there: an open trigger and a
+ * chosen tab take no hover at all, so their icon would have stayed dimmed with
+ * the menu sitting open beneath it. `*:` reaches the icon because `ButtonIcon`
+ * clones it as a direct child, and an `iconOnly` button's icon is its only
+ * child.
  */
 const ICON_STEPS_BACK = clsx(
-  "*:not-data-colored-icon:text-low enabled-hover:*:not-data-colored-icon:text-default",
+  "*:not-data-colored-icon:text-low enabled-hover:*:not-data-colored-icon:text-default on:*:not-data-colored-icon:text-default",
 );
 
 /**
@@ -67,7 +70,7 @@ const EDGE = clsx(
 
 const variantClassNames: Record<ButtonVariant, string> = {
   primary:
-    "text-white bg-primary-solid enabled-hover:bg-primary-solid-hover enabled-active:bg-primary-solid-active aria-expanded:bg-primary-solid-active",
+    "text-white bg-primary-solid enabled-hover:bg-primary-solid-hover enabled-active:bg-primary-solid-active on:bg-primary-solid-active",
   // A wash rather than a fill: `bg-ui` at half opacity lifts the button off
   // whatever it sits on — the app background, a panel, an image — without
   // reading as a filled button next to `primary`. Icons sit one step back from
@@ -81,7 +84,6 @@ const variantClassNames: Record<ButtonVariant, string> = {
     // the fill as well made a control that is already on look like it was
     // about to change.
     "on:bg-raised-active on:enabled-hover:bg-raised-active on:text-default",
-    "aria-expanded:bg-raised-active data-popup-open:bg-raised-active",
   ),
   // No fill at rest, and the same "on" fill as `secondary` once it has one, so
   // a toolbar mixing the two never shows the state two shades apart.
@@ -92,7 +94,6 @@ const variantClassNames: Record<ButtonVariant, string> = {
     // the fill as well made a control that is already on look like it was
     // about to change.
     "on:bg-raised-active on:enabled-hover:bg-raised-active on:text-default",
-    "aria-expanded:bg-raised-active",
   ),
   // The quiet colored actions — approve, reject, delete — as opposed to
   // `destructive`, which is a solid call to action. The color is in the icon and
@@ -108,17 +109,17 @@ const variantClassNames: Record<ButtonVariant, string> = {
     "on:bg-success-active on:enabled-hover:bg-success-active on:enabled-hover:text-success",
   ),
   destructive:
-    "text-white bg-danger-solid enabled-hover:bg-danger-solid-hover enabled-active:bg-danger-solid-active aria-expanded:bg-danger-solid-active",
+    "text-white bg-danger-solid enabled-hover:bg-danger-solid-hover enabled-active:bg-danger-solid-active on:bg-danger-solid-active",
   github:
-    "text-white bg-github enabled-hover:bg-github-hover enabled-active:bg-github-active aria-expanded:bg-github-active",
+    "text-white bg-github enabled-hover:bg-github-hover enabled-active:bg-github-active on:bg-github-active",
   gitlab:
-    "text-white bg-gitlab enabled-hover:bg-gitlab-hover enabled-active:bg-gitlab-active aria-expanded:bg-gitlab-active",
+    "text-white bg-gitlab enabled-hover:bg-gitlab-hover enabled-active:bg-gitlab-active on:bg-gitlab-active",
   // The only fill that is the page color itself, so the hairline is the whole
   // of the button's shape — it takes the same gray as a quiet button rather
   // than the near-black the solid fills sit behind. It used to be a `ring-1`,
   // which the focus ring then had to fight with.
   google:
-    "text-default edge-default bg-google enabled-hover:bg-google-hover enabled-active:bg-google-active aria-expanded:bg-google-active",
+    "text-default edge-default bg-google enabled-hover:bg-google-hover enabled-active:bg-google-active on:bg-google-active",
 };
 
 // With the edge out of the layout, the line box and the padding are the whole

--- a/apps/frontend/src/ui/Button.tsx
+++ b/apps/frontend/src/ui/Button.tsx
@@ -77,10 +77,10 @@ const variantClassNames: Record<ButtonVariant, string> = {
     "text-default bg-raised enabled-hover:bg-raised-hover enabled-active:bg-raised-active",
     EDGE,
     ICON_STEPS_BACK,
-    // Pressed, the fill stays put and only the icon brightens on hover: moving
+    // On, the fill stays put and only the icon brightens on hover: moving
     // the fill as well made a control that is already on look like it was
     // about to change.
-    "aria-pressed:bg-raised-active aria-pressed:enabled-hover:bg-raised-active aria-pressed:text-default",
+    "on:bg-raised-active on:enabled-hover:bg-raised-active on:text-default",
     "aria-expanded:bg-raised-active data-popup-open:bg-raised-active",
   ),
   // No fill at rest, and the same "on" fill as `secondary` once it has one, so
@@ -88,10 +88,10 @@ const variantClassNames: Record<ButtonVariant, string> = {
   ghost: clsx(
     "text-default bg-transparent enabled-hover:bg-hover enabled-active:bg-raised-active",
     ICON_STEPS_BACK,
-    // Pressed, the fill stays put and only the icon brightens on hover: moving
+    // On, the fill stays put and only the icon brightens on hover: moving
     // the fill as well made a control that is already on look like it was
     // about to change.
-    "aria-pressed:bg-raised-active aria-pressed:enabled-hover:bg-raised-active aria-pressed:text-default",
+    "on:bg-raised-active on:enabled-hover:bg-raised-active on:text-default",
     "aria-expanded:bg-raised-active",
   ),
   // The quiet colored actions — approve, reject, delete — as opposed to
@@ -100,12 +100,12 @@ const variantClassNames: Record<ButtonVariant, string> = {
   danger: clsx(
     "text-danger-low bg-raised enabled-hover:bg-danger-hover/50 enabled-active:bg-danger-active",
     "edge-default enabled-hover:edge-danger-hover group-[*]/button-group:enabled-hover:edge-default",
-    "aria-pressed:bg-danger-active aria-pressed:edge-danger aria-pressed:enabled-hover:bg-danger-active aria-pressed:enabled-hover:text-danger",
+    "on:bg-danger-active on:edge-danger on:enabled-hover:bg-danger-active on:enabled-hover:text-danger",
   ),
   success: clsx(
     "text-success-low bg-raised enabled-hover:bg-success-hover/50 enabled-active:bg-success-active",
     "edge-default enabled-hover:edge-success-hover group-[*]/button-group:enabled-hover:edge-default",
-    "aria-pressed:bg-success-active aria-pressed:enabled-hover:bg-success-active aria-pressed:enabled-hover:text-success",
+    "on:bg-success-active on:enabled-hover:bg-success-active on:enabled-hover:text-success",
   ),
   destructive:
     "text-white bg-danger-solid enabled-hover:bg-danger-solid-hover enabled-active:bg-danger-solid-active aria-expanded:bg-danger-solid-active",
@@ -220,7 +220,7 @@ export function getButtonClassName(options: {
     // the lift — pressed in rather than standing off the surface. `ghost` is
     // the exception, and the exception is the point of it: no edge at all, so
     // nothing marks it out until it is hovered.
-    variant !== "ghost" && "shadow-control aria-pressed:shadow-control-flat",
+    variant !== "ghost" && "shadow-control on:shadow-control-flat",
     variantClassName,
     sizeClassName,
     ring.focusVisible,

--- a/apps/frontend/src/ui/FormSubmit.tsx
+++ b/apps/frontend/src/ui/FormSubmit.tsx
@@ -24,8 +24,11 @@ export function FormSubmit<
     <Button
       type="submit"
       {...props}
-      // Required to focus correctly the field when we use `setError` in the `onSubmit`
-      preventFocusOnPress
+      // Keeps focus off the submit button when it is pressed, so a `setError`
+      // in `onSubmit` can put it on the offending field instead. This was
+      // react-aria's `preventFocusOnPress`; refusing the mousedown is what it
+      // did underneath.
+      onMouseDown={(event) => event.preventDefault()}
       isDisabled={isDisabled}
       isPending={props.isPending || formState.isSubmitting}
     >

--- a/apps/frontend/src/ui/Tab.stories.tsx
+++ b/apps/frontend/src/ui/Tab.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { TabPanel, Tabs } from "react-aria-components";
 
-import { Tab, TabList } from "./Tab";
+import { PillTab, Tab, TabList } from "./Tab";
 
 const meta = {
   title: "UI/Tab",
@@ -27,6 +27,30 @@ export const Default: Story = {
       </TabPanel>
       <TabPanel id="settings" className="p-4 text-sm">
         Settings content
+      </TabPanel>
+    </Tabs>
+  ),
+};
+
+/**
+ * The pill tabs, which wear the button's surface so a row of them lines up
+ * with a row of buttons. That sharing is exactly why the selected one needs
+ * the `on` variant: a tab says it is chosen with `aria-selected`, a toggle
+ * button with `aria-pressed`, and the button's "on" look has to answer to
+ * either — without it the selected pill sat there looking untouched.
+ */
+export const Pill: Story = {
+  render: () => (
+    <Tabs>
+      <TabList className="flex gap-2 p-4">
+        <PillTab id="snapshot">Snapshot</PillTab>
+        <PillTab id="review">Review</PillTab>
+      </TabList>
+      <TabPanel id="snapshot" className="px-4 pb-4 text-sm">
+        Snapshot content
+      </TabPanel>
+      <TabPanel id="review" className="px-4 pb-4 text-sm">
+        Review content
       </TabPanel>
     </Tabs>
   ),

--- a/apps/frontend/src/ui/Tab.tsx
+++ b/apps/frontend/src/ui/Tab.tsx
@@ -43,10 +43,6 @@ export function PillTab(
       {...props}
       className={clsx(
         getButtonClassName({ variant: "secondary", size: "small" }),
-        "cursor-pointer",
-        // Selected reads like a pressed button — the same fill, so the two are
-        // never a shade apart.
-        "data-selected:bg-raised-active data-selected:data-hovered:bg-raised-active data-selected:text-default data-selected:cursor-default",
         props.className,
       )}
     />


### PR DESCRIPTION
Batch 3 of the react-aria → Base UI migration: **Button and LinkButton** — the component the earlier batches were waiting on, since every trigger wraps one.

**Internals only. Not one call site changes**, which is the point: `Button.tsx` carries 38 state variants, so a PR that swaps the element underneath without touching a single `onPress` makes anything the Argos builds show unambiguously the new internals. The ~150-site prop rename is the next PR.

## What changed underneath

Base UI's `Button` is a native `<button>` with a `render` prop and nothing else — no press abstraction — so the state variants move to the CSS the browser already had: `data-hovered` → `:hover`, `data-focus-visible` → `:focus-visible`, `data-focused` → `:focus`. The `data-pressed:x active:x` pairs that earlier batches carried as belt-and-braces collapse to the one that was doing the work.

## Two things react-aria was quietly doing

**Hover stops at a disabled control.** `data-hovered` was never set on a disabled button. `:hover` matches one happily, and `aria-disabled` — which a pending button wears so it keeps its focus and its tooltip — is invisible to `:disabled`. New `enabled-hover` / `enabled-active` variants restore it in one place rather than 20.

**Pending.** react-aria's button had it built in; Base UI's does not. It is `aria-disabled` rather than `disabled` so the button stays focusable and keeps its tooltip, it swallows the press, and it shows the spinner.

`FormSubmit` also loses `preventFocusOnPress` in favour of refusing the mousedown, which is what react-aria was doing underneath — that is what lets a `setError` in `onSubmit` put focus on the offending field instead of the submit button.

`LinkButton` becomes a `RouterLink` wearing the button's classes, which is what keeps an in-app href on the client router now that `RouterProvider` is gone. It still accepts `onPress` and `isDisabled`, mapped to a click and a refused navigation, so its call sites are untouched too.

## Verification

`static-checks` 11/11 · Storybook **80/80** · chromium e2e **97 passed** (the one red is the local rate-limiter).

Two checks worth calling out, because a button's most important states cannot be photographed:

- **`ui-button--default` is pixel-identical** to its current baseline across every variant, size, pressed, disabled, pending and link state.
- **The generated CSS was diffed declaration-by-declaration against main: zero blocks lost, zero added.** Only selectors changed. That is the only automated guard on the ~85 hover/press tokens the screenshot pipeline can't reach, and it is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)