### PR TITLE
refactor(ui): move the text field and radio groups off react-aria

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -84,7 +84,13 @@
                   "Tabs",
                   "Tab",
                   "TabList",
-                  "TabPanel"
+                  "TabPanel",
+                  "Radio",
+                  "RadioGroup",
+                  "RadioButton",
+                  "RadioField",
+                  "Input",
+                  "Label"
                 ],
                 "message": "These have moved to Base UI: import from @/ui/Select, @/ui/ListBox, @/ui/Dialog, @/ui/Modal, @/ui/Popover, @/ui/Link, @/ui/Tab or @/ui/menu-kit. A react-aria part inside a Base UI tree type-checks and then throws at runtime, which no screenshot catches."
               }

--- a/apps/frontend/.storybook/preview.ts
+++ b/apps/frontend/.storybook/preview.ts
@@ -4,6 +4,10 @@ import { MemoryRouter } from "react-router";
 
 import { TooltipProvider } from "../src/ui/Tooltip";
 import "../src/index.css";
+import { trackFocusModality } from "../src/util/focus-modality";
+
+// `TextInput`'s keyboard-only focus ring reads the modality this publishes.
+trackFocusModality();
 
 // Provide a mock clientData so that `src/config.ts` does not throw when
 // modules are eagerly resolved by Vite.

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -324,6 +324,20 @@
 @custom-variant search-cancel (&::-webkit-search-cancel-button);
 
 /**
+ * Focused, and reached by keyboard.
+ *
+ * For everything that is not a text field, `focus-visible:` already means
+ * this. A text input is the exception: the browser matches `:focus-visible` on
+ * a plain click too, so a field that should only ring for the keyboard has to
+ * be told how focus arrived — see `util/focus-modality`, which publishes it.
+ *
+ * Use this **only** in `ui/TextInput`.
+ */
+@custom-variant kbd-focus (
+  &:where(html[data-focus-modality="keyboard"] *):focus
+);
+
+/**
  * Hover, but only where it can lead somewhere.
  *
  * Hovering promises that pressing will do something. Three kinds of control

--- a/apps/frontend/src/index.tsx
+++ b/apps/frontend/src/index.tsx
@@ -7,6 +7,7 @@ import "./index.css";
 import { config } from "./config";
 import { APIError } from "./util/api";
 import { getSingleErrorCode } from "./util/error";
+import { trackFocusModality } from "./util/focus-modality";
 
 if (process.env["NODE_ENV"] === "production") {
   Sentry.init({
@@ -60,6 +61,10 @@ if (process.env["NODE_ENV"] === "production") {
     },
   });
 }
+
+// Before the first render, so a field focused on load is judged against a
+// modality that is already published.
+trackFocusModality();
 
 const container = document.querySelector("#root");
 invariant(container, "No #root element found");

--- a/apps/frontend/src/pages/Project/GettingStarted.tsx
+++ b/apps/frontend/src/pages/Project/GettingStarted.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { useQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
+import { Radio } from "@base-ui/react/radio";
+import { RadioGroup } from "@base-ui/react/radio-group";
 import { clsx } from "clsx";
 import {
   CheckIcon,
@@ -8,7 +10,6 @@ import {
   GitCommitHorizontalIcon,
   SquareTerminalIcon,
 } from "lucide-react";
-import { RadioButton, RadioField, RadioGroup } from "react-aria-components";
 import { useResolvedPath } from "react-router";
 
 import { BuildStatusChip } from "@/containers/BuildStatusChip";
@@ -350,7 +351,7 @@ function InstallStep(props: {
           <RadioGroup
             aria-label="Test framework"
             value={framework.id}
-            onChange={(value) => {
+            onValueChange={(value) => {
               if (checkIsFrameworkId(value)) {
                 selectFramework(value);
               }
@@ -358,12 +359,16 @@ function InstallStep(props: {
             className="grid grid-cols-3 gap-2 sm:grid-cols-6"
           >
             {FRAMEWORKS.map((framework) => (
-              <RadioField key={framework.id} value={framework.id}>
-                <RadioButton className="data-selected:border-primary-active data-selected:bg-primary-subtle data-selected:text-primary hover:bg-hover data-focus-visible:ring-primary-active flex h-full cursor-default flex-col items-center gap-2 rounded-md border px-2 py-3 transition focus:outline-hidden data-focus-visible:ring-2">
-                  {framework.logo}
-                  <span className="text-xs">{framework.name}</span>
-                </RadioButton>
-              </RadioField>
+              // react-aria split the label from the thing it labelled;
+              // `Radio.Root` is both, so the pair collapses into one tile.
+              <Radio.Root
+                key={framework.id}
+                value={framework.id}
+                className="data-checked:border-primary-active data-checked:bg-primary-subtle data-checked:text-primary hover:bg-hover focus-visible:ring-primary-active flex h-full cursor-default flex-col items-center gap-2 rounded-md border px-2 py-3 transition focus:outline-hidden focus-visible:ring-2"
+              >
+                {framework.logo}
+                <span className="text-xs">{framework.name}</span>
+              </Radio.Root>
             ))}
           </RadioGroup>
           <p className="text-low text-sm">

--- a/apps/frontend/src/pages/Signup.tsx
+++ b/apps/frontend/src/pages/Signup.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useId, useState, type ReactNode } from "react";
 import { assertNever } from "@argos/util/assertNever";
+import { Radio } from "@base-ui/react/radio";
+import { RadioGroup } from "@base-ui/react/radio-group";
 import clsx from "clsx";
 import { CheckIcon } from "lucide-react";
-import { Radio, RadioGroup } from "react-aria-components";
 import { Helmet } from "react-helmet";
 import {
   useController,
@@ -47,17 +48,21 @@ function AccountTypeField<
   const { control, name } = props;
   const { field } = useController({ control, name });
   const { ref } = field;
+  const labelId = useId();
   return (
     <RadioGroup
-      orientation="vertical"
+      aria-orientation="vertical"
       className={clsx("w-full", props.className)}
       ref={ref}
-      onChange={field.onChange}
+      onValueChange={field.onChange}
       value={field.value}
-      isDisabled={field.disabled}
+      disabled={field.disabled}
       onBlur={field.onBlur}
+      // react-aria's `RadioGroup` named itself from the `Label` it found in
+      // context. Base UI's is a plain group, so the two are wired by hand.
+      aria-labelledby={labelId}
     >
-      <Label>Choose your use case to get started</Label>
+      <Label id={labelId}>Choose your use case to get started</Label>
       <div className="flex flex-col">
         <RadioAccordion value="hobby">
           <div className="flex items-center justify-between gap-4">
@@ -91,29 +96,24 @@ function AccountTypeField<
 function RadioAccordion(props: { value: string; children: ReactNode }) {
   const { children, ...rest } = props;
   return (
-    <Radio
+    <Radio.Root
       {...rest}
       className={clsx(
-        "bg-app peer flex items-center gap-4 border p-4 text-sm",
-        "data-hovered:bg-subtle",
+        "bg-app group peer flex items-center gap-4 border p-4 text-sm",
+        "hover:bg-subtle",
         "first:rounded-t first:border-b-0",
         "last:rounded-b",
         "not-first:not-last:border-b-0",
       )}
     >
-      {({ isSelected }) => (
-        <>
-          {isSelected ? (
-            <div className="bg-primary-solid flex size-5 items-center justify-center rounded-full">
-              <CheckIcon className="size-3.5 text-white" />
-            </div>
-          ) : (
-            <div className="bg-active m-1 size-3 rounded-full" />
-          )}
-          <div className="flex-1">{children}</div>
-        </>
-      )}
-    </Radio>
+      {/* react-aria handed the row its `isSelected`; Base UI publishes it as
+          `data-checked`, so the two marks swap in CSS instead. */}
+      <div className="bg-primary-solid hidden size-5 items-center justify-center rounded-full group-data-checked:flex">
+        <CheckIcon className="size-3.5 text-white" />
+      </div>
+      <div className="bg-active m-1 size-3 rounded-full group-data-checked:hidden" />
+      <div className="flex-1">{children}</div>
+    </Radio.Root>
   );
 }
 

