### PR TITLE
refactor(ui): move links and chips off react-aria

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,15 @@
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["--filter", "@argos/frontend", "storybook"],
       "port": 6006
+    },
+    {
+      "name": "web",
+      "runtimeExecutable": "sh",
+      "runtimeArgs": [
+        "-c",
+        "NODE_ENV=test pnpm run --filter @argos/backend start-web"
+      ],
+      "port": 3000
     }
   ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -79,9 +79,14 @@
                   "MenuTrigger",
                   "MenuItem",
                   "Autocomplete",
-                  "SearchField"
+                  "SearchField",
+                  "Link",
+                  "Tabs",
+                  "Tab",
+                  "TabList",
+                  "TabPanel"
                 ],
-                "message": "These have moved to Base UI: import from @/ui/Select, @/ui/ListBox, @/ui/Dialog, @/ui/Modal, @/ui/Popover or @/ui/menu-kit. A react-aria part inside a Base UI tree type-checks and then throws at runtime, which no screenshot catches."
+                "message": "These have moved to Base UI: import from @/ui/Select, @/ui/ListBox, @/ui/Dialog, @/ui/Modal, @/ui/Popover, @/ui/Link, @/ui/Tab or @/ui/menu-kit. A react-aria part inside a Base UI tree type-checks and then throws at runtime, which no screenshot catches."
               }
             ]
           }

--- a/apps/frontend/src/containers/AuthWithEmail.tsx
+++ b/apps/frontend/src/containers/AuthWithEmail.tsx
@@ -4,7 +4,7 @@ import { AlertCircleIcon } from "lucide-react";
 
 import { graphql } from "@/gql";
 import { ErrorMessage } from "@/ui/ErrorMessage";
-import { LinkButton } from "@/ui/Link";
+import { LinkStyleButton } from "@/ui/Link";
 import { Loader } from "@/ui/Loader";
 import { OTPInput } from "@/ui/OTPInput";
 import { checkIsErrorCode, getErrorMessage } from "@/util/error";
@@ -78,9 +78,9 @@ export function AuthWithEmail(props: {
             Verifying…
           </div>
         ) : (
-          <LinkButton className="w-full text-center" onClick={onBack}>
+          <LinkStyleButton className="w-full text-center" onClick={onBack}>
             ← Back
-          </LinkButton>
+          </LinkStyleButton>
         )}
       </div>
     </div>

--- a/apps/frontend/src/containers/SignupOptions.tsx
+++ b/apps/frontend/src/containers/SignupOptions.tsx
@@ -18,7 +18,7 @@ import { Form } from "@/ui/Form";
 import { FormRootToastError } from "@/ui/FormRootError";
 import { FormSubmit } from "@/ui/FormSubmit";
 import { FormTextInput } from "@/ui/FormTextInput";
-import { LinkButton } from "@/ui/Link";
+import { LinkStyleButton } from "@/ui/Link";
 
 import { AuthWithEmail } from "./AuthWithEmail";
 import { lastLoginMethodAtom } from "./LastLoginMethod";
@@ -134,9 +134,9 @@ function EmailScreen(props: {
         </ButtonIcon>
         Continue with email
       </FormSubmit>
-      <LinkButton className="mt-6 w-full text-center" onClick={onBack}>
+      <LinkStyleButton className="mt-6 w-full text-center" onClick={onBack}>
         ← Other Sign Up options
-      </LinkButton>
+      </LinkStyleButton>
     </Form>
   );
 }
@@ -173,12 +173,12 @@ function ProvidersScreen(props: {
       >
         Continue with GitLab
       </GitLabLoginButton>
-      <LinkButton
+      <LinkStyleButton
         className="mt-2 w-full text-center"
         onClick={onContinueWithEmail}
       >
         Continue with Email →
-      </LinkButton>
+      </LinkStyleButton>
     </div>
   );
 }

