### PR TITLE
chore(e2e): stabilize the test view screenshots

### DIFF
--- a/tests/project-tests.spec.ts
+++ b/tests/project-tests.spec.ts
@@ -18,6 +18,15 @@ function doc(text: string) {
   };
 }
 
+/**
+ * The test ID in the breadcrumb is a sqid of the `tests` row id, so the Postgres
+ * sequence decides it and it differs from one run to the next. Mask it, or every
+ * screenshot of the test view reports a change.
+ */
+function maskTestId(testId: string) {
+  return { replacements: { [testId]: "SPARKLE-XXX" } };
+}
+
 loggedTest.beforeEach(async ({ auth, team }) => {
   await ensureTeamOwner({ team: team.team, user: auth.user });
 });
@@ -45,11 +54,7 @@ loggedTest("test detail", async ({ page, team, project, builds }) => {
     throw new Error("Test ID should be present in the URL");
   }
   const testId = match[1];
-  await screenshot(page, "test-detail", {
-    replacements: {
-      [testId]: "SPARKLE-XXX",
-    },
-  });
+  await screenshot(page, "test-detail", maskTestId(testId));
 });
 
 loggedTest("test view with a change", async ({ page, team, project }) => {
@@ -83,7 +88,7 @@ loggedTest("test view with a change", async ({ page, team, project }) => {
     )
     .toBe(true);
 
-  await screenshot(page, "test-view-change");
+  await screenshot(page, "test-view-change", maskTestId(testId));
 });
 
 loggedTest(
@@ -114,7 +119,7 @@ loggedTest(
     // The filter is in the URL, so the view survives a reload and can be shared.
     await expect(page).toHaveURL(/changes=ignored/);
 
-    await screenshot(page, "test-view-ignored-changes");
+    await screenshot(page, "test-view-ignored-changes", maskTestId(testId));
   },
 );
 
@@ -149,7 +154,7 @@ loggedTest(
     const unsubscribe = page.getByRole("button", { name: "Unsubscribe" });
     await expect(unsubscribe).toBeVisible();
 
-    await screenshot(page, "test-view-comment");
+    await screenshot(page, "test-view-comment", maskTestId(testId));
 
     // And the toggle opts back out.
     await unsubscribe.click();
@@ -195,7 +200,7 @@ loggedTest(
       page.getByRole("img", { name: /^Posted through/ }),
     ).toHaveCount(1);
 
-    await screenshot(page, "test-view-agent-comment");
+    await screenshot(page, "test-view-agent-comment", maskTestId(testId));
   },
 );
 


### PR DESCRIPTION
Every screenshot of the test view reported a change every few builds. [Build 5623](https://app.argos-ci.com/argos-ci/argos/builds/5623/412078254) is the example: the only differing pixels are at `x 615–659, y 26–37` — the breadcrumb — where the baseline read `SPARKLE-9PN4` and the head read `SPARKLE-C8W0`.

## Why it happens

`TestBreadcrumbItem` renders the test ID as literal text, and `formatTestId` is `PROJECTNAME-<sqid of tests.id>`. `tests.id` is a Postgres sequence: Playwright truncates the DB once in `setup`, then each test seeds its own rows, so the value the seeded test lands on depends on worker scheduling, test order and retries. Different run, different ID, different glyphs.

Argos had already isolated this. `test-detail` is the one screenshot in the file that masks the ID, and it is the only stable one:

| screenshot | stability | changes / 43 builds |
| --- | --- | --- |
| `test-detail` (masked) | 1.00 | 0 |
| `test-view-change` | 0.93 / 0.95 | 2–3 |
| `test-view-ignored-changes` | 0.93 / 0.95 | 2–3 |
| `test-view-comment` | 0.93 / 0.95 | 2–3 |
| `test-view-agent-comment` | 0.93 / 0.96 | 1–2 |

The mechanism was already solved in this file — it just was not applied to the four screenshots added later.

## The change

Pull the replacement out of `test-detail` into a helper and use it on all five test-view screenshots:

```ts
function maskTestId(testId: string) {
  return { replacements: { [testId]: "SPARKLE-XXX" } };
}
```

Kept `replacements` rather than marking the breadcrumb `data-visual-test="transparent"`, so the baseline still shows a rendered ID — a breadcrumb with an icon and blank text reads like a bug in review — and so the change stays in test code. The tradeoff is that `transparent` on `TestBreadcrumbItem` would be structurally immune to a sixth screenshot being added without the mask; happy to switch if you prefer that.

## Reviewer notes

- **Expect a one-time baseline change on four screenshots**, where the random ID becomes `SPARKLE-XXX`. `test-detail` is untouched.
- `pnpm run static-checks` passes (11/11).
- I could not run the suite locally — port 3000 was held by a dev server and Playwright refuses to start its own. The mechanism is verified in CI instead: the same helper, the same search/replace pair, on the same breadcrumb element, is what holds `test-detail` at stability 1.0, and its baseline visibly reads `SPARKLE-XXX`. `replaceText` also asserts the searched text is visible, so a mask that stops matching fails the test rather than passing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
