### PR TITLE
refactor(ui): move the remaining buttons off react-aria

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -90,7 +90,10 @@
                   "RadioButton",
                   "RadioField",
                   "Input",
-                  "Label"
+                  "Label",
+                  "Button",
+                  "ButtonProps",
+                  "ToggleButton"
                 ],
                 "message": "These have moved to Base UI: import from @/ui/Select, @/ui/ListBox, @/ui/Dialog, @/ui/Modal, @/ui/Popover, @/ui/Link, @/ui/Tab or @/ui/menu-kit. A react-aria part inside a Base UI tree type-checks and then throws at runtime, which no screenshot catches."
               }

--- a/apps/frontend/src/containers/Comment/CommentCard.tsx
+++ b/apps/frontend/src/containers/Comment/CommentCard.tsx
@@ -9,7 +9,6 @@ import {
   MessageSquareCheckIcon,
 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { Button as RACButton } from "react-aria-components";
 import { useClipboard } from "use-clipboard-copy";
 
 import { AccountAvatar } from "@/containers/AccountAvatar";
@@ -466,7 +465,8 @@ function ResolvedThreadHeader(props: {
 }) {
   const { collapsed, commentCount, authorName, onToggle } = props;
   return (
-    <RACButton
+    <button
+      type="button"
       onClick={onToggle}
       aria-label={collapsed ? "Expand thread" : "Collapse thread"}
       className="text-low hover:text-default flex w-full items-center gap-1.5 px-2 py-1.5 text-left text-xs transition select-none"
@@ -486,7 +486,7 @@ function ResolvedThreadHeader(props: {
           <ChevronsDownUpIcon className="size-3.5 shrink-0" />
         </>
       )}
-    </RACButton>
+    </button>
   );
 }
 
@@ -640,14 +640,15 @@ function CommentMessage(props: {
                   </div>
                 }
               >
-                <RACButton
+                <button
+                  type="button"
                   onClick={copyLink}
                   aria-label="Copy link to comment"
                   className="text-low hover:text-default shrink-0 text-left text-xs transition"
                 >
                   <Time date={comment.date} tooltip="none" />
                   {isEdited ? " (edited)" : null}
-                </RACButton>
+                </button>
               </Tooltip>
               {comment.pending ? <PendingCommentBadge /> : null}
             </div>

--- a/apps/frontend/src/containers/Comment/CommentReactions.tsx
+++ b/apps/frontend/src/containers/Comment/CommentReactions.tsx
@@ -1,7 +1,6 @@
 import { useApolloClient } from "@apollo/client/react";
 import { clsx } from "clsx";
 import { SmilePlusIcon } from "lucide-react";
-import { Button as RACButton } from "react-aria-components";
 
 import { useProjectPermission } from "@/containers/Project/PermissionsContext";
 import { DocumentType, graphql } from "@/gql";
@@ -154,13 +153,14 @@ export function CommentReactionList(props: { comment: Comment }) {
     <div className="flex flex-wrap items-center gap-1 px-2 pb-2">
       {comment.reactions.map((group) => (
         <Tooltip key={group.emoji} content={getReactionTooltip(group)}>
-          <RACButton
-            isDisabled={!canReact}
+          <button
+            type="button"
+            disabled={!canReact}
             onClick={() => toggle(group)}
             className={clsx(
               "flex h-6 items-center gap-1 rounded-full border px-2 text-xs font-medium transition",
-              "cursor-default focus:outline-hidden data-focus-visible:ring-4",
-              canReact && "data-hovered:border-hover",
+              "cursor-default focus:outline-hidden focus-visible:ring-4",
+              canReact && "hover:border-hover",
               group.reactedByMe
                 ? "border-primary bg-active text-default"
                 : "text-low",
@@ -168,7 +168,7 @@ export function CommentReactionList(props: { comment: Comment }) {
           >
             <span className="text-sm leading-none">{group.emoji}</span>
             <span className="tabular-nums">{group.count}</span>
-          </RACButton>
+          </button>
         </Tooltip>
       ))}
       <CommentAddReactionButton comment={comment} />

--- a/apps/frontend/src/containers/Media/MediaComments.tsx
+++ b/apps/frontend/src/containers/Media/MediaComments.tsx
@@ -8,7 +8,6 @@ import {
   UploadIcon,
   XIcon,
 } from "lucide-react";
-import { Button as RACButton } from "react-aria-components";
 import { useLocation } from "react-router";
 
 import { useAuth } from "@/containers/Auth";
@@ -441,12 +440,13 @@ function MediaPinnedReference(props: {
         ? `Pinned on v${version.number}`
         : "Pinned on another version";
   return (
-    <RACButton
+    <button
+      type="button"
       onClick={onNavigate}
       aria-label="Go to the pinned comment"
       // No hover style or default cursor of its own: the surrounding card
       // shares this button's navigation and carries the hover affordance.
-      className="text-low rac-focus flex w-full cursor-pointer items-center gap-2 rounded-t-md px-2 py-1.5 text-left text-xs select-none"
+      className="text-low focus-ring flex w-full cursor-pointer items-center gap-2 rounded-t-md px-2 py-1.5 text-left text-xs select-none"
     >
       {thumbnailUrl ? (
         <MediaWell className="size-6 shrink-0">
@@ -457,6 +457,6 @@ function MediaPinnedReference(props: {
       ) : null}
       <span className="min-w-0 flex-1 truncate font-medium">{label}</span>
       <MapPinPenIcon aria-hidden="true" className="size-3.5 shrink-0" />
-    </RACButton>
+    </button>
   );
 }

--- a/apps/frontend/src/containers/Media/MediaVersions.tsx
+++ b/apps/frontend/src/containers/Media/MediaVersions.tsx
@@ -1,6 +1,5 @@
-import { clsx } from "clsx";
+import { Toggle } from "@base-ui/react/toggle";
 import { CheckIcon } from "lucide-react";
-import { ToggleButton } from "react-aria-components";
 
 import { MediaWell } from "@/ui/MediaFrame";
 import { Panel, PanelHeader, PanelTitle } from "@/ui/Panel";
@@ -50,51 +49,45 @@ export function MediaVersions(props: {
             ? version.posterUrl
             : version.fileUrl;
           return (
-            <ToggleButton
+            <Toggle
               key={version.id}
-              isSelected={version.id === selectedId}
+              pressed={version.id === selectedId}
               // Radio semantics on a toggle: picking the selected row again
-              // keeps it selected instead of leaving nothing on screen.
-              onChange={() => onSelect(version.id)}
-              className="rac-focus hover:bg-hover data-selected:bg-ui flex w-full cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-xs"
+              // keeps it selected instead of leaving nothing on screen, which
+              // is why the new pressed state is ignored.
+              onPressedChange={() => onSelect(version.id)}
+              className="focus-ring group hover:bg-hover data-pressed:bg-ui flex w-full cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-xs"
             >
-              {({ isSelected }) => (
-                <>
-                  {thumbnailUrl ? (
-                    <MediaWell className="size-8 shrink-0">
-                      {/* Contained, not cropped: what this thumbnail is for is
-                          telling one version from another at a glance, and a
-                          square crop out of the middle of a wide screenshot
-                          shows the same patch of background for every one of
-                          them. The well's ground is the letterbox. */}
-                      <img
-                        src={thumbnailUrl}
-                        alt=""
-                        className="size-full object-contain"
-                      />
-                    </MediaWell>
-                  ) : null}
-                  <span className="shrink-0 font-mono font-medium tabular-nums">
-                    v{version.number}
-                  </span>
-                  <span className="text-low min-w-0 flex-1 truncate">
-                    <Time date={version.createdAt} />
-                  </span>
-                  {index === 0 ? (
-                    <span className="text-low shrink-0">Latest</span>
-                  ) : null}
-                  {/* Always in the row so the "Latest" column lines up; only
-                      visible on the selected one. */}
-                  <CheckIcon
-                    aria-hidden="true"
-                    className={clsx(
-                      "size-3.5 shrink-0",
-                      !isSelected && "invisible",
-                    )}
+              {thumbnailUrl ? (
+                <MediaWell className="size-8 shrink-0">
+                  {/* Contained, not cropped: what this thumbnail is for is
+                      telling one version from another at a glance, and a
+                      square crop out of the middle of a wide screenshot
+                      shows the same patch of background for every one of
+                      them. The well's ground is the letterbox. */}
+                  <img
+                    src={thumbnailUrl}
+                    alt=""
+                    className="size-full object-contain"
                   />
-                </>
-              )}
-            </ToggleButton>
+                </MediaWell>
+              ) : null}
+              <span className="shrink-0 font-mono font-medium tabular-nums">
+                v{version.number}
+              </span>
+              <span className="text-low min-w-0 flex-1 truncate">
+                <Time date={version.createdAt} />
+              </span>
+              {index === 0 ? (
+                <span className="text-low shrink-0">Latest</span>
+              ) : null}
+              {/* Always in the row so the "Latest" column lines up; only
+                  visible on the selected one. */}
+              <CheckIcon
+                aria-hidden="true"
+                className="invisible size-3.5 shrink-0 group-data-pressed:visible"
+              />
+            </Toggle>
           );
         })}
       </div>

--- a/apps/frontend/src/containers/NavUserControl.tsx
+++ b/apps/frontend/src/containers/NavUserControl.tsx
@@ -12,7 +12,6 @@ import {
   ShieldUserIcon,
   SunIcon,
 } from "lucide-react";
-import { Button as RACButton } from "react-aria-components";
 import { useLocation } from "react-router";
 
 import { logout, useAuth, type AuthAccount } from "@/containers/Auth";
@@ -94,15 +93,16 @@ function UserMenu(props: { account: AuthAccount }) {
   return (
     <MenuRoot>
       <MenuTrigger>
-        <RACButton
+        <button
+          type="button"
           className={clsx(
-            "rac-focus bg-ui size-8 shrink-0 cursor-default rounded-full border-2 transition",
-            "data-hovered:border-primary-hover data-pressed:border-primary-active aria-expanded:border-primary-active",
+            "focus-ring bg-ui size-8 shrink-0 cursor-default rounded-full border-2 transition",
+            "enabled-hover:border-primary-hover active:border-primary-active aria-expanded:border-primary-active",
           )}
           aria-label="User settings"
         >
           <AccountAvatar avatar={account.avatar} className="size-7" />
-        </RACButton>
+        </button>
       </MenuTrigger>
       <Menu side="bottom" align="end" className="w-60">
         <MenuItem

--- a/apps/frontend/src/containers/User/Auth.tsx
+++ b/apps/frontend/src/containers/User/Auth.tsx
@@ -2,7 +2,6 @@ import { useMutation } from "@apollo/client/react";
 import { formatRelativeDate } from "@argos/util/date-format";
 import { invariant } from "@argos/util/invariant";
 import { MonitorIcon, SmartphoneIcon } from "lucide-react";
-import { Button as RACButton } from "react-aria-components";
 
 import { logout } from "@/containers/Auth";
 import { DocumentType, graphql } from "@/gql";
@@ -295,10 +294,11 @@ function UserSessions(props: { sessions: readonly Session[] }) {
               </DialogTrigger>
             </div>
             {others.map((session) => (
-              <RACButton
+              <button
+                type="button"
                 key={session.id}
                 onClick={() => revoking.open(session)}
-                className="group bg-app data-focus-visible:bg-hover data-hovered:bg-hover flex w-full items-center gap-3 border-b p-4 last:border-b-0 focus:outline-hidden"
+                className="group bg-app focus-visible:bg-hover hover:bg-hover flex w-full items-center gap-3 border-b p-4 last:border-b-0 focus:outline-hidden"
               >
                 <SessionRowLayout
                   session={session}
@@ -315,7 +315,7 @@ function UserSessions(props: { sessions: readonly Session[] }) {
                     </span>
                   }
                 />
-              </RACButton>
+              </button>
             ))}
           </List>
         ) : null}

--- a/apps/frontend/src/containers/User/providers/PasskeyAuth.tsx
+++ b/apps/frontend/src/containers/User/providers/PasskeyAuth.tsx
@@ -7,7 +7,6 @@ import {
   PlusIcon,
   Trash2Icon,
 } from "lucide-react";
-import { Button as RACButton } from "react-aria-components";
 import { useForm } from "react-hook-form";
 
 import {
@@ -308,8 +307,9 @@ export function PasskeyAuth(props: {
         <ProviderContent>
           <div className="font-medium">Passkeys</div>
           {passkeys.length > 0 ? (
-            <RACButton
-              className="text-low data-focus-visible:text-default data-hovered:text-default flex items-center gap-1 focus:outline-hidden"
+            <button
+              type="button"
+              className="text-low focus-visible:text-default hover:text-default flex items-center gap-1 focus:outline-hidden"
               onClick={() => setIsExpanded((expanded) => !expanded)}
             >
               {passkeys.length} passkey{passkeys.length > 1 ? "s" : ""}{" "}
@@ -319,7 +319,7 @@ export function PasskeyAuth(props: {
               ) : (
                 <ChevronDownIcon className="size-4" />
               )}
-            </RACButton>
+            </button>
           ) : (
             <div className="text-low">No passkeys registered</div>
           )}

--- a/apps/frontend/src/pages/Build/BuildDiffList.tsx
+++ b/apps/frontend/src/pages/Build/BuildDiffList.tsx
@@ -1,4 +1,12 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentPropsWithRef,
+} from "react";
 import { assertNever } from "@argos/util/assertNever";
 import { invariant } from "@argos/util/invariant";
 import {
@@ -15,10 +23,6 @@ import {
   SquareStackIcon,
 } from "lucide-react";
 import memoize from "memoize";
-import {
-  Button as RACButton,
-  ButtonProps as RACButtonProps,
-} from "react-aria-components";
 
 import {
   checkIsDiffGroupName,
@@ -296,7 +300,7 @@ function getRows(
 
 function ListHeader(props: {
   style: React.HTMLProps<HTMLButtonElement>["style"];
-  onClick: RACButtonProps["onClick"];
+  onClick: ComponentPropsWithRef<"button">["onClick"];
   item: ListHeaderRow;
   activeIndex: number;
 }) {
@@ -304,17 +308,18 @@ function ListHeader(props: {
   const borderB = item.borderBottom ? "border-b-thin" : "";
   const def = getDiffGroupDefinition(item.name);
   return (
-    <RACButton
+    <button
+      type="button"
       className={clsx(
         borderB,
-        "group/list-header bg-app data-hovered:bg-subtle data-focus-visible:bg-subtle border-t-thin z-10 flex w-full cursor-default items-center pr-2 text-left select-none focus:outline-hidden",
+        "group/list-header bg-app hover:bg-subtle focus-visible:bg-subtle border-t-thin z-10 flex w-full cursor-default items-center pr-2 text-left select-none focus:outline-hidden",
       )}
       style={style}
       onClick={onClick}
     >
       <ChevronDownIcon
         className={clsx(
-          "text-low m-0.75 size-2.5 shrink-0 opacity-0 transition group-hover/sidebar:opacity-100 group-data-focus-visible/list-header:opacity-100",
+          "text-low m-0.75 size-2.5 shrink-0 opacity-0 transition group-hover/sidebar:opacity-100 group-focus-visible/list-header:opacity-100",
           !item.expanded && "-rotate-90",
         )}
       />
@@ -324,7 +329,7 @@ function ListHeader(props: {
         {activeIndex !== -1 ? <>{activeIndex + 1} / </> : null}
         {item.count}
       </Badge>
-    </RACButton>
+    </button>
   );
 }
 

--- a/apps/frontend/src/pages/Build/BuildOverview/ImpactAnalysisSection.tsx
+++ b/apps/frontend/src/pages/Build/BuildOverview/ImpactAnalysisSection.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { ComponentIcon, FlaskConicalIcon, RadarIcon } from "lucide-react";
-import { Button as RACButton } from "react-aria-components";
 
 import { DocumentType, graphql } from "@/gql";
 import { Panel, PanelHeader, PanelTitle } from "@/ui/Panel";
@@ -93,12 +92,13 @@ function AffectedItemsSection(props: {
         ))}
       </ul>
       {collapsible && !expanded ? (
-        <RACButton
+        <button
+          type="button"
           onClick={() => setExpanded((value) => !value)}
-          className="rac-focus text-low data-hovered:bg-ui data-hovered:text-default mx-2 mt-3 cursor-default rounded-full px-2 py-0.5 text-sm transition"
+          className="focus-ring text-low hover:bg-ui hover:text-default mx-2 mt-3 cursor-default rounded-full px-2 py-0.5 text-sm transition"
         >
           {props.seeAllLabel(items.length)}
-        </RACButton>
+        </button>
       ) : null}
     </Panel>
   );

--- a/apps/frontend/src/pages/Build/BuildStatsIndicator.tsx
+++ b/apps/frontend/src/pages/Build/BuildStatsIndicator.tsx
@@ -2,7 +2,6 @@ import { Fragment, memo } from "react";
 import { assertNever } from "@argos/util/assertNever";
 import { clsx } from "clsx";
 import type { LucideIcon } from "lucide-react";
-import { Button as RACButton } from "react-aria-components";
 
 import {
   DIFF_STATS_GROUPS,
@@ -26,20 +25,23 @@ const getStatCountColorClassName = (
 ) => {
   switch (color) {
     case "danger":
-      return clsx("text-danger-low", interactive && "data-hovered:text-danger");
+      return clsx(
+        "text-danger-low",
+        interactive && "not-disabled:hover:text-danger",
+      );
     case "warning":
       return clsx(
         "text-warning-low",
-        interactive && "data-hovered:text-warning",
+        interactive && "not-disabled:hover:text-warning",
       );
     case "success":
       return clsx(
         "text-success-low",
-        interactive && "data-hovered:text-success",
+        interactive && "not-disabled:hover:text-success",
       );
     case "neutral":
     default:
-      return clsx("text-low", interactive && "data-hovered:text");
+      return clsx("text-low", interactive && "not-disabled:hover:text");
   }
 };
 
@@ -83,17 +85,18 @@ function InteractiveStatCount({
   const hotkey = useBuildHotkey(hotkeyName, onActive);
   return (
     <HotkeyTooltip keys={hotkey.displayKeys} description={hotkey.description}>
-      <RACButton
+      <button
+        type="button"
         className={clsx(
           colorClassName,
-          "data-disabled:opacity-disabled rac-focus flex cursor-default items-center gap-1 py-2 transition",
+          "disabled:opacity-disabled focus-ring flex cursor-default items-center gap-1 py-2 transition",
         )}
         onClick={onActive}
-        isDisabled={count === 0}
+        disabled={count === 0}
       >
         <Icon className="size-3" />
         <span className="text-xs">{count}</span>
-      </RACButton>
+      </button>
     </HotkeyTooltip>
   );
 }

--- a/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/AddCommentForm.tsx
@@ -3,7 +3,6 @@ import { useApolloClient } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { clsx } from "clsx";
 import { EyeOffIcon } from "lucide-react";
-import { Button } from "react-aria-components";
 
 import { useMentionableUsers } from "@/containers/Comment/MentionableUsersContext";
 import { DocumentType, graphql } from "@/gql";
@@ -68,12 +67,13 @@ function AttachedSnapshotToggle(props: {
           : "Click to attach this snapshot to your comment."
       }
     >
-      <Button
+      <button
+        type="button"
         onClick={onToggle}
         aria-pressed={attached}
         aria-label={`${attached ? "Detach" : "Attach"} snapshot ${name}`}
         className={clsx(
-          "border-thin hover:bg-hover rac-focus flex min-w-0 items-center gap-1.5 rounded-md py-0.5 pr-2 pl-1 text-xs transition",
+          "border-thin hover:bg-hover focus-ring flex min-w-0 items-center gap-1.5 rounded-md py-0.5 pr-2 pl-1 text-xs transition",
           attached ? "text-default" : "text-low opacity-60",
         )}
       >
@@ -90,7 +90,7 @@ function AttachedSnapshotToggle(props: {
           )}
         </span>
         <span className="min-w-0 truncate font-medium">{name}</span>
-      </Button>
+      </button>
     </Tooltip>
   );
 }

--- a/apps/frontend/src/pages/Build/sidebar/CommentScreenshotReference.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/CommentScreenshotReference.tsx
@@ -1,7 +1,6 @@
 import { invariant } from "@argos/util/invariant";
 import { useSetAtom } from "jotai/react";
 import { MapPinIcon } from "lucide-react";
-import { Button } from "react-aria-components";
 
 import {
   commentsVisibleAtom,
@@ -106,12 +105,13 @@ export function CommentScreenshotReference(props: {
   const isPoint = anchor?.__typename === "CommentPointAnchor";
 
   return (
-    <Button
+    <button
+      type="button"
       onClick={goToDiff}
       aria-label={`Go to snapshot ${screenshotDiff.name}`}
       // No hover style or default cursor of its own: the surrounding card
       // shares this button's navigation and carries the hover affordance.
-      className="text-low rac-focus flex w-full cursor-pointer items-center gap-2 rounded-t-md px-2 py-1.5 text-left text-xs select-none"
+      className="text-low focus-ring flex w-full cursor-pointer items-center gap-2 rounded-t-md px-2 py-1.5 text-left text-xs select-none"
     >
       <ScreenshotDiffThumbnail
         screenshotDiff={screenshotDiff}
@@ -127,6 +127,6 @@ export function CommentScreenshotReference(props: {
       {linesLabel ? (
         <span className="shrink-0 tabular-nums">{linesLabel}</span>
       ) : null}
-    </Button>
+    </button>
   );
 }

--- a/apps/frontend/src/ui/CopyButton.tsx
+++ b/apps/frontend/src/ui/CopyButton.tsx
@@ -1,7 +1,10 @@
-import { useImperativeHandle, useState } from "react";
+import {
+  useImperativeHandle,
+  useState,
+  type ComponentPropsWithRef,
+} from "react";
 import { clsx } from "clsx";
 import { CheckIcon, CopyIcon } from "lucide-react";
-import { Button, ButtonProps } from "react-aria-components";
 import { useClipboard } from "use-clipboard-copy";
 
 import { Tooltip } from "./Tooltip";
@@ -12,7 +15,10 @@ export function CopyButton({
   className,
   copyRef,
   ...props
-}: ButtonProps & { text: string; copyRef?: React.Ref<() => void> }) {
+}: ComponentPropsWithRef<"button"> & {
+  text: string;
+  copyRef?: React.Ref<() => void>;
+}) {
   const clipboard = useClipboard({ copiedTimeout: 2000 });
   const copy = useEventCallback(() => clipboard.copy(text));
   useImperativeHandle(copyRef, () => copy, [copy]);
@@ -23,9 +29,10 @@ export function CopyButton({
       open={clipboard.copied || isTooltipOpen}
       onOpenChange={setIsTooltipOpen}
     >
-      <Button
+      <button
+        type="button"
         className={clsx(
-          "text-low data-hovered:text-default bg-ui data-hovered:bg-hover data-pressed:bg-active data-focus-visible:ring-default cursor-default rounded-sm p-1 transition focus:outline-hidden data-focus-visible:ring-4",
+          "text-low hover:text-default bg-ui hover:bg-hover active:bg-active focus-visible:ring-default cursor-default rounded-sm p-1 transition focus:outline-hidden focus-visible:ring-4",
           className,
         )}
         onClick={copy}
@@ -47,7 +54,7 @@ export function CopyButton({
             <CheckIcon className="size-[1em]" />
           </div>
         </div>
-      </Button>
+      </button>
     </Tooltip>
   );
 }


### PR DESCRIPTION
Twelve raw react-aria `Button` call sites and one `ToggleButton` become the elements they always were. After this, react-aria is down to `DateRangePicker` and `router.tsx`'s `RouterProvider`.

The state classes follow the same translation as the earlier batches: `data-hovered` → `hover`, `data-pressed` → `active`, `data-focus-visible` → `focus-visible`, `data-disabled` → `disabled`, `rac-focus` → `focus-ring`.

## The version rows

`MediaVersions` had a `ToggleButton` with deliberate radio semantics — picking the selected row again keeps it selected rather than leaving nothing on screen. Base UI's `Toggle` preserves that, since the handler ignores the new pressed state. The check mark that read `isSelected` from a render prop now follows `data-pressed` in CSS, which is what removes the render prop and flattens the row.

## One finding worth reading

Two of these buttons can genuinely be disabled, so hover had to stay off them in that state. The obvious tool was the `enabled-hover` variant — but it is wrong here, and I only found out by measuring in the browser.

`enabled-hover` excludes `[data-popup-open]`. That was written for a **menu** trigger, where the attribute means "the menu is showing". Base UI sets the same attribute on a **tooltip** trigger, where it means "the pointer is on this button right now". The stat counts are wrapped in `HotkeyTooltip`, so every `enabled-hover:` class on them switched itself off at exactly the moment it was supposed to apply — the hover colour never appeared at all.

They use `not-disabled:hover:` instead, which guards the state I actually cared about. Confirmed in the built app: the colour now changes on hover while the tooltip is open. The avatar menu trigger in `NavUserControl` keeps `enabled-hover`, because there the exclusion is the whole point — an open menu's trigger should not answer hover.

I have **not** established whether the shipped `ui/Button` has the same problem. `getButtonClassName()` uses `enabled-hover`, and on the build page alone 5 buttons are both tooltip triggers and users of it; they correctly report not matching the `enabled-hover` selector while the tooltip is open, yet their computed background still changes, so something else is painting them. That is a separate question and I left it out of this PR rather than widening it on a guess.

## Verification

- Static checks 11/11, Storybook 82/82.
- In the built app: the stat buttons render as native `<button type="button">` and their hover colour fires; the diff-list headers and the reworked buttons all render.
- I did not run the local e2e suite; CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)