### PR TITLE
feat(build): review a journey as one — flow context in the build review

### DIFF
--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -1010,6 +1010,210 @@ export async function createFallbackBaselineScenario(input: {
 }
 
 /**
+ * A build whose screenshots come from a test that walks a checkout step by
+ * step, with the SDK's capture order recorded — plus one screenshot from a
+ * test that is not a journey. Names are chosen so that neither the
+ * alphabetical order (cart, confirmation, payment, shipping) nor the diff
+ * score order matches the journey (cart, shipping, payment, confirmation):
+ * a review that follows the journey can only be following the metadata.
+ */
+export async function createFlowScenario(input: {
+  projectId: string;
+}): Promise<{ build: Build }> {
+  const { projectId } = input;
+  const seededAt = getSeedInstant();
+  const sdk = { name: "@argos-ci/playwright", version: "6.0.0" };
+  const automationLibrary = { name: "playwright", version: "1.61.0" };
+  const browser = { name: "chromium", version: "126.0" };
+  const viewport = { width: 375, height: 1024 };
+
+  const steps: {
+    name: string;
+    index: number;
+    /** Diff score; `null` for an unchanged screenshot. */
+    score: number | null;
+  }[] = [
+    { name: "checkout/cart.png", index: 0, score: null },
+    { name: "checkout/shipping.png", index: 1, score: null },
+    { name: "checkout/payment.png", index: 2, score: 0.3 },
+    // Scores higher than the payment step, so the server (score first) lists
+    // it before payment while the journey lists it after.
+    { name: "checkout/confirmation.png", index: 3, score: 0.5 },
+  ];
+  const journey = {
+    title: "complete a purchase",
+    titlePath: ["checkout.spec.ts", "complete a purchase"],
+    location: { file: "e2e/checkout.spec.ts", line: 8, column: 5 },
+    retries: 0,
+    retry: 0,
+  };
+  const other = {
+    name: "account/settings.png",
+    score: 0.1,
+    test: {
+      title: "shows the account settings",
+      titlePath: ["account.spec.ts", "shows the account settings"],
+      location: { file: "e2e/account.spec.ts", line: 4, column: 5 },
+      retries: 0,
+      retry: 0,
+    },
+  };
+
+  const bucketProps = {
+    name: "default",
+    projectId,
+    complete: true,
+    valid: true,
+    screenshotCount: steps.length + 1,
+    storybookScreenshotCount: 0,
+    createdAt: seededAt,
+    updatedAt: seededAt,
+  };
+  const [baseBucket, compareBucket] =
+    await ScreenshotBucket.query().insertAndFetch([
+      {
+        ...bucketProps,
+        branch: "main",
+        commit: "5f1e0c2b7a9d4e6f8c3b1a0d9e7f6c5b4a3d2e1f",
+      },
+      {
+        ...bucketProps,
+        branch: "feat/apple-pay",
+        commit: "9c8b7a6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a0b",
+      },
+    ]);
+  invariant(baseBucket && compareBucket);
+
+  const [baseFile, compareFile, diffFile] = await Promise.all([
+    ensureFile({
+      type: "screenshot",
+      width: 375,
+      height: 1024,
+      key: "dummy-375x1024.png",
+      contentType: "image/png",
+    }),
+    ensureFile({
+      type: "screenshot",
+      width: 375,
+      height: 720,
+      key: "dummy-375x720.png",
+      contentType: "image/png",
+    }),
+    ensureFile({
+      type: "screenshotDiff",
+      width: 375,
+      height: 1024,
+      key: "diff-1024-to-720.png",
+      contentType: "image/png",
+    }),
+  ]);
+
+  const screenshots = [
+    ...steps.map((step) => ({
+      name: step.name,
+      score: step.score,
+      metadata: {
+        url: `https://shop.example.com/${step.name.replace(/\.png$/, "")}`,
+        viewport,
+        colorScheme: "light" as const,
+        mediaType: "screen" as const,
+        test: journey,
+        capture: { index: step.index },
+        browser,
+        automationLibrary,
+        sdk,
+      } satisfies ScreenshotMetadata,
+    })),
+    {
+      name: other.name,
+      score: other.score,
+      metadata: {
+        url: "https://shop.example.com/account/settings",
+        viewport,
+        colorScheme: "light" as const,
+        mediaType: "screen" as const,
+        test: other.test,
+        capture: { index: 0 },
+        browser,
+        automationLibrary,
+        sdk,
+      } satisfies ScreenshotMetadata,
+    },
+  ];
+
+  const tests = await Test.query().insertAndFetch(
+    screenshots.map((screenshot) => ({
+      name: screenshot.name,
+      buildName: "default",
+      projectId,
+    })),
+  );
+  const testIdByName = new Map(tests.map((test) => [test.name, test.id]));
+
+  const baseScreenshots = await Screenshot.query().insertAndFetch(
+    screenshots.map((screenshot) => ({
+      screenshotBucketId: baseBucket.id,
+      testId: testIdByName.get(screenshot.name) ?? null,
+      name: screenshot.name,
+      s3Id: baseFile.key,
+      fileId: baseFile.id,
+      metadata: screenshot.metadata,
+    })),
+  );
+  const compareScreenshots = await Screenshot.query().insertAndFetch(
+    screenshots.map((screenshot) => ({
+      screenshotBucketId: compareBucket.id,
+      testId: testIdByName.get(screenshot.name) ?? null,
+      name: screenshot.name,
+      s3Id: screenshot.score === null ? baseFile.key : compareFile.key,
+      fileId: screenshot.score === null ? baseFile.id : compareFile.id,
+      metadata: screenshot.metadata,
+    })),
+  );
+
+  const [build] = await Build.query().insertAndFetch([
+    {
+      name: "default",
+      number: 1,
+      type: "check" as const,
+      jobStatus: "complete" as const,
+      baseScreenshotBucketId: baseBucket.id,
+      compareScreenshotBucketId: compareBucket.id,
+      baseBranch: "main",
+      projectId,
+      createdAt: seededAt,
+      updatedAt: seededAt,
+    },
+  ]);
+  invariant(build);
+
+  await ScreenshotDiff.query().insert(
+    screenshots.map((screenshot, index) => {
+      const baseScreenshot = baseScreenshots[index];
+      const compareScreenshot = compareScreenshots[index];
+      invariant(baseScreenshot && compareScreenshot);
+      const changed = screenshot.score !== null;
+      return {
+        buildId: build.id,
+        baseScreenshotId: baseScreenshot.id,
+        compareScreenshotId: compareScreenshot.id,
+        testId: testIdByName.get(screenshot.name) ?? null,
+        score: screenshot.score ?? 0,
+        jobStatus: "complete" as const,
+        s3Id: changed ? diffFile.key : null,
+        fileId: changed ? diffFile.id : null,
+        createdAt: seededAt,
+        updatedAt: seededAt,
+      };
+    }),
+  );
+
+  await concludeBuild({ build, notify: false });
+
+  return { build };
+}
+
+/**
  * Two builds sharing one head commit and branch, told apart by their build
  * name — the shape a project gets when a commit runs several suites. Both end
  * up with changes waiting, so finishing one leaves the other to review.

--- a/apps/backend/src/graphql/definitions/Screenshot.ts
+++ b/apps/backend/src/graphql/definitions/Screenshot.ts
@@ -78,6 +78,10 @@ export const typeDefs = gql`
     play: Boolean
   }
 
+  type ScreenshotMetadataCapture {
+    index: Int!
+  }
+
   type ScreenshotMetadata {
     url: String
     previewUrl: String
@@ -89,6 +93,7 @@ export const typeDefs = gql`
     automationLibrary: ScreenshotMetadataAutomationLibrary!
     sdk: ScreenshotMetadataSDK!
     story: ScreenshotMetadataStory
+    capture: ScreenshotMetadataCapture
     tags: [String!]
   }
 

--- a/apps/backend/src/graphql/services/variant-key.test.ts
+++ b/apps/backend/src/graphql/services/variant-key.test.ts
@@ -19,6 +19,18 @@ describe("#getVariantKey", () => {
     );
   });
 
+  it("strips trailing color-scheme tokens", async () => {
+    expect(getVariantKey("homepage+-dark vw-1536.png")).toBe("homepage+");
+    expect(getVariantKey("homepage+ vw-1536.png")).toBe("homepage+");
+    expect(getVariantKey("pricing dark.png")).toBe("pricing");
+    expect(getVariantKey("pricing-light.png")).toBe("pricing");
+    expect(getVariantKey("chromium/pages/home-dark vw-375.png")).toBe(
+      "pages/home",
+    );
+    // No separator: the token is part of the name, not a scheme suffix.
+    expect(getVariantKey("darkroom.png")).toBe("darkroom");
+  });
+
   it("handles failed variant keys", async () => {
     expect(getVariantKey("chromium/role/edit/space-ui #123 (failed).png")).toBe(
       "role/edit/space-ui",

--- a/apps/backend/src/graphql/services/variant-key.ts
+++ b/apps/backend/src/graphql/services/variant-key.ts
@@ -8,6 +8,8 @@
  * 4. Removes any occurrence of " #<digits> (failed).png".
  * 5. Removes any occurrence of "mode-[]" followed by ".png".
  * 6. Removes the ".png" extension.
+ * 7. Removes a trailing color-scheme token (" dark", "-dark", " light",
+ *    "-light") so light and dark captures of the same screen are variants.
  *
  * @param name - The name string to be sanitized.
  * @returns The sanitized variant key.
@@ -24,6 +26,10 @@ export function getVariantKey(name: string): string {
       .replace(/\s+vw-\d+\.png$/, "")
       .replace(/ #\d+ \(failed\)\.png$/, "")
       .replace(/\.png$/, "")
+      // There is no canonical suffix for color schemes, so suites encode
+      // them ad hoc in the name ("homepage-dark", "homepage dark"): strip
+      // the common forms once every other suffix is gone.
+      .replace(/[\s-]+(dark|light)$/i, "")
       .trim()
   );
 }

--- a/apps/frontend/src/containers/Build/BuildHotkeys.tsx
+++ b/apps/frontend/src/containers/Build/BuildHotkeys.tsx
@@ -94,6 +94,18 @@ const hotkeyGroups = [
         description: "Go to next media",
         envs: ["media"],
       },
+      goToPreviousFlowStep: {
+        keys: ["⇧", "ArrowLeft"],
+        displayKeys: ["⇧", "←"],
+        description: "Go to previous flow step",
+        envs: ["test", "build"],
+      },
+      goToNextFlowStep: {
+        keys: ["⇧", "ArrowRight"],
+        displayKeys: ["⇧", "→"],
+        description: "Go to next flow step",
+        envs: ["test", "build"],
+      },
       toggleDiffGroup: {
         keys: ["KeyG"],
         displayKeys: ["G"],
@@ -360,10 +372,24 @@ function checkHotkeyMatches(hotkey: Hotkey, event: KeyboardEvent): boolean {
     return false;
   }
 
-  // Only demanded, never forbidden: plenty of existing keys ("?") are typed
-  // *with* shift without declaring it.
   if (shiftShouldBePressed && !event.shiftKey) {
     return false;
+  }
+  if (!shiftShouldBePressed && event.shiftKey) {
+    // Plenty of existing keys ("?") are typed *with* shift without declaring
+    // it, so shift is only discriminating for physical keys, where holding it
+    // can only mean another shortcut (⇧← vs ←).
+    const physicalKeysOnly = hotkey.keys.every(
+      (key) =>
+        key === "⌘" ||
+        key === "⌥" ||
+        key.startsWith("Key") ||
+        key.startsWith("Digit") ||
+        key.startsWith("Arrow"),
+    );
+    if (physicalKeysOnly) {
+      return false;
+    }
   }
 
   return hotkey.keys.every((key) => {

--- a/apps/frontend/src/pages/Build/BuildDetailHeader.tsx
+++ b/apps/frontend/src/pages/Build/BuildDetailHeader.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 import { invariant } from "@argos/util/invariant";
+import { WaypointsIcon } from "lucide-react";
 import { Link } from "react-router";
 
 import { BuildDiffDetailToolbar } from "@/containers/Build/BuildDiffDetailToolbar";
@@ -15,6 +16,7 @@ import {
   PreviousButton,
 } from "@/containers/Build/toolbar/NavButtons";
 import { BuildType } from "@/gql/graphql";
+import { Button } from "@/ui/Button";
 import { Separator } from "@/ui/Separator";
 import { Tooltip } from "@/ui/Tooltip";
 import { useEventCallback } from "@/ui/useEventCallback";
@@ -24,6 +26,8 @@ import { getTestURL } from "../Test/TestParams";
 import {
   checkDiffCanBeReviewed,
   Diff,
+  useActiveDiffFlow,
+  useFlowMinimapState,
   useGoToBuildOverview,
   useGoToNextDiff,
   useGoToPreviousDiff,
@@ -58,28 +62,32 @@ export const BuildDetailHeader = memo(function BuildDetailHeader(props: {
       <DetailToolbarNav>
         <BuildNavButtons />
       </DetailToolbarNav>
-      <DetailToolbarTitle
-        render={
-          testId
-            ? (title) => (
-                <Tooltip content="View test details">
-                  <Link
-                    to={getTestURL(
-                      { ...params, testId },
-                      { change: diff.change?.id },
-                    )}
-                    className="group hover:underline-link"
-                  >
-                    {title}
-                  </Link>
-                </Tooltip>
-              )
-            : undefined
-        }
-      >
-        {diff.name}
-      </DetailToolbarTitle>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <FlowLine />
+        <DetailToolbarTitle
+          render={
+            testId
+              ? (title) => (
+                  <Tooltip content="View test details">
+                    <Link
+                      to={getTestURL(
+                        { ...params, testId },
+                        { change: diff.change?.id },
+                      )}
+                      className="group hover:underline-link"
+                    >
+                      {title}
+                    </Link>
+                  </Tooltip>
+                )
+              : undefined
+          }
+        >
+          {diff.name}
+        </DetailToolbarTitle>
+      </div>
       <BuildDiffDetailToolbar diff={diff} fitControls={<AriaSnapshotToggle />}>
+        <FlowMinimapToggle />
         <BuildDetailIgnoreButton diff={diff} />
         <TrackButtons diff={diff} disabled={!canBeReviewed} />
         <Separator orientation="vertical" className="mx-1 h-6" />
@@ -110,6 +118,52 @@ function BuildDetailIgnoreButton(props: { diff: Diff }) {
   });
 
   return <IgnoreButton diff={diff} onIgnoreChange={handleIgnoreChange} />;
+}
+
+/**
+ * Journey context above the screenshot name: the flow's title and the step
+ * position, secondary and single-line. Nothing when the screenshot is not a
+ * step of a multi-step flow.
+ */
+function FlowLine() {
+  const flow = useActiveDiffFlow();
+  if (!flow) {
+    return null;
+  }
+  return (
+    <div
+      className="text-low truncate text-xs"
+      title={flow.identity.key}
+      data-testid="flow-line"
+    >
+      {flow.identity.title}
+      {flow.stepIndex !== -1
+        ? ` · ${flow.stepIndex + 1}/${flow.steps.length}`
+        : null}
+    </div>
+  );
+}
+
+/** Same look and behavior as the other toolbar toggles. */
+function FlowMinimapToggle() {
+  const flow = useActiveDiffFlow();
+  const { visible, setVisible } = useFlowMinimapState();
+  if (!flow) {
+    return null;
+  }
+  return (
+    <Tooltip content={visible ? "Hide flow minimap" : "Show flow minimap"}>
+      <Button
+        variant="secondary"
+        iconOnly
+        aria-label="Flow minimap"
+        aria-pressed={visible}
+        onClick={() => setVisible(!visible)}
+      >
+        <WaypointsIcon />
+      </Button>
+    </Tooltip>
+  );
 }
 
 const BuildNavButtons = memo(function BuildNavButtons() {

--- a/apps/frontend/src/pages/Build/BuildDiffState.tsx
+++ b/apps/frontend/src/pages/Build/BuildDiffState.tsx
@@ -33,11 +33,20 @@ import {
 } from "./BuildParams";
 import { useBuildReviewState } from "./BuildReviewState";
 import { EvaluationStatus } from "./EvaluationStatus";
+import {
+  compareSteps,
+  getCaptureIndex,
+  getVariantSignature,
+  resolveFlowIdentity,
+  type FlowIdentity,
+} from "./flow-model";
+import { orderDiffsByFlow } from "./flow-order";
 import { FilterStateContext } from "./metadata/filters/FilterState";
 import {
   diffMatchesFilters,
   useCreateFilterState,
 } from "./metadata/filters/util";
+import { resolveDiffMetadata } from "./sidebar/metadata/utils";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ScreenshotDiffFragment = graphql(`
@@ -84,6 +93,9 @@ const ScreenshotDiffFragment = graphql(`
           mode
           play
           tags
+        }
+        capture {
+          index
         }
         viewport {
           width
@@ -146,6 +158,9 @@ const ScreenshotDiffFragment = graphql(`
           mode
           play
           tags
+        }
+        capture {
+          index
         }
         viewport {
           width
@@ -549,8 +564,121 @@ function groupDiffs(
     }
     return groups;
   }, {});
-  return DIFF_GROUPS.map((groupName) => diffByGroups[groupName] ?? null).filter(
-    (x) => x !== null,
+  return DIFF_GROUPS.map((groupName) => diffByGroups[groupName] ?? null)
+    .filter((x) => x !== null)
+    .map((group) => ({
+      ...group,
+      // Within a status section, follow the journeys: the diffs of a flow
+      // stay adjacent, in step order.
+      diffs: orderDiffsByFlow(
+        group.diffs.filter((diff) => diff !== null),
+        describeDiffForFlow,
+      ),
+    }));
+}
+
+function describeDiffForFlow(diff: Diff) {
+  return {
+    name: diff.name,
+    variantKey: diff.variantKey,
+    group: diff.group ?? null,
+    metadata: resolveDiffMetadata(diff),
+  };
+}
+
+/**
+ * Visibility of the flow minimap in the build detail, persisted as a user
+ * preference.
+ */
+const FLOW_MINIMAP_STORAGE_KEY = "preferences.build.flow-minimap";
+
+type FlowMinimapContextValue = {
+  visible: boolean;
+  setVisible: (visible: boolean) => void;
+};
+
+const FlowMinimapContext = createContext<FlowMinimapContextValue | null>(null);
+
+export function useFlowMinimapState() {
+  const context = use(FlowMinimapContext);
+  invariant(
+    context,
+    "useFlowMinimapState must be used within a BuildDiffProvider",
+  );
+  return context;
+}
+
+export type ActiveDiffFlow = {
+  identity: FlowIdentity;
+  /** The steps of the journey in order, each with its variants. */
+  steps: { key: string; diffs: Diff[] }[];
+  /** Position of the active diff's step in `steps`. */
+  stepIndex: number;
+};
+
+/**
+ * The flow context of the active diff: the journey it belongs to, its steps
+ * (variants collapsed) in order, and the active step position. Null when the
+ * active diff has no flow information or the journey has a single step —
+ * a test that captures one screen is regular visual testing, not a journey.
+ */
+export function useActiveDiffFlow(): ActiveDiffFlow | null {
+  const { activeDiff, allDiffs } = useBuildDiffState();
+  return useMemo(() => {
+    if (!activeDiff) {
+      return null;
+    }
+    const identity = resolveFlowIdentity(resolveDiffMetadata(activeDiff));
+    if (!identity) {
+      return null;
+    }
+    const stepMap = new Map<
+      string,
+      { key: string; captureIndex: number | null; diffs: Diff[] }
+    >();
+    for (const diff of allDiffs) {
+      const metadata = resolveDiffMetadata(diff);
+      if (resolveFlowIdentity(metadata)?.key !== identity.key) {
+        continue;
+      }
+      const key = diff.variantKey;
+      const step = stepMap.get(key) ?? { key, captureIndex: null, diffs: [] };
+      stepMap.set(key, step);
+      step.diffs.push(diff);
+      const captureIndex = getCaptureIndex(metadata);
+      if (captureIndex !== null) {
+        step.captureIndex = Math.min(
+          step.captureIndex ?? Number.MAX_SAFE_INTEGER,
+          captureIndex,
+        );
+      }
+    }
+    const steps = [...stepMap.values()].toSorted(compareSteps);
+    if (steps.length < 2) {
+      return null;
+    }
+    return {
+      identity,
+      steps,
+      stepIndex: steps.findIndex((step) => step.key === activeDiff.variantKey),
+    };
+  }, [activeDiff, allDiffs]);
+}
+
+/**
+ * The diff of `step` that is the same variant as `reference` (same browser,
+ * viewport, scheme…), or the step's first diff when that variant is missing.
+ * Moving between steps stays on one viewport this way.
+ */
+export function pickStepDiff(
+  step: ActiveDiffFlow["steps"][number],
+  reference: Diff,
+): Diff | null {
+  const signature = getVariantSignature(reference);
+  return (
+    step.diffs.find((diff) => getVariantSignature(diff) === signature) ??
+    step.diffs[0] ??
+    null
   );
 }
 
@@ -727,6 +855,21 @@ export function BuildDiffProvider(props: {
 
   const [scrolledDiff, setScrolledDiff] = useState<Diff | null>(null);
 
+  const [minimapVisible, setMinimapVisibleState] = useState<boolean>(
+    () => localStorage.getItem(FLOW_MINIMAP_STORAGE_KEY) === "true",
+  );
+  const setMinimapVisible = useCallback((visible: boolean) => {
+    localStorage.setItem(FLOW_MINIMAP_STORAGE_KEY, String(visible));
+    setMinimapVisibleState(visible);
+  }, []);
+  const minimapValue = useMemo(
+    (): FlowMinimapContextValue => ({
+      visible: minimapVisible,
+      setVisible: setMinimapVisible,
+    }),
+    [minimapVisible, setMinimapVisible],
+  );
+
   const groups = useMemo(() => {
     return groupDiffs(filteredDiffs, reviewState?.diffStatuses ?? {});
   }, [filteredDiffs, reviewState?.diffStatuses]);
@@ -845,7 +988,9 @@ export function BuildDiffProvider(props: {
     <FilterStateContext value={filterState}>
       <SearchModeContext value={searchModeValue}>
         <SearchContext value={searchValue}>
-          <BuildDiffContext value={value}>{children}</BuildDiffContext>
+          <FlowMinimapContext value={minimapValue}>
+            <BuildDiffContext value={value}>{children}</BuildDiffContext>
+          </FlowMinimapContext>
         </SearchContext>
       </SearchModeContext>
     </FilterStateContext>

--- a/apps/frontend/src/pages/Build/BuildFlowMinimap.tsx
+++ b/apps/frontend/src/pages/Build/BuildFlowMinimap.tsx
@@ -1,0 +1,142 @@
+import { clsx } from "clsx";
+import { ChevronRightIcon } from "lucide-react";
+
+import { useBuildHotkey } from "@/containers/Build/BuildHotkeys";
+import { ScreenshotDiffStatus } from "@/gql/graphql";
+import { useEventCallback } from "@/ui/useEventCallback";
+
+import {
+  pickStepDiff,
+  useActiveDiffFlow,
+  useBuildDiffState,
+  useFlowMinimapState,
+} from "./BuildDiffState";
+import { getStepLabel } from "./flow-model";
+import { getViewportIconKind } from "./metadata/metadataIcons";
+import { resolveDiffMetadata } from "./sidebar/metadata/utils";
+import { ScreenshotDiffThumbnail } from "./sidebar/ScreenshotDiffThumbnail";
+
+/**
+ * ⇧← / ⇧→ walk the journey of the active diff, across status sections —
+ * the keyboard counterpart of the minimap (and independent from it).
+ */
+export function FlowStepHotkeys() {
+  const flow = useActiveDiffFlow();
+  const { activeDiff, setActiveDiff } = useBuildDiffState();
+  const goToStep = useEventCallback((delta: -1 | 1) => {
+    if (!flow || !activeDiff) {
+      return;
+    }
+    const target = flow.steps[flow.stepIndex + delta];
+    if (!target) {
+      return;
+    }
+    const diff = pickStepDiff(target, activeDiff);
+    if (diff) {
+      setActiveDiff(diff, true);
+    }
+  });
+  useBuildHotkey("goToPreviousFlowStep", () => goToStep(-1), {
+    preventDefault: true,
+  });
+  useBuildHotkey("goToNextFlowStep", () => goToStep(1), {
+    preventDefault: true,
+  });
+  return null;
+}
+
+const ATTENTION_STATUSES: string[] = [
+  ScreenshotDiffStatus.Failure,
+  ScreenshotDiffStatus.Changed,
+  ScreenshotDiffStatus.Added,
+  ScreenshotDiffStatus.Removed,
+];
+
+/**
+ * The journey of the active diff as a strip of steps, on demand: shows where
+ * the change sits in the flow and jumps between steps. Only rendered when
+ * the user asked for it and the active diff belongs to a multi-step flow.
+ */
+export function BuildFlowMinimap() {
+  const { visible } = useFlowMinimapState();
+  const flow = useActiveDiffFlow();
+  const { activeDiff, setActiveDiff } = useBuildDiffState();
+  if (!visible || !flow || !activeDiff) {
+    return null;
+  }
+  // The strip stays within the active diff's variant, so every box shares one
+  // viewport: it can take its shape from it, portrait for a mobile run.
+  const viewportWidth = resolveDiffMetadata(activeDiff)?.viewport?.width;
+  const portrait =
+    viewportWidth !== undefined &&
+    getViewportIconKind(viewportWidth) === "mobile";
+  return (
+    // An inset card in the viewer column, aligned on the diff area gutters
+    // (`p-4`) and styled like the diff panels. The inner padding keeps the
+    // selection ring and focus outline of edge thumbnails from being
+    // clipped by the scroll container.
+    <div className="shrink-0 px-4 pt-2" data-testid="flow-minimap">
+      <div className="bg-app border-thin flex items-center gap-1 overflow-x-auto rounded-md px-2 pt-2 pb-1.5">
+        {flow.steps.map((step, index) => {
+          const diff = pickStepDiff(step, activeDiff);
+          if (!diff) {
+            return null;
+          }
+          const isActive = index === flow.stepIndex;
+          const needsAttention = step.diffs.some((candidate) =>
+            ATTENTION_STATUSES.includes(candidate.status),
+          );
+          return (
+            <div key={step.key} className="flex shrink-0 items-center gap-0.5">
+              {index > 0 && (
+                <ChevronRightIcon className="text-low size-3 shrink-0" />
+              )}
+              <button
+                type="button"
+                data-flow-step={step.key}
+                aria-current={isActive ? "step" : undefined}
+                onClick={() => setActiveDiff(diff, true)}
+                className={clsx(
+                  "flex flex-col items-center gap-1 rounded-md p-1",
+                  !isActive && "hover:bg-hover",
+                )}
+              >
+                <span className="relative">
+                  <ScreenshotDiffThumbnail
+                    screenshotDiff={diff}
+                    className={clsx(
+                      "h-12",
+                      portrait ? "w-6.5" : "w-16",
+                      isActive && "ring-primary-active ring-2",
+                    )}
+                    fit="cover"
+                    // A top crop at 2x the rendered box. Fitting inside a
+                    // square instead would hand `object-cover` a sliver of a
+                    // full-page capture to upscale.
+                    transformations={
+                      portrait
+                        ? ["w-52", "h-96", "fo-top"]
+                        : ["w-128", "h-96", "fo-top"]
+                    }
+                  />
+                  {needsAttention ? (
+                    <span className="bg-warning-solid absolute -top-1 -right-1 size-2.5 rounded-full ring-2 ring-(--background-color-app)" />
+                  ) : null}
+                </span>
+                <span
+                  className={clsx(
+                    "max-w-28 truncate text-center text-[0.6875rem] leading-none",
+                    isActive ? "font-medium" : "text-low",
+                  )}
+                  title={getStepLabel(step.key)}
+                >
+                  {index + 1} · {getStepLabel(step.key)}
+                </span>
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/Build/BuildWorkspace.tsx
+++ b/apps/frontend/src/pages/Build/BuildWorkspace.tsx
@@ -17,6 +17,7 @@ import { Code } from "../../ui/Code";
 import { Link } from "../../ui/Link";
 import { BuildDetailHeader } from "./BuildDetailHeader";
 import { useBuildDiffState } from "./BuildDiffState";
+import { BuildFlowMinimap, FlowStepHotkeys } from "./BuildFlowMinimap";
 import { BuildOverview } from "./BuildOverview";
 import { BuildParams } from "./BuildParams";
 import { BuildLeftSidebar } from "./LeftSidebar";
@@ -118,49 +119,55 @@ export function BuildWorkspace(props: {
         <BuildLeftSidebar build={build} repoUrl={repoUrl} params={params} />
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           <BuildDetailProviders>
+            <FlowStepHotkeys />
             <Toolbar build={build} />
             <div className="bg-subtle flex min-h-0 flex-1">
-              {(() => {
-                switch (build.status) {
-                  case BuildStatus.Aborted:
-                  case BuildStatus.Error:
-                  case BuildStatus.Expired:
-                    return (
-                      <div className="min-h-0 flex-1 p-6 text-xl">
-                        <Alert className="mx-auto max-w-xl rounded-sm border p-4">
-                          <AlertTitle>
-                            {
+              <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+                <BuildFlowMinimap />
+                {(() => {
+                  switch (build.status) {
+                    case BuildStatus.Aborted:
+                    case BuildStatus.Error:
+                    case BuildStatus.Expired:
+                      return (
+                        <div className="min-h-0 flex-1 p-6 text-xl">
+                          <Alert className="mx-auto max-w-xl rounded-sm border p-4">
+                            <AlertTitle>
                               {
-                                [BuildStatus.Error]: "Build failed",
-                                [BuildStatus.Expired]: "Build expired",
-                                [BuildStatus.Aborted]: "Build aborted",
-                              }[build.status]
-                            }
-                          </AlertTitle>
-                          <AlertText>
-                            <BuildStatusDescription build={build} />
-                          </AlertText>
-                        </Alert>
-                      </div>
-                    );
-                  case BuildStatus.Pending:
-                  case BuildStatus.Progress:
-                    return <BuildProgress parallel={build.parallel} />;
-                  default:
-                    if (
-                      !params.diffId &&
-                      build.type !== BuildType.Skipped &&
-                      ((build.stats?.total ?? 0) > 0 ||
-                        build.type === BuildType.Orphan)
-                    ) {
-                      return <BuildOverview build={build} repoUrl={repoUrl} />;
-                    }
+                                {
+                                  [BuildStatus.Error]: "Build failed",
+                                  [BuildStatus.Expired]: "Build expired",
+                                  [BuildStatus.Aborted]: "Build aborted",
+                                }[build.status]
+                              }
+                            </AlertTitle>
+                            <AlertText>
+                              <BuildStatusDescription build={build} />
+                            </AlertText>
+                          </Alert>
+                        </div>
+                      );
+                    case BuildStatus.Pending:
+                    case BuildStatus.Progress:
+                      return <BuildProgress parallel={build.parallel} />;
+                    default:
+                      if (
+                        !params.diffId &&
+                        build.type !== BuildType.Skipped &&
+                        ((build.stats?.total ?? 0) > 0 ||
+                          build.type === BuildType.Orphan)
+                      ) {
+                        return (
+                          <BuildOverview build={build} repoUrl={repoUrl} />
+                        );
+                      }
 
-                    return (
-                      build && <BuildDetail build={build} repoUrl={repoUrl} />
-                    );
-                }
-              })()}
+                      return (
+                        build && <BuildDetail build={build} repoUrl={repoUrl} />
+                      );
+                  }
+                })()}
+              </div>
               <RightSidebar
                 build={build}
                 repoUrl={repoUrl}

--- a/apps/frontend/src/pages/Build/flow-model.test.ts
+++ b/apps/frontend/src/pages/Build/flow-model.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compareSteps,
+  getStepLabel,
+  getVariantSignature,
+  resolveFlowIdentity,
+} from "./flow-model";
+
+describe("#resolveFlowIdentity", () => {
+  it("groups by test title path", () => {
+    expect(
+      resolveFlowIdentity({
+        test: { titlePath: ["checkout.spec.ts", "complete a purchase"] },
+      }),
+    ).toEqual({
+      key: "checkout.spec.ts › complete a purchase",
+      prefix: "checkout.spec.ts",
+      title: "complete a purchase",
+    });
+  });
+
+  it("groups stories by component", () => {
+    expect(
+      resolveFlowIdentity({
+        story: { id: "components-button--primary" },
+        test: {
+          titlePath: ["storybook.spec.ts", "components-button--primary"],
+        },
+      }),
+    ).toEqual({
+      key: "storybook › components-button",
+      prefix: "storybook",
+      title: "components-button",
+    });
+  });
+
+  it("merges color-scheme test runs into one journey", () => {
+    // Real fixtures from argos-ci.com: the dark run carries a marker on two
+    // levels — the "dark mode" suite and the "(dark)" title suffix.
+    const light = resolveFlowIdentity({
+      test: {
+        titlePath: [
+          "screenshot-pages.spec.ts",
+          "Screenshot pages",
+          "Screenshots for about ",
+        ],
+      },
+    });
+    const dark = resolveFlowIdentity({
+      test: {
+        titlePath: [
+          "screenshot-pages.spec.ts",
+          "Screenshot pages dark mode",
+          "Screenshots for about  (dark)",
+        ],
+      },
+    });
+    expect(light?.key).toBe(
+      "screenshot-pages.spec.ts › Screenshot pages › Screenshots for about",
+    );
+    expect(dark?.key).toBe(light?.key);
+  });
+
+  it("drops describe segments that are nothing but a scheme wrapper", () => {
+    expect(
+      resolveFlowIdentity({
+        test: { titlePath: ["home.spec.ts", "Dark mode", "Homepage"] },
+      })?.key,
+    ).toBe("home.spec.ts › Homepage");
+  });
+
+  it("leaves words that merely contain a scheme token untouched", () => {
+    expect(
+      resolveFlowIdentity({
+        test: { titlePath: ["app.spec.ts", "The darkroom"] },
+      })?.key,
+    ).toBe("app.spec.ts › The darkroom");
+    expect(
+      resolveFlowIdentity({
+        test: { titlePath: ["app.spec.ts", "Skylight"] },
+      })?.key,
+    ).toBe("app.spec.ts › Skylight");
+  });
+
+  it("returns null without test or story metadata", () => {
+    expect(resolveFlowIdentity(null)).toBeNull();
+    expect(resolveFlowIdentity({})).toBeNull();
+    expect(resolveFlowIdentity({ test: { titlePath: [] } })).toBeNull();
+    expect(resolveFlowIdentity({ test: { titlePath: ["dark"] } })).toBeNull();
+  });
+});
+
+describe("#getVariantSignature", () => {
+  it("keeps what tells variants apart", () => {
+    expect(
+      getVariantSignature({
+        name: "chromium/checkout/cart vw-375.png",
+        variantKey: "checkout/cart",
+      }),
+    ).toBe("chromium/ vw-375.png");
+    expect(
+      getVariantSignature({
+        name: "chromium/checkout/payment vw-375.png",
+        variantKey: "checkout/payment",
+      }),
+    ).toBe("chromium/ vw-375.png");
+    expect(
+      getVariantSignature({ name: "home dark.png", variantKey: "home" }),
+    ).toBe(" dark.png");
+  });
+});
+
+describe("#getStepLabel", () => {
+  it("keeps the last path segment", () => {
+    expect(getStepLabel("checkout/cart")).toBe("cart");
+    expect(getStepLabel("cart")).toBe("cart");
+  });
+});
+
+describe("#compareSteps", () => {
+  it("follows the capture order, then the key", () => {
+    const steps = [
+      { key: "b", captureIndex: null },
+      { key: "z", captureIndex: 0 },
+      { key: "a", captureIndex: null },
+      { key: "y", captureIndex: 1 },
+    ];
+    expect(steps.toSorted(compareSteps).map((step) => step.key)).toEqual([
+      "z",
+      "y",
+      "a",
+      "b",
+    ]);
+  });
+});

--- a/apps/frontend/src/pages/Build/flow-model.ts
+++ b/apps/frontend/src/pages/Build/flow-model.ts
@@ -1,0 +1,117 @@
+/**
+ * The journey a screenshot belongs to, derived from the metadata the SDK
+ * records — nothing to configure on the user's side.
+ *
+ * A *flow* is the test that took the screenshot: its title path (file ›
+ * describe › test) is the identity. Storybook uploads carry a story id
+ * instead: stories group by component, one step per story.
+ *
+ * A *step* is a logical screen, not a file: the viewport, browser and
+ * color-scheme variants of one screen collapse into one step, keyed by the
+ * backend `variantKey`. Steps follow the capture order recorded by the SDK,
+ * and fall back to the alphabetical order of their key when it is missing.
+ */
+
+/** The part of a screenshot's metadata the flow model reads. */
+export type FlowMetadata = {
+  test?: { titlePath: string[] } | null;
+  story?: { id: string } | null;
+  capture?: { index: number } | null;
+} | null;
+
+export type FlowIdentity = {
+  /** Stable key, e.g. the joined test title path or a story component id. */
+  key: string;
+  /** Muted context shown before the title (test file, "storybook"…). */
+  prefix: string;
+  title: string;
+};
+
+/**
+ * Strips a trailing color-scheme marker from a test title or describe
+ * ("Homepage (dark)", "Homepage dark", "Screenshot pages dark mode"): a suite
+ * run twice for theming is one journey whose steps have dark/light variants,
+ * not two journeys. A segment that is nothing but a marker ("dark mode")
+ * disappears entirely, merging with the run that has no wrapper describe.
+ */
+function stripSchemeMarker(segment: string): string {
+  return segment
+    .replace(/\s*\((dark|light)([\s-]+mode)?\)$/i, "")
+    .replace(/[\s-]*\b(dark|light)([\s-]+mode)?$/i, "")
+    .trim();
+}
+
+export function resolveFlowIdentity(
+  metadata: FlowMetadata,
+): FlowIdentity | null {
+  // Story first: Storybook runs through a Playwright test runner, so its
+  // screenshots may carry test metadata too — but the journey users care
+  // about is the component (one step per story), not the runner's test.
+  const storyId = metadata?.story?.id;
+  if (storyId) {
+    const [component = storyId] = storyId.split("--");
+    return {
+      key: `storybook › ${component}`,
+      prefix: "storybook",
+      title: component,
+    };
+  }
+  const rawTitlePath = metadata?.test?.titlePath;
+  if (rawTitlePath && rawTitlePath.length > 0) {
+    // Color-scheme markers can sit at any level ("Screenshot pages dark mode"
+    // describe, "Screenshots for about (dark)" title): every segment is
+    // normalized so both runs resolve to the same journey.
+    const titlePath = rawTitlePath
+      .map((segment) => stripSchemeMarker(segment.trim()))
+      .filter(Boolean);
+    const title = titlePath.at(-1);
+    if (!title) {
+      return null;
+    }
+    return {
+      key: titlePath.join(" › "),
+      prefix: titlePath.slice(0, -1).join(" › "),
+      title,
+    };
+  }
+  return null;
+}
+
+/** Short display label for a step, from its key. */
+export function getStepLabel(stepKey: string): string {
+  return stepKey.split("/").pop() || stepKey;
+}
+
+/**
+ * What is left of a screenshot name once its variant key is taken out: the
+ * browser prefix, viewport suffix, scheme token… — everything that tells one
+ * variant of a screen from another. Two screenshots of different steps with
+ * the same signature are the same variant of the journey, which is how the
+ * minimap and ⇧←/⇧→ stay on one viewport while moving between steps.
+ */
+export function getVariantSignature(screenshot: {
+  name: string;
+  variantKey: string;
+}): string {
+  return screenshot.name.replace(screenshot.variantKey, "");
+}
+
+const LAST = Number.MAX_SAFE_INTEGER;
+
+/**
+ * Orders steps: capture order when the SDK recorded it, alphabetical by key
+ * otherwise. A step without an index sorts after those that have one.
+ */
+export function compareSteps(
+  a: { key: string; captureIndex: number | null },
+  b: { key: string; captureIndex: number | null },
+): number {
+  return (
+    (a.captureIndex ?? LAST) - (b.captureIndex ?? LAST) ||
+    a.key.localeCompare(b.key)
+  );
+}
+
+export function getCaptureIndex(metadata: FlowMetadata): number | null {
+  return metadata?.capture?.index ?? null;
+}

--- a/apps/frontend/src/pages/Build/flow-order.test.ts
+++ b/apps/frontend/src/pages/Build/flow-order.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import { orderDiffsByFlow, type FlowOrderable } from "./flow-order";
+
+type TestDiff = FlowOrderable & { id: string };
+
+function diff(
+  id: string,
+  options: {
+    test?: string;
+    index?: number;
+    group?: string;
+    variantKey?: string;
+  } = {},
+): TestDiff {
+  return {
+    id,
+    name: `${id}.png`,
+    variantKey: options.variantKey ?? id,
+    group: options.group ?? null,
+    metadata: options.test
+      ? {
+          test: { titlePath: ["e2e.spec.ts", options.test] },
+          capture:
+            options.index === undefined ? null : { index: options.index },
+        }
+      : null,
+  };
+}
+
+function order(diffs: TestDiff[]) {
+  return orderDiffsByFlow(diffs, (d) => d).map((d) => d.id);
+}
+
+describe("#orderDiffsByFlow", () => {
+  it("keeps the server order when nothing belongs to a flow", () => {
+    expect(order([diff("b"), diff("a"), diff("c")])).toEqual(["b", "a", "c"]);
+  });
+
+  it("gathers a journey where its first diff sat, in capture order", () => {
+    expect(
+      order([
+        diff("checkout/payment", { test: "checkout", index: 2 }),
+        diff("settings"),
+        diff("checkout/cart", { test: "checkout", index: 0 }),
+        diff("checkout/shipping", { test: "checkout", index: 1 }),
+      ]),
+    ).toEqual([
+      "checkout/cart",
+      "checkout/shipping",
+      "checkout/payment",
+      "settings",
+    ]);
+  });
+
+  it("falls back to the step key when no capture order was recorded", () => {
+    expect(
+      order([
+        diff("checkout/shipping", { test: "checkout" }),
+        diff("checkout/cart", { test: "checkout" }),
+        diff("checkout/payment", { test: "checkout", index: 0 }),
+      ]),
+    ).toEqual(["checkout/payment", "checkout/cart", "checkout/shipping"]);
+  });
+
+  it("keeps the variants of a step together", () => {
+    const cartMobile: TestDiff = {
+      ...diff("checkout/cart vw-375", { test: "checkout", index: 0 }),
+      variantKey: "checkout/cart",
+    };
+    const cartDesktop: TestDiff = {
+      ...diff("checkout/cart vw-1280", { test: "checkout", index: 0 }),
+      variantKey: "checkout/cart",
+    };
+    const paymentMobile: TestDiff = {
+      ...diff("checkout/payment vw-375", { test: "checkout", index: 1 }),
+      variantKey: "checkout/payment",
+    };
+    expect(order([paymentMobile, cartMobile, cartDesktop])).toEqual([
+      "checkout/cart vw-1280",
+      "checkout/cart vw-375",
+      "checkout/payment vw-375",
+    ]);
+  });
+
+  it("orders journeys by their most significant diff, not by name", () => {
+    expect(
+      order([
+        diff("signup/verify", { test: "signup", index: 1 }),
+        diff("checkout/cart", { test: "checkout", index: 0 }),
+        diff("signup/account", { test: "signup", index: 0 }),
+        diff("checkout/payment", { test: "checkout", index: 1 }),
+      ]),
+    ).toEqual([
+      "signup/account",
+      "signup/verify",
+      "checkout/cart",
+      "checkout/payment",
+    ]);
+  });
+
+  it("moves a similar-change group as one block", () => {
+    // The footer changed on the cart and on the settings page: the two
+    // diffs are one group. The cart's journey pulls the group with it,
+    // rather than leaving the settings page in the middle of the checkout.
+    expect(
+      order([
+        diff("checkout/cart", { test: "checkout", index: 0, group: "footer" }),
+        diff("settings", { group: "footer" }),
+        diff("checkout/payment", { test: "checkout", index: 1 }),
+        diff("checkout/confirmation", { test: "checkout", index: 2 }),
+      ]),
+    ).toEqual([
+      "checkout/cart",
+      "settings",
+      "checkout/payment",
+      "checkout/confirmation",
+    ]);
+  });
+
+  it("never splits a group between two journeys", () => {
+    expect(
+      order([
+        diff("checkout/cart", { test: "checkout", index: 0, group: "g" }),
+        diff("signup/account", { test: "signup", index: 0, group: "g" }),
+        diff("checkout/payment", { test: "checkout", index: 1 }),
+        diff("signup/verify", { test: "signup", index: 1 }),
+      ]),
+    ).toEqual([
+      "checkout/cart",
+      "signup/account",
+      "checkout/payment",
+      "signup/verify",
+    ]);
+  });
+
+  it("does not treat a lone group member as a group", () => {
+    expect(
+      order([
+        diff("checkout/payment", { test: "checkout", index: 1, group: "g" }),
+        diff("checkout/cart", { test: "checkout", index: 0 }),
+      ]),
+    ).toEqual(["checkout/cart", "checkout/payment"]);
+  });
+});

--- a/apps/frontend/src/pages/Build/flow-order.ts
+++ b/apps/frontend/src/pages/Build/flow-order.ts
@@ -1,0 +1,97 @@
+import {
+  compareSteps,
+  getCaptureIndex,
+  getVariantSignature,
+  resolveFlowIdentity,
+  type FlowMetadata,
+} from "./flow-model";
+
+/** What the ordering needs to know about a diff. */
+export type FlowOrderable = {
+  name: string;
+  variantKey: string;
+  /** Similar-change group the diff belongs to, if any. */
+  group: string | null;
+  metadata: FlowMetadata;
+};
+
+/**
+ * Reorders the diffs of one status section so that a journey reads in
+ * order: the diffs of a flow become adjacent, in step order, at the place the
+ * server gave the first of them — a journey sits where its most significant
+ * screenshot sat, and everything else keeps the server order (biggest change
+ * first).
+ *
+ * Similar-change groups stay whole: the list renders a group as one
+ * collapsible item and expects its members side by side, so a group is moved
+ * as a block to the position of its best-placed member rather than split
+ * between journeys.
+ *
+ * `diffs` must be in server order; the section they come from is what makes
+ * groups contiguous to begin with.
+ */
+export function orderDiffsByFlow<T>(
+  diffs: T[],
+  describe: (diff: T) => FlowOrderable,
+): T[] {
+  const entries = diffs.map((diff, index) => {
+    const description = describe(diff);
+    const flow = resolveFlowIdentity(description.metadata);
+    return {
+      diff,
+      index,
+      group: description.group,
+      flowKey: flow?.key ?? null,
+      step: {
+        key: description.variantKey,
+        captureIndex: getCaptureIndex(description.metadata),
+      },
+      signature: getVariantSignature(description),
+    };
+  });
+
+  // A flow ranks where its first diff was; a diff outside any flow ranks
+  // where it was. Ranks never collide across flows since a flow's rank is one
+  // of its own members' index.
+  const flowRanks = new Map<string, number>();
+  for (const entry of entries) {
+    if (entry.flowKey !== null && !flowRanks.has(entry.flowKey)) {
+      flowRanks.set(entry.flowKey, entry.index);
+    }
+  }
+  const rank = (entry: (typeof entries)[number]) =>
+    entry.flowKey === null ? entry.index : (flowRanks.get(entry.flowKey) ?? 0);
+
+  const sorted = entries.toSorted(
+    (a, b) =>
+      rank(a) - rank(b) ||
+      // Same rank means same flow: walk the journey, one variant after
+      // another within a step.
+      compareSteps(a.step, b.step) ||
+      a.signature.localeCompare(b.signature) ||
+      a.index - b.index,
+  );
+
+  const groupSizes = new Map<string, number>();
+  for (const entry of entries) {
+    if (entry.group !== null) {
+      groupSizes.set(entry.group, (groupSizes.get(entry.group) ?? 0) + 1);
+    }
+  }
+  const blocks: T[][] = [];
+  const groupBlocks = new Map<string, T[]>();
+  for (const entry of sorted) {
+    if (entry.group !== null && (groupSizes.get(entry.group) ?? 0) > 1) {
+      let block = groupBlocks.get(entry.group);
+      if (!block) {
+        block = [];
+        groupBlocks.set(entry.group, block);
+        blocks.push(block);
+      }
+      block.push(entry.diff);
+    } else {
+      blocks.push([entry.diff]);
+    }
+  }
+  return blocks.flat();
+}

--- a/apps/frontend/src/pages/Build/sidebar/MetadataSection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/MetadataSection.tsx
@@ -7,6 +7,7 @@ import { AutomationLibraryRow } from "./metadata/AutomationLibraryRow";
 import { BaselineRow } from "./metadata/BaselineRow";
 import { BrowserRow } from "./metadata/BrowserRow";
 import { ColorSchemeRow } from "./metadata/ColorSchemeRow";
+import { FlowRow } from "./metadata/FlowRow";
 import { MediaTypeRow } from "./metadata/MediaTypeRow";
 import { RepeatRow } from "./metadata/RepeatRow";
 import { RetryRow } from "./metadata/RetryRow";
@@ -84,6 +85,7 @@ export function MetadataSection(props: MetadataSectionProps) {
             automationLibrary={metadata?.automationLibrary ?? null}
           />
           <TestRow test={test} branch={branch} repoUrl={repoUrl} />
+          <FlowRow />
           <AnnotationsRow
             annotations={test?.annotations ?? null}
             repoUrl={repoUrl}

--- a/apps/frontend/src/pages/Build/sidebar/ScreenshotDiffThumbnail.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/ScreenshotDiffThumbnail.tsx
@@ -33,12 +33,18 @@ export function ScreenshotDiffThumbnail(props: {
   iconClassName?: string;
   /** How the image fills the box. */
   fit?: "contain" | "cover";
+  /**
+   * ImageKit transformations; size them for the rendered box (at 2x) or the
+   * thumbnail comes out blurry.
+   */
+  transformations?: string[];
 }) {
   const {
     screenshotDiff,
     className,
     iconClassName = className,
     fit = "contain",
+    transformations = ["w-32", "h-32", "c-at_max"],
   } = props;
   const screenshot =
     screenshotDiff.compareScreenshot ?? screenshotDiff.baseScreenshot ?? null;
@@ -57,10 +63,12 @@ export function ScreenshotDiffThumbnail(props: {
       >
         <ImageKitPicture
           src={thumbnailUrl}
-          transformations={["w-32", "h-32", "c-at_max"]}
+          transformations={transformations}
           className={clsx(
             "size-full",
-            fit === "cover" ? "object-cover" : "object-contain",
+            // Cropping a page capture from the top keeps the part that makes
+            // it recognizable; a centred crop lands on a random band of body.
+            fit === "cover" ? "object-cover object-top" : "object-contain",
           )}
           alt=""
         />

--- a/apps/frontend/src/pages/Build/sidebar/metadata/FlowRow.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/metadata/FlowRow.tsx
@@ -1,0 +1,31 @@
+import { WaypointsIcon } from "lucide-react";
+
+import { Chip } from "@/ui/Chip";
+import { Tooltip } from "@/ui/Tooltip";
+
+import { useActiveDiffFlow } from "../../BuildDiffState";
+import { MetadataRow } from "./MetadataRow";
+
+/**
+ * The journey the active screenshot is a step of, and where in it: the test
+ * row above says which test took the screenshot, this one says what that
+ * test walks through.
+ */
+export function FlowRow() {
+  const flow = useActiveDiffFlow();
+  if (!flow) {
+    return null;
+  }
+  return (
+    <MetadataRow>
+      <Tooltip content={`Flow: ${flow.identity.key}`}>
+        <Chip icon={WaypointsIcon}>
+          {flow.identity.title}
+          {flow.stepIndex !== -1
+            ? ` · step ${flow.stepIndex + 1}/${flow.steps.length}`
+            : null}
+        </Chip>
+      </Tooltip>
+    </MetadataRow>
+  );
+}

--- a/packages/schemas/src/screenshot-metadata.ts
+++ b/packages/schemas/src/screenshot-metadata.ts
@@ -129,6 +129,15 @@ const StoryMetadataSchema = z
   })
   .meta({ description: "Storybook story metadata" });
 
+const CaptureSchema = z
+  .object({
+    index: z.number().int().min(0).meta({
+      description:
+        "The 0-based position of the screenshot within its test, following capture order",
+    }),
+  })
+  .meta({ description: "How the screenshot was captured within its test" });
+
 export const ScreenshotMetadataSchema = z
   .object({
     $schema: z
@@ -162,6 +171,7 @@ export const ScreenshotMetadataSchema = z
     story: StoryMetadataSchema.nullish().meta({
       description: "Storybook story metadata",
     }),
+    capture: CaptureSchema.nullish(),
     tags: z
       .array(z.string())
       .optional()

--- a/tests/build-flow.spec.ts
+++ b/tests/build-flow.spec.ts
@@ -1,0 +1,96 @@
+import { expect } from "@playwright/test";
+
+import { createFlowScenario } from "../apps/backend/src/database/seeds";
+import { loggedTest } from "./logged-test";
+import { ensureTeamOwner, screenshot } from "./util";
+
+loggedTest(
+  "reviews the screenshots of a test in the order of its journey",
+  async ({ page, auth, team, project }) => {
+    await ensureTeamOwner({ team: team.team, user: auth.user });
+    const { build } = await createFlowScenario({ projectId: project.id });
+
+    await page.goto(
+      `/${team.account.slug}/${project.name}/builds/${build.number}`,
+    );
+    await page.getByRole("button", { name: /^Start review/ }).click();
+
+    // The list follows the journey, not the alphabet nor the diff score:
+    // payment (step 3) before confirmation (step 4), and the journey leads
+    // since it holds the biggest change.
+    const list = page.locator("[role='button'][data-index]");
+    await expect(list).toHaveText([
+      /checkout\/payment\.png/,
+      /checkout\/confirmation\.png/,
+      /account\/settings\.png/,
+    ]);
+    // Unchanged steps sit in their own section, still in journey order.
+    await page.getByRole("button", { name: /^Unchanged/ }).click();
+    await expect(list).toHaveText([
+      /checkout\/payment\.png/,
+      /checkout\/confirmation\.png/,
+      /account\/settings\.png/,
+      /checkout\/cart\.png/,
+      /checkout\/shipping\.png/,
+    ]);
+
+    // The first change is the third step of the purchase, and the review
+    // says so above the screenshot name and in the metadata.
+    await expect(
+      page.getByRole("heading", { name: "checkout/payment.png" }),
+    ).toBeVisible();
+    const flowLine = page.getByTestId("flow-line");
+    await expect(flowLine).toHaveText("complete a purchase · 3/4");
+    await expect(
+      page.getByText("complete a purchase · step 3/4"),
+    ).toBeVisible();
+
+    // ⇧→ walks to the next step, ⇧← back — across status sections.
+    await page.keyboard.press("Shift+ArrowRight");
+    await expect(
+      page.getByRole("heading", { name: "checkout/confirmation.png" }),
+    ).toBeVisible();
+    await expect(flowLine).toHaveText("complete a purchase · 4/4");
+    await page.keyboard.press("Shift+ArrowLeft");
+    await expect(flowLine).toHaveText("complete a purchase · 3/4");
+    await page.keyboard.press("Shift+ArrowLeft");
+    await expect(
+      page.getByRole("heading", { name: "checkout/shipping.png" }),
+    ).toBeVisible();
+    await expect(flowLine).toHaveText("complete a purchase · 2/4");
+
+    // The minimap unfolds the whole journey, marks the current step and the
+    // ones with changes, and jumps between steps.
+    await page.getByRole("button", { name: "Flow minimap" }).click();
+    const minimap = page.getByTestId("flow-minimap");
+    await expect(minimap.getByRole("button")).toHaveText([
+      "1 · cart",
+      "2 · shipping",
+      "3 · payment",
+      "4 · confirmation",
+    ]);
+    await expect(minimap.locator("[aria-current='step']")).toHaveText(
+      "2 · shipping",
+    );
+    await minimap.getByRole("button", { name: "4 · confirmation" }).click();
+    await expect(
+      page.getByRole("heading", { name: "checkout/confirmation.png" }),
+    ).toBeVisible();
+
+    await screenshot(page, "build-flow-context", {
+      replacements: {
+        [team.account.slug]: "acme",
+      },
+    });
+
+    // A screenshot outside any journey shows no flow context.
+    await list.filter({ hasText: "account/settings.png" }).click();
+    await expect(
+      page.getByRole("heading", { name: "account/settings.png" }),
+    ).toBeVisible();
+    await expect(flowLine).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Flow minimap" }),
+    ).toHaveCount(0);
+  },
+);


### PR DESCRIPTION
The review-side scope of the flows work (#2452), carved out so it can ship on its own: a build that captured a journey is reviewed as one. The Flows tab, the flow view and the local step curation stay in #2452 for a later decision.

[![flow-review-context.png](https://files.argos-ci.com/media/9/e0248f7eaaf4c5a10b57fe35b1a5a63a27b5b6a3b8bcbc89209789f4830ec87f.webp)](https://app.argos-ci.com/m/452b6dppkvv6nypyjpqa)

## What changes for a reviewer

A test that captures a checkout step by step used to be reviewed as a flat, alphabetical list: cart, confirmation, payment, review, shipping. Now, derived from the SDK metadata (test title path, or the story component for Storybook) with nothing to configure:

- **Journey order** — within each status section, the diffs of a flow sit together in step order: capture order when the SDK recorded it, alphabetical otherwise. The journey sits where its first diff sat, so the biggest change still leads.
- **Flow context** — the flow's title and the step position (`complete a purchase · 4/5`) above the screenshot name, and a Flow chip in the Metadata panel.
- **Flow minimap** — a toolbar toggle unfolds the whole journey as a strip of thumbnails under the header, marking the steps that need attention. Persisted as a preference.
- **`⇧←` / `⇧→`** move between the steps of the flow, staying on the same variant, across status sections. `←` / `→` keep switching between baseline and changes.

Screenshots outside a multi-step journey see none of this: a test that captures one screen is regular visual testing.

## What is different from #2452

- **Similar-change groups stay whole.** #2452 re-sorted each status section by flow, which split `group`ed diffs (a footer changed on 20 pages) apart — the list assumes group members are adjacent, so headers duplicated and members went missing under a collapsed header — and dropped the server's "biggest change first" order for everyone. Here a group moves as one block, and everything that is not part of a journey keeps the server order. `orderDiffsByFlow` is pure and table-tested.
- **Steps are keyed by the backend `variantKey`** rather than a client-side re-implementation of the name normalization, and the "same variant" match across steps is what is left of the name once the variant key is taken out — no hard-coded browser list or viewport regex on the frontend.
- **No local curation**, no `poc/`, no Flows tab or route.

## Also in here

- `packages/schemas` / GraphQL accept and expose `metadata.capture.index` (recorded by argos-ci/argos-javascript#360; old backends silently drop it, old SDKs simply lack it — both directions verified compatible).
- `getVariantKey` strips a trailing color-scheme token (`home dark`, `home-light`), so a theme run counts as a variant of the screen rather than a separate screen — in the review's variant navigation as well as here.
- `ScreenshotDiffThumbnail` gains a `transformations` prop and crops `cover` thumbnails from the top (a centred crop of a full-page capture lands on a random band of body).

## Tests

- `tests/build-flow.spec.ts` seeds a four-step checkout with capture order recorded, named so that neither the alphabetical nor the score order matches the journey, and checks the list order, flow line and chip, `⇧←`/`⇧→` across sections, and the minimap.
- Unit tests for `flow-model` (identity, scheme-run merging, variant signature) and `flow-order` (journey gathering, group blocks, fallbacks).
- Full chromium e2e suite green locally (101/101), `pnpm static-checks` green.

## Rollout

Ships on its own. Journey order needs the SDK release to be exact; until then steps fall back to alphabetical within the flow, which is what the review did before. The changelog in argos-ci/argos-ci.com#352 needs re-scoping to this perimeter ("journey order in the review"), and argos-ci/docs#248 covers the Flows tab as well and should be trimmed accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