--- a/apps/frontend/src/pages/Welcome.tsx
+++ b/apps/frontend/src/pages/Welcome.tsx
@@ -1,5 +1,7 @@
-import { useRef, useState } from "react";
+import { useId, useRef, useState } from "react";
 import { useApolloClient, useQuery } from "@apollo/client/react";
+import { Radio } from "@base-ui/react/radio";
+import { RadioGroup } from "@base-ui/react/radio-group";
 import { MarkGithubIcon } from "@primer/octicons-react";
 import clsx from "clsx";
 import {
@@ -10,7 +12,6 @@ import {
   SparklesIcon,
   UsersIcon,
 } from "lucide-react";
-import { Radio, RadioGroup } from "react-aria-components";
 import { Helmet } from "react-helmet";
 import {
   useController,
@@ -122,32 +123,36 @@ function SourceField(props: { control: Control<Inputs> }) {
   // use-case field.
   const { ref, value, onChange, onBlur, disabled } = field;
   const error = fieldState.error?.message;
+  const labelId = useId();
   return (
     <RadioGroup
       className="w-full"
       ref={ref}
       value={value}
-      onChange={onChange}
+      onValueChange={onChange}
       onBlur={onBlur}
-      isDisabled={disabled}
-      // React Hook Form owns the validation: `aria` keeps the group's invalid
-      // state and its message wired up for assistive tech without the browser
-      // running a second, native round of its own on submit.
-      validationBehavior="aria"
-      isInvalid={Boolean(error)}
+      disabled={disabled}
+      // React Hook Form owns the validation, so the group only has to say what
+      // it found for assistive tech — no native round of its own on submit.
+      aria-invalid={Boolean(error) || undefined}
+      // react-aria's `RadioGroup` named itself from the `Label` it found in
+      // context. Base UI's is a plain group, so the two are wired by hand.
+      aria-labelledby={labelId}
     >
-      <Label invalid={Boolean(error)}>How did you hear about us?</Label>
+      <Label id={labelId} invalid={Boolean(error)}>
+        How did you hear about us?
+      </Label>
       <div className="mt-1 grid grid-cols-1 gap-2.5 sm:grid-cols-2">
         {SOURCES.map(({ value, label, Icon }) => (
-          <Radio
+          <Radio.Root
             key={value}
             value={value}
             className={clsx(
               "group bg-app relative flex cursor-pointer items-center gap-3 rounded-xl border p-3 text-sm",
               "transition-[background-color,border-color,box-shadow]",
-              "data-hovered:border-hover data-hovered:bg-subtle",
-              "data-focus-visible:ring-primary data-focus-visible:ring-2 data-focus-visible:outline-hidden",
-              "data-selected:border-primary-active data-selected:bg-primary-app data-selected:shadow-xs",
+              "hover:border-hover hover:bg-subtle",
+              "focus-visible:ring-primary focus-visible:ring-2 focus-visible:outline-hidden",
+              "data-checked:border-primary-active data-checked:bg-primary-app data-checked:shadow-xs",
             )}
           >
             {/* The icon gets its own plate, so the tile reads as an object with
@@ -155,7 +160,7 @@ function SourceField(props: { control: Control<Inputs> }) {
             <span
               className={clsx(
                 "bg-ui text-low flex size-9 shrink-0 items-center justify-center rounded-lg transition-colors",
-                "group-data-selected:bg-primary-ui group-data-selected:text-primary-low",
+                "group-data-checked:bg-primary-ui group-data-checked:text-primary-low",
               )}
             >
               <Icon className="size-4.5" size={18} />
@@ -163,8 +168,8 @@ function SourceField(props: { control: Control<Inputs> }) {
             <span className="flex-1 leading-tight font-medium">{label}</span>
             {/* Only shown on the pick, so the grid stays quiet until the user
                 acts. */}
-            <CheckIcon className="text-primary-low size-4 shrink-0 opacity-0 transition-opacity group-data-selected:opacity-100" />
-          </Radio>
+            <CheckIcon className="text-primary-low size-4 shrink-0 opacity-0 transition-opacity group-data-checked:opacity-100" />
+          </Radio.Root>
         ))}
       </div>
       {/* Under the grid rather than under the label: it answers the Continue

--- a/apps/frontend/src/ui/Label.tsx
+++ b/apps/frontend/src/ui/Label.tsx
@@ -1,18 +1,14 @@
+import { ComponentPropsWithRef } from "react";
 import { clsx } from "clsx";
-import {
-  Label as RACLabel,
-  LabelProps as RACLabelProps,
-} from "react-aria-components";
 
-type LabelProps = RACLabelProps & {
-  ref?: React.ForwardedRef<HTMLLabelElement>;
+type LabelProps = ComponentPropsWithRef<"label"> & {
   invalid?: boolean;
 };
 
 export function Label(props: LabelProps) {
   const { invalid, ...rest } = props;
   return (
-    <RACLabel
+    <label
       {...rest}
       className={clsx(
         "mb-2 inline-block text-sm font-medium",

--- a/apps/frontend/src/ui/TextInput.stories.tsx
+++ b/apps/frontend/src/ui/TextInput.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { userEvent } from "storybook/test";
+import { expect, screen, userEvent, waitFor } from "storybook/test";
 
 import { Label } from "./Label";
 import { StoryTitle } from "./StoryTitle";
@@ -53,6 +53,13 @@ export const Default: Story = {
 export const KeyboardFocus: Story = {
   play: async () => {
     await userEvent.tab();
+    const input = await screen.findByPlaceholderText("Focused");
+    await expect(input).toHaveFocus();
+    // Asserted, not merely photographed: paired with `PointerFocus`, this is
+    // what says the ring tracks the keyboard rather than never appearing.
+    await waitFor(() => {
+      expect(getComputedStyle(input).boxShadow).not.toBe("none");
+    });
   },
   render: () => (
     <div className="flex max-w-xs flex-col gap-4 p-4">
@@ -63,6 +70,38 @@ export const KeyboardFocus: Story = {
       <div>
         <Label invalid>Invalid</Label>
         <TextInput placeholder="Invalid" aria-invalid="true" />
+      </div>
+    </div>
+  ),
+};
+
+/**
+ * The other half of the contract, and the half a wrong translation would break
+ * quietly: clicked into, the field takes the focus border but **no ring**.
+ *
+ * `focus-visible:` would have looked right in every other component and been
+ * wrong here — the browser matches a clicked text input too — so the ring is
+ * asserted away rather than left to a baseline nobody re-reads.
+ */
+export const PointerFocus: Story = {
+  play: async () => {
+    const input = await screen.findByPlaceholderText("Clicked");
+    const restingBorder = getComputedStyle(input).borderColor;
+    await userEvent.click(input);
+    await expect(input).toHaveFocus();
+    await waitFor(() => {
+      // Tailwind draws the ring as a box-shadow, so its absence is the test.
+      expect(getComputedStyle(input).boxShadow).toBe("none");
+    });
+    // The border still moves, so a clicked field does read as focused — the
+    // ring is the only thing the keyboard buys.
+    await expect(getComputedStyle(input).borderColor).not.toBe(restingBorder);
+  },
+  render: () => (
+    <div className="flex max-w-xs flex-col gap-4 p-4">
+      <div>
+        <Label>Clicked</Label>
+        <TextInput placeholder="Clicked" />
       </div>
     </div>
   ),

--- a/apps/frontend/src/ui/TextInput.tsx
+++ b/apps/frontend/src/ui/TextInput.tsx
@@ -1,11 +1,9 @@
-import { ComponentPropsWithRef, type RefAttributes } from "react";
+import { ComponentPropsWithRef } from "react";
 import { clsx } from "clsx";
-import { Input, InputProps } from "react-aria-components";
 
 type TextInputScale = "sm" | "md" | "lg";
 
-export interface TextInputProps
-  extends InputProps, RefAttributes<HTMLInputElement> {
+export interface TextInputProps extends ComponentPropsWithRef<"input"> {
   scale?: TextInputScale;
 }
 
@@ -18,7 +16,7 @@ const sizeClassNames: Record<TextInputScale, string> = {
 export function TextInput(props: TextInputProps) {
   const { scale = "md", ...rest } = props;
   return (
-    <Input
+    <input
       {...rest}
       className={clsx(
         rest.className,
@@ -31,12 +29,13 @@ export function TextInput(props: TextInputProps) {
         /* Focus: the border marks the field however it was reached, the ring
            only when it was reached by keyboard. CSS `:focus-visible` cannot
            draw that line — a text input matches it on a plain click too — so
-           the ring keys off react-aria's own modality tracking instead. */
+           the ring keys off the modality `util/focus-modality` publishes,
+           which is the one thing react-aria was still doing here. */
         "focus:border-active focus:outline-hidden",
-        "data-focus-visible:ring-primary-active data-focus-visible:ring-2",
+        "kbd-focus:ring-primary-active kbd-focus:ring-2",
         /* Invalid: red all the way through, ring included. */
         "aria-invalid:border-danger aria-invalid:focus:border-danger-active aria-invalid:not-disabled:hover:border-danger-hover",
-        "aria-invalid:data-focus-visible:ring-danger-active",
+        "aria-invalid:kbd-focus:ring-danger-active",
         /* Disabled */
         "disabled:opacity-disabled",
         /* Addon  */

--- a/apps/frontend/src/util/focus-modality.ts
+++ b/apps/frontend/src/util/focus-modality.ts
@@ -1,0 +1,71 @@
+/**
+ * Which device the user last reached for, published on the root element as
+ * `data-focus-modality`. Call {@link trackFocusModality} once, from the entry
+ * point.
+ *
+ * `:focus-visible` answers "should this draw a focus ring?" for buttons, links
+ * and every other control — but not for text fields. The browser matches a
+ * focused text input on a plain click too, on the reasoning that typing is
+ * coming either way, so a field that wants a ring only when it was reached by
+ * keyboard cannot ask CSS: it has to know how focus arrived. That is what
+ * react-aria's modality tracking was doing, and this is what replaces it.
+ *
+ * Read it through the `kbd-focus` variant, and only from `ui/TextInput` —
+ * everything else is served by `:focus-visible`.
+ */
+
+type Modality = "keyboard" | "pointer";
+
+/**
+ * A chord is a command, not navigation: Cmd-R reloads, it does not move focus,
+ * so it must not flip the page into keyboard modality. Nor may a lone
+ * modifier, which is only ever the first half of one.
+ */
+function isNavigationKey(event: KeyboardEvent): boolean {
+  return !(
+    event.metaKey ||
+    event.ctrlKey ||
+    event.altKey ||
+    event.key === "Meta" ||
+    event.key === "Control" ||
+    event.key === "Alt" ||
+    event.key === "Shift"
+  );
+}
+
+function setModality(modality: Modality): void {
+  if (document.documentElement.dataset["focusModality"] === modality) {
+    return;
+  }
+  document.documentElement.dataset["focusModality"] = modality;
+}
+
+let tracking = false;
+
+/**
+ * Start publishing the modality. Idempotent.
+ *
+ * Called rather than imported for its side effect: the frontend package
+ * declares `"sideEffects": false`, so a bare `import "./focus-modality"` is
+ * dropped from the production bundle — which cost text inputs their keyboard
+ * ring, silently, everywhere except Storybook.
+ */
+export function trackFocusModality(): void {
+  if (tracking) {
+    return;
+  }
+  tracking = true;
+  setModality("pointer");
+  // Capture phase, so a handler that stops propagation cannot leave the page
+  // wrong about how the user is driving it.
+  document.addEventListener(
+    "keydown",
+    (event) => {
+      if (isNavigationKey(event)) {
+        setModality("keyboard");
+      }
+    },
+    true,
+  );
+  document.addEventListener("pointerdown", () => setModality("pointer"), true);
+}


### PR DESCRIPTION
Continues the Base UI migration with the plan's B5 batch. Checkbox, Switch, Slider, Separator, Details and the colour picker were already done, so what was left of the form controls is the text field and the three radio groups.

## The text field, and the one exception in the whole migration

`TextInput` renders an `<input>` and `Label` a `<label>`. Mechanical everywhere except the focus ring, which is the single place `:focus-visible` is **not** a drop-in — a text input matches it on a plain click too, since typing is coming either way. Only "was the keyboard used" can draw that line, and react-aria was what kept track.

`util/focus-modality` now publishes that on the root element, and a `kbd-focus` variant reads it. It is used **only** in `TextInput`; everything else is served by `:focus-visible`.

## A bug the browser caught and the tests could not

The first version imported that module for its side effect. The frontend package declares `"sideEffects": false`, so **Rollup dropped it from the production bundle entirely** — text inputs would have lost their keyboard ring everywhere, with nothing failing: the stories kept passing, because Storybook's preview does not tree-shake the same way. It is an exported `trackFocusModality()` the entry points call, which cannot be dropped.

That is also why both halves of the contract are now asserted instead of photographed — a wrong translation looks correct in either one alone:

- `KeyboardFocus` expects a ring
- `PointerFocus` expects none

## The radio groups

Signup's use case, welcome's source grid and the getting-started framework picker move to `RadioGroup` / `Radio.Root`. `data-selected` → `data-checked`, `data-hovered` / `data-focus-visible` → the DOM's own, and `RadioField` + `RadioButton` collapse into the one part that is both.

Two things react-aria did implicitly had to be said out loud:

- The group named itself from whichever `Label` it found in context. Base UI's is a plain group, so that is an `aria-labelledby` written by hand — verified resolving to the right text in the running app.
- Signup's row took its mark from an `isSelected` render prop; the checked and unchecked marks now swap on `data-checked`.

## Verification

- Static checks 11/11, Storybook 82/82.
- In the built app: clicking the field focuses it and moves the border with **no ring**; tabbing to it publishes `data-focus-modality="keyboard"` and paints the 2px violet ring. Radio selection works and the group resolves its accessible name.
- I did **not** run the local e2e suite on this branch — CI covers it.

`Radio`, `RadioGroup`, `Input` and `Label` join the `no-restricted-imports` list.

Left on react-aria after this: 12 raw `Button` call sites, one `ToggleButton`, `DateRangePicker` (which still needs react-day-picker), and `router.tsx`'s `RouterProvider`, which goes last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)