### PR TITLE
refactor(ui): move the tabs off react-aria

### DIFF
--- a/apps/frontend/src/containers/Team/members/Members.tsx
+++ b/apps/frontend/src/containers/Team/members/Members.tsx
@@ -1,5 +1,4 @@
 import { Suspense, useState } from "react";
-import { TabPanel, Tabs } from "react-aria-components";
 
 import { useAssertAuthAccount } from "@/containers/Auth";
 import { DocumentType, graphql } from "@/gql";
@@ -15,7 +14,7 @@ import {
 import { DialogTrigger } from "@/ui/Dialog";
 import { List, ListRowLoader } from "@/ui/List";
 import { Modal } from "@/ui/Modal";
-import { Tab, TabList } from "@/ui/Tab";
+import { Tab, TabList, TabPanel, Tabs } from "@/ui/Tab";
 
 import { TeamGithubMembersList } from "./GitHubMembersList";
 import { InviteDialog } from "./InviteDialog";
@@ -95,15 +94,15 @@ export function TeamMembers(props: {
         <CardParagraph>
           Add members to your team to give them access to your projects.
         </CardParagraph>
-        <Tabs>
+        <Tabs defaultValue="members">
           <TabList className="border-b">
-            <Tab id="members">Members</Tab>
+            <Tab value="members">Members</Tab>
             {team.ssoGithubAccount ? (
-              <Tab id="pending-github-members">Pending GitHub Members</Tab>
+              <Tab value="pending-github-members">Pending GitHub Members</Tab>
             ) : null}
-            {amOwner ? <Tab id="pending">Pending Invitations</Tab> : null}
+            {amOwner ? <Tab value="pending">Pending Invitations</Tab> : null}
           </TabList>
-          <TabPanel id="members" className="my-4">
+          <TabPanel value="members" className="my-4">
             <Suspense fallback={<ListPlaceholder />}>
               <TeamMembersList
                 teamId={team.id}
@@ -115,7 +114,7 @@ export function TeamMembers(props: {
             </Suspense>
           </TabPanel>
           {team.ssoGithubAccount ? (
-            <TabPanel id="pending-github-members" className="my-4">
+            <TabPanel value="pending-github-members" className="my-4">
               <Suspense fallback={<ListPlaceholder aria-busy />}>
                 <TeamGithubMembersList
                   teamId={team.id}
@@ -129,7 +128,7 @@ export function TeamMembers(props: {
             </TabPanel>
           ) : null}
           {amOwner ? (
-            <TabPanel id="pending" className="my-4">
+            <TabPanel value="pending" className="my-4">
               <Suspense fallback={<ListPlaceholder aria-busy />}>
                 <TeamInvitesList team={team} amOwner={amOwner} />
               </Suspense>

--- a/apps/frontend/src/pages/Account/index.tsx
+++ b/apps/frontend/src/pages/Account/index.tsx
@@ -8,8 +8,7 @@ import { PaymentBanner } from "@/containers/PaymentBanner";
 import { DocumentType, graphql } from "@/gql";
 import { AccountPermission } from "@/gql/graphql";
 import { PageLoader } from "@/ui/PageLoader";
-import { TabList } from "@/ui/Tab";
-import { TabLink, TabLinkPanel, TabsLink } from "@/ui/TabLink";
+import { TabLink, TabLinkPanel, TabsLink, TabLinkList } from "@/ui/TabLink";
 
 import { NotFound } from "../NotFound";
 
@@ -37,12 +36,12 @@ export const useAccountContext = () => {
 function AccountTabs({ account }: { account: Account }) {
   return (
     <TabsLink className="flex min-h-0 flex-1 flex-col">
-      <TabList className="px-4" aria-label="Account navigation">
+      <TabLinkList className="px-4" aria-label="Account navigation">
         <TabLink href="">Projects</TabLink>
         <TabLink href="~/analytics">Analytics</TabLink>
         <TabLink href="~/tests">Tests</TabLink>
         <TabLink href="settings">Settings</TabLink>
-      </TabList>
+      </TabLinkList>
       <hr className="border-t" />
       <PaymentBanner account={account} />
       <TabLinkPanel className="flex flex-1 flex-col">

--- a/apps/frontend/src/pages/Build/LeftSidebar.tsx
+++ b/apps/frontend/src/pages/Build/LeftSidebar.tsx
@@ -1,13 +1,12 @@
 import { memo, startTransition, useCallback, useRef } from "react";
 import { SearchIcon, XIcon } from "lucide-react";
-import { TabList as RACTabList, TabPanel, Tabs } from "react-aria-components";
 
 import { useBuildHotkey } from "@/containers/Build/BuildHotkeys";
 import { DocumentType, graphql } from "@/gql";
 import { BuildType } from "@/gql/graphql";
 import { Button } from "@/ui/Button";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
-import { PillTab } from "@/ui/Tab";
+import { PillTab, TabList, TabPanel, Tabs } from "@/ui/Tab";
 
 import { BuildDiffList } from "./BuildDiffList";
 import { useSearchModeState, useSearchState } from "./BuildDiffState";
@@ -93,7 +92,7 @@ const LeftSidebarTabs = memo(function LeftSidebarTabs(props: {
   });
   return (
     <Tabs
-      defaultSelectedKey={!build.stats?.total ? "info" : "snapshots"}
+      defaultValue={!build.stats?.total ? "info" : "snapshots"}
       className="group/sidebar flex min-h-0 flex-1 shrink-0 flex-col"
     >
       {build.type !== BuildType.Skipped ? (
@@ -117,13 +116,13 @@ const LeftSidebarTabs = memo(function LeftSidebarTabs(props: {
             </>
           ) : (
             <>
-              <RACTabList
+              <TabList
                 className="flex flex-1 shrink-0 gap-2"
                 aria-label="Build details"
               >
-                <PillTab id="snapshots">Snapshots</PillTab>
-                <PillTab id="info">Info</PillTab>
-              </RACTabList>
+                <PillTab value="snapshots">Snapshots</PillTab>
+                <PillTab value="info">Info</PillTab>
+              </TabList>
               <HotkeyTooltip
                 keys={searchModeHotKey.displayKeys}
                 description="Find"
@@ -151,13 +150,16 @@ const LeftSidebarTabs = memo(function LeftSidebarTabs(props: {
       ) : (
         <>
           {build.type !== BuildType.Skipped ? (
-            <TabPanel id="snapshots" className="flex min-h-0 flex-1 flex-col">
+            <TabPanel
+              value="snapshots"
+              className="flex min-h-0 flex-1 flex-col"
+            >
               <FilterChips />
               <BuildDiffList />
             </TabPanel>
           ) : null}
 
-          <TabPanel id="info" className="flex-1 overflow-auto p-4">
+          <TabPanel value="info" className="flex-1 overflow-auto p-4">
             <BuildInfos
               build={build}
               repoUrl={props.repoUrl}

--- a/apps/frontend/src/pages/Build/RightSidebar.tsx
+++ b/apps/frontend/src/pages/Build/RightSidebar.tsx
@@ -2,12 +2,6 @@ import { useEffect } from "react";
 import clsx from "clsx";
 import { useAtom } from "jotai";
 import { PanelRightIcon } from "lucide-react";
-import {
-  TabList as RACTabList,
-  TabPanel,
-  Tabs,
-  type TabPanelProps,
-} from "react-aria-components";
 import { useLocation } from "react-router";
 
 import { useBuildHotkey } from "@/containers/Build/BuildHotkeys";
@@ -15,7 +9,7 @@ import { DocumentType, graphql } from "@/gql";
 import { Button } from "@/ui/Button";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 import { Sidebar } from "@/ui/Sidebar";
-import { PillTab } from "@/ui/Tab";
+import { PillTab, TabList, TabPanel, Tabs } from "@/ui/Tab";
 
 import { useBuildDiffState } from "./BuildDiffState";
 import {
@@ -79,50 +73,48 @@ export function RightSidebar(
   }
   return (
     <Tabs
-      selectedKey={tab}
-      onSelectionChange={(key) => setTab(key as RightSidebarTab)}
+      value={tab}
+      onValueChange={(key) => setTab(key as RightSidebarTab)}
       className="flex min-h-0 max-w-80 flex-1 flex-col"
     >
-      {() => (
-        <Sidebar>
-          <RACTabList aria-label="Sidebar" className="flex shrink-0 gap-2 py-2">
-            <PillTab id="snapshot">Snapshot</PillTab>
-            <PillTab id="review">Review</PillTab>
-          </RACTabList>
-          <SidebarTabPanel id="snapshot">
-            <MetadataSection
-              diff={activeDiff}
-              siblingDiffs={siblingDiffs}
-              {...context}
-            />
-            {activeDiff.test ? (
-              <>
-                {activeDiff.change ? (
-                  <TestChangeSection
-                    test={activeDiff.test}
-                    change={activeDiff.change}
-                    occurrences={activeDiff.last7daysOccurrences}
-                  />
-                ) : null}
-                <TestInsightsSection test={activeDiff.test} />
-                <TestActivitySection
+      <Sidebar>
+        <TabList aria-label="Sidebar" className="flex shrink-0 gap-2 py-2">
+          <PillTab value="snapshot">Snapshot</PillTab>
+          <PillTab value="review">Review</PillTab>
+        </TabList>
+        <SidebarTabPanel value="snapshot">
+          <MetadataSection
+            diff={activeDiff}
+            siblingDiffs={siblingDiffs}
+            {...context}
+          />
+          {activeDiff.test ? (
+            <>
+              {activeDiff.change ? (
+                <TestChangeSection
                   test={activeDiff.test}
-                  change={activeDiff.change ?? null}
+                  change={activeDiff.change}
+                  occurrences={activeDiff.last7daysOccurrences}
                 />
-              </>
-            ) : null}
-          </SidebarTabPanel>
-          <SidebarTabPanel id="review">
-            <ReviewersSection build={build} />
-            <ReviewActivitySection build={build} />
-          </SidebarTabPanel>
-        </Sidebar>
-      )}
+              ) : null}
+              <TestInsightsSection test={activeDiff.test} />
+              <TestActivitySection
+                test={activeDiff.test}
+                change={activeDiff.change ?? null}
+              />
+            </>
+          ) : null}
+        </SidebarTabPanel>
+        <SidebarTabPanel value="review">
+          <ReviewersSection build={build} />
+          <ReviewActivitySection build={build} />
+        </SidebarTabPanel>
+      </Sidebar>
     </Tabs>
   );
 }
 
-function SidebarTabPanel(props: TabPanelProps) {
+function SidebarTabPanel(props: React.ComponentProps<typeof TabPanel>) {
   return (
     <TabPanel
       {...props}

--- a/apps/frontend/src/pages/Project/index.tsx
+++ b/apps/frontend/src/pages/Project/index.tsx
@@ -8,8 +8,7 @@ import { PaymentBanner } from "@/containers/PaymentBanner";
 import { DocumentType, graphql } from "@/gql";
 import { ProjectPermission } from "@/gql/graphql";
 import { PageLoader } from "@/ui/PageLoader";
-import { TabList } from "@/ui/Tab";
-import { TabLink, TabLinkPanel, TabsLink } from "@/ui/TabLink";
+import { TabLink, TabLinkPanel, TabsLink, TabLinkList } from "@/ui/TabLink";
 
 import { NotFound } from "../NotFound";
 import type { ProjectOutletContext } from "./ProjectOutletContext";
@@ -51,7 +50,7 @@ function ProjectTabs(props: {
     isTeam && permissions.includes(ProjectPermission.ViewSettings);
   return (
     <TabsLink className="flex min-h-0 flex-1 flex-col">
-      <TabList className="px-4" aria-label="Project navigation">
+      <TabLinkList className="px-4" aria-label="Project navigation">
         <TabLink href="">Builds</TabLink>
         <TabLink href="tests">Tests</TabLink>
         {/* The ignore ledger is only meaningful while the feature is on; the
@@ -64,7 +63,7 @@ function ProjectTabs(props: {
         {permissions.includes(ProjectPermission.ViewSettings) && (
           <TabLink href="settings">Settings</TabLink>
         )}
-      </TabList>
+      </TabLinkList>
       <hr className="border-t" />
       <PaymentBanner account={account} />
       <TabLinkPanel className="flex min-h-0 flex-1 flex-col">

--- a/apps/frontend/src/pages/Staff/index.tsx
+++ b/apps/frontend/src/pages/Staff/index.tsx
@@ -2,8 +2,7 @@ import { Suspense } from "react";
 import { Outlet } from "react-router";
 
 import { PageLoader } from "@/ui/PageLoader";
-import { TabList } from "@/ui/Tab";
-import { TabLink, TabLinkPanel, TabsLink } from "@/ui/TabLink";
+import { TabLink, TabLinkPanel, TabsLink, TabLinkList } from "@/ui/TabLink";
 
 /**
  * Shell for the staff-only pages, mirroring the account layout so the staff
@@ -17,10 +16,10 @@ export function Component() {
   // tab bar sits on the app background like the account tabs do.
   return (
     <TabsLink className="flex min-h-0 flex-1 flex-col">
-      <TabList className="px-4" aria-label="Staff navigation">
+      <TabLinkList className="px-4" aria-label="Staff navigation">
         <TabLink href="teams">All teams</TabLink>
         <TabLink href="trials">Trials</TabLink>
-      </TabList>
+      </TabLinkList>
       <hr className="border-t" />
       <TabLinkPanel className="flex flex-1 flex-col">
         <Suspense fallback={<PageLoader />}>

--- a/apps/frontend/src/ui/Tab.stories.tsx
+++ b/apps/frontend/src/ui/Tab.stories.tsx
@@ -1,11 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { TabPanel, Tabs } from "react-aria-components";
 
-import { PillTab, Tab, TabList } from "./Tab";
+import { PillTab, Tab, TabList, TabPanel, Tabs } from "./Tab";
 
 const meta = {
   title: "UI/Tab",
   component: Tab,
+  args: { value: "overview", children: "Overview" },
 } satisfies Meta<typeof Tab>;
 
 export default meta;
@@ -13,19 +13,19 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: () => (
-    <Tabs>
+    <Tabs defaultValue="overview">
       <TabList>
-        <Tab id="overview">Overview</Tab>
-        <Tab id="builds">Builds</Tab>
-        <Tab id="settings">Settings</Tab>
+        <Tab value="overview">Overview</Tab>
+        <Tab value="builds">Builds</Tab>
+        <Tab value="settings">Settings</Tab>
       </TabList>
-      <TabPanel id="overview" className="p-4 text-sm">
+      <TabPanel value="overview" className="p-4 text-sm">
         Overview content
       </TabPanel>
-      <TabPanel id="builds" className="p-4 text-sm">
+      <TabPanel value="builds" className="p-4 text-sm">
         Builds content
       </TabPanel>
-      <TabPanel id="settings" className="p-4 text-sm">
+      <TabPanel value="settings" className="p-4 text-sm">
         Settings content
       </TabPanel>
     </Tabs>
@@ -41,15 +41,15 @@ export const Default: Story = {
  */
 export const Pill: Story = {
   render: () => (
-    <Tabs>
+    <Tabs defaultValue="snapshot">
       <TabList className="flex gap-2 p-4">
-        <PillTab id="snapshot">Snapshot</PillTab>
-        <PillTab id="review">Review</PillTab>
+        <PillTab value="snapshot">Snapshot</PillTab>
+        <PillTab value="review">Review</PillTab>
       </TabList>
-      <TabPanel id="snapshot" className="px-4 pb-4 text-sm">
+      <TabPanel value="snapshot" className="px-4 pb-4 text-sm">
         Snapshot content
       </TabPanel>
-      <TabPanel id="review" className="px-4 pb-4 text-sm">
+      <TabPanel value="review" className="px-4 pb-4 text-sm">
         Review content
       </TabPanel>
     </Tabs>

--- a/apps/frontend/src/ui/Tab.tsx
+++ b/apps/frontend/src/ui/Tab.tsx
@@ -1,45 +1,63 @@
+import type { ComponentPropsWithRef, ReactNode } from "react";
+import { Tabs as BaseTabs } from "@base-ui/react/tabs";
 import { clsx } from "clsx";
-import {
-  Tab as RACTab,
-  TabList as RACTabList,
-  TabListProps,
-  type TabProps,
-} from "react-aria-components";
 
 import { getButtonClassName } from "./Button";
 
-export function TabList<T extends object>(props: TabListProps<T>) {
+/**
+ * A set of tabs and the panels they switch between.
+ *
+ * Only for tabs that swap content in place. A row of links that happens to
+ * look like tabs is navigation, and lives in `TabLink`.
+ */
+export function Tabs(props: {
+  children: ReactNode;
+  value?: string | null;
+  defaultValue?: string | null;
+  onValueChange?: (value: string | null) => void;
+  className?: string;
+}) {
+  return <BaseTabs.Root {...props} />;
+}
+
+export function TabList(
+  props: ComponentPropsWithRef<"div"> & { "aria-label"?: string },
+) {
   return (
-    <RACTabList
+    <BaseTabs.List
       {...props}
-      className={clsx("relative container mx-auto", props.className)}
+      className={clsx(tabListClassName, props.className)}
     />
   );
 }
 
-export function Tab(props: TabProps) {
+export function TabPanel(
+  props: ComponentPropsWithRef<"div"> & { value: string },
+) {
+  return <BaseTabs.Panel {...props} />;
+}
+
+/** How a tab looks. Shared with `TabLink`, which is one wearing a link. */
+export const tabClassName =
+  "text-low hover:text-default aria-selected:text-default focus-visible:ring-default z-10 -mb-px inline-block cursor-pointer rounded-t border-b-2 border-b-transparent p-3 text-sm font-medium transition focus:outline-hidden aria-selected:cursor-default aria-selected:border-b-current focus-visible:ring-2";
+
+/** The row a set of tabs sits in. Shared with `TabLink`'s own list. */
+export const tabListClassName = "relative container mx-auto";
+
+export function Tab(props: BaseTabs.Tab.Props & { value: string }) {
   return (
-    <RACTab
-      {...props}
-      className={clsx(
-        "text-low hover:text-default aria-selected:text-default data-focus-visible:ring-default z-10 -mb-px inline-block cursor-pointer rounded-t border-b-2 border-b-transparent p-3 text-sm font-medium transition focus:outline-hidden aria-selected:cursor-default aria-selected:border-b-current data-focus-visible:ring-2",
-        props.className,
-      )}
-    />
+    <BaseTabs.Tab {...props} className={clsx(tabClassName, props.className)} />
   );
 }
 
 /**
  * A tab that sits in a row of controls rather than under a page title: it wears
- * the secondary button surface, and fills in when selected.
+ * the secondary button surface, and fills in when selected — which the `on`
+ * variant reads off its `aria-selected`.
  */
-export function PillTab(
-  props: TabProps & {
-    ref?: React.Ref<HTMLDivElement>;
-  },
-) {
+export function PillTab(props: BaseTabs.Tab.Props & { value: string }) {
   return (
-    <RACTab
+    <BaseTabs.Tab
       {...props}
       className={clsx(
         getButtonClassName({ variant: "secondary", size: "small" }),

--- a/apps/frontend/src/ui/TabLink.tsx
+++ b/apps/frontend/src/ui/TabLink.tsx
@@ -1,7 +1,9 @@
-import { TabPanel, Tabs } from "react-aria-components";
+import type { ReactNode } from "react";
+import { clsx } from "clsx";
 import { useHref, useLocation, useResolvedPath } from "react-router";
 
-import { Tab } from "./Tab";
+import { RouterLink } from "./RouterLink";
+import { tabClassName, tabListClassName } from "./Tab";
 
 function stripAfterFirstSegment(pathname: string): string {
   // Do not consider /~/ as a segment
@@ -18,35 +20,68 @@ function useSelectedKey() {
   return selectedKey;
 }
 
-export function TabsLink(props: {
-  children: React.ReactNode;
+/**
+ * A row of tabs whose selection is the route.
+ *
+ * Spelled out rather than built on Base UI's `Tabs`: these are links, and the
+ * thing below them is the router's outlet, so there is no state for a tab
+ * widget to own. Handing `Tabs.Tab` a `render` element it rebuilds every
+ * render sent its registration into a loop — React error #185 — and the
+ * machinery bought nothing, because the route already decides which one is
+ * selected.
+ *
+ * The roles stay what react-aria produced, which is also what the project
+ * spec locates them by: a `tablist` of `tab`s that happen to be anchors.
+ */
+export function TabsLink(props: { children: ReactNode; className?: string }) {
+  return <div {...props} />;
+}
+
+export function TabLinkList(props: {
+  children: ReactNode;
   className?: string;
+  "aria-label"?: string;
 }) {
-  const resolvedPath = useResolvedPath("");
-  const selectedKey = useSelectedKey();
+  const { className, ...rest } = props;
   return (
-    <Tabs key={resolvedPath.pathname} selectedKey={selectedKey} {...props} />
+    <div
+      role="tablist"
+      {...rest}
+      className={clsx(tabListClassName, className)}
+    />
   );
 }
 
 export function TabLinkPanel(props: {
-  children: React.ReactNode;
+  children: ReactNode;
   className?: string;
 }) {
-  const selectedKey = useSelectedKey();
-  return <TabPanel id={selectedKey} {...props} />;
+  return <div role="tabpanel" {...props} />;
 }
 
 export function TabLink({
   href,
+  className,
   ...props
 }: {
   href: string;
-  children: React.ReactNode;
+  children: ReactNode;
   className?: string;
 }) {
   const resolvedPath = useResolvedPath("");
   const resolvedHref = useHref(href);
   const id = resolvedHref.replace(resolvedPath.pathname, "");
-  return <Tab key={id} id={id} href={resolvedHref} {...props} />;
+  const selected = id === useSelectedKey();
+  return (
+    <RouterLink
+      role="tab"
+      aria-selected={selected}
+      // The one you are on is also the current page, which is what the
+      // settings navigation next to it says of itself.
+      aria-current={selected ? "page" : undefined}
+      href={resolvedHref}
+      className={clsx(tabClassName, className)}
+      {...props}
+    />
+  );
 }


### PR DESCRIPTION
Next batch: **Tab, TabList, TabPanel, PillTab and the page tabs.**

Two things wore the same component and wanted different halves of it, which is the whole story of this one.

## Real tabs → Base UI

The members card and the two build sidebars are genuine tab widgets: they swap content in place. They are Base UI's `Tabs` now — `id` becomes `value`, `selectedKey`/`onSelectionChange` become `value`/`onValueChange`, and `TabPanel` comes from `ui/Tab` instead of being imported from react-aria at each call site.

## The page tabs are links, and stay hand-written

`TabLink` drives the account, project and staff page navigation. Base UI's `Tabs` looked like the obvious home for it and was the wrong one, twice over:

- Handing `Tabs.Tab` a `render` element — which is how you make a tab an anchor — rebuilds that element every render, and Base UI's tab registration looped on it. **React error #185, every one of those pages a blank error screen.** The e2e caught it; nothing else would have.
- The machinery bought nothing anyway. There is no state for a tab widget to own here: the route decides which tab is on, and the thing below is the router's outlet, not a panel.

So they are spelled out — a `tablist` of anchors, which is exactly the shape react-aria produced and the shape `project.spec.ts` locates them by (`getByRole("tab", …)`). They share the real tabs' look through an exported `tabClassName`, so the two cannot drift apart.

I also gave the current tab `aria-current="page"` alongside `aria-selected`, matching what the settings navigation beside it already said of itself.

## A correction worth recording

My first attempt made these plain `NavLink`s, reasoning that navigation should be links and that `NavLink` gives `aria-current` for free. That was wrong on this codebase's contract: the spec asserts `role="tab"`, and "Deployments" exists as *both* a page tab and a settings-sidebar link — so demoting the tab to a link made that locator ambiguous. The `aria-current` assertion the migration plan flagged turned out to belong to `ui/Nav`, which this batch does not touch.

## Verification

`static-checks` 11/11 · Storybook **81/81** · chromium e2e **98 passed, 0 failed**.

`ui-tab--default` and `ui-tab--pill` both render identical to their baselines, and the pill's selected fill still comes from the `on` variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)