### PR TITLE
refactor(ui): call a button's props what the DOM calls them

### DIFF
--- a/apps/frontend/src/containers/AiPromptButton.tsx
+++ b/apps/frontend/src/containers/AiPromptButton.tsx
@@ -196,7 +196,7 @@ export function AiPromptButton(props: {
             aria-label={
               iconOnly ? (clipboard.copied ? "Copied" : copyLabel) : undefined
             }
-            onPress={() => copy(primary)}
+            onClick={() => copy(primary)}
           >
             <PrimaryContent
               iconOnly={iconOnly}

--- a/apps/frontend/src/containers/AuthWithEmail.tsx
+++ b/apps/frontend/src/containers/AuthWithEmail.tsx
@@ -78,7 +78,7 @@ export function AuthWithEmail(props: {
             Verifying…
           </div>
         ) : (
-          <LinkButton className="w-full text-center" onPress={onBack}>
+          <LinkButton className="w-full text-center" onClick={onBack}>
             ← Back
           </LinkButton>
         )}

--- a/apps/frontend/src/containers/Build/BuildDiffListPrimitives.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffListPrimitives.tsx
@@ -1,15 +1,14 @@
 import { ComponentPropsWithRef, memo, Suspense } from "react";
 import { assertNever } from "@argos/util/assertNever";
 import { invariant } from "@argos/util/invariant";
+import { Button as BaseButton } from "@base-ui/react/button";
 import { clsx } from "clsx";
-import { AriaButtonProps, HoverProps, useButton } from "react-aria";
 
 import { useOverlayStyle } from "@/containers/Build/OverlayStyle";
 import { graphql, type DocumentType } from "@/gql";
 import { ScreenshotDiffStatus } from "@/gql/graphql";
 import { ImageKitPicture, ImageKitPictureProps } from "@/ui/ImageKitPicture";
 import { Truncable, type TruncableProps } from "@/ui/Truncable";
-import { useObjectRef } from "@/ui/useObjectRef";
 import { checkIsImageContentType } from "@/util/content-type";
 
 import { RemoteMinimap } from "./RemoteMinimap";
@@ -228,34 +227,30 @@ export function DiffCard(props: DiffCardProps) {
   );
 }
 
+/**
+ * A row that behaves as a button while staying a `<div>` — the diff list needs
+ * the element to be a div for its virtualiser's measurements.
+ *
+ * `nativeButton={false}` is how Base UI is told that: it then supplies the
+ * role, the tab index and the Enter/Space handling that a real button gets for
+ * free, which is what react-aria's `useButton` was doing here.
+ */
 export function ListItemButton(
-  props: Pick<AriaButtonProps<"div">, "onPress" | "isDisabled"> &
-    Pick<HoverProps, "onHoverChange"> &
-    ComponentPropsWithRef<"div">,
+  props: Omit<
+    React.ComponentProps<typeof BaseButton>,
+    "nativeButton" | "render"
+  >,
 ) {
-  const { ref: propRef, onPress, isDisabled, className, ...rest } = props;
-  const ref = useObjectRef(propRef);
-  const { buttonProps } = useButton(
-    {
-      elementType: "div",
-      onPress,
-      isDisabled,
-      // Handed to `useButton` rather than left to the spread below: it returns
-      // an `aria-current` of its own, and being spread last it would overwrite
-      // the caller's with the undefined it read from props it was never given.
-      "aria-current": rest["aria-current"],
-    },
-    ref,
-  );
+  const { className, ...rest } = props;
   return (
-    <div
-      ref={ref}
+    <BaseButton
+      nativeButton={false}
+      render={<div />}
       className={clsx(
         "group/item relative cursor-default text-left focus:outline-hidden",
         className,
       )}
       {...rest}
-      {...buttonProps}
     />
   );
 }

--- a/apps/frontend/src/containers/Build/BuildHotkeys.tsx
+++ b/apps/frontend/src/containers/Build/BuildHotkeys.tsx
@@ -525,7 +525,7 @@ const BuildHotkeysDialogWithState = memo(
             <Button
               variant="secondary"
               iconOnly
-              onPress={() => state.setIsOpen(false)}
+              onClick={() => state.setIsOpen(false)}
               aria-label="Close"
               className="absolute top-3 right-3 z-10"
             >

--- a/apps/frontend/src/containers/Build/Zoomer.tsx
+++ b/apps/frontend/src/containers/Build/Zoomer.tsx
@@ -376,7 +376,7 @@ const FitViewButton = memo(() => {
   });
   return (
     <HotkeyTooltip side="left" description="Fit view" keys={hotkey.displayKeys}>
-      <Button variant="secondary" iconOnly onPress={reset}>
+      <Button variant="secondary" iconOnly onClick={reset}>
         <MaximizeIcon />
       </Button>
     </HotkeyTooltip>
@@ -390,8 +390,8 @@ const ZoomInButton = memo((props: { disabled: boolean }) => {
       <Button
         variant="secondary"
         iconOnly
-        onPress={zoomIn}
-        isDisabled={props.disabled}
+        onClick={zoomIn}
+        disabled={props.disabled}
       >
         <PlusIcon />
       </Button>
@@ -406,8 +406,8 @@ const ZoomOutButton = memo((props: { disabled: boolean }) => {
       <Button
         variant="secondary"
         iconOnly
-        onPress={zoomOut}
-        isDisabled={props.disabled}
+        onClick={zoomOut}
+        disabled={props.disabled}
       >
         <MinusIcon />
       </Button>

--- a/apps/frontend/src/containers/Build/toolbar/AriaSnapshotToggle.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/AriaSnapshotToggle.tsx
@@ -39,7 +39,7 @@ function Toggle() {
     >
       {/* The icon is the destination, not the state: the aria tree while looking
           at the screenshot, the screenshot while reading the tree. */}
-      <Button variant="secondary" iconOnly onPress={toggle}>
+      <Button variant="secondary" iconOnly onClick={toggle}>
         {snapshotType === "aria" ? <ImageIcon /> : <ScanTextIcon />}
       </Button>
     </HotkeyTooltip>

--- a/apps/frontend/src/containers/Build/toolbar/CommentToolToggle.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/CommentToolToggle.tsx
@@ -28,7 +28,7 @@ export const CommentToolToggle = memo(() => {
           iconOnly
           aria-pressed={mode === "hand"}
           aria-label="Move tool"
-          onPress={activateHand}
+          onClick={activateHand}
         >
           <HandIcon />
         </Button>
@@ -43,7 +43,7 @@ export const CommentToolToggle = memo(() => {
           iconOnly
           aria-pressed={mode === "comment"}
           aria-label="Comment tool"
-          onPress={activateComment}
+          onClick={activateComment}
         >
           <MessageSquarePlusIcon />
         </Button>

--- a/apps/frontend/src/containers/Build/toolbar/CommentsVisibilityToggle.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/CommentsVisibilityToggle.tsx
@@ -17,7 +17,7 @@ export const CommentsVisibilityToggle = memo(() => {
         variant="secondary"
         iconOnly
         aria-label={label}
-        onPress={() => setCommentsVisible(!visible)}
+        onClick={() => setCommentsVisible(!visible)}
       >
         {visible ? <MessageSquareIcon /> : <MessageSquareOffIcon />}
       </Button>

--- a/apps/frontend/src/containers/Build/toolbar/FitToggle.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/FitToggle.tsx
@@ -28,7 +28,7 @@ export const FitToggle = memo(() => {
     >
       {/* The icon says which way the button goes, so it needs no pressed
           state on top: shrink to fit, expand back to full size. */}
-      <Button variant="secondary" iconOnly onPress={toggle}>
+      <Button variant="secondary" iconOnly onClick={toggle}>
         {contained ? <ExpandIcon /> : <ShrinkIcon />}
       </Button>
     </HotkeyTooltip>

--- a/apps/frontend/src/containers/Build/toolbar/HighlightButton.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/HighlightButton.tsx
@@ -21,8 +21,8 @@ export const HighlightButton = memo(() => {
       <Button
         variant="secondary"
         iconOnly
-        onPress={highlight}
-        isDisabled={!enabled}
+        onClick={highlight}
+        disabled={!enabled}
       >
         <LocateFixedIcon />
       </Button>

--- a/apps/frontend/src/containers/Build/toolbar/IgnoreButton.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/IgnoreButton.tsx
@@ -166,7 +166,7 @@ function EnabledIgnoreButton(props: {
       >
         <BaseIgnoreButton
           aria-pressed={isIgnored}
-          onPress={toggle}
+          onClick={toggle}
           variant={isIgnored ? "danger" : "secondary"}
         />
       </HotkeyTooltip>
@@ -207,7 +207,7 @@ function EnabledIgnoreButton(props: {
                 </Checkbox>
               </div>
               <DialogDismiss>Cancel</DialogDismiss>
-              <Button variant="destructive" onPress={ignoreChange}>
+              <Button variant="destructive" onClick={ignoreChange}>
                 Ignore Change
               </Button>
             </DialogFooter>
@@ -239,7 +239,7 @@ function EnabledIgnoreButton(props: {
             </DialogBody>
             <DialogFooter>
               <DialogDismiss>Cancel</DialogDismiss>
-              <Button variant="destructive" onPress={unignoreChange}>
+              <Button variant="destructive" onClick={unignoreChange}>
                 Unignore Change
               </Button>
             </DialogFooter>
@@ -266,5 +266,5 @@ export const IgnoreButton = memo(function IgnoreButton(props: {
     return <EnabledIgnoreButton diff={diff} onIgnoreChange={onIgnoreChange} />;
   }
 
-  return <BaseIgnoreButton isDisabled />;
+  return <BaseIgnoreButton disabled />;
 });

--- a/apps/frontend/src/containers/Build/toolbar/NavButtons.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/NavButtons.tsx
@@ -8,28 +8,23 @@ import { Button } from "@/ui/Button";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 
 export function NextButton(props: {
-  onPress: () => void;
-  isDisabled: boolean;
+  onClick: () => void;
+  disabled: boolean;
   /**
    * The shortcut this button owns. Same arrow key either way — what differs is
    * how the `?` dialog words it, which depends on what is being navigated.
    */
   hotkeyName?: HotkeyName;
 }) {
-  const { onPress, isDisabled, hotkeyName = "goToNextDiff" } = props;
-  const hotkey = useBuildHotkey(hotkeyName, onPress, {
+  const { onClick, disabled, hotkeyName = "goToNextDiff" } = props;
+  const hotkey = useBuildHotkey(hotkeyName, onClick, {
     preventDefault: true,
-    enabled: !isDisabled,
+    enabled: !disabled,
     allowInInput: true,
   });
   return (
     <HotkeyTooltip description={hotkey.description} keys={hotkey.displayKeys}>
-      <Button
-        variant="ghost"
-        iconOnly
-        isDisabled={isDisabled}
-        onPress={onPress}
-      >
+      <Button variant="ghost" iconOnly disabled={disabled} onClick={onClick}>
         <ArrowDownIcon />
       </Button>
     </HotkeyTooltip>
@@ -37,8 +32,8 @@ export function NextButton(props: {
 }
 
 export function PreviousButton(props: {
-  onPress: () => void;
-  isDisabled?: boolean;
+  onClick: () => void;
+  disabled?: boolean;
   /**
    * On the first snapshot, the button returns to the build overview. Only the
    * tooltip says so: the sidebar already has a home button for the overview, and
@@ -49,14 +44,14 @@ export function PreviousButton(props: {
   hotkeyName?: HotkeyName;
 }) {
   const {
-    onPress,
-    isDisabled = false,
+    onClick,
+    disabled = false,
     toOverview = false,
     hotkeyName = "goToPreviousDiff",
   } = props;
-  const hotkey = useBuildHotkey(hotkeyName, onPress, {
+  const hotkey = useBuildHotkey(hotkeyName, onClick, {
     preventDefault: true,
-    enabled: !isDisabled,
+    enabled: !disabled,
     allowInInput: true,
   });
   return (
@@ -64,12 +59,7 @@ export function PreviousButton(props: {
       description={toOverview ? "Go to overview" : hotkey.description}
       keys={hotkey.displayKeys}
     >
-      <Button
-        variant="ghost"
-        iconOnly
-        isDisabled={isDisabled}
-        onPress={onPress}
-      >
+      <Button variant="ghost" iconOnly disabled={disabled} onClick={onClick}>
         <ArrowUpIcon />
       </Button>
     </HotkeyTooltip>

--- a/apps/frontend/src/containers/Build/toolbar/NavChangesButton.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/NavChangesButton.tsx
@@ -24,7 +24,7 @@ function GoToChangesButton(props: { direction: -1 | 1 }) {
   const Icon = direction === -1 ? ChevronLeft : ChevronRight;
   return (
     <HotkeyTooltip description={hotkey.description} keys={hotkey.displayKeys}>
-      <Button variant="secondary" iconOnly onPress={go} isDisabled={!enabled}>
+      <Button variant="secondary" iconOnly onClick={go} disabled={!enabled}>
         <Icon />
       </Button>
     </HotkeyTooltip>

--- a/apps/frontend/src/containers/Build/toolbar/OverlayToggle.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/OverlayToggle.tsx
@@ -19,7 +19,7 @@ export const OverlayToggle = memo(() => {
       description={visible ? "Hide changes overlay" : "Show changes overlay"}
       keys={hotkey.displayKeys}
     >
-      <Button variant="danger" iconOnly aria-pressed={visible} onPress={toggle}>
+      <Button variant="danger" iconOnly aria-pressed={visible} onClick={toggle}>
         <EyeIcon />
       </Button>
     </HotkeyTooltip>

--- a/apps/frontend/src/containers/Build/toolbar/ViewToggle.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/ViewToggle.tsx
@@ -175,7 +175,7 @@ function ViewButton(props: {
         iconOnly
         aria-pressed={isCurrent}
         aria-label={label}
-        onPress={() => {
+        onClick={() => {
           onSelect(viewMode);
         }}
       >

--- a/apps/frontend/src/containers/Comment/CommentCard.tsx
+++ b/apps/frontend/src/containers/Comment/CommentCard.tsx
@@ -467,7 +467,7 @@ function ResolvedThreadHeader(props: {
   const { collapsed, commentCount, authorName, onToggle } = props;
   return (
     <RACButton
-      onPress={onToggle}
+      onClick={onToggle}
       aria-label={collapsed ? "Expand thread" : "Collapse thread"}
       className="text-low hover:text-default flex w-full items-center gap-1.5 px-2 py-1.5 text-left text-xs transition select-none"
     >
@@ -641,7 +641,7 @@ function CommentMessage(props: {
                 }
               >
                 <RACButton
-                  onPress={copyLink}
+                  onClick={copyLink}
                   aria-label="Copy link to comment"
                   className="text-low hover:text-default shrink-0 text-left text-xs transition"
                 >
@@ -790,8 +790,8 @@ function ReplyComposer(props: {
             size="small"
             aria-label="Submit the reply"
             aria-disabled={isEmpty}
-            isDisabled={isPending}
-            onPress={submit}
+            disabled={isPending}
+            onClick={submit}
             className="mt-0.5 shrink-0"
           >
             <ArrowUpIcon />

--- a/apps/frontend/src/containers/Comment/CommentDraftPopover.tsx
+++ b/apps/frontend/src/containers/Comment/CommentDraftPopover.tsx
@@ -31,12 +31,12 @@ export function CommentDraftPopover(props: {
   const [value, setValue] = useState<EditorValue>(null);
   // Remounts the editor to clear it after a successful submit.
   const [editorKey, setEditorKey] = useState(0);
-  const [isPending, setIsPending] = useState(false);
+  const [pending, setIsPending] = useState(false);
   const emptyToastId = useId();
   const isEmpty = !hasEditorContent(value);
 
   const submit = () => {
-    if (isPending) {
+    if (pending) {
       return;
     }
     if (isEmpty) {
@@ -78,7 +78,7 @@ export function CommentDraftPopover(props: {
           onSubmit={submit}
           mentions={mentions}
           placeholder="Add a comment"
-          disabled={isPending}
+          disabled={pending}
           autoFocus
           aria-label="Add a comment"
           variant="plain"
@@ -90,8 +90,8 @@ export function CommentDraftPopover(props: {
           altHeld={altHeld}
           fallbackLabel="Submit the comment"
           isEmpty={isEmpty}
-          isPending={isPending}
-          onPress={submit}
+          pending={pending}
+          onClick={submit}
           className="shrink-0"
         />
       </div>

--- a/apps/frontend/src/containers/Comment/CommentReactions.tsx
+++ b/apps/frontend/src/containers/Comment/CommentReactions.tsx
@@ -156,7 +156,7 @@ export function CommentReactionList(props: { comment: Comment }) {
         <Tooltip key={group.emoji} content={getReactionTooltip(group)}>
           <RACButton
             isDisabled={!canReact}
-            onPress={() => toggle(group)}
+            onClick={() => toggle(group)}
             className={clsx(
               "flex h-6 items-center gap-1 rounded-full border px-2 text-xs font-medium transition",
               "cursor-default focus:outline-hidden data-focus-visible:ring-4",

--- a/apps/frontend/src/containers/Comment/DeleteCommentDialog.tsx
+++ b/apps/frontend/src/containers/Comment/DeleteCommentDialog.tsx
@@ -60,8 +60,8 @@ export function DeleteCommentDialog(props: { commentId: string }) {
         <DialogDismiss disabled={loading}>Cancel</DialogDismiss>
         <Button
           variant="destructive"
-          isPending={loading}
-          onPress={() => {
+          pending={loading}
+          onClick={() => {
             deleteComment().catch(() => {
               // Error is surfaced through the `error` state above.
             });

--- a/apps/frontend/src/containers/Comment/SubscribeToggleButton.tsx
+++ b/apps/frontend/src/containers/Comment/SubscribeToggleButton.tsx
@@ -49,7 +49,7 @@ export function SubscribeToggleButton(props: {
         iconOnly
         size="small"
         aria-label={label}
-        onPress={handlePress}
+        onClick={handlePress}
       >
         {subscribed ? <BellOffIcon /> : <BellIcon />}
       </Button>

--- a/apps/frontend/src/containers/GithubRepositoryList.tsx
+++ b/apps/frontend/src/containers/GithubRepositoryList.tsx
@@ -78,7 +78,7 @@ function PaginationItem(props: {
   return (
     <PaginationButtonItem
       isActive={props.index === props.page}
-      onPress={() => props.setPage(props.index)}
+      onClick={() => props.setPage(props.index)}
     >
       {props.index}
     </PaginationButtonItem>
@@ -106,8 +106,8 @@ function ReposPagination({
     <Pagination>
       <PaginationContent>
         <PaginationPrevious
-          onPress={() => setPage(page - 1)}
-          isDisabled={page === 1}
+          onClick={() => setPage(page - 1)}
+          disabled={page === 1}
         />
         <PaginationItem index={1} page={page} setPage={setPage} />
         {page > paginationItemCount / 2 + 1 && <PaginationEllipsis />}
@@ -122,8 +122,8 @@ function ReposPagination({
         {page < pageCount - paginationItemCount / 2 && <PaginationEllipsis />}
         <PaginationItem index={pageCount} page={page} setPage={setPage} />
         <PaginationNext
-          onPress={() => setPage(page + 1)}
-          isDisabled={page === pageCount}
+          onClick={() => setPage(page + 1)}
+          disabled={page === pageCount}
         />
       </PaginationContent>
     </Pagination>
@@ -182,10 +182,10 @@ export function GithubRepositoryList(props: {
               {repo.name} • <Time date={repo.updated_at} className="text-low" />
             </div>
             <Button
-              onPress={() => {
+              onClick={() => {
                 props.onSelectRepository(repo);
               }}
-              isDisabled={props.disabled}
+              disabled={props.disabled}
             >
               {props.connectButtonLabel}
             </Button>

--- a/apps/frontend/src/containers/GitlabProjectList.tsx
+++ b/apps/frontend/src/containers/GitlabProjectList.tsx
@@ -104,10 +104,10 @@ export function GitlabProjectList(props: GitlabProjectListProps) {
             />
           </div>
           <Button
-            onPress={() => {
+            onClick={() => {
               props.onSelectProject(project);
             }}
-            isDisabled={props.disabled}
+            disabled={props.disabled}
           >
             {props.connectButtonLabel}
           </Button>

--- a/apps/frontend/src/containers/LoginOptions.tsx
+++ b/apps/frontend/src/containers/LoginOptions.tsx
@@ -30,7 +30,7 @@ type Screen = "providers" | "verifyEmail" | "saml";
 
 export function LoginOptions(props: {
   redirect?: string | null;
-  isDisabled?: boolean;
+  disabled?: boolean;
   className?: string;
   email: string;
   onEmailChange: (email: string) => void;
@@ -61,8 +61,8 @@ export function LoginOptions(props: {
                 redirect={redirect}
                 size="large"
                 className="w-full justify-center"
-                isDisabled={props.isDisabled}
-                onPress={() => setLastLoginMethod("google")}
+                disabled={props.disabled}
+                onClick={() => setLastLoginMethod("google")}
               >
                 Continue with Google
               </GoogleLoginButton>
@@ -72,8 +72,8 @@ export function LoginOptions(props: {
                 redirect={redirect}
                 size="large"
                 className="w-full justify-center"
-                isDisabled={props.isDisabled}
-                onPress={() => setLastLoginMethod("github")}
+                disabled={props.disabled}
+                onClick={() => setLastLoginMethod("github")}
               >
                 Continue with GitHub
               </GitHubLoginButton>
@@ -83,8 +83,8 @@ export function LoginOptions(props: {
                 redirect={redirect}
                 size="large"
                 className="w-full justify-center"
-                isDisabled={props.isDisabled}
-                onPress={() => setLastLoginMethod("gitlab")}
+                disabled={props.disabled}
+                onClick={() => setLastLoginMethod("gitlab")}
               >
                 Continue with GitLab
               </GitLabLoginButton>
@@ -93,8 +93,8 @@ export function LoginOptions(props: {
               variant="secondary"
               size="large"
               className="w-full justify-center"
-              isDisabled={props.isDisabled}
-              onPress={() => setScreen("saml")}
+              disabled={props.disabled}
+              onClick={() => setScreen("saml")}
             >
               Continue with SAML SSO
             </Button>
@@ -104,7 +104,7 @@ export function LoginOptions(props: {
                   redirect={redirect}
                   size="large"
                   className="w-full justify-center"
-                  isDisabled={props.isDisabled}
+                  disabled={props.disabled}
                   onSuccess={() => setLastLoginMethod("passkey")}
                 />
               </LastUsedIndicator>
@@ -186,7 +186,7 @@ function SamlForm(props: {
         <Button
           variant="secondary"
           className="flex-1 justify-center"
-          onPress={props.onBack}
+          onClick={props.onBack}
           type="button"
         >
           Back

--- a/apps/frontend/src/containers/Media/MediaComments.tsx
+++ b/apps/frontend/src/containers/Media/MediaComments.tsx
@@ -277,7 +277,7 @@ function PinCommentToggle(props: {
         size="small"
         iconOnly
         aria-label="Cancel"
-        onPress={() => onPlacingChange(false)}
+        onClick={() => onPlacingChange(false)}
       >
         <XIcon />
       </Button>
@@ -289,7 +289,7 @@ function PinCommentToggle(props: {
         size="small"
         iconOnly
         aria-label="Pin a comment"
-        onPress={() => onPlacingChange(true)}
+        onClick={() => onPlacingChange(true)}
       >
         <MapPinPlusInsideIcon />
       </Button>
@@ -442,7 +442,7 @@ function MediaPinnedReference(props: {
         : "Pinned on another version";
   return (
     <RACButton
-      onPress={onNavigate}
+      onClick={onNavigate}
       aria-label="Go to the pinned comment"
       // No hover style or default cursor of its own: the surrounding card
       // shares this button's navigation and carries the hover affordance.

--- a/apps/frontend/src/containers/Media/MediaPullRequestList.tsx
+++ b/apps/frontend/src/containers/Media/MediaPullRequestList.tsx
@@ -154,7 +154,7 @@ function MediaListItem(props: {
   return (
     <ListItemButton
       ref={ref}
-      onPress={() => {
+      onClick={() => {
         // The row already on screen: navigating to it would reload the page it
         // is showing.
         if (!isActive) {

--- a/apps/frontend/src/containers/Media/MediaViewer.tsx
+++ b/apps/frontend/src/containers/Media/MediaViewer.tsx
@@ -464,13 +464,13 @@ function MediaViewToolbar(props: {
           <DetailToolbarNav>
             <PreviousButton
               hotkeyName="goToPreviousMedia"
-              onPress={nav.onPrevious}
-              isDisabled={!nav.hasPrevious}
+              onClick={nav.onPrevious}
+              disabled={!nav.hasPrevious}
             />
             <NextButton
               hotkeyName="goToNextMedia"
-              onPress={nav.onNext}
-              isDisabled={!nav.hasNext}
+              onClick={nav.onNext}
+              disabled={!nav.hasNext}
             />
           </DetailToolbarNav>
         ) : null}

--- a/apps/frontend/src/containers/Project/ConnectRepository.tsx
+++ b/apps/frontend/src/containers/Project/ConnectRepository.tsx
@@ -214,7 +214,7 @@ enum GitProvider {
 }
 
 function GitHubButton(props: {
-  onPress: ButtonProps["onPress"];
+  onClick: React.MouseEventHandler<HTMLElement>;
   hasInstallations: boolean;
   hasValidGitHubToken: boolean;
   children?: React.ReactNode;
@@ -247,12 +247,12 @@ function GitHubButton(props: {
 }
 
 function GitHubBaseButton(props: {
-  onPress: ButtonProps["onPress"];
+  onClick: React.MouseEventHandler<HTMLElement>;
   children?: React.ReactNode;
   size?: ButtonProps["size"];
 }) {
   return (
-    <Button variant="github" size={props.size} onPress={props.onPress}>
+    <Button variant="github" size={props.size} onClick={props.onClick}>
       <ButtonIcon>
         <MarkGithubIcon />
       </ButtonIcon>
@@ -401,7 +401,7 @@ export function ConnectRepository(props: ConnectRepositoryProps) {
             </LinkButton>
             <LinkButton
               variant="secondary"
-              onPress={() => setAndStoreProvider(null)}
+              onClick={() => setAndStoreProvider(null)}
             >
               Use another Git provider
             </LinkButton>
@@ -422,7 +422,7 @@ export function ConnectRepository(props: ConnectRepositoryProps) {
         <div className="flex items-center justify-between gap-4">
           <div className="flex gap-4">
             <GitHubButton
-              onPress={() => setAndStoreProvider(GitProvider.GitHub)}
+              onClick={() => setAndStoreProvider(GitProvider.GitHub)}
               hasInstallations={hasGhInstallations}
               hasValidGitHubToken={hasValidGitHubToken}
             >
@@ -430,13 +430,13 @@ export function ConnectRepository(props: ConnectRepositoryProps) {
             </GitHubButton>
             {ghLightGhInstallation && (
               <GitHubBaseButton
-                onPress={() => setAndStoreProvider(GitProvider.GitHubLight)}
+                onClick={() => setAndStoreProvider(GitProvider.GitHubLight)}
               >
                 GitHub (no content-access)
               </GitHubBaseButton>
             )}
             <GitLabButton
-              onPress={() => setAndStoreProvider(GitProvider.GitLab)}
+              onClick={() => setAndStoreProvider(GitProvider.GitLab)}
             >
               GitLab
             </GitLabButton>
@@ -459,7 +459,7 @@ export function ConnectRepository(props: ConnectRepositoryProps) {
           </div>
           <div className="flex flex-col items-center gap-3">
             <GitHubButton
-              onPress={() => setAndStoreProvider(GitProvider.GitHub)}
+              onClick={() => setAndStoreProvider(GitProvider.GitHub)}
               hasInstallations={hasGhInstallations}
               hasValidGitHubToken={hasValidGitHubToken}
             >
@@ -467,13 +467,13 @@ export function ConnectRepository(props: ConnectRepositoryProps) {
             </GitHubButton>
             {ghLightGhInstallation && (
               <GitHubBaseButton
-                onPress={() => setAndStoreProvider(GitProvider.GitHubLight)}
+                onClick={() => setAndStoreProvider(GitProvider.GitHubLight)}
               >
                 Continue with GitHub (no content-access)
               </GitHubBaseButton>
             )}
             <GitLabButton
-              onPress={() => setAndStoreProvider(GitProvider.GitLab)}
+              onClick={() => setAndStoreProvider(GitProvider.GitLab)}
             >
               Continue with GitLab
             </GitLabButton>

--- a/apps/frontend/src/containers/Project/Contributors/AddProjectContributor.tsx
+++ b/apps/frontend/src/containers/Project/Contributors/AddProjectContributor.tsx
@@ -175,7 +175,7 @@ function TeamContributorsList(props: {
               })()}
               {data.team.members.pageInfo.hasNextPage && (
                 <ListLoadMore
-                  onPress={() => {
+                  onClick={() => {
                     result.fetchMore({
                       variables: {
                         after: members.length,

--- a/apps/frontend/src/containers/Project/Contributors/ProjectContributorsList.tsx
+++ b/apps/frontend/src/containers/Project/Contributors/ProjectContributorsList.tsx
@@ -124,7 +124,7 @@ export function ProjectContributorsList(props: {
               )}
               {result.data.project.contributors.pageInfo.hasNextPage && (
                 <ListLoadMore
-                  onPress={() => {
+                  onClick={() => {
                     result.fetchMore({
                       variables: { after: contributors.length },
                       updateQuery: (prev, { fetchMoreResult }) => {

--- a/apps/frontend/src/containers/Project/Contributors/ProjectRemoveContributor.tsx
+++ b/apps/frontend/src/containers/Project/Contributors/ProjectRemoveContributor.tsx
@@ -68,9 +68,9 @@ export const LeaveProjectDialog = memo(
           {error && <ErrorMessage>{getErrorMessage(error)}</ErrorMessage>}
           <DialogDismiss>Cancel</DialogDismiss>
           <Button
-            isDisabled={loading}
+            disabled={loading}
             variant="destructive"
-            onPress={() => {
+            onClick={() => {
               leaveProject().catch(() => {});
             }}
           >
@@ -137,9 +137,9 @@ export const RemoveFromProjectDialog = memo(
           )}
           <DialogDismiss>Cancel</DialogDismiss>
           <Button
-            isDisabled={loading}
+            disabled={loading}
             variant="destructive"
-            onPress={() => {
+            onClick={() => {
               removeFromProject().catch(() => {});
             }}
           >

--- a/apps/frontend/src/containers/Project/Contributors/ProjectTeamMembersList.tsx
+++ b/apps/frontend/src/containers/Project/Contributors/ProjectTeamMembersList.tsx
@@ -85,7 +85,7 @@ export function ProjectTeamMembersList(props: {
             </List>
             {data.team.members.pageInfo.hasNextPage && (
               <ListLoadMore
-                onPress={() => {
+                onClick={() => {
                   result.fetchMore({
                     variables: {
                       after: members.length,

--- a/apps/frontend/src/containers/Project/GitRepository.tsx
+++ b/apps/frontend/src/containers/Project/GitRepository.tsx
@@ -121,7 +121,7 @@ function UnlinkGithubRepositoryButton(props: {
   return (
     <Button
       variant="secondary"
-      onPress={() => {
+      onClick={() => {
         unlink().catch(() => {});
       }}
     >
@@ -150,7 +150,7 @@ const UnlinkGitlabProjectButton = (props: {
   return (
     <Button
       variant="secondary"
-      onPress={() => {
+      onClick={() => {
         unlink().catch(() => {});
       }}
     >

--- a/apps/frontend/src/containers/Project/Transfer.tsx
+++ b/apps/frontend/src/containers/Project/Transfer.tsx
@@ -109,10 +109,10 @@ const SelectAccountStep = (props: SelectAccountStepProps) => {
       <DialogFooter>
         <DialogDismiss>Cancel</DialogDismiss>
         <Button
-          onPress={() => {
+          onClick={() => {
             props.onContinue();
           }}
-          isDisabled={!props.targetAccountId}
+          disabled={!props.targetAccountId}
         >
           Continue
         </Button>
@@ -342,7 +342,7 @@ const ReviewStep = (props: ReviewStepProps) => {
           })()}
         </DialogBody>
         <DialogFooter>
-          <Button variant="secondary" onPress={props.onBack}>
+          <Button variant="secondary" onClick={props.onBack}>
             Back
           </Button>
           <FormSubmit control={form.control}>Transfer</FormSubmit>

--- a/apps/frontend/src/containers/PullRequestButton.tsx
+++ b/apps/frontend/src/containers/PullRequestButton.tsx
@@ -215,7 +215,7 @@ export function PullRequestButton(props: {
           variant="secondary"
           size={props.size}
           className={clsx("min-w-0 cursor-pointer", props.className)}
-          onPress={
+          onClick={
             props.emulateLink
               ? (event) => {
                   window.open(

--- a/apps/frontend/src/containers/SignupOptions.tsx
+++ b/apps/frontend/src/containers/SignupOptions.tsx
@@ -134,7 +134,7 @@ function EmailScreen(props: {
         </ButtonIcon>
         Continue with email
       </FormSubmit>
-      <LinkButton className="mt-6 w-full text-center" onPress={onBack}>
+      <LinkButton className="mt-6 w-full text-center" onClick={onBack}>
         ← Other Sign Up options
       </LinkButton>
     </Form>
@@ -153,7 +153,7 @@ function ProvidersScreen(props: {
         redirect={redirect}
         size="large"
         className="w-full justify-center"
-        onPress={() => setLastLoginMethod("google")}
+        onClick={() => setLastLoginMethod("google")}
       >
         Continue with Google
       </GoogleLoginButton>
@@ -161,7 +161,7 @@ function ProvidersScreen(props: {
         redirect={redirect}
         size="large"
         className="w-full justify-center"
-        onPress={() => setLastLoginMethod("github")}
+        onClick={() => setLastLoginMethod("github")}
       >
         Continue with GitHub
       </GitHubLoginButton>
@@ -169,13 +169,13 @@ function ProvidersScreen(props: {
         redirect={redirect}
         size="large"
         className="w-full justify-center"
-        onPress={() => setLastLoginMethod("gitlab")}
+        onClick={() => setLastLoginMethod("gitlab")}
       >
         Continue with GitLab
       </GitLabLoginButton>
       <LinkButton
         className="mt-2 w-full text-center"
-        onPress={onContinueWithEmail}
+        onClick={onContinueWithEmail}
       >
         Continue with Email →
       </LinkButton>

--- a/apps/frontend/src/containers/Team/Delete.tsx
+++ b/apps/frontend/src/containers/Team/Delete.tsx
@@ -185,7 +185,7 @@ export function TeamDelete(props: {
           </div>
           <Tooltip content="Cancel your subscription before deleting the team.">
             <div className="flex">
-              <DeleteButton isDisabled />
+              <DeleteButton disabled />
             </div>
           </Tooltip>
         </CardFooter>

--- a/apps/frontend/src/containers/Team/Discord.tsx
+++ b/apps/frontend/src/containers/Team/Discord.tsx
@@ -323,8 +323,8 @@ function DeleteWebhookDialog(props: { webhook: DiscordWebhook }) {
         <DialogDismiss disabled={loading}>Cancel</DialogDismiss>
         <Button
           variant="destructive"
-          isPending={loading}
-          onPress={() => {
+          pending={loading}
+          onClick={() => {
             deleteWebhook().catch(() => {
               // The error is shown in the dialog.
             });

--- a/apps/frontend/src/containers/Team/Domains.tsx
+++ b/apps/frontend/src/containers/Team/Domains.tsx
@@ -194,8 +194,8 @@ function RemoveTeamDomainDialog(props: { teamDomain: TeamDomain }) {
         <DialogDismiss disabled={loading}>Cancel</DialogDismiss>
         <Button
           variant="destructive"
-          isPending={loading}
-          onPress={() => {
+          pending={loading}
+          onClick={() => {
             removeTeamDomain().catch(() => {
               // The error is shown in the dialog.
             });

--- a/apps/frontend/src/containers/Team/GitHubSSO/Configure.tsx
+++ b/apps/frontend/src/containers/Team/GitHubSSO/Configure.tsx
@@ -252,7 +252,7 @@ export function ConfigureGitHubSSO(props: {
     return (
       <Tooltip content={props.disabledReason}>
         <div className="flex">
-          <Button isDisabled>{getButtonLabel(props.priced)}</Button>
+          <Button disabled>{getButtonLabel(props.priced)}</Button>
         </div>
       </Tooltip>
     );

--- a/apps/frontend/src/containers/Team/MsTeams.tsx
+++ b/apps/frontend/src/containers/Team/MsTeams.tsx
@@ -323,8 +323,8 @@ function DeleteWebhookDialog(props: { webhook: MsTeamsWebhook }) {
         <DialogDismiss disabled={loading}>Cancel</DialogDismiss>
         <Button
           variant="destructive"
-          isPending={loading}
-          onPress={() => {
+          pending={loading}
+          onClick={() => {
             deleteWebhook().catch(() => {
               // The error is shown in the dialog.
             });

--- a/apps/frontend/src/containers/Team/SAMLSSO.tsx
+++ b/apps/frontend/src/containers/Team/SAMLSSO.tsx
@@ -191,7 +191,7 @@ export function TeamSAMLSSO(props: {
               </div>
               <div className="flex items-center gap-3">
                 <DialogTrigger>
-                  <Button variant="secondary" isDisabled={!hasSamlAccess}>
+                  <Button variant="secondary" disabled={!hasSamlAccess}>
                     Manage
                   </Button>
                   <Modal>
@@ -292,7 +292,7 @@ export function TeamSAMLSSO(props: {
               </p>
             </div>
             <DialogTrigger>
-              <Button variant="secondary" isDisabled={!hasSamlAccess}>
+              <Button variant="secondary" disabled={!hasSamlAccess}>
                 Configure
               </Button>
               <Modal>

--- a/apps/frontend/src/containers/Team/SAMLSSOAddOn.tsx
+++ b/apps/frontend/src/containers/Team/SAMLSSOAddOn.tsx
@@ -74,7 +74,7 @@ export function EnableSAMLSSOAddOnButton(props: {
     return (
       <Tooltip content={disabledReason}>
         <div className="flex">
-          <Button isDisabled>Enable</Button>
+          <Button disabled>Enable</Button>
         </div>
       </Tooltip>
     );

--- a/apps/frontend/src/containers/Team/Slack.tsx
+++ b/apps/frontend/src/containers/Team/Slack.tsx
@@ -142,7 +142,7 @@ export function TeamSlack(props: {
           account.slackInstallation ? (
             <Button
               variant="secondary"
-              onPress={() => {
+              onClick={() => {
                 uninstallSlack().catch(() => {});
               }}
             >

--- a/apps/frontend/src/containers/Team/SubscribeDialog.tsx
+++ b/apps/frontend/src/containers/Team/SubscribeDialog.tsx
@@ -104,7 +104,7 @@ export function TeamSubscribeDialog({
             <DialogDismiss>Cancel</DialogDismiss>
 
             <StripeCheckoutButton
-              isDisabled={
+              disabled={
                 team
                   ? checkHasSubscriptionStatus(team.subscriptionStatus)
                   : false

--- a/apps/frontend/src/containers/Team/members/GitHubMembersList.tsx
+++ b/apps/frontend/src/containers/Team/members/GitHubMembersList.tsx
@@ -173,7 +173,7 @@ export function TeamGithubMembersList(props: TeamGithubMembersListProps) {
           <EmptyStateActions>
             <Button
               variant="secondary"
-              onPress={() => {
+              onClick={() => {
                 setSearch("");
               }}
             >
@@ -191,7 +191,7 @@ export function TeamGithubMembersList(props: TeamGithubMembersListProps) {
       )}
       {data.team.githubMembers.pageInfo.hasNextPage && (
         <ListLoadMore
-          onPress={() => {
+          onClick={() => {
             fetchMore({
               variables: {
                 after: members.length,

--- a/apps/frontend/src/containers/Team/members/InviteDialog.tsx
+++ b/apps/frontend/src/containers/Team/members/InviteDialog.tsx
@@ -134,7 +134,7 @@ export function InviteDialog(props: {
           </div>
           <ResetInviteLinkButton
             teamAccountId={team.id}
-            isDisabled={isSubmitting}
+            disabled={isSubmitting}
           />
           <Separator className="my-8" />
           <div className="flex flex-col gap-4">
@@ -180,10 +180,10 @@ export function InviteDialog(props: {
               <Button
                 variant="secondary"
                 className="self-start"
-                onPress={() =>
+                onClick={() =>
                   append({ email: "", level: TeamUserLevel.Member })
                 }
-                isDisabled={fields.length >= 10 || isSubmitting}
+                disabled={fields.length >= 10 || isSubmitting}
               >
                 <ButtonIcon>
                   <PlusCircleIcon />
@@ -218,7 +218,7 @@ const ResetInviteLinkMutation = graphql(`
 
 function ResetInviteLinkButton(props: {
   teamAccountId: string;
-  isDisabled?: boolean;
+  disabled?: boolean;
 }) {
   const client = useApolloClient();
   return (
@@ -234,7 +234,7 @@ function ResetInviteLinkButton(props: {
       }}
       variant="secondary"
       className="w-full justify-center"
-      isDisabled={props.isDisabled}
+      disabled={props.disabled}
     >
       Reset Invite Link
     </DialogActionButton>

--- a/apps/frontend/src/containers/Team/members/InvitesList.tsx
+++ b/apps/frontend/src/containers/Team/members/InvitesList.tsx
@@ -249,7 +249,7 @@ export function TeamInvitesList(props: TeamInvitesListProps) {
           <EmptyStateActions>
             <Button
               variant="secondary"
-              onPress={() => {
+              onClick={() => {
                 setSearch("");
               }}
             >
@@ -275,7 +275,7 @@ export function TeamInvitesList(props: TeamInvitesListProps) {
       )}
       {data.team.invites.pageInfo.hasNextPage && (
         <ListLoadMore
-          onPress={() => {
+          onClick={() => {
             fetchMore({
               variables: {
                 after: invites.length,

--- a/apps/frontend/src/containers/Team/members/LeaveTeamDialog.tsx
+++ b/apps/frontend/src/containers/Team/members/LeaveTeamDialog.tsx
@@ -52,9 +52,9 @@ export const LeaveTeamDialog = memo(
           {error && <ErrorMessage>{getErrorMessage(error)}</ErrorMessage>}
           <DialogDismiss>Cancel</DialogDismiss>
           <Button
-            isDisabled={loading}
+            disabled={loading}
             variant="destructive"
-            onPress={() => {
+            onClick={() => {
               leaveTeam().catch(() => {});
             }}
           >

--- a/apps/frontend/src/containers/Team/members/MembersList.tsx
+++ b/apps/frontend/src/containers/Team/members/MembersList.tsx
@@ -153,7 +153,7 @@ export function TeamMembersList(props: TeamMembersListProps) {
                 )}
                 {isMe || props.amOwner ? (
                   <RemoveMenu
-                    isDisabled={lastOne || member.fromSSO}
+                    disabled={lastOne || member.fromSSO}
                     tooltip={
                       isMe && lastOne
                         ? "You are the last user of this team, you can't leave it"
@@ -181,7 +181,7 @@ export function TeamMembersList(props: TeamMembersListProps) {
           <EmptyStateActions>
             <Button
               variant="secondary"
-              onPress={() => {
+              onClick={() => {
                 setSearch("");
                 setSource("everyone");
                 setOrderBy(TeamMembersOrderBy.Date);
@@ -194,7 +194,7 @@ export function TeamMembersList(props: TeamMembersListProps) {
       )}
       {data.team.members.pageInfo.hasNextPage && (
         <ListLoadMore
-          onPress={() => {
+          onClick={() => {
             fetchMore({
               variables: {
                 after: members.length,

--- a/apps/frontend/src/containers/Team/members/RemoveFromTeamDialog.tsx
+++ b/apps/frontend/src/containers/Team/members/RemoveFromTeamDialog.tsx
@@ -100,9 +100,9 @@ export const RemoveFromTeamDialog = memo(
           )}
           <DialogDismiss>Cancel</DialogDismiss>
           <Button
-            isDisabled={loading}
+            disabled={loading}
             variant="destructive"
-            onPress={() => {
+            onClick={() => {
               removeFromTeam().catch(() => {});
             }}
           >

--- a/apps/frontend/src/containers/User/Auth.tsx
+++ b/apps/frontend/src/containers/User/Auth.tsx
@@ -181,8 +181,8 @@ function RevokeSessionDialog(props: { session: Session }) {
         <DialogDismiss disabled={loading}>Cancel</DialogDismiss>
         <Button
           variant="destructive"
-          isPending={loading}
-          onPress={() => {
+          pending={loading}
+          onClick={() => {
             revokeSession().catch(() => {});
           }}
         >
@@ -224,8 +224,8 @@ function RevokeAllSessionsDialog(props: { count: number }) {
         <DialogDismiss disabled={loading}>Cancel</DialogDismiss>
         <Button
           variant="destructive"
-          isPending={loading}
-          onPress={() => {
+          pending={loading}
+          onClick={() => {
             revokeAllSessions().catch(() => {});
           }}
         >
@@ -268,7 +268,7 @@ function UserSessions(props: { sessions: readonly Session[] }) {
                     <Button
                       variant="secondary"
                       size="small"
-                      onPress={() => logout()}
+                      onClick={() => logout()}
                     >
                       Log out
                     </Button>
@@ -297,7 +297,7 @@ function UserSessions(props: { sessions: readonly Session[] }) {
             {others.map((session) => (
               <RACButton
                 key={session.id}
-                onPress={() => revoking.open(session)}
+                onClick={() => revoking.open(session)}
                 className="group bg-app data-focus-visible:bg-hover data-hovered:bg-hover flex w-full items-center gap-3 border-b p-4 last:border-b-0 focus:outline-hidden"
               >
                 <SessionRowLayout

--- a/apps/frontend/src/containers/User/emails/AddUserEmailDialog.tsx
+++ b/apps/frontend/src/containers/User/emails/AddUserEmailDialog.tsx
@@ -110,7 +110,7 @@ export function AddUserEmailDialog() {
                 existing resources you wish to keep must be transferred before
                 the account deletion.
               </p>
-              <Button className="self-center" onPress={() => logout()}>
+              <Button className="self-center" onClick={() => logout()}>
                 Switch account
               </Button>
             </Card>

--- a/apps/frontend/src/containers/User/emails/DeleteUserEmailDialog.tsx
+++ b/apps/frontend/src/containers/User/emails/DeleteUserEmailDialog.tsx
@@ -58,8 +58,8 @@ export function DeleteUserEmailDialog(props: DeleteUserEmailDialogProps) {
         <DialogDismiss disabled={loading}>Cancel</DialogDismiss>
         <Button
           variant="destructive"
-          isPending={loading}
-          onPress={() => {
+          pending={loading}
+          onClick={() => {
             deleteUserEmail().catch(() => {
               // Ignore errors
             });

--- a/apps/frontend/src/containers/User/emails/SendUserEmailVerificationButton.tsx
+++ b/apps/frontend/src/containers/User/emails/SendUserEmailVerificationButton.tsx
@@ -47,8 +47,8 @@ export function SendUserEmailVerificationButton(
   return (
     <Button
       variant="secondary"
-      isPending={loading}
-      onPress={() => {
+      pending={loading}
+      onClick={() => {
         sendUserEmailVerification().catch(() => {
           // Ignore error here
         });

--- a/apps/frontend/src/containers/User/providers/PasskeyAuth.tsx
+++ b/apps/frontend/src/containers/User/providers/PasskeyAuth.tsx
@@ -246,7 +246,7 @@ function PasskeyRow(props: {
           variant="secondary"
           iconOnly
           aria-label={`Rename ${passkey.name}`}
-          onPress={() => onEdit(passkey)}
+          onClick={() => onEdit(passkey)}
         >
           <PencilIcon />
         </Button>
@@ -254,7 +254,7 @@ function PasskeyRow(props: {
           variant="danger"
           iconOnly
           aria-label={`Delete ${passkey.name}`}
-          onPress={() => onDelete(passkey)}
+          onClick={() => onDelete(passkey)}
         >
           <Trash2Icon />
         </Button>
@@ -310,7 +310,7 @@ export function PasskeyAuth(props: {
           {passkeys.length > 0 ? (
             <RACButton
               className="text-low data-focus-visible:text-default data-hovered:text-default flex items-center gap-1 focus:outline-hidden"
-              onPress={() => setIsExpanded((expanded) => !expanded)}
+              onClick={() => setIsExpanded((expanded) => !expanded)}
             >
               {passkeys.length} passkey{passkeys.length > 1 ? "s" : ""}{" "}
               registered

--- a/apps/frontend/src/containers/User/tokens/DeleteTokenDialog.tsx
+++ b/apps/frontend/src/containers/User/tokens/DeleteTokenDialog.tsx
@@ -68,8 +68,8 @@ export function DeleteTokenDialog(props: DeleteTokenDialogProps) {
         <DialogDismiss disabled={loading}>Cancel</DialogDismiss>
         <Button
           variant="destructive"
-          isPending={loading}
-          onPress={() => {
+          pending={loading}
+          onClick={() => {
             deleteToken();
           }}
         >

--- a/apps/frontend/src/containers/UserList.tsx
+++ b/apps/frontend/src/containers/UserList.tsx
@@ -18,7 +18,7 @@ export function RemoveMenu(props: {
   label: string;
   actionLabel: string;
   onRemove: () => void;
-  isDisabled?: boolean;
+  disabled?: boolean;
   tooltip?: string | null;
 }) {
   return (
@@ -34,7 +34,7 @@ export function RemoveMenu(props: {
           onAction={() => {
             props.onRemove();
           }}
-          disabled={props.isDisabled}
+          disabled={props.disabled}
         >
           {props.tooltip && <MenuItemTooltip content={props.tooltip} />}
           {props.actionLabel}

--- a/apps/frontend/src/pages/Account/Analytics.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.tsx
@@ -497,7 +497,7 @@ export function AnalyticsDashboard(props: {
           description="Builds created, by project."
           action={
             <ExportButton
-              isDisabled={!metrics}
+              disabled={!metrics}
               onExport={() => {
                 invariant(metrics);
                 exportToCSV({
@@ -543,7 +543,7 @@ export function AnalyticsDashboard(props: {
           description="Screenshots captured, by project."
           action={
             <ExportButton
-              isDisabled={!metrics}
+              disabled={!metrics}
               onExport={() => {
                 invariant(metrics);
                 exportToCSV({
@@ -933,14 +933,14 @@ function ChartCard(props: {
   );
 }
 
-function ExportButton(props: { isDisabled: boolean; onExport: () => void }) {
+function ExportButton(props: { disabled: boolean; onExport: () => void }) {
   return (
     <Tooltip content="Export to CSV">
       <Button
         variant="secondary"
         iconOnly
-        isDisabled={props.isDisabled}
-        onPress={props.onExport}
+        disabled={props.disabled}
+        onClick={props.onExport}
       >
         <FileDownIcon />
       </Button>

--- a/apps/frontend/src/pages/Account/Tests.tsx
+++ b/apps/frontend/src/pages/Account/Tests.tsx
@@ -190,7 +190,7 @@ function PageContent(props: { accountSlug: string }) {
         <Heading>No tests</Heading>
         <Text slot="description">There is no tests matching the filters.</Text>
         <EmptyStateActions>
-          <Button onPress={() => setFilters(null)}>Reset filters</Button>
+          <Button onClick={() => setFilters(null)}>Reset filters</Button>
         </EmptyStateActions>
       </EmptyState>
     );

--- a/apps/frontend/src/pages/AuthCLI.tsx
+++ b/apps/frontend/src/pages/AuthCLI.tsx
@@ -139,8 +139,8 @@ function AuthCLIContent(props: {
 
       <div className="flex w-full flex-col gap-2">
         <Button
-          onPress={authorize}
-          isDisabled={status === "loading" || !me}
+          onClick={authorize}
+          disabled={status === "loading" || !me}
           size="large"
           className="w-full justify-center"
         >

--- a/apps/frontend/src/pages/Automation/AutomationForm.tsx
+++ b/apps/frontend/src/pages/Automation/AutomationForm.tsx
@@ -49,13 +49,13 @@ export function Task(props: { children: React.ReactNode }) {
   );
 }
 
-export function RemoveButton(props: { onPress: ButtonProps["onPress"] }) {
+export function RemoveButton(props: { onClick: ButtonProps["onClick"] }) {
   return (
     <Tooltip content="Remove">
       <Button
         variant="secondary"
         iconOnly
-        onPress={props.onPress}
+        onClick={props.onClick}
         aria-label="Remove"
       >
         <Trash2Icon />

--- a/apps/frontend/src/pages/Automation/AutomationFormActionsStep.tsx
+++ b/apps/frontend/src/pages/Automation/AutomationFormActionsStep.tsx
@@ -333,7 +333,7 @@ export function AutomationActionsStep(props: { form: AutomationForm }) {
               <Suspense fallback={<div>Loading…</div>}>
                 <ActionDetail form={form} name={`${name}.${index}`} />
               </Suspense>
-              <RemoveButton onPress={() => remove(index)} />
+              <RemoveButton onClick={() => remove(index)} />
             </Task>
           );
         })}

--- a/apps/frontend/src/pages/Automation/AutomationFormConditionsStep.tsx
+++ b/apps/frontend/src/pages/Automation/AutomationFormConditionsStep.tsx
@@ -484,7 +484,7 @@ export function AutomationConditionsStep(props: {
               form={form}
               name={`${name}.${index}`}
             />
-            <RemoveButton onPress={() => remove(index)} />
+            <RemoveButton onClick={() => remove(index)} />
           </Task>
         ))}
 

--- a/apps/frontend/src/pages/Automation/AutomationTestNotification.tsx
+++ b/apps/frontend/src/pages/Automation/AutomationTestNotification.tsx
@@ -52,8 +52,8 @@ function useTestAutomation(props: UseTestAutomationProps) {
   return {
     isSent,
     buttonProps: {
-      isPending: testResult.loading,
-      onPress: async () => {
+      pending: testResult.loading,
+      onClick: async () => {
         try {
           form.clearErrors();
           await form.trigger();
@@ -94,14 +94,14 @@ function useTestAutomation(props: UseTestAutomationProps) {
 }
 
 interface TestAutomationButtonProps extends UseTestAutomationProps {
-  isDisabled?: boolean;
+  disabled?: boolean;
 }
 
 export function TestAutomationButton(props: TestAutomationButtonProps) {
-  const { isDisabled } = props;
+  const { disabled } = props;
   const { isSent, buttonProps } = useTestAutomation(props);
   return (
-    <Button variant="secondary" {...buttonProps} isDisabled={isDisabled}>
+    <Button variant="secondary" {...buttonProps} disabled={disabled}>
       {isSent ? (
         <>
           <ButtonIcon>

--- a/apps/frontend/src/pages/Automation/DeleteAutomation.tsx
+++ b/apps/frontend/src/pages/Automation/DeleteAutomation.tsx
@@ -84,7 +84,7 @@ export function DeleteAutomationDialog(props: {
         <DialogDismiss>Cancel</DialogDismiss>
         <Button
           variant="destructive"
-          onPress={() => {
+          onClick={() => {
             deactivateAutomationRule().catch((error) => {
               console.error("Failed to delete automation rule:", error);
             });

--- a/apps/frontend/src/pages/Automation/EditAutomation.tsx
+++ b/apps/frontend/src/pages/Automation/EditAutomation.tsx
@@ -179,7 +179,7 @@ function EditAutomationForm(props: {
               <TestAutomationButton
                 form={form}
                 projectId={project.id}
-                isDisabled={!hasEditPermission || form.formState.isSubmitting}
+                disabled={!hasEditPermission || form.formState.isSubmitting}
               />
             </div>
             <FormRootError control={form.control} />
@@ -220,7 +220,7 @@ function EditAutomationForm(props: {
             >
               <Button
                 type="submit"
-                isDisabled={!hasEditPermission || form.formState.isSubmitting}
+                disabled={!hasEditPermission || form.formState.isSubmitting}
                 className="order-3"
               >
                 Save Changes

--- a/apps/frontend/src/pages/Automation/NewAutomation.tsx
+++ b/apps/frontend/src/pages/Automation/NewAutomation.tsx
@@ -202,7 +202,7 @@ function NewAutomationForm(props: { project: ProjectDocument }) {
               <TestAutomationButton
                 form={form}
                 projectId={project.id}
-                isDisabled={form.formState.isSubmitting}
+                disabled={form.formState.isSubmitting}
               />
             </div>
             <FormRootError control={form.control} />
@@ -220,7 +220,7 @@ function NewAutomationForm(props: { project: ProjectDocument }) {
             </LinkButton>
             <Button
               type="submit"
-              isDisabled={form.formState.isSubmitting}
+              disabled={form.formState.isSubmitting}
               className="order-3"
             >
               Create Rule

--- a/apps/frontend/src/pages/Build/BuildDetailHeader.tsx
+++ b/apps/frontend/src/pages/Build/BuildDetailHeader.tsx
@@ -122,11 +122,11 @@ const BuildNavButtons = memo(function BuildNavButtons() {
     <>
       <PreviousButton
         toOverview={!hasPreviousDiff}
-        onPress={() =>
+        onClick={() =>
           hasPreviousDiff ? goToPreviousDiff() : goToBuildOverview()
         }
       />
-      <NextButton onPress={goToNextDiff} isDisabled={!hasNextDiff} />
+      <NextButton onClick={goToNextDiff} disabled={!hasNextDiff} />
     </>
   );
 });

--- a/apps/frontend/src/pages/Build/BuildDiffList.tsx
+++ b/apps/frontend/src/pages/Build/BuildDiffList.tsx
@@ -296,7 +296,7 @@ function getRows(
 
 function ListHeader(props: {
   style: React.HTMLProps<HTMLButtonElement>["style"];
-  onClick: RACButtonProps["onPress"];
+  onClick: RACButtonProps["onClick"];
   item: ListHeaderRow;
   activeIndex: number;
 }) {
@@ -310,7 +310,7 @@ function ListHeader(props: {
         "group/list-header bg-app data-hovered:bg-subtle data-focus-visible:bg-subtle border-t-thin z-10 flex w-full cursor-default items-center pr-2 text-left select-none focus:outline-hidden",
       )}
       style={style}
-      onPress={onClick}
+      onClick={onClick}
     >
       <ChevronDownIcon
         className={clsx(
@@ -381,7 +381,7 @@ function ShowSubItemToggle(
       <Button
         variant="secondary"
         size="small"
-        onPress={() => {
+        onClick={() => {
           onToggleGroupItem();
         }}
       >
@@ -451,12 +451,12 @@ const ListItem = memo(function ListItem(props: {
     <ListItemButton
       ref={ref}
       data-index={index}
-      onPress={() => {
+      onClick={() => {
         if (item.diff) {
           setActiveDiff(item.diff);
         }
       }}
-      isDisabled={!item.diff}
+      disabled={!item.diff}
       className="size-full"
     >
       <StatusDiffCard isActive={active} status={status}>
@@ -496,7 +496,7 @@ const ListItem = memo(function ListItem(props: {
               {isGroupItem && (
                 <div className="shrink-0 py-2">
                   <ShowSubItemToggle
-                    onPress={() => {
+                    onClick={() => {
                       onToggleGroupItem(item.diff?.group ?? null);
                     }}
                     onToggleGroupItem={() =>

--- a/apps/frontend/src/pages/Build/BuildOverview/BuildSummary.tsx
+++ b/apps/frontend/src/pages/Build/BuildOverview/BuildSummary.tsx
@@ -65,7 +65,7 @@ function BrowseSnapshotSection(props: { build: Build }) {
         <Button
           autoFocus
           variant={canStartReview ? "primary" : "secondary"}
-          onPress={browse}
+          onClick={browse}
         >
           {label}
         </Button>

--- a/apps/frontend/src/pages/Build/BuildOverview/ImpactAnalysisSection.tsx
+++ b/apps/frontend/src/pages/Build/BuildOverview/ImpactAnalysisSection.tsx
@@ -94,7 +94,7 @@ function AffectedItemsSection(props: {
       </ul>
       {collapsible && !expanded ? (
         <RACButton
-          onPress={() => setExpanded((value) => !value)}
+          onClick={() => setExpanded((value) => !value)}
           className="rac-focus text-low data-hovered:bg-ui data-hovered:text-default mx-2 mt-3 cursor-default rounded-full px-2 py-0.5 text-sm transition"
         >
           {props.seeAllLabel(items.length)}

--- a/apps/frontend/src/pages/Build/BuildPreviousReviewDialog.tsx
+++ b/apps/frontend/src/pages/Build/BuildPreviousReviewDialog.tsx
@@ -99,7 +99,7 @@ function ReapplyPreviousApprovalsButton(props: {
   const { close } = useOverlayTriggerState();
   return (
     <Button
-      onPress={() => {
+      onClick={() => {
         if (checkIsPending()) {
           return;
         }

--- a/apps/frontend/src/pages/Build/BuildReviewButton.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewButton.tsx
@@ -40,7 +40,7 @@ function BaseReviewButton(props: {
     <DialogTrigger open={isOpen} onOpenChange={setIsOpen}>
       <Button
         className="shrink-0"
-        isDisabled={props.disabled}
+        disabled={props.disabled}
         autoFocus={props.autoFocus}
       >
         {props.children ?? "Submit review"}
@@ -64,7 +64,7 @@ export function DisabledBuildReviewButton(props: { tooltip: React.ReactNode }) {
   return (
     <Tooltip content={props.tooltip}>
       <div>
-        <Button isDisabled>Submit review</Button>
+        <Button disabled>Submit review</Button>
       </div>
     </Tooltip>
   );

--- a/apps/frontend/src/pages/Build/BuildReviewForm.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewForm.tsx
@@ -162,8 +162,8 @@ export function BuildReviewForm(props: {
             size="small"
             iconOnly
             aria-label="Close"
-            onPress={() => state.close()}
-            isDisabled={isSubmitting}
+            onClick={() => state.close()}
+            disabled={isSubmitting}
           >
             <XIcon />
           </Button>
@@ -214,8 +214,8 @@ export function BuildReviewForm(props: {
                   variant={definition.variant}
                   size="small"
                   className="shrink-0"
-                  isPending={pendingEvent === event}
-                  isDisabled={
+                  pending={pendingEvent === event}
+                  disabled={
                     isLoading || (isSubmitting && pendingEvent !== event)
                   }
                   autoFocus={isDefault}

--- a/apps/frontend/src/pages/Build/BuildStatsIndicator.tsx
+++ b/apps/frontend/src/pages/Build/BuildStatsIndicator.tsx
@@ -88,7 +88,7 @@ function InteractiveStatCount({
           colorClassName,
           "data-disabled:opacity-disabled rac-focus flex cursor-default items-center gap-1 py-2 transition",
         )}
-        onPress={onActive}
+        onClick={onActive}
         isDisabled={count === 0}
       >
         <Icon className="size-3" />

--- a/apps/frontend/src/pages/Build/LeftSidebar.tsx
+++ b/apps/frontend/src/pages/Build/LeftSidebar.tsx
@@ -109,7 +109,7 @@ const LeftSidebarTabs = memo(function LeftSidebarTabs(props: {
                   variant="ghost"
                   iconOnly
                   size="small"
-                  onPress={() => setSearchMode(false)}
+                  onClick={() => setSearchMode(false)}
                 >
                   <XIcon />
                 </Button>
@@ -131,7 +131,7 @@ const LeftSidebarTabs = memo(function LeftSidebarTabs(props: {
                 <Button
                   variant="ghost"
                   iconOnly
-                  onPress={() => enterSearchMode()}
+                  onClick={() => enterSearchMode()}
                   size="small"
                 >
                   <SearchIcon />

--- a/apps/frontend/src/pages/Build/RejectCommentDialog.tsx
+++ b/apps/frontend/src/pages/Build/RejectCommentDialog.tsx
@@ -281,15 +281,15 @@ function RejectCommentDialog(props: {
         </div>
         {/*
           DialogDismiss disables itself while the modal action is pending and
-          closes the dialog after `onPress`. Skipping still advances to the next
+          closes the dialog after the click. Skipping still advances to the next
           diff to review, matching a submitted note.
         */}
         <DialogDismiss onClick={onProceed}>Skip</DialogDismiss>
         <Button
           variant="primary"
-          isPending={isPending}
+          pending={isPending}
           aria-disabled={isEmpty}
-          onPress={submit}
+          onClick={submit}
         >
           Add to review
         </Button>

--- a/apps/frontend/src/pages/Build/ReviewCommentSubmitButton.tsx
+++ b/apps/frontend/src/pages/Build/ReviewCommentSubmitButton.tsx
@@ -52,9 +52,9 @@ export function ReviewCommentSubmitButton(props: {
   /** Label/tooltip used when the build can't be drafted against. */
   fallbackLabel: string;
   isEmpty: boolean;
-  isPending: boolean;
+  pending: boolean;
   disabled?: boolean;
-  onPress: () => void;
+  onClick: () => void;
   className?: string;
 }) {
   const {
@@ -62,9 +62,9 @@ export function ReviewCommentSubmitButton(props: {
     altHeld,
     fallbackLabel,
     isEmpty,
-    isPending,
+    pending,
     disabled,
-    onPress,
+    onClick,
     className,
   } = props;
   const reviewMode = canAddToReview && !altHeld;
@@ -99,9 +99,9 @@ export function ReviewCommentSubmitButton(props: {
         // Truly disabled (not focusable/clickable) while submitting or when
         // disabled by the parent. When merely empty it only *looks* disabled but
         // stays clickable so the press can surface the "empty" toast.
-        isDisabled={disabled || isPending}
+        disabled={disabled || pending}
         aria-disabled={isEmpty}
-        onPress={onPress}
+        onClick={onClick}
         className={className}
       >
         <Icon />

--- a/apps/frontend/src/pages/Build/RightSidebar.tsx
+++ b/apps/frontend/src/pages/Build/RightSidebar.tsx
@@ -145,7 +145,7 @@ export function RightSidebarToggle() {
       description={open ? "Hide sidebar" : "Show sidebar"}
       keys={hotkey.displayKeys}
     >
-      <Button variant="secondary" iconOnly aria-pressed={open} onPress={toggle}>
+      <Button variant="secondary" iconOnly aria-pressed={open} onClick={toggle}>
         <PanelRightIcon />
       </Button>
     </HotkeyTooltip>

--- a/apps/frontend/src/pages/Build/TrackButtons.tsx
+++ b/apps/frontend/src/pages/Build/TrackButtons.tsx
@@ -83,8 +83,8 @@ function AcceptButton(props: {
         variant={isActive ? "success" : "secondary"}
         iconOnly
         aria-pressed={isActive}
-        onPress={toggle}
-        isDisabled={props.disabled}
+        onClick={toggle}
+        disabled={props.disabled}
       >
         <ThumbsUpIcon />
       </Button>
@@ -116,8 +116,8 @@ function RejectButton(props: {
         variant={isActive ? "danger" : "secondary"}
         iconOnly
         aria-pressed={isActive}
-        onPress={toggle}
-        isDisabled={props.disabled}
+        onClick={toggle}
+        disabled={props.disabled}
       >
         <ThumbsDownIcon />
       </Button>

--- a/apps/frontend/src/pages/Build/diffComments/DiffCommentDraft.tsx
+++ b/apps/frontend/src/pages/Build/diffComments/DiffCommentDraft.tsx
@@ -92,8 +92,8 @@ export function DiffCommentDraft(props: {
           <Button
             variant="ghost"
             size="small"
-            onPress={onCancel}
-            isDisabled={isPending}
+            onClick={onCancel}
+            disabled={isPending}
           >
             Cancel
           </Button>
@@ -118,10 +118,10 @@ export function DiffCommentDraft(props: {
             <Button
               variant="secondary"
               size="small"
-              onPress={submit}
+              onClick={submit}
               // Stays clickable while empty so the press can surface the toast;
               // only truly disabled while a submit is in flight.
-              isDisabled={isPending}
+              disabled={isPending}
               aria-disabled={isEmpty}
             >
               {reviewMode ? (

--- a/apps/frontend/src/pages/Build/metadata/filters/FilterChips.tsx
+++ b/apps/frontend/src/pages/Build/metadata/filters/FilterChips.tsx
@@ -66,7 +66,7 @@ const FilterChip = (props: {
         className="shrink-0"
         scale="xs"
         icon={XIcon}
-        onPress={() => {
+        onClick={() => {
           const otherKeys = state.active.difference(filterGroup.filterKeys);
           state.setActive(otherKeys);
         }}

--- a/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
@@ -69,7 +69,7 @@ function AttachedSnapshotToggle(props: {
       }
     >
       <Button
-        onPress={onToggle}
+        onClick={onToggle}
         aria-pressed={attached}
         aria-label={`${attached ? "Detach" : "Attach"} snapshot ${name}`}
         className={clsx(
@@ -145,15 +145,15 @@ export function AddCommentForm(props: {
         description: "Please add a comment before submitting.",
       }}
       aria-label="Add a comment"
-      renderSubmit={({ submit, isEmpty, isPending, disabled }) => (
+      renderSubmit={({ submit, isEmpty, pending, disabled }) => (
         <ReviewCommentSubmitButton
           canAddToReview={canAddToReview}
           altHeld={altHeld}
           fallbackLabel="Submit the comment"
           isEmpty={isEmpty}
-          isPending={isPending}
+          pending={pending}
           disabled={disabled}
-          onPress={submit}
+          onClick={submit}
         />
       )}
       footerStart={

--- a/apps/frontend/src/pages/Build/sidebar/CommentScreenshotReference.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentScreenshotReference.tsx
@@ -107,7 +107,7 @@ export function CommentScreenshotReference(props: {
 
   return (
     <Button
-      onPress={goToDiff}
+      onClick={goToDiff}
       aria-label={`Go to snapshot ${screenshotDiff.name}`}
       // No hover style or default cursor of its own: the surrounding card
       // shares this button's navigation and carries the hover affordance.

--- a/apps/frontend/src/pages/ConfirmAccountDeletion.tsx
+++ b/apps/frontend/src/pages/ConfirmAccountDeletion.tsx
@@ -70,7 +70,7 @@ function ConfirmProcess(props: { token: string }) {
           <Button
             variant="primary"
             size="large"
-            onPress={() => {
+            onClick={() => {
               logout({ redirectTo: "" });
             }}
           >
@@ -94,7 +94,7 @@ function ConfirmProcess(props: { token: string }) {
           <Button
             variant="primary"
             size="large"
-            onPress={() => {
+            onClick={() => {
               navigate("/");
             }}
           >
@@ -121,8 +121,8 @@ function ConfirmProcess(props: { token: string }) {
           variant="destructive"
           size="large"
           className="px-14!"
-          isPending={loading}
-          onPress={() => {
+          pending={loading}
+          onClick={() => {
             confirmDeletion().catch(() => {
               // Errors are surfaced via the `error` state above.
             });

--- a/apps/frontend/src/pages/Invite.tsx
+++ b/apps/frontend/src/pages/Invite.tsx
@@ -61,7 +61,7 @@ const AcceptInviteMutation = graphql(`
 `);
 
 function AcceptInviteButton(
-  props: { secret: string } & Omit<ButtonProps, "onPress">,
+  props: { secret: string } & Omit<ButtonProps, "onClick">,
 ) {
   const navigate = useNavigate();
   const auth = useAuth();
@@ -87,8 +87,8 @@ function AcceptInviteButton(
   return (
     <Button
       {...props}
-      isDisabled={loading || !!data || props.isDisabled}
-      onPress={() => {
+      disabled={loading || !!data || props.disabled}
+      onClick={() => {
         accept().catch(() => {});
       }}
     />

--- a/apps/frontend/src/pages/MediaShare.tsx
+++ b/apps/frontend/src/pages/MediaShare.tsx
@@ -629,7 +629,7 @@ function MediaActions(props: {
           variant="secondary"
           iconOnly
           aria-label="Copy link"
-          onPress={copyLink}
+          onClick={copyLink}
         >
           <LinkIcon />
         </Button>
@@ -639,7 +639,7 @@ function MediaActions(props: {
           variant="secondary"
           iconOnly
           aria-label="Download"
-          onPress={download}
+          onClick={download}
         >
           <DownloadIcon />
         </Button>
@@ -655,7 +655,7 @@ function MediaActions(props: {
             variant="secondary"
             iconOnly
             aria-label={format.label}
-            onPress={() => copyFormat(format)}
+            onClick={() => copyFormat(format)}
           >
             <FileTextIcon />
           </Button>

--- a/apps/frontend/src/pages/OAuthAuthorize.tsx
+++ b/apps/frontend/src/pages/OAuthAuthorize.tsx
@@ -389,7 +389,7 @@ function ConsentForm(props: {
         <div className="mt-4 flex w-full flex-col gap-2">
           <Button
             type="submit"
-            isDisabled={status === "loading"}
+            disabled={status === "loading"}
             size="large"
             className="w-full justify-center"
           >

--- a/apps/frontend/src/pages/Project/Builds.tsx
+++ b/apps/frontend/src/pages/Project/Builds.tsx
@@ -494,7 +494,7 @@ function PageContent(props: {
               There are no builds matching the filters.
             </Text>
             <EmptyStateActions>
-              <Button onPress={() => setFilters(null)}>Reset filters</Button>
+              <Button onClick={() => setFilters(null)}>Reset filters</Button>
             </EmptyStateActions>
           </EmptyState>
         ) : (

--- a/apps/frontend/src/pages/Project/GettingStarted.tsx
+++ b/apps/frontend/src/pages/Project/GettingStarted.tsx
@@ -338,7 +338,7 @@ function InstallStep(props: {
         status === "complete" && (
           <span className="text-low text-sm">
             Set up with {framework.name} ·{" "}
-            <TextLinkButton onPress={() => setForceOpen((open) => !open)}>
+            <TextLinkButton onClick={() => setForceOpen((open) => !open)}>
               {forceOpen ? "close" : "change"}
             </TextLinkButton>
           </span>

--- a/apps/frontend/src/pages/Project/IgnoredChanges.tsx
+++ b/apps/frontend/src/pages/Project/IgnoredChanges.tsx
@@ -705,7 +705,7 @@ function IgnoredChangeRow(props: {
             variant="secondary"
             size="small"
             className="opacity-0 transition-opacity group-focus-within/row:opacity-100 group-hover/row:opacity-100"
-            onPress={() =>
+            onClick={() =>
               onUnignore({
                 changeId: ignoredChange.id,
                 testName: test.name,

--- a/apps/frontend/src/pages/Project/Tests.tsx
+++ b/apps/frontend/src/pages/Project/Tests.tsx
@@ -298,7 +298,7 @@ function PageContent(props: {
               There is no tests matching the filters.
             </Text>
             <EmptyStateActions>
-              <Button onPress={() => setFilters(null)}>Reset filters</Button>
+              <Button onClick={() => setFilters(null)}>Reset filters</Button>
             </EmptyStateActions>
           </EmptyState>
         ) : (

--- a/apps/frontend/src/pages/Staff/Teams.tsx
+++ b/apps/frontend/src/pages/Staff/Teams.tsx
@@ -296,7 +296,7 @@ function StaffTeamRow(props: {
           </div>
         </td>
         <td className="p-4 text-right text-sm">
-          <Button variant="secondary" size="small" onPress={toggleMembers}>
+          <Button variant="secondary" size="small" onClick={toggleMembers}>
             {isOpened ? "Hide details" : "View details"}
           </Button>
         </td>
@@ -577,8 +577,8 @@ function StaffTeamsList() {
           <Button
             variant="secondary"
             size="small"
-            onPress={() => setPage((value) => Math.max(1, value - 1))}
-            isDisabled={currentPage <= 1}
+            onClick={() => setPage((value) => Math.max(1, value - 1))}
+            disabled={currentPage <= 1}
           >
             Previous
           </Button>
@@ -588,8 +588,8 @@ function StaffTeamsList() {
           <Button
             variant="secondary"
             size="small"
-            onPress={() => setPage((value) => Math.min(totalPages, value + 1))}
-            isDisabled={currentPage >= totalPages}
+            onClick={() => setPage((value) => Math.min(totalPages, value + 1))}
+            disabled={currentPage >= totalPages}
           >
             Next
           </Button>

--- a/apps/frontend/src/pages/Staff/Trials.tsx
+++ b/apps/frontend/src/pages/Staff/Trials.tsx
@@ -692,7 +692,7 @@ function ContactCell(props: { team: PipelineTeam }) {
         size="small"
         iconOnly
         aria-label="Draft outreach email"
-        onPress={() => {
+        onClick={() => {
           if (!contactedAt) {
             markContacted(true);
           }

--- a/apps/frontend/src/pages/Teams.tsx
+++ b/apps/frontend/src/pages/Teams.tsx
@@ -192,7 +192,7 @@ const JoinMutation = graphql(`
 function JoinButton(
   props: { teamAccountId: string; redirect?: string | null } & Omit<
     ButtonProps,
-    "onPress"
+    "onClick"
   >,
 ) {
   const { redirect, teamAccountId, ...buttonProps } = props;
@@ -210,8 +210,8 @@ function JoinButton(
   return (
     <Button
       {...buttonProps}
-      isDisabled={loading || !!data || buttonProps.isDisabled}
-      onPress={() => {
+      disabled={loading || !!data || buttonProps.disabled}
+      onClick={() => {
         accept().catch(() => {});
       }}
     />

--- a/apps/frontend/src/pages/TeamsInvite.tsx
+++ b/apps/frontend/src/pages/TeamsInvite.tsx
@@ -63,8 +63,8 @@ function JoinTeamButton(props: { secret: string; children: React.ReactNode }) {
   return (
     <Button
       size="large"
-      isDisabled={loading || !!data}
-      onPress={() => {
+      disabled={loading || !!data}
+      onClick={() => {
         accept().catch(() => {});
       }}
     >

--- a/apps/frontend/src/pages/Test/ChangesFilter.tsx
+++ b/apps/frontend/src/pages/Test/ChangesFilter.tsx
@@ -46,7 +46,7 @@ export function ChangesFilterToggle(props: { state: ChangesFilterState }) {
         variant="secondary"
         size="small"
         aria-pressed={state.value === "all"}
-        onPress={() => state.setValue("all")}
+        onClick={() => state.setValue("all")}
       >
         All
       </Button>
@@ -55,7 +55,7 @@ export function ChangesFilterToggle(props: { state: ChangesFilterState }) {
           variant="secondary"
           size="small"
           aria-pressed={state.value === "ignored"}
-          onPress={() => state.setValue("ignored")}
+          onClick={() => state.setValue("ignored")}
         >
           Ignored
         </Button>

--- a/apps/frontend/src/pages/Test/index.tsx
+++ b/apps/frontend/src/pages/Test/index.tsx
@@ -385,7 +385,7 @@ function ChangesExplorer(props: {
             <EmptyStateActions>
               <Button
                 variant="secondary"
-                onPress={() => filterState.setValue("all")}
+                onClick={() => filterState.setValue("all")}
               >
                 See all changes
               </Button>
@@ -469,11 +469,8 @@ function BuildHeader(props: {
   return (
     <div className="flex flex-wrap items-center justify-between gap-4">
       <div className="flex shrink-0 gap-1">
-        <PreviousButton
-          onPress={goToPreviousDiff}
-          isDisabled={!previousChange}
-        />
-        <NextButton onPress={goToNextDiff} isDisabled={!nextChange} />
+        <PreviousButton onClick={goToPreviousDiff} disabled={!previousChange} />
+        <NextButton onClick={goToNextDiff} disabled={!nextChange} />
       </div>
       <BuildDiffDetailToolbar diff={change.stats.lastSeenDiff}>
         <IgnoreButton diff={change.stats.lastSeenDiff} />
@@ -550,7 +547,7 @@ function ChangesList(props: {
       {test.changes.edges.map((change) => {
         const isActive = activeChange?.id === change.id;
         return (
-          <ListItemButton key={change.id} onPress={() => onSelect(change.id)}>
+          <ListItemButton key={change.id} onClick={() => onSelect(change.id)}>
             <DiffCard isActive={isActive} variant="primary">
               <DiffImage
                 diff={change.stats.lastSeenDiff}

--- a/apps/frontend/src/pages/VerifyEmail.tsx
+++ b/apps/frontend/src/pages/VerifyEmail.tsx
@@ -96,8 +96,8 @@ function VerifyProcess(props: { email: string; token: string }) {
           variant="primary"
           size="large"
           className="!px-14"
-          isPending={loading}
-          onPress={() => {
+          pending={loading}
+          onClick={() => {
             verifyEmail().catch(() => {
               // Ignore errors
             });

--- a/apps/frontend/src/pages/Welcome.tsx
+++ b/apps/frontend/src/pages/Welcome.tsx
@@ -408,7 +408,7 @@ function WelcomeForm() {
           <LinkButton
             className="text-sm"
             isDisabled={isSkipping || form.formState.isSubmitting}
-            onPress={() => {
+            onClick={() => {
               setIsSkipping(true);
               complete(null).catch(() => {
                 // The answers are optional, so a failure here is no reason to

--- a/apps/frontend/src/ui/Button.stories.tsx
+++ b/apps/frontend/src/ui/Button.stories.tsx
@@ -89,23 +89,23 @@ export const Default: Story = {
 
       <StoryTitle>Disabled</StoryTitle>
       <div className="flex flex-wrap items-center gap-4">
-        <Button variant="primary" isDisabled>
+        <Button variant="primary" disabled>
           Primary
         </Button>
-        <Button variant="secondary" isDisabled>
+        <Button variant="secondary" disabled>
           Secondary
         </Button>
-        <Button variant="destructive" isDisabled>
+        <Button variant="destructive" disabled>
           Destructive
         </Button>
       </div>
 
       <StoryTitle>Pending</StoryTitle>
       <div className="flex flex-wrap items-center gap-4">
-        <Button variant="primary" isPending>
+        <Button variant="primary" pending>
           Saving…
         </Button>
-        <Button variant="secondary" isPending>
+        <Button variant="secondary" pending>
           Loading…
         </Button>
       </div>

--- a/apps/frontend/src/ui/Button.tsx
+++ b/apps/frontend/src/ui/Button.tsx
@@ -3,7 +3,6 @@ import {
   cloneElement,
   useState,
   type ComponentPropsWithRef,
-  type MouseEvent,
 } from "react";
 import { Button as BaseButton } from "@base-ui/react/button";
 import { clsx } from "clsx";
@@ -264,30 +263,23 @@ function getButtonProps(options: ButtonOptions) {
 }
 
 export interface ButtonProps
-  extends Omit<ComponentPropsWithRef<"button">, "disabled">, ButtonOptions {
-  /**
-   * Kept from react-aria for now, and mapped to a click: renaming it at ~150
-   * call sites is its own change, so that a visual diff here can only be the
-   * new internals.
-   */
-  onPress?: (event: MouseEvent<HTMLElement>) => void;
-  isDisabled?: boolean;
+  extends ComponentPropsWithRef<"button">, ButtonOptions {
   /**
    * Holds the button in flight: it keeps its focus and its tooltip — hence
-   * `aria-disabled` rather than `disabled` — swallows presses, and shows a
+   * `aria-disabled` rather than `disabled` — swallows clicks, and shows a
    * spinner. react-aria's button had this built in; Base UI's does not.
    */
-  isPending?: boolean;
+  pending?: boolean;
   /**
    * Run an asynchronous action when the button is pressed.
    * Automatically set the button in pending mode and
    * handles errors.
    *
    * Deliberately *not* named `onAction`: react-aria spells a menu item's
-   * activation handler that way, and once `onPress` becomes `onClick` the two
-   * would be indistinguishable at a call site — `onClick={async () => …}` on a
-   * Button still type-checks and still runs, but silently loses the pending
-   * state, the error handling and the toast.
+   * activation handler that way, and `onClick` is indistinguishable from it at
+   * a call site — `onClick={async () => …}` on a Button still type-checks and
+   * still runs, but silently loses the pending state, the error handling and
+   * the toast.
    *
    * @example
    * <Button
@@ -309,10 +301,9 @@ export function Button({
   showFocusRing,
   children,
   onAsyncAction,
-  onPress,
   onClick,
-  isDisabled,
-  isPending,
+  disabled,
+  pending: pendingProp,
   type = "button",
   ...props
 }: ButtonProps) {
@@ -323,12 +314,12 @@ export function Button({
     showFocusRing,
   });
   const [isRunning, setIsRunning] = useState(false);
-  const pending = isPending ?? isRunning;
+  const pending = pendingProp ?? isRunning;
   return (
     <BaseButton
       {...buttonProps}
       className={clsx(buttonProps.className, "cursor-default", className)}
-      disabled={isDisabled}
+      disabled={disabled}
       // Pending is not disabled: the button stays focusable, so it keeps its
       // place in the tab order and its tooltip stays reachable.
       aria-disabled={pending || undefined}
@@ -338,7 +329,6 @@ export function Button({
           event.preventDefault();
           return;
         }
-        onPress?.(event);
         onClick?.(event);
         const promise = onAsyncAction?.();
         if (promise) {
@@ -374,13 +364,11 @@ export function Button({
 
 export interface LinkButtonProps
   extends ComponentPropsWithRef<"a">, ButtonOptions {
-  /** Mapped to a click, like `Button`'s — renamed in its own change. */
-  onPress?: (event: MouseEvent<HTMLElement>) => void;
   /**
-   * A link cannot be `disabled`, so it says so and refuses the navigation —
-   * which is what react-aria's `Link` did with the same prop.
+   * A link cannot really be disabled, so it says so and refuses the
+   * navigation — which is what react-aria's `Link` did with the same prop.
    */
-  isDisabled?: boolean;
+  disabled?: boolean;
 }
 
 /**
@@ -394,9 +382,8 @@ export function LinkButton({
   size,
   iconOnly,
   showFocusRing,
-  onPress,
   onClick,
-  isDisabled,
+  disabled,
   ...props
 }: LinkButtonProps) {
   const buttonProps = getButtonProps({
@@ -409,13 +396,12 @@ export function LinkButton({
     <RouterLink
       {...buttonProps}
       className={clsx(buttonProps.className, className)}
-      aria-disabled={isDisabled || undefined}
+      aria-disabled={disabled || undefined}
       onClick={(event) => {
-        if (isDisabled) {
+        if (disabled) {
           event.preventDefault();
           return;
         }
-        onPress?.(event);
         onClick?.(event);
       }}
       {...props}

--- a/apps/frontend/src/ui/Chip.stories.tsx
+++ b/apps/frontend/src/ui/Chip.stories.tsx
@@ -79,7 +79,7 @@ export const Default: Story = {
 
       <StoryTitle>Interactive</StoryTitle>
       <div className="flex flex-wrap gap-3">
-        <ChipButton color="primary" onPress={() => {}}>
+        <ChipButton color="primary" onClick={() => {}}>
           Button Chip
         </ChipButton>
         <ChipLink color="info" href="#">
@@ -95,13 +95,13 @@ export const Default: Story = {
               Color scheme
             </Chip>
             <Chip scale={scale}>is</Chip>
-            <ChipButton scale={scale} icon={SunIcon} onPress={() => {}}>
+            <ChipButton scale={scale} icon={SunIcon} onClick={() => {}}>
               light
             </ChipButton>
             <ChipButton
               scale={scale}
               icon={XIcon}
-              onPress={() => {}}
+              onClick={() => {}}
               aria-label="Remove Color scheme filter"
             />
           </ButtonGroup>
@@ -122,10 +122,10 @@ export const KeyboardFocus: Story = {
   },
   render: () => (
     <div className="flex flex-wrap items-center gap-4 p-4">
-      <ChipButton color="primary" icon={ZapIcon} onPress={() => {}}>
+      <ChipButton color="primary" icon={ZapIcon} onClick={() => {}}>
         Focused
       </ChipButton>
-      <ChipButton color="danger" icon={FlameIcon} onPress={() => {}}>
+      <ChipButton color="danger" icon={FlameIcon} onClick={() => {}}>
         Danger
       </ChipButton>
     </div>

--- a/apps/frontend/src/ui/CopyButton.tsx
+++ b/apps/frontend/src/ui/CopyButton.tsx
@@ -28,7 +28,7 @@ export function CopyButton({
           "text-low data-hovered:text-default bg-ui data-hovered:bg-hover data-pressed:bg-active data-focus-visible:ring-default cursor-default rounded-sm p-1 transition focus:outline-hidden data-focus-visible:ring-4",
           className,
         )}
-        onPress={copy}
+        onClick={copy}
         {...props}
       >
         <div className="relative size-[1em] overflow-hidden">

--- a/apps/frontend/src/ui/Dialog.stories.tsx
+++ b/apps/frontend/src/ui/Dialog.stories.tsx
@@ -141,7 +141,7 @@ export const OpenPending: Story = {
           </DialogBody>
           <DialogFooter>
             <DialogDismiss disabled>Cancel</DialogDismiss>
-            <Button variant="primary" isPending>
+            <Button variant="primary" pending>
               Transfer
             </Button>
           </DialogFooter>

--- a/apps/frontend/src/ui/Dialog.tsx
+++ b/apps/frontend/src/ui/Dialog.tsx
@@ -126,11 +126,11 @@ export function DialogDismiss(props: {
       ref={ref}
       className={rest.single ? "flex-1 justify-center" : undefined}
       variant="secondary"
-      onPress={() => {
+      onClick={() => {
         props.onClick?.();
         state.close();
       }}
-      isDisabled={rest.disabled || actionContext?.isPending}
+      disabled={rest.disabled || actionContext?.isPending}
     >
       {rest.children}
     </Button>
@@ -155,7 +155,7 @@ export function DialogActionButton(
   return (
     <Button
       {...rest}
-      isPending={actionContext.isPending ?? undefined}
+      pending={actionContext.isPending ?? undefined}
       onAsyncAction={async () => {
         actionContext.setIsPending(true);
         try {

--- a/apps/frontend/src/ui/Editor/EditorToolbar.tsx
+++ b/apps/frontend/src/ui/Editor/EditorToolbar.tsx
@@ -175,8 +175,8 @@ function FormatToolbar(props: {
         keys={[MOD, "B"]}
         icon={<BoldIcon />}
         isActive={state.isBold}
-        isDisabled={!state.canBold}
-        onPress={(chain) => chain.toggleBold()}
+        disabled={!state.canBold}
+        apply={(chain) => chain.toggleBold()}
       />
       <MarkButton
         editor={editor}
@@ -184,8 +184,8 @@ function FormatToolbar(props: {
         keys={[MOD, "I"]}
         icon={<ItalicIcon />}
         isActive={state.isItalic}
-        isDisabled={!state.canItalic}
-        onPress={(chain) => chain.toggleItalic()}
+        disabled={!state.canItalic}
+        apply={(chain) => chain.toggleItalic()}
       />
       <MarkButton
         editor={editor}
@@ -193,8 +193,8 @@ function FormatToolbar(props: {
         keys={[MOD, SHIFT, "S"]}
         icon={<StrikethroughIcon />}
         isActive={state.isStrike}
-        isDisabled={!state.canStrike}
-        onPress={(chain) => chain.toggleStrike()}
+        disabled={!state.canStrike}
+        apply={(chain) => chain.toggleStrike()}
       />
       <MarkButton
         editor={editor}
@@ -202,8 +202,8 @@ function FormatToolbar(props: {
         keys={[MOD, "U"]}
         icon={<UnderlineIcon />}
         isActive={state.isUnderline}
-        isDisabled={!state.canUnderline}
-        onPress={(chain) => chain.toggleUnderline()}
+        disabled={!state.canUnderline}
+        apply={(chain) => chain.toggleUnderline()}
       />
       <LinkButton state={state} onEnterLinkMode={onEnterLinkMode} />
       <MarkButton
@@ -212,8 +212,8 @@ function FormatToolbar(props: {
         keys={[MOD, SHIFT, "B"]}
         icon={<QuoteIcon />}
         isActive={state.isBlockquote}
-        isDisabled={!state.canBlockquote}
-        onPress={(chain) => chain.toggleBlockquote()}
+        disabled={!state.canBlockquote}
+        apply={(chain) => chain.toggleBlockquote()}
       />
       <MarkButton
         editor={editor}
@@ -221,8 +221,8 @@ function FormatToolbar(props: {
         keys={[MOD, "E"]}
         icon={<CodeIcon />}
         isActive={state.isCode}
-        isDisabled={!state.canCode}
-        onPress={(chain) => chain.toggleCode()}
+        disabled={!state.canCode}
+        apply={(chain) => chain.toggleCode()}
       />
       <MarkButton
         editor={editor}
@@ -230,8 +230,8 @@ function FormatToolbar(props: {
         keys={[MOD, ALT, "C"]}
         icon={<SquareCodeIcon />}
         isActive={state.isCodeBlock}
-        isDisabled={!state.canCodeBlock}
-        onPress={(chain) => chain.toggleCodeBlock()}
+        disabled={!state.canCodeBlock}
+        apply={(chain) => chain.toggleCodeBlock()}
       />
       <ListMenu editor={editor} state={state} />
     </>
@@ -251,8 +251,8 @@ function LinkButton(props: {
         size="small"
         aria-label="Link"
         aria-pressed={state.isLink}
-        isDisabled={!state.isLink && !state.canSetLink}
-        onPress={onEnterLinkMode}
+        disabled={!state.isLink && !state.canSetLink}
+        onClick={onEnterLinkMode}
       >
         <LinkIcon />
       </Button>

--- a/apps/frontend/src/ui/Editor/EditorToolbarLinkInput.tsx
+++ b/apps/frontend/src/ui/Editor/EditorToolbarLinkInput.tsx
@@ -119,8 +119,8 @@ export function EditorToolbarLinkInput(props: EditorToolbarLinkInputProps) {
           iconOnly
           size="small"
           aria-label="Open link"
-          isDisabled={!normalized}
-          onPress={open}
+          disabled={!normalized}
+          onClick={open}
         >
           <ExternalLinkIcon />
         </Button>
@@ -131,8 +131,8 @@ export function EditorToolbarLinkInput(props: EditorToolbarLinkInputProps) {
           iconOnly
           size="small"
           aria-label="Remove link"
-          isDisabled={!hasLink}
-          onPress={remove}
+          disabled={!hasLink}
+          onClick={remove}
         >
           <Trash2Icon />
         </Button>

--- a/apps/frontend/src/ui/Editor/MarkButton.tsx
+++ b/apps/frontend/src/ui/Editor/MarkButton.tsx
@@ -11,10 +11,15 @@ export function MarkButton(props: {
   keys: string[];
   icon: ReactElement;
   isActive: boolean;
-  isDisabled: boolean;
-  onPress: (chain: ReturnType<Editor["chain"]>) => ReturnType<Editor["chain"]>;
+  disabled: boolean;
+  /**
+   * The tiptap transform this button applies — deliberately not `onPress` or
+   * `onClick`: it takes a command chain and returns it, and a name that reads
+   * as a click handler invites someone to pass one.
+   */
+  apply: (chain: ReturnType<Editor["chain"]>) => ReturnType<Editor["chain"]>;
 }) {
-  const { editor, label, keys, icon, isActive, isDisabled, onPress } = props;
+  const { editor, label, keys, icon, isActive, disabled, apply } = props;
   return (
     <HotkeyTooltip description={label} keys={keys}>
       <Button
@@ -23,8 +28,8 @@ export function MarkButton(props: {
         size="small"
         aria-label={label}
         aria-pressed={isActive}
-        isDisabled={isDisabled}
-        onPress={() => onPress(editor.chain().focus()).run()}
+        disabled={disabled}
+        onClick={() => apply(editor.chain().focus()).run()}
       >
         {icon}
       </Button>

--- a/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
+++ b/apps/frontend/src/ui/Editor/StandaloneEditor.tsx
@@ -66,7 +66,7 @@ export interface StandaloneEditorProps {
   renderSubmit?: (args: {
     submit: () => void;
     isEmpty: boolean;
-    isPending: boolean;
+    pending: boolean;
     disabled: boolean;
   }) => React.ReactNode;
   /** Users that can be mentioned with `@`, forwarded to the {@link Editor}. */
@@ -170,8 +170,8 @@ export function StandaloneEditor(props: StandaloneEditorProps) {
             <Button
               variant="ghost"
               size="small"
-              onPress={onCancel}
-              isDisabled={isPending}
+              onClick={onCancel}
+              disabled={isPending}
             >
               Cancel
             </Button>
@@ -183,12 +183,12 @@ export function StandaloneEditor(props: StandaloneEditorProps) {
               <Button
                 variant="secondary"
                 size="small"
-                onPress={submit}
+                onClick={submit}
                 // Truly disabled (not focusable/clickable) while submitting or
                 // when disabled by the parent. When the editor is merely empty
                 // it only *looks* disabled but stays clickable, so the press can
                 // surface the "empty" toast.
-                isDisabled={disabled || isPending}
+                disabled={disabled || isPending}
                 aria-disabled={isEmpty}
               >
                 {submitLabel}
@@ -207,7 +207,7 @@ export function StandaloneEditor(props: StandaloneEditorProps) {
                 {renderSubmit({
                   submit,
                   isEmpty,
-                  isPending,
+                  pending: isPending,
                   disabled: Boolean(disabled),
                 })}
               </div>
@@ -226,9 +226,9 @@ export function StandaloneEditor(props: StandaloneEditorProps) {
                   // disabled by the parent. When the editor is merely empty it only
                   // *looks* disabled but stays clickable, so the press can surface the
                   // "empty" toast.
-                  isDisabled={disabled || isPending}
+                  disabled={disabled || isPending}
                   aria-disabled={isEmpty}
-                  onPress={submit}
+                  onClick={submit}
                   className="ml-auto"
                 >
                   <ArrowUpIcon />

--- a/apps/frontend/src/ui/EmojiPicker.tsx
+++ b/apps/frontend/src/ui/EmojiPicker.tsx
@@ -128,7 +128,7 @@ export function EmojiPickerField<TFieldValues extends FieldValues>(
         aria-label={ariaLabel}
         {...buttonProps}
         ref={mergedRef}
-        isDisabled={field.disabled || buttonProps?.isDisabled}
+        disabled={field.disabled || buttonProps?.disabled}
         onBlur={(event) => {
           field.onBlur();
           buttonProps?.onBlur?.(event);

--- a/apps/frontend/src/ui/FormCardFooter.tsx
+++ b/apps/frontend/src/ui/FormCardFooter.tsx
@@ -12,11 +12,11 @@ export function FormCardFooter<
 >(props: {
   children?: React.ReactNode;
   actions?: React.ReactNode;
-  isDisabled?: boolean;
+  disabled?: boolean;
   isSuccessful?: boolean;
   control: Control<TFieldValues, TContext, TTransformedValues>;
 }) {
-  const { control, children, actions, isDisabled, isSuccessful } = props;
+  const { control, children, actions, disabled, isSuccessful } = props;
   return (
     <CardFooter className="flex items-center justify-between gap-4">
       <div>{children}</div>
@@ -26,11 +26,7 @@ export function FormCardFooter<
         <FormSuccess control={control} isSuccessful={isSuccessful}>
           Saved
         </FormSuccess>
-        <FormSubmit
-          control={control}
-          isDisabled={isDisabled}
-          disableIfPristine
-        />
+        <FormSubmit control={control} disabled={disabled} disableIfPristine />
       </div>
     </CardFooter>
   );

--- a/apps/frontend/src/ui/FormSubmit.tsx
+++ b/apps/frontend/src/ui/FormSubmit.tsx
@@ -16,10 +16,10 @@ export function FormSubmit<
   TContext = any,
   TTransformedValues = TFieldValues,
 >(props: FormSubmitProps<TFieldValues, TContext, TTransformedValues>) {
-  const { control, isDisabled: isDisabledProp } = props;
+  const { control, disabled: disabledProp } = props;
   const formState = useFormState({ control });
-  const isDisabled =
-    isDisabledProp || (props.disableIfPristine && !formState.isDirty);
+  const disabled =
+    disabledProp || (props.disableIfPristine && !formState.isDirty);
   return (
     <Button
       type="submit"
@@ -29,8 +29,8 @@ export function FormSubmit<
       // react-aria's `preventFocusOnPress`; refusing the mousedown is what it
       // did underneath.
       onMouseDown={(event) => event.preventDefault()}
-      isDisabled={isDisabled}
-      isPending={props.isPending || formState.isSubmitting}
+      disabled={disabled}
+      pending={props.pending || formState.isSubmitting}
     >
       {props.children ?? "Save"}
     </Button>

--- a/apps/frontend/src/ui/List.tsx
+++ b/apps/frontend/src/ui/List.tsx
@@ -87,17 +87,17 @@ export function ListRowLoader(props: ListRowProps & ListLoaderProps) {
   );
 }
 
-export function ListLoadMore(props: { onPress: () => void }) {
+export function ListLoadMore(props: { onClick: () => void }) {
   const [isPending, startTransition] = useTransition();
   return (
     <div className="pt-2">
       <Button
         variant="secondary"
         className="w-full justify-center"
-        isPending={isPending}
-        onPress={() => {
+        pending={isPending}
+        onClick={() => {
           startTransition(() => {
-            props.onPress();
+            props.onClick();
           });
         }}
       >

--- a/apps/frontend/src/ui/StripeLink.tsx
+++ b/apps/frontend/src/ui/StripeLink.tsx
@@ -64,8 +64,8 @@ export function StripePortalLink({
 
   return asButton ? (
     <Button
-      isDisabled={disabled}
-      onPress={handlePress}
+      disabled={disabled}
+      onClick={handlePress}
       className="!cursor-pointer"
     >
       {children}
@@ -74,7 +74,7 @@ export function StripePortalLink({
     <LinkButton
       isDisabled={disabled}
       className="inline-flex cursor-pointer items-center"
-      onPress={handlePress}
+      onClick={handlePress}
     >
       {children}
     </LinkButton>
@@ -119,7 +119,7 @@ const useRedirectToStripeCheckout = () => {
 };
 
 export function StripeCheckoutButton({
-  isDisabled,
+  disabled,
   accountId,
   successUrl,
   cancelUrl,
@@ -134,14 +134,14 @@ export function StripeCheckoutButton({
   return (
     <Button
       type="button"
-      onPress={() => {
+      onClick={() => {
         redirect({
           accountId,
           successUrl,
           cancelUrl,
         });
       }}
-      isDisabled={isDisabled || status === "loading"}
+      disabled={disabled || status === "loading"}
       {...props}
     />
   );

--- a/apps/frontend/src/ui/Toaster.stories.tsx
+++ b/apps/frontend/src/ui/Toaster.stories.tsx
@@ -25,37 +25,37 @@ export const Default: Story = {
     <div className="flex flex-wrap gap-2">
       <Button
         variant="secondary"
-        onPress={() => toast("Issue URL copied to clipboard")}
+        onClick={() => toast("Issue URL copied to clipboard")}
       >
         Default
       </Button>
       <Button
         variant="secondary"
-        onPress={() => toast.info("A new version of Argos is available")}
+        onClick={() => toast.info("A new version of Argos is available")}
       >
         Info
       </Button>
       <Button
         variant="secondary"
-        onPress={() => toast.success("Invitations sent successfully")}
+        onClick={() => toast.success("Invitations sent successfully")}
       >
         Success
       </Button>
       <Button
         variant="secondary"
-        onPress={() => toast.error("Something went wrong, please try again")}
+        onClick={() => toast.error("Something went wrong, please try again")}
       >
         Danger
       </Button>
       <Button
         variant="secondary"
-        onPress={() => toast.warning("Your trial expires in 3 days")}
+        onClick={() => toast.warning("Your trial expires in 3 days")}
       >
         Warning
       </Button>
       <Button
         variant="secondary"
-        onPress={() =>
+        onClick={() =>
           toast("greg/arg-462-expose-all-flakiness-stats-in-the-apicli", {
             description:
               "Branch name copied to clipboard. Paste it into your favorite git client.",
@@ -66,7 +66,7 @@ export const Default: Story = {
       </Button>
       <Button
         variant="secondary"
-        onPress={() =>
+        onClick={() =>
           toast.success("Build #4821 approved", {
             description: "12 screenshots changed",
             action: {
@@ -80,7 +80,7 @@ export const Default: Story = {
       </Button>
       <Button
         variant="secondary"
-        onPress={() =>
+        onClick={() =>
           toast.promise(
             new Promise((resolve) => {
               setTimeout(resolve, 2000);
@@ -97,7 +97,7 @@ export const Default: Story = {
       </Button>
       <Button
         variant="secondary"
-        onPress={() =>
+        onClick={() =>
           toast('"ARG-462" copied to clipboard', { id: "copy-issue-id" })
         }
       >


### PR DESCRIPTION
The other half of the Button batch: `onPress` → `onClick`, `isDisabled` → `disabled`, `isPending` → `pending`, across ~270 call sites.

**The rename only, on purpose.** The elements underneath did not move, so this cannot shift a pixel — and the generated CSS is **byte-identical** to the commit before it, which is the check that says so.

## Two names were traps, not renames

`tsc` caught both, which is the whole reason the plan wanted the wrapper declarations renamed first and the oracle trusted over grep.

**`MarkButton.onPress(chain)` was never a click handler.** It takes a tiptap command chain and returns it. An attribute-scoped rename turned seven toolbar call sites into `onClick={(chain) => chain.toggleBold()}` — which type-checks against a `MouseEvent` parameter and would have quietly broken bold, italic, strike, underline, blockquote, code and code-block. It is `apply` now, a name nobody will hand a click handler to.

**Not every `isDisabled` was ours.** The rules match attributes, not components, so they also hit things still speaking react-aria: the `RadioGroup`s in Signup and Welcome, the two bare `RACButton`s, and `ui/Link`'s own `LinkButton` — a different component from `ui/Button`'s, and still react-aria underneath. All reverted; they keep react-aria's spelling until their own batch.

## Along for the ride

`ListItemButton` was the last `useButton`. Base UI says the same thing with `nativeButton={false}` — it supplies the role, the tab index and the Enter/Space handling that the hook was providing for a `<div>` — which also retires an `onHoverChange` prop no caller ever passed.

## Verification

`static-checks` 11/11 · Storybook **81/81** · chromium e2e **97 passed** (the one red is the local rate-limiter).

Most importantly: **the built CSS is identical to the previous commit's, declaration for declaration**. A rename that had accidentally dropped a handler or a state would not show up in a screenshot, so the e2e suite is what covers behaviour, and it is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)