### PR TITLE
fix(ui): keep the hover look on a button whose tooltip is showing

### DIFF
--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -348,16 +348,19 @@
  *   `aria-disabled` — which a pending button wears so it keeps its focus and
  *   its tooltip — is invisible to `:disabled`.
  * - **The chosen tab.** It is already the one you are on.
- * - **The open trigger.** Its menu is already showing; the fill it wears says
- *   so, and moving it under the pointer reads as the menu about to change.
+ * - **The open trigger.** Its popup is already showing; the fill it wears says
+ *   so, and moving it under the pointer reads as the popup about to change.
  *
  * A pressed *toggle* is none of these — pressing it again turns it off — so it
  * keeps its hover.
+ *
+ * An open trigger is recognised by `aria-expanded="true"` alone, and
+ * deliberately not by Base UI's `data-popup-open` — see `on` below for why.
  */
 @custom-variant enabled-hover (
   &:not(:disabled):not([aria-disabled="true"]):not([aria-selected="true"]):not(
       [aria-expanded="true"]
-    ):not([data-popup-open]):hover
+    ):hover
 );
 @custom-variant enabled-active (
   &:not(:disabled):not([aria-disabled="true"]):active
@@ -366,21 +369,25 @@
 /**
  * A control that is currently on.
  *
- * Four attributes for one idea, because each kind of control spells it its own
+ * Three attributes for one idea, because each kind of control spells it its own
  * way: a toggle says `aria-pressed`, a tab says `aria-selected`, and a trigger
- * whose menu is showing says `aria-expanded` — plus Base UI's own
- * `data-popup-open`, which its triggers set alongside it. The button surface
- * is worn by all of them, so the "on" look has to answer to any of them.
+ * whose popup is showing says `aria-expanded`. The button surface is worn by
+ * all of them, so the "on" look has to answer to any of them.
+ *
+ * Not Base UI's `data-popup-open`, which its triggers set alongside
+ * `aria-expanded`: a **tooltip** trigger sets it too, and it sets it exactly
+ * while the pointer is resting on the control. Reading it made a tooltip's own
+ * trigger wear the pressed look — darker fill, no lift — the moment its
+ * tooltip appeared, and took `enabled-hover` off it at the same time, so a
+ * hover ran backwards. A tooltip is not a state its trigger is in; it shows
+ * because the pointer is there. Every trigger this app dresses as a button —
+ * menu, popover, select, dialog, all Base UI popovers underneath — sets
+ * `aria-expanded`, so nothing is lost by reading only that.
  *
  * `="true"` matters: `aria-selected="false"` is on every unselected tab.
  */
 @custom-variant on (
-  &:is(
-      [aria-pressed="true"],
-      [aria-selected="true"],
-      [aria-expanded="true"],
-      [data-popup-open]
-    )
+  &:is([aria-pressed="true"], [aria-selected="true"], [aria-expanded="true"])
 );
 
 @utility rac-focus {


### PR DESCRIPTION
## What

`enabled-hover` and `on` in `apps/frontend/src/index.css` both read Base UI's
`data-popup-open` — the first to bow out of the hover look, the second to put
the pressed look on. That attribute is not only a menu trigger's: a **tooltip**
trigger wears it too, and wears it exactly while the pointer is resting on the
control.

So every button wrapped in `Tooltip` / `HotkeyTooltip` ran its hover *backwards*
the moment the tooltip appeared — `enabled-hover:` switched itself off and `on:`
switched itself on at the same instant.

Measured on the identical element under the identical pointer (`UI/Tooltip →
Default`, light theme), by stripping `data-popup-open` mid-hover to get the
counterfactual:

|                        | fill                          | edge                  | lift   |
| ---------------------- | ----------------------------- | --------------------- | ------ |
| before, tooltip open   | `#f0f0f0` (`--raised-active`) | default `0.849`       | **no** |
| what hover should be   | `#ffffff` (`--raised-hover`)  | `edge-hover` `0.732`  | yes    |

Darker and pressed in, where it should be brighter and standing off the surface.
The `on:` half is why this stayed hard to pin down: the computed background *does*
change on hover, just to the pressed shade, so "the hover works" and "the hover
rule matches" disagreed.

## The fix

Drop `data-popup-open` from both variants and read `aria-expanded="true"` alone.

Splitting the variant per call site can't work — the same `getButtonClassName()`
output serves both menu triggers and tooltip triggers, so the discrimination has
to live in the selector. It turns out none is needed: `data-popup-open` was pure
redundancy. Every element carrying it *and* the button surface also carries
`aria-expanded="true"`, verified across the stories — menu, popover, dialog, the
split button's menu half — and all still wear the on look after the change, as
does the selected pill tab through `aria-selected`. The app has no
`@base-ui/react/menu`, `context-menu` or `preview-card` (menu-kit is built on
`popover`), so the tooltip trigger was the only element setting `data-popup-open`
without `aria-expanded`.

## Review notes

- **One Argos baseline changes, correctly.** `UI/Tooltip Open` holds six
  tooltips open through the `open` prop, without hovering, so those triggers had
  been rendering pressed and flat where they should render at rest. That story
  is also the standing guard against the `on:` half regressing, so no new test —
  the hover half can't be pinned by Argos, since the pointer moves to (0, 0)
  before capture.
- **One latent twin left alone.** `getSelectButtonClassName()` uses
  `data-popup-open:shadow-none` directly (`ui/Select.tsx:141`). Same trap, but no
  select-styled trigger is tooltip-wrapped today, so it is not a bug — flagged
  rather than changed.
- `pnpm run static-checks` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