--- a/apps/frontend/src/containers/Test/SeenChange.tsx
+++ b/apps/frontend/src/containers/Test/SeenChange.tsx
@@ -36,7 +36,7 @@ export function SeenChange(props: {
         <div className="text-low text-xs">
           In build{" "}
           <HeadlessLink
-            className="rac-focus hover:text-default underline"
+            className="hover:text-default underline"
             href={getBuildURL({
               ...params,
               buildNumber: diff.build.number,

--- a/apps/frontend/src/pages/Account/Tests.tsx
+++ b/apps/frontend/src/pages/Account/Tests.tsx
@@ -375,7 +375,7 @@ function TestRow(props: {
       <div className="w-40 truncate">
         <HeadlessLink
           href={`/${accountSlug}/${projectName}/tests`}
-          className="rac-focus hover:text-default truncate underline"
+          className="hover:text-default truncate underline"
         >
           {projectName}
         </HeadlessLink>

--- a/apps/frontend/src/pages/Build/header/BuildHeader.tsx
+++ b/apps/frontend/src/pages/Build/header/BuildHeader.tsx
@@ -82,7 +82,7 @@ const ProjectLink = memo(
       <Tooltip content="See all builds">
         <HeadlessLink
           href={`${getProjectURL({ accountSlug, projectName })}/builds`}
-          className="text-low data-hovered:text-default rac-focus truncate text-xs leading-tight transition"
+          className="text-low hover:text-default truncate text-xs leading-tight transition"
         >
           {accountSlug}/{projectName}
         </HeadlessLink>
@@ -228,7 +228,7 @@ export const BuildHeader = memo(
                     projectName: props.projectName,
                     buildNumber: props.buildNumber,
                   })}
-                  className="data-hovered:text-default rac-focus truncate text-sm leading-tight font-medium transition"
+                  className="hover:text-default truncate text-sm leading-tight font-medium transition"
                 >
                   Build {props.buildNumber}
                   {build && build.name !== "default" ? ` • ${build.name}` : ""}

--- a/apps/frontend/src/pages/MediaShare.tsx
+++ b/apps/frontend/src/pages/MediaShare.tsx
@@ -767,7 +767,7 @@ function PageHeader(props: { media: Media }) {
           <Tooltip content="See all builds">
             <HeadlessLink
               href={`/${media.project.slug}/builds`}
-              className="text-low data-hovered:text-default rac-focus min-w-0 truncate text-xs leading-none transition"
+              className="text-low hover:text-default min-w-0 truncate text-xs leading-none transition"
             >
               {media.project.slug}
             </HeadlessLink>

--- a/apps/frontend/src/pages/Project/GettingStarted.tsx
+++ b/apps/frontend/src/pages/Project/GettingStarted.tsx
@@ -15,7 +15,7 @@ import { BuildStatusChip } from "@/containers/BuildStatusChip";
 import { DocumentType, graphql } from "@/gql";
 import { LinkButton } from "@/ui/Button";
 import { Code } from "@/ui/Code";
-import { HeadlessLink, Link, LinkButton as TextLinkButton } from "@/ui/Link";
+import { HeadlessLink, Link, LinkStyleButton } from "@/ui/Link";
 import { Loader } from "@/ui/Loader";
 import { PageLoader } from "@/ui/PageLoader";
 import { Pre } from "@/ui/Pre";
@@ -338,9 +338,9 @@ function InstallStep(props: {
         status === "complete" && (
           <span className="text-low text-sm">
             Set up with {framework.name} ·{" "}
-            <TextLinkButton onClick={() => setForceOpen((open) => !open)}>
+            <LinkStyleButton onClick={() => setForceOpen((open) => !open)}>
               {forceOpen ? "close" : "change"}
-            </TextLinkButton>
+            </LinkStyleButton>
           </span>
         )
       }

--- a/apps/frontend/src/pages/Welcome.tsx
+++ b/apps/frontend/src/pages/Welcome.tsx
@@ -33,7 +33,7 @@ import { FormSubmit } from "@/ui/FormSubmit";
 import { FormTextInput } from "@/ui/FormTextInput";
 import { Heading } from "@/ui/Heading";
 import { Label } from "@/ui/Label";
-import { LinkButton } from "@/ui/Link";
+import { LinkStyleButton } from "@/ui/Link";
 import { resolveWelcomeRedirect } from "@/util/welcome";
 
 const AutoJoinQuery = graphql(`
@@ -405,9 +405,9 @@ function WelcomeForm() {
         ) : null}
 
         <div className="mt-8 flex items-center justify-between gap-4">
-          <LinkButton
+          <LinkStyleButton
             className="text-sm"
-            isDisabled={isSkipping || form.formState.isSubmitting}
+            disabled={isSkipping || form.formState.isSubmitting}
             onClick={() => {
               setIsSkipping(true);
               complete(null).catch(() => {
@@ -418,7 +418,7 @@ function WelcomeForm() {
             }}
           >
             Skip
-          </LinkButton>
+          </LinkStyleButton>
           <div className="flex items-center gap-4">
             <FormRootError control={form.control} />
             <FormSubmit control={form.control} size="large">

--- a/apps/frontend/src/ui/Chip.stories.tsx
+++ b/apps/frontend/src/ui/Chip.stories.tsx
@@ -112,9 +112,9 @@ export const Default: Story = {
 };
 
 /**
- * Keyboard focus on a chip button — the one baseline of the `rac-focus`
- * utility, which encodes react-aria's "outline on keyboard focus only" contract
- * and has to be rebuilt on `:focus-visible`.
+ * Keyboard focus on a chip button — the one baseline of the `focus-ring`
+ * utility, which keeps react-aria's "outline on keyboard focus only" contract
+ * now that it is the browser's own `:focus-visible` doing the deciding.
  */
 export const KeyboardFocus: Story = {
   play: async () => {

--- a/apps/frontend/src/ui/Chip.tsx
+++ b/apps/frontend/src/ui/Chip.tsx
@@ -1,23 +1,19 @@
 import {
   cloneElement,
-  ComponentProps,
+  ComponentPropsWithRef,
   createContext,
   isValidElement,
   use,
 } from "react";
 import { clsx } from "clsx";
-import {
-  Button as RACButton,
-  ButtonProps as RACButtonProps,
-  Link as RACLink,
-  LinkProps as RACLinkProps,
-} from "react-aria-components";
 
 import {
   lowTextColorClassNames,
   textColorClassNames,
   UIColor,
 } from "@/util/colors";
+
+import { RouterLink } from "./RouterLink";
 
 export type ChipColor = UIColor | "blank";
 
@@ -65,30 +61,30 @@ function useChipContextProps<T extends Partial<ChipOptions>>(props: T): T {
 
 const interactiveClassNames: Record<ChipColor, string> = {
   primary: clsx(
-    "data-hovered:not-aria-[current=page]:bg-primary-hover",
-    "data-hovered:not-aria-[current=page]:text-primary",
+    "hover:not-aria-[current=page]:bg-primary-hover",
+    "hover:not-aria-[current=page]:text-primary",
     "aria-[current=page]:bg-primary-active",
     "aria-[current=page]:text-primary",
-    "data-pressed:bg-primary-active",
-    "data-pressed:text-primary",
+    "active:bg-primary-active",
+    "active:text-primary",
   ),
-  info: "data-hovered:not-aria-[current=page]:bg-info-hover aria-[current=page]:bg-info-active data-pressed:bg-info-active",
+  info: "hover:not-aria-[current=page]:bg-info-hover aria-[current=page]:bg-info-active active:bg-info-active",
   success:
-    "data-hovered:not-aria-[current=page]:bg-success-hover aria-[current=page]:bg-success-active data-pressed:bg-success-active",
+    "hover:not-aria-[current=page]:bg-success-hover aria-[current=page]:bg-success-active active:bg-success-active",
   neutral:
-    "data-hovered:not-aria-[current=page]:bg-hover aria-[current=page]:bg-active aria-[current=page]:text-default data-pressed:bg-active",
+    "hover:not-aria-[current=page]:bg-hover aria-[current=page]:bg-active aria-[current=page]:text-default active:bg-active",
   pending:
-    "data-hovered:not-aria-[current=page]:bg-pending-hover aria-[current=page]:bg-pending-active data-pressed:bg-pending-active",
+    "hover:not-aria-[current=page]:bg-pending-hover aria-[current=page]:bg-pending-active active:bg-pending-active",
   danger:
-    "data-hovered:not-aria-[current=page]:bg-danger-hover aria-[current=page]:bg-danger-active data-pressed:bg-danger-active",
+    "hover:not-aria-[current=page]:bg-danger-hover aria-[current=page]:bg-danger-active active:bg-danger-active",
   warning:
-    "data-hovered:not-aria-[current=page]:bg-warning-hover aria-[current=page]:bg-warning-active data-pressed:bg-warning-active",
+    "hover:not-aria-[current=page]:bg-warning-hover aria-[current=page]:bg-warning-active active:bg-warning-active",
   storybook:
-    "data-hovered:not-aria-[current=page]:bg-storybook-hover aria-[current=page]:bg-storybook-active data-pressed:bg-storybook-active",
+    "hover:not-aria-[current=page]:bg-storybook-hover aria-[current=page]:bg-storybook-active active:bg-storybook-active",
   blank: clsx(
-    "data-hovered:not-aria-[current=page]:bg-hover data-pressed:bg-active",
+    "hover:not-aria-[current=page]:bg-hover active:bg-active",
     "group-[*]/button-group:not-aria-[current=page]:opacity-60",
-    "group-[*]/button-group:data-hovered:not-aria-[current=page]:opacity-100",
+    "group-[*]/button-group:hover:not-aria-[current=page]:opacity-100",
     "group-[*]/button-group:border-default",
   ),
 };
@@ -153,7 +149,7 @@ function getChipClassName(props: {
   return clsx(
     colorClassNames[color],
     interactive && interactiveClassNames[color],
-    interactive && "rac-focus",
+    interactive && "focus-ring",
     textSizeClassName[scale],
     spacingClassName[scale],
     "py-(--chip-py)",
@@ -233,28 +229,20 @@ export function Chip(rawProps: ChipProps) {
   return <div {...chipProps} />;
 }
 
-export type ChipLinkProps = Omit<
-  RACLinkProps,
-  "color" | "className" | "children"
-> &
-  Pick<ComponentProps<"a">, "className" | "children"> &
+export type ChipLinkProps = Omit<ComponentPropsWithRef<"a">, "color"> &
   ChipOptions;
 
 export function ChipLink(rawProps: ChipLinkProps) {
   const props = useChipContextProps(rawProps);
   const { chipProps } = useChip({ ...props, elementType: "a" });
-  return <RACLink {...chipProps} />;
+  return <RouterLink {...chipProps} />;
 }
 
-type ChipButtonProps = Omit<
-  RACButtonProps,
-  "color" | "className" | "children"
-> &
-  Pick<ComponentProps<"button">, "className" | "children"> &
+type ChipButtonProps = Omit<ComponentPropsWithRef<"button">, "color"> &
   ChipOptions;
 
-export function ChipButton(rawProps: ChipButtonProps) {
+export function ChipButton({ type = "button", ...rawProps }: ChipButtonProps) {
   const props = useChipContextProps(rawProps);
   const { chipProps } = useChip({ ...props, elementType: "button" });
-  return <RACButton {...chipProps} />;
+  return <button type={type} {...chipProps} />;
 }

--- a/apps/frontend/src/ui/Link.tsx
+++ b/apps/frontend/src/ui/Link.tsx
@@ -1,24 +1,23 @@
 import {
   createContext,
   use,
+  type ComponentPropsWithRef,
   type HTMLAttributeAnchorTarget,
-  type RefAttributes,
 } from "react";
-import { invariant } from "@argos/util/invariant";
 import { clsx } from "clsx";
 import { ExternalLinkIcon } from "lucide-react";
-import {
-  Button,
-  Link as RACLink,
-  LinkProps as RACLinkProps,
-  type ButtonProps,
-} from "react-aria-components";
 
-export type HeadlessLinkProps = RACLinkProps & {
-  ref?: React.Ref<HTMLAnchorElement>;
+import { RouterLink } from "./RouterLink";
+
+export type HeadlessLinkProps = ComponentPropsWithRef<"a"> & {
   external?: boolean;
 };
 
+/**
+ * Whether we are already inside a link. An anchor nested in an anchor is
+ * invalid HTML — the parser closes the outer one at the inner one's tag — so a
+ * link that finds itself inside another renders as a {@link FakeLink}.
+ */
 const LinkContext = createContext<boolean>(false);
 
 export function HeadlessLink({
@@ -30,16 +29,12 @@ export function HeadlessLink({
   ...props
 }: HeadlessLinkProps) {
   const inLink = use(LinkContext);
-  const isExternal =
-    external !== undefined
-      ? external
-      : typeof children !== "function" && target === "_blank";
+  const isExternal = external ?? target === "_blank";
 
   if (inLink || !props.href) {
-    invariant(typeof children !== "function");
     return (
       <FakeLink
-        className={clsx("rac-focus", className)}
+        className={clsx("focus-ring", className)}
         href={props.href}
         target={target}
         isExternal={isExternal}
@@ -49,50 +44,51 @@ export function HeadlessLink({
     );
   }
   return (
-    <RACLink
-      ref={ref}
-      className={clsx("rac-focus", className)}
-      target={target}
-      {...props}
-    >
-      {(props) => {
-        const content =
-          typeof children === "function" ? children(props) : children;
-        return (
-          <LinkContext value>
-            {isExternal ? (
-              <>
-                {content}
-                <ExternalIndicator />
-              </>
-            ) : (
-              content
-            )}
-          </LinkContext>
-        );
-      }}
-    </RACLink>
+    <LinkContext value>
+      <RouterLink
+        ref={ref}
+        className={clsx("focus-ring", className)}
+        target={target}
+        {...props}
+      >
+        {children}
+        {isExternal ? <ExternalIndicator /> : null}
+      </RouterLink>
+    </LinkContext>
   );
 }
 
 function getLinkClassName(props: Pick<LinkProps, "variant">) {
   const { variant = "primary" } = props;
   return clsx(
-    "rac-focus no-underline",
-    "not-data-disabled:hover:underline no-data-disabled:cursor-pointer",
+    "focus-ring no-underline",
+    // A dead link stops reading as one, and it dies two ways: an anchor with
+    // no href — `FakeLink` marks it `data-disabled` — or a disabled
+    // `LinkStyleButton`. react-aria spelled both `data-disabled`; the DOM
+    // spells the second one `:disabled`.
+    "not-data-disabled:not-disabled:hover:underline",
+    "not-data-disabled:not-disabled:cursor-pointer",
     { neutral: "text-default", primary: "text-primary-low" }[variant],
   );
 }
 
-export function LinkButton({
+/**
+ * A button that reads as a link: the same colour, and the same underline on
+ * hover, but it runs an action instead of going somewhere.
+ *
+ * Named for what it wears, because `ui/Button`'s `LinkButton` is the mirror
+ * image — a link wearing a button — and the two used to be told apart only by
+ * which module they were imported from.
+ */
+export function LinkStyleButton({
   className,
   variant,
+  type = "button",
   ...props
-}: ButtonProps &
-  RefAttributes<HTMLButtonElement> &
-  Pick<LinkProps, "variant">) {
+}: ComponentPropsWithRef<"button"> & Pick<LinkProps, "variant">) {
   return (
-    <Button
+    <button
+      type={type}
       className={clsx(getLinkClassName({ variant }), className)}
       {...props}
     />

--- a/apps/frontend/src/ui/List.tsx
+++ b/apps/frontend/src/ui/List.tsx
@@ -30,7 +30,7 @@ export function ListRowLink(props: Omit<HeadlessLinkProps, "external">) {
       {...props}
       className={clsx(
         listRowClassName,
-        "data-hovered:bg-hover data-focus-visible:bg-hover focus:outline-hidden",
+        "hover:bg-hover focus-visible:bg-hover focus:outline-hidden",
         props.className,
       )}
     />

--- a/apps/frontend/src/ui/StripeLink.tsx
+++ b/apps/frontend/src/ui/StripeLink.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { APIError, fetchApi } from "@/util/api";
 
 import { Button, ButtonProps } from "./Button";
-import { LinkButton } from "./Link";
+import { LinkStyleButton } from "./Link";
 import { toast } from "./Toaster";
 import { useEventCallback } from "./useEventCallback";
 
@@ -71,13 +71,13 @@ export function StripePortalLink({
       {children}
     </Button>
   ) : (
-    <LinkButton
-      isDisabled={disabled}
-      className="inline-flex cursor-pointer items-center"
+    <LinkStyleButton
+      disabled={disabled}
+      className="inline-flex items-center"
       onClick={handlePress}
     >
       {children}
-    </LinkButton>
+    </LinkStyleButton>
   );
 }
 


### PR DESCRIPTION
Continues the Base UI migration. `ui/Link` was the root of what was left in this batch: `Breadcrumb` has no react-aria of its own, it just composes `HeadlessLink`, and `Chip` was reaching for react-aria's `Link` and `Button` directly.

## Links

`HeadlessLink` renders `RouterLink`, so routing is React Router's rather than a `RouterProvider` react-aria reads through, and `rac-focus` becomes `focus-ring` — the browser's `:focus-visible` doing what react-aria's modality tracking stood in for. No call site passed render-prop children, so those went too, and the nested-link branch lost the `invariant` guarding against them.

**`LinkButton` is now `LinkStyleButton`.** `ui/Button` exports the mirror image under the old name — a link wearing a button, rather than a button wearing a link — and one call site had already resorted to `import { LinkButton as TextLinkButton }` to keep them straight in the same file.

## Chips

`ChipLink` is a `RouterLink`, `ChipButton` a plain button, and the sixteen state classes are respelled in the DOM's vocabulary: `data-hovered` → `hover`, `data-pressed` → `active`.

I used plain `hover` rather than the `enabled-hover` variant. A blank chip in a button group sits at `opacity-60` until hovered, so excluding an expanded trigger the way a button now does would leave the filter chip on the build page visibly dimmed while its own menu is open. **That is the same open-trigger question still outstanding on buttons** — worth settling for both at once rather than deciding it quietly here.

## Two bugs found on the way

- `no-data-disabled:cursor-pointer` in `getLinkClassName` was never a Tailwind variant, so it compiled to nothing and link-styled buttons have been rendering without a pointer cursor. It is `not-data-disabled:not-disabled:` now, which also stops a disabled one underlining itself on hover.
- Five `HeadlessLink` call sites styled themselves on `data-hovered` and `rac-focus`. Those attributes leave with react-aria, so the classes would have gone silently dead — the hover colour on the build header's breadcrumb, the list row's hover background. Respelled where they are read.

## Verification

- The built CSS, with react-aria's state vocabulary normalised onto the DOM's, is **identical except for the two rules above** — every chip colour, hover, active and focus rule compiles the same.
- Storybook 81/81, including the `KeyboardFocus` story planted in an earlier batch precisely to hold the focus ring still across this swap.
- e2e 96/98 on chromium; both failures pass in isolation and are the known local rate-limiting under parallel load.
- In the built app: breadcrumb hover goes `text-low` → `text-default`, list-row hover changes background, the external-link indicator renders, and clicking a link navigates client-side without a reload.

`Link`, `Tabs`, `Tab`, `TabList` and `TabPanel` join the `no-restricted-imports` ban list — a react-aria part inside a Base UI tree type-checks and then throws at runtime, which no screenshot catches.

Still on react-aria after this: `Button` (13 call sites), the radio group, `DateRangePicker`, `ToggleButton` and the form controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)