### PR TITLE
fix(build): keep the sidebar level with the toolbar in search mode

### DIFF
--- a/apps/frontend/src/pages/Build/LeftSidebar.tsx
+++ b/apps/frontend/src/pages/Build/LeftSidebar.tsx
@@ -28,9 +28,8 @@ const _BuildFragment = graphql(`
 function SearchInput({ ref }: { ref: React.Ref<HTMLInputElement> }) {
   const { search, setSearch } = useSearchState();
   return (
-    // `pl-1.375` is the overview button's hairline plus its padding, so the
-    // magnifier lands exactly where the home icon was and the row does not
-    // shift when search takes it over.
+    // `pl-1` keeps the magnifier off the sidebar's edge, in line with the icons
+    // the list below starts its rows with.
     <div className="relative flex-1 pl-1">
       <SearchIcon className="text-low pointer-events-none absolute top-1/2 size-3.5 -translate-y-1/2" />
       <input
@@ -38,7 +37,12 @@ function SearchInput({ ref }: { ref: React.Ref<HTMLInputElement> }) {
         type="text"
         autoFocus
         placeholder="Find..."
-        className="text-default placeholder:text-low w-full bg-transparent pr-2 pl-6 text-xs leading-6 outline-hidden"
+        // `block` and `leading-6` make the field exactly as tall as a pill tab
+        // (24px), so the row search takes over keeps the height it has in tabs
+        // mode and its hairline stays level with the toolbar's. Left inline, the
+        // field would sit in a line box 2px taller than itself — the space under
+        // its baseline — and the whole row would grow by those 2px.
+        className="text-default placeholder:text-low block w-full bg-transparent pr-2 pl-6 text-xs leading-6 outline-hidden"
         value={search}
         onChange={(event) => setSearch(event.target.value)}
         onKeyDown={(event) => {


### PR DESCRIPTION
Clicking the magnifier in a build's sidebar dropped the sidebar's hairline 2px below the toolbar's, so the two rows no longer read as one band across the top of the page.

## Cause

The search field is an `<input>`, inline-level by default, so the wrapper `<div>` formed a line box 26px tall — the field's own 24px plus 2px of space under its baseline. The row's `p-3` sat on top of that, so search mode measured 51px where tabs mode measures 49px.

## Fix

`block` on the input. Its `leading-6` line box is then the whole height: exactly 24px, the same as the `PillTab`s it replaces, so the row keeps the height it has in tabs mode.

Measured on the running app, before and after:

| | tabs mode | search mode | toolbar |
|---|---|---|---|
| before | 49px | **51px** | 49px |
| after | 49px | **49px** | 49px |

The field also now starts at `y=77`, exactly where the "Snapshots" / "Info" pills sit, so its text lands on the toolbar's line rather than 1px under it.

## Also in here

The comment above the wrapper credited `pl-1.375` for aligning the magnifier with the overview button's home icon. The class is `pl-1`, and that button moved out of this row into the stats row two commits later — the comment described neither the code nor the layout any more, so it is rewritten. The padding value itself is untouched; horizontal position was not the problem.

## Verifying

Measured with a throwaway Playwright spec against the built app (`getBoundingClientRect` on the sidebar row, the search field and the toolbar, in both modes), then removed. No new test: this is a one-off rendering detail, which per [CLAUDE.md](CLAUDE.md#what-to-test) is fixed and left at that.

`pnpm run static-checks` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)