### PR TITLE
chore(ui): drop the rac-focus utilities

### DIFF
--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -383,32 +383,13 @@
     )
 );
 
-@utility rac-focus {
-  &[data-focused]:not([data-focus-visible]) {
-    @apply outline-none;
-  }
-
-  &[data-focus-visible] {
-    @apply outline-1 outline-offset-1 outline-(--violet-10);
-  }
-}
-
-@utility rac-focus-group {
-  .group:focus & {
-    @apply outline-none;
-  }
-
-  .group[data-focus-visible] & {
-    @apply outline-1 outline-offset-1 outline-(--violet-10);
-  }
-}
-
 /**
- * The same focus contract as `rac-focus`, on an element that is itself
- * focusable rather than a child of one. Base UI parts are the control — a
- * `Switch.Root` *is* the button — so they need no `group` indirection, and no
- * `data-focus-visible` either: the browser's own `:focus-visible` is what
- * react-aria's modality tracking was standing in for.
+ * An outline on keyboard focus, and nothing on a click.
+ *
+ * Goes on the focusable element itself: a Base UI part *is* the control — a
+ * `Switch.Root` is the button — so there is no `group` indirection to make,
+ * and no attribute to read either. The browser's own `:focus-visible` is what
+ * react-aria's modality tracking used to stand in for.
  *
  * Text inputs are the exception and must not use this — see the comment in
  * `ui/TextInput.tsx`.


### PR DESCRIPTION
Tail end of the react-aria migration. `rac-focus` and `rac-focus-group` were still defined in `index.css` but nothing has applied them since the last react-aria component left — they match `[data-focused]` / `[data-focus-visible]`, which only react-aria ever set.

Dead CSS is cheap; the misleading name is not. `focus-ring` is the one that survived, and its doc no longer points at a neighbour that is gone.

I checked the rest of the state-attribute classes while I was there, and the remaining ones are all legitimate:

- `data-pressed` — Base UI's `Toggle`
- `data-selected` — Base UI's select item
- `data-invalid` — our own, set explicitly by `ui/Checkbox`
- `data-placeholder` — tiptap's placeholder extension

Static checks 11/11 and the frontend builds. No react-aria left in the tree: no imports, nothing in `package.json`, nothing in the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)