### PR TITLE
feat(build): find the commit's builds across projects

### DIFF
--- a/apps/backend/db/migrations/20260818120000_builds-prheadcommit-index.js
+++ b/apps/backend/db/migrations/20260818120000_builds-prheadcommit-index.js
@@ -1,0 +1,30 @@
+/**
+ * Index backing the cross-project lookup of a commit's builds.
+ *
+ * `Build.siblingBuilds` starts from a commit SHA and has to find every project
+ * that built it, so it can no longer lean on `projectId` to narrow the scan.
+ * `screenshot_buckets.commit` is already indexed on its own; the head commit of
+ * a pull request build lives on `builds."prHeadCommit"` instead, and had no
+ * index that did not start with `projectId`. Partial, because the column is
+ * null on every build that did not come from a pull request.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async (knex) => {
+  await knex.raw(
+    `CREATE INDEX CONCURRENTLY IF NOT EXISTS builds_prheadcommit_idx
+       ON builds ("prHeadCommit")
+       WHERE "prHeadCommit" IS NOT NULL`,
+  );
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async (knex) => {
+  await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS builds_prheadcommit_idx`);
+};
+
+export const config = { transaction: false };

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict I3c71ozcUc6qIxshE9FEt2xxcp0iTprj3I7DbqFDTBMY5k3xcGbjx5vlNVrhV8O
+\restrict 5RhyAs841JlVJNR1LIh9P6SJCznUR94GrKXX1oPTcgDMpLo9yQql3wcfO8FUnY9
 
 -- Dumped from database version 18.4
 -- Dumped by pg_dump version 18.4
@@ -4504,6 +4504,13 @@ CREATE INDEX builds_number_index ON public.builds USING btree (number);
 
 
 --
+-- Name: builds_prheadcommit_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX builds_prheadcommit_idx ON public.builds USING btree ("prHeadCommit") WHERE ("prHeadCommit" IS NOT NULL);
+
+
+--
 -- Name: builds_project_type_name_createdat_id_idx; Type: INDEX; Schema: public; Owner: postgres
 --
 
@@ -6237,7 +6244,7 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-\unrestrict I3c71ozcUc6qIxshE9FEt2xxcp0iTprj3I7DbqFDTBMY5k3xcGbjx5vlNVrhV8O
+\unrestrict 5RhyAs841JlVJNR1LIh9P6SJCznUR94GrKXX1oPTcgDMpLo9yQql3wcfO8FUnY9
 
 -- Knex migrations
 
@@ -6484,3 +6491,4 @@ INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('2026081
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260813191611_comment-agent.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260814161900_build-review-agent.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260816090349_subscription-flat-price.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260818120000_builds-prheadcommit-index.js', 1, NOW());

--- a/apps/backend/src/build/siblings.e2e.test.ts
+++ b/apps/backend/src/build/siblings.e2e.test.ts
@@ -1,0 +1,287 @@
+import { invariant } from "@argos/util/invariant";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type {
+  Account,
+  Build,
+  Project,
+  ScreenshotBucket,
+  User,
+} from "@/database/models";
+import { factory, setupDatabase } from "@/database/testing";
+
+import { getSiblingBuilds } from "./siblings";
+
+const BRANCH = "feat/sparkle";
+const COMMIT = "c2b8b5b2f6a1d4e3c0b9f8a7d6e5c4b3a2f1e0d9";
+
+/**
+ * A build of the commit under test, in the given project.
+ */
+async function createCommitBuild(input: {
+  projectId: string;
+  name: string;
+  branch?: string;
+  commit?: string;
+  prHeadCommit?: string;
+}): Promise<Build> {
+  const bucket = await factory.ScreenshotBucket.create({
+    projectId: input.projectId,
+    name: input.name,
+    branch: input.branch ?? BRANCH,
+    commit: input.commit ?? COMMIT,
+  });
+  return factory.Build.create({
+    projectId: input.projectId,
+    name: input.name,
+    compareScreenshotBucketId: bucket.id,
+    conclusion: "changes-detected",
+    prHeadCommit: input.prHeadCommit ?? null,
+  });
+}
+
+async function getCompareBucket(build: Build): Promise<ScreenshotBucket> {
+  await build.$fetchGraph("compareScreenshotBucket");
+  const bucket = build.compareScreenshotBucket;
+  invariant(bucket);
+  return bucket;
+}
+
+const test = it.extend<{
+  /** A member of the team owning `project` and `siblingProject`. */
+  user: User;
+  teamAccount: Account;
+  project: Project;
+  /** Another project of the same team, so of the same member. */
+  siblingProject: Project;
+  /** A project of a team the user has nothing to do with. */
+  foreignProject: Project;
+  build: Build;
+}>({
+  user: async ({}, use) => {
+    await use(await factory.User.create());
+  },
+  teamAccount: async ({ user }, use) => {
+    const account = await factory.TeamAccount.create();
+    invariant(account.teamId);
+    await factory.TeamUser.create({
+      teamId: account.teamId,
+      userId: user.id,
+      userLevel: "member",
+    });
+    await use(account);
+  },
+  project: async ({ teamAccount }, use) => {
+    await use(
+      await factory.Project.create({
+        accountId: teamAccount.id,
+        name: "sparkle",
+      }),
+    );
+  },
+  siblingProject: async ({ teamAccount }, use) => {
+    await use(
+      await factory.Project.create({
+        accountId: teamAccount.id,
+        name: "sparkle-docs",
+      }),
+    );
+  },
+  foreignProject: async ({}, use) => {
+    await use(await factory.Project.create({ name: "not-yours" }));
+  },
+  build: async ({ project }, use) => {
+    await use(
+      await createCommitBuild({ projectId: project.id, name: "default" }),
+    );
+  },
+});
+
+describe("getSiblingBuilds", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  test("returns the commit's other suites in the same project", async ({
+    user,
+    project,
+    build,
+  }) => {
+    const storybookBuild = await createCommitBuild({
+      projectId: project.id,
+      name: "storybook",
+    });
+
+    const siblings = await getSiblingBuilds({
+      build,
+      compareBucket: await getCompareBucket(build),
+      user,
+    });
+    expect(siblings.map((sibling) => sibling.id)).toEqual([storybookBuild.id]);
+  });
+
+  test("returns the commit's builds in another project of the viewer", async ({
+    user,
+    siblingProject,
+    build,
+  }) => {
+    // Same build name as the reviewed one: two projects of a monorepo both
+    // call their suite `default`, so the name cannot be what excludes a build.
+    const docsBuild = await createCommitBuild({
+      projectId: siblingProject.id,
+      name: "default",
+    });
+
+    const siblings = await getSiblingBuilds({
+      build,
+      compareBucket: await getCompareBucket(build),
+      user,
+    });
+    expect(siblings.map((sibling) => sibling.id)).toEqual([docsBuild.id]);
+  });
+
+  test("matches the head commit of a pull request build", async ({
+    user,
+    project,
+    siblingProject,
+  }) => {
+    // A pull request build is checked out on the merge commit, so the two
+    // projects only agree on the head commit — and each carries it on
+    // `prHeadCommit` rather than on its bucket.
+    const build = await createCommitBuild({
+      projectId: project.id,
+      name: "default",
+      commit: "1111111111111111111111111111111111111111",
+      prHeadCommit: COMMIT,
+    });
+    const docsBuild = await createCommitBuild({
+      projectId: siblingProject.id,
+      name: "default",
+      commit: "2222222222222222222222222222222222222222",
+      prHeadCommit: COMMIT,
+    });
+
+    const siblings = await getSiblingBuilds({
+      build,
+      compareBucket: await getCompareBucket(build),
+      user,
+    });
+    expect(siblings.map((sibling) => sibling.id)).toEqual([docsBuild.id]);
+  });
+
+  test("keeps only the latest run of a suite", async ({
+    user,
+    siblingProject,
+    build,
+  }) => {
+    await createCommitBuild({ projectId: siblingProject.id, name: "default" });
+    const rerun = await createCommitBuild({
+      projectId: siblingProject.id,
+      name: "default",
+    });
+
+    const siblings = await getSiblingBuilds({
+      build,
+      compareBucket: await getCompareBucket(build),
+      user,
+    });
+    expect(siblings.map((sibling) => sibling.id)).toEqual([rerun.id]);
+  });
+
+  test("ignores the commit's builds in a project the viewer is not a member of", async ({
+    user,
+    foreignProject,
+    build,
+  }) => {
+    await createCommitBuild({ projectId: foreignProject.id, name: "default" });
+
+    const siblings = await getSiblingBuilds({
+      build,
+      compareBucket: await getCompareBucket(build),
+      user,
+    });
+    expect(siblings).toEqual([]);
+  });
+
+  test("ignores a public project the viewer is not a member of", async ({
+    user,
+    foreignProject,
+    build,
+  }) => {
+    // A commit SHA travels far enough that a build hung off someone else's
+    // commit must not be offered as the next thing to review, public or not.
+    await foreignProject.$query().patch({ private: false });
+    await createCommitBuild({ projectId: foreignProject.id, name: "default" });
+
+    const siblings = await getSiblingBuilds({
+      build,
+      compareBucket: await getCompareBucket(build),
+      user,
+    });
+    expect(siblings).toEqual([]);
+  });
+
+  test("returns nothing outside the build's own project for an anonymous viewer", async ({
+    project,
+    siblingProject,
+    build,
+  }) => {
+    const storybookBuild = await createCommitBuild({
+      projectId: project.id,
+      name: "storybook",
+    });
+    await createCommitBuild({ projectId: siblingProject.id, name: "default" });
+
+    const siblings = await getSiblingBuilds({
+      build,
+      compareBucket: await getCompareBucket(build),
+      user: null,
+    });
+    expect(siblings.map((sibling) => sibling.id)).toEqual([storybookBuild.id]);
+  });
+
+  test("ignores the commit's builds on another branch", async ({
+    user,
+    siblingProject,
+    build,
+  }) => {
+    await createCommitBuild({
+      projectId: siblingProject.id,
+      name: "default",
+      branch: "main",
+    });
+
+    const siblings = await getSiblingBuilds({
+      build,
+      compareBucket: await getCompareBucket(build),
+      user,
+    });
+    expect(siblings).toEqual([]);
+  });
+
+  test("lists this project's builds before the other projects'", async ({
+    user,
+    project,
+    siblingProject,
+    build,
+  }) => {
+    const docsBuild = await createCommitBuild({
+      projectId: siblingProject.id,
+      name: "default",
+    });
+    const storybookBuild = await createCommitBuild({
+      projectId: project.id,
+      name: "storybook",
+    });
+
+    const siblings = await getSiblingBuilds({
+      build,
+      compareBucket: await getCompareBucket(build),
+      user,
+    });
+    expect(siblings.map((sibling) => sibling.id)).toEqual([
+      storybookBuild.id,
+      docsBuild.id,
+    ]);
+  });
+});

--- a/apps/backend/src/build/siblings.ts
+++ b/apps/backend/src/build/siblings.ts
@@ -1,0 +1,145 @@
+import { Build, Project, ScreenshotBucket } from "@/database/models";
+import type { User } from "@/database/models";
+import { queryBuilds } from "@/database/services/build";
+
+/**
+ * The other suites a commit produced: one build per name, latest run each, the
+ * build's own suite excluded.
+ *
+ * A commit does not stop at a project boundary. A monorepo wired to several
+ * Argos projects leaves one build per project on the same commit, and those are
+ * exactly the builds the reviewer still has to go through — so the search spans
+ * every project, not just this build's own.
+ *
+ * Access is re-derived per project rather than assumed from this build: another
+ * project only contributes when the viewer is a *member* of it. Being public is
+ * deliberately not enough — a commit SHA travels far enough that anyone could
+ * otherwise hang a build of their own off someone else's commit and have it
+ * offered as the next thing to review. This build's own project is always in
+ * scope, since the viewer is already looking at it.
+ */
+export async function getSiblingBuilds(input: {
+  build: Build;
+  /** The build's compare bucket, which carries its branch and commit. */
+  compareBucket: ScreenshotBucket;
+  user: User | null;
+}): Promise<Build[]> {
+  const { build, compareBucket, user } = input;
+
+  // Without a branch we cannot tell a sibling from any other build that
+  // happens to share the commit.
+  if (!compareBucket.branch) {
+    return [];
+  }
+  const branch = compareBucket.branch;
+  const commit = build.prHeadCommit ?? compareBucket.commit;
+
+  const projectIds = await getReachableProjectIds({
+    build,
+    branch,
+    commit,
+    user,
+  });
+
+  // One build per name, per project: a suite that was re-run leaves older
+  // builds behind on the same commit, and only its latest run is worth
+  // reviewing. The name alone is not the key — two projects of the same
+  // monorepo both call their suite `default`.
+  const latestPerName = queryBuilds({
+    projectId: projectIds,
+    filters: { branch, commit },
+  })
+    .select("builds.id")
+    .distinctOn(["builds.projectId", "builds.name"])
+    .orderBy("builds.projectId")
+    .orderBy("builds.name")
+    .orderBy("builds.id", "desc");
+
+  return (
+    Build.query()
+      .whereIn("builds.id", latestPerName)
+      // Told apart by name, not by id: siblings are the commit's *other*
+      // suites. Dropping this build's name rather than this build drops its
+      // own earlier runs with it — a re-run of one suite is the same suite,
+      // and offering it as somewhere else to go would list the same word twice
+      // and put a switcher on every build of every re-run commit. Scoped to
+      // its project: the same name in another project is another suite.
+      .whereNot((qb) => {
+        qb.where("builds.projectId", build.projectId).where(
+          "builds.name",
+          build.name,
+        );
+      })
+      // This build's own project first — the reviewer is already there — then
+      // a stable order across the others.
+      .orderByRaw(`("builds"."projectId" = ?) desc`, [build.projectId])
+      .orderBy("builds.projectId")
+      .orderBy("builds.name")
+  );
+}
+
+/**
+ * The projects whose builds of this commit the viewer may see: this build's
+ * own, plus every other project that built the commit and that the viewer is a
+ * member of.
+ */
+async function getReachableProjectIds(input: {
+  build: Build;
+  branch: string;
+  commit: string;
+  user: User | null;
+}): Promise<string[]> {
+  const { build, branch, commit, user } = input;
+
+  // An anonymous visitor is a member of nothing, so no other project can be
+  // reached — skip the lookup entirely.
+  if (!user) {
+    return [build.projectId];
+  }
+
+  const candidateIds = await getProjectIdsWithCommit({ branch, commit });
+  const otherIds = candidateIds.filter((id) => id !== build.projectId);
+  if (otherIds.length === 0) {
+    return [build.projectId];
+  }
+
+  const projects = await Project.query()
+    .whereIn("id", otherIds)
+    .withGraphFetched("account");
+  const memberOf = await Promise.all(
+    projects.map(async (project) => {
+      const permissions = await Project.getMembershipPermissions(project, user);
+      return permissions.includes("view") ? project.id : null;
+    }),
+  );
+
+  return [build.projectId, ...memberOf.filter((id) => id !== null)];
+}
+
+/**
+ * Every project that has a build on this commit, this build's own included.
+ *
+ * Both halves of the commit predicate are searched, since neither index covers
+ * the other: the head commit of a pull request build sits on
+ * `builds."prHeadCommit"`, while a build that is not from a pull request only
+ * carries its commit on the compare bucket.
+ */
+async function getProjectIdsWithCommit(input: {
+  branch: string;
+  commit: string;
+}): Promise<string[]> {
+  const { branch, commit } = input;
+  const [buckets, prBuilds] = await Promise.all([
+    ScreenshotBucket.query()
+      .distinct("projectId")
+      .where("commit", commit)
+      .where("branch", branch),
+    Build.query().distinct("projectId").where("prHeadCommit", commit),
+  ]);
+  return [
+    ...new Set([
+      ...buckets.map((bucket) => bucket.projectId),
+      ...prBuilds.map((prBuild) => prBuild.projectId),
+    ]),
+  ];
+}

--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -1010,13 +1010,22 @@ export async function createFallbackBaselineScenario(input: {
 }
 
 /**
- * Two builds sharing one head commit and branch, told apart by their build
- * name — the shape a project gets when a commit runs several suites. Both end
- * up with changes waiting, so finishing one leaves the other to review.
+ * Three builds sharing one head commit and branch — the shape a commit gets
+ * when it runs several suites, and when a monorepo splits them over several
+ * Argos projects. Two live in the given project, told apart by their build
+ * name; the third lives in a second project of the same account and reuses the
+ * `default` name, which is what a build name alone cannot disambiguate. All
+ * three end up with changes waiting, so finishing one leaves the others to
+ * review.
  */
 export async function createSiblingBuildsScenario(input: {
   projectId: string;
-}): Promise<{ defaultBuild: Build; storybookBuild: Build }> {
+}): Promise<{
+  defaultBuild: Build;
+  storybookBuild: Build;
+  docsBuild: Build;
+  docsProject: Project;
+}> {
   const { projectId } = input;
   const seededAt = getSeedInstant();
   const branch = "feat/sparkle";
@@ -1047,8 +1056,12 @@ export async function createSiblingBuildsScenario(input: {
     }),
   ]);
 
-  async function createSiblingBuild(options: { name: string; number: number }) {
-    const { name, number } = options;
+  async function createSiblingBuild(options: {
+    name: string;
+    number: number;
+    projectId?: string;
+  }) {
+    const { name, number, projectId = input.projectId } = options;
     const bucketProps = {
       name,
       projectId,
@@ -1122,9 +1135,24 @@ export async function createSiblingBuildsScenario(input: {
     return build;
   }
 
+  const project = await Project.query().findById(projectId);
+  invariant(project, "Project not found");
+  const docsProject = await createProject({
+    accountId: project.accountId,
+    name: `${project.name}-docs`,
+  });
+
   return {
     defaultBuild: await createSiblingBuild({ name: "default", number: 1 }),
     storybookBuild: await createSiblingBuild({ name: "storybook", number: 2 }),
+    // A number of its own: build numbers run per project, so the pair
+    // (project, number) is what addresses a build across the commit.
+    docsBuild: await createSiblingBuild({
+      name: "default",
+      number: 7,
+      projectId: docsProject.id,
+    }),
+    docsProject,
   };
 }
 

--- a/apps/backend/src/database/services/build.ts
+++ b/apps/backend/src/database/services/build.ts
@@ -38,24 +38,28 @@ export type BuildsFilters = {
 };
 
 /**
- * Build a query matching the builds of a project with optional filters
- * applied. The returned query has no ordering or pagination, callers are
- * expected to apply their own.
+ * Build a query matching the builds of a project — or of several, when the
+ * caller spans projects, as the sibling builds of a commit do — with optional
+ * filters applied. The returned query has no ordering or pagination, callers
+ * are expected to apply their own.
  *
  * Branch and commit predicates go through project-scoped subqueries on
  * `screenshot_buckets` instead of a join, so they stay indexable on
  * projects with a large number of builds.
  */
 export function queryBuilds(input: {
-  projectId: string;
+  projectId: string | string[];
   filters?: BuildsFilters | null;
 }) {
-  const { projectId, filters } = input;
+  const { filters } = input;
+  const projectIds = Array.isArray(input.projectId)
+    ? input.projectId
+    : [input.projectId];
   const projectBucketsQuery = () =>
-    ScreenshotBucket.query().select("id").where("projectId", projectId);
+    ScreenshotBucket.query().select("id").whereIn("projectId", projectIds);
 
   return Build.query()
-    .where("builds.projectId", projectId)
+    .whereIn("builds.projectId", projectIds)
     .where((query) => {
       if (filters?.name) {
         query.where("builds.name", filters.name);

--- a/apps/backend/src/graphql/definitions/Build.ts
+++ b/apps/backend/src/graphql/definitions/Build.ts
@@ -8,8 +8,8 @@ import {
   type BuildBaselineIneligibilityReason,
 } from "@/build/baselineEligibility";
 import { getBuildImpactAnalysis } from "@/build/impact-analysis";
+import { getSiblingBuilds } from "@/build/siblings";
 import { Build, BuildNotificationSubscription } from "@/database/models";
-import { queryBuilds } from "@/database/services/build";
 import { sortScreenshotDiffsForBuild } from "@/database/services/screenshot-diffs";
 import { getProjectMemberIds } from "@/project/members";
 
@@ -140,7 +140,9 @@ export const typeDefs = gql`
     commentsCount: Int!
     "Previous approved diffs from a build with the same branch"
     branchApprovedDiffs: [ID!]!
-    "The commit's other suites on this branch: one build per name, latest run, this build's own name excluded"
+    "Project the build belongs to"
+    project: Project!
+    "The commit's other suites on this branch, across every project the viewer can reach: one build per name, latest run, this build's own suite excluded"
     siblingBuilds: [Build!]!
     "Build is triggered in a merge queue"
     mergeQueue: Boolean!
@@ -470,34 +472,14 @@ export const resolvers: IResolvers = {
     },
     siblingBuilds: async (build, _args, ctx) => {
       const compareBucket = await getCompareScreenshotBucket(ctx, build);
-      // Without a branch we cannot tell a sibling from any other build that
-      // happens to share the commit.
-      if (!compareBucket.branch) {
-        return [];
-      }
-      // One build per name: a suite that was re-run leaves older builds behind
-      // on the same commit, and only its latest run is worth reviewing.
-      const latestPerName = queryBuilds({
-        projectId: build.projectId,
-        filters: {
-          branch: compareBucket.branch,
-          commit: build.prHeadCommit ?? compareBucket.commit,
-        },
-      })
-        .select("builds.id")
-        .distinctOn("builds.name")
-        .orderBy("builds.name")
-        .orderBy("builds.id", "desc");
-
-      // Told apart by name, not by id: siblings are the commit's *other*
-      // suites. Dropping this build's name rather than this build drops its
-      // own earlier runs with it — a re-run of one suite is the same suite,
-      // and offering it as somewhere else to go would list the same word
-      // twice and put a switcher on every build of every re-run commit.
-      return Build.query()
-        .whereIn("builds.id", latestPerName)
-        .whereNot("builds.name", build.name)
-        .orderBy("builds.name");
+      return getSiblingBuilds({
+        build,
+        compareBucket,
+        user: ctx.auth?.user ?? null,
+      });
+    },
+    project: async (build, _args, ctx) => {
+      return getProject(ctx, build);
     },
     subscribed: async (build, _args, ctx) => {
       if (!ctx.auth) {

--- a/apps/frontend/src/pages/Build/BuildNextReviewDialog.tsx
+++ b/apps/frontend/src/pages/Build/BuildNextReviewDialog.tsx
@@ -1,5 +1,6 @@
 import { createContext, use, useEffect, useMemo } from "react";
 import { invariant } from "@argos/util/invariant";
+import { clsx } from "clsx";
 
 import { BuildStatusChip } from "@/containers/BuildStatusChip";
 import { DocumentType, graphql } from "@/gql";
@@ -19,12 +20,16 @@ import { Modal } from "@/ui/Modal";
 import { Truncable } from "@/ui/Truncable";
 import { useEventCallback } from "@/ui/useEventCallback";
 
-import { useProjectParams } from "../Project/ProjectParams";
-import { getBuildOverviewURL } from "./BuildParams";
+import { getBuildOverviewURL, getBuildParams } from "./BuildParams";
 import { BuildStatsIndicator } from "./BuildStatsIndicator";
 
 const _BuildFragment = graphql(`
   fragment BuildNextReviewDialog_Build on Build {
+    id
+    project {
+      id
+      slug
+    }
     siblingBuilds {
       id
       number
@@ -32,6 +37,15 @@ const _BuildFragment = graphql(`
       status
       subset
       viewerHasSubmittedReview
+      project {
+        id
+        slug
+        name
+        account {
+          id
+          slug
+        }
+      }
       stats {
         ...BuildStatsIndicator_BuildStats
       }
@@ -40,9 +54,8 @@ const _BuildFragment = graphql(`
   }
 `);
 
-export type SiblingBuild = DocumentType<
-  typeof _BuildFragment
->["siblingBuilds"][number];
+type ReviewedBuild = DocumentType<typeof _BuildFragment>;
+export type SiblingBuild = ReviewedBuild["siblingBuilds"][number];
 
 /**
  * The builds still waiting for the viewer to make a call: nobody has concluded
@@ -61,7 +74,7 @@ type ContextValue = {
    * Offer to move on to the next build of the same commit awaiting a review.
    * Does nothing when there is none — the reviewer is done with this commit.
    */
-  promptNextReview: (builds: SiblingBuild[]) => void;
+  promptNextReview: (build: ReviewedBuild) => void;
 };
 
 const BuildNextReviewDialogContext = createContext<ContextValue | null>(null);
@@ -80,13 +93,13 @@ export function BuildNextReviewDialogProvider(props: {
   children: React.ReactNode;
 }) {
   const { buildNumber, children } = props;
-  const dialog = useDialogValueState<SiblingBuild[] | null>(null);
+  const dialog = useDialogValueState<ReviewedBuild | null>(null);
 
-  const promptNextReview = useEventCallback((builds: SiblingBuild[]) => {
-    if (getBuildsAwaitingReview(builds).length === 0) {
+  const promptNextReview = useEventCallback((build: ReviewedBuild) => {
+    if (getBuildsAwaitingReview(build.siblingBuilds).length === 0) {
       return;
     }
-    dialog.open(builds);
+    dialog.open(build);
   });
   const value = useMemo(() => ({ promptNextReview }), [promptNextReview]);
 
@@ -107,7 +120,7 @@ export function BuildNextReviewDialogProvider(props: {
           onOpenChange={dialog.onOpenChange}
           dismissible
         >
-          <BuildNextReviewDialog builds={dialog.value} />
+          <BuildNextReviewDialog build={dialog.value} />
         </Modal>
       ) : null}
       <BuildNextReviewDialogContext value={value}>
@@ -117,13 +130,19 @@ export function BuildNextReviewDialogProvider(props: {
   );
 }
 
-function BuildNextReviewDialog(props: { builds: SiblingBuild[] }) {
-  const { builds } = props;
-  const projectParams = useProjectParams();
-  invariant(projectParams, "The build page always has project params");
+function BuildNextReviewDialog(props: { build: ReviewedBuild }) {
+  const { build } = props;
+  const builds = build.siblingBuilds;
   const awaitingReview = getBuildsAwaitingReview(builds);
   const [nextBuild] = awaitingReview;
   invariant(nextBuild, "The dialog only opens when a build awaits a review");
+  // A commit can spread its suites over several projects, and then the build
+  // name alone stops being enough to tell them apart — both projects of a
+  // monorepo call theirs `default`. Named only when it is somewhere else than
+  // the project being reviewed, so the usual case stays quiet.
+  const showProject = builds.some(
+    (sibling) => sibling.project.id !== build.project.id,
+  );
 
   return (
     <Dialog size="medium">
@@ -135,13 +154,10 @@ function BuildNextReviewDialog(props: { builds: SiblingBuild[] }) {
             : `${awaitingReview.length} more builds ran on this commit and still need your review.`}
         </DialogText>
         <List>
-          {builds.map((build) => (
+          {builds.map((sibling) => (
             <ListRowLink
-              key={build.id}
-              href={getBuildOverviewURL({
-                ...projectParams,
-                buildNumber: build.number,
-              })}
+              key={sibling.id}
+              href={getBuildOverviewURL(getBuildParams(sibling))}
               className="flex items-center gap-4 p-3 text-sm"
             >
               {/*
@@ -149,20 +165,24 @@ function BuildNextReviewDialog(props: { builds: SiblingBuild[] }) {
                * name is what tells the builds apart, and it is the same word
                * the reviewer configured in CI.
                */}
-              <div className="w-28 shrink-0">
-                <Truncable className="font-medium">{build.name}</Truncable>
-                <div className="text-low mt-0.5 text-xs tabular-nums">
-                  Build {build.number}
+              <div className={clsx("shrink-0", showProject ? "w-44" : "w-28")}>
+                <Truncable className="font-medium">{sibling.name}</Truncable>
+                <div className="text-low mt-0.5 text-xs">
+                  {showProject ? (
+                    <Truncable>{sibling.project.slug}</Truncable>
+                  ) : (
+                    <span className="tabular-nums">Build {sibling.number}</span>
+                  )}
                 </div>
               </div>
               <div className="w-44 shrink-0">
-                <BuildStatusChip build={build} scale="sm" />
+                <BuildStatusChip build={sibling} scale="sm" />
               </div>
               <div className="hidden grow justify-end sm:flex">
-                {build.stats ? (
+                {sibling.stats ? (
                   <BuildStatsIndicator
-                    stats={build.stats}
-                    isSubsetBuild={build.subset}
+                    stats={sibling.stats}
+                    isSubsetBuild={sibling.subset}
                     className="flex-wrap justify-end"
                   />
                 ) : null}
@@ -174,10 +194,7 @@ function BuildNextReviewDialog(props: { builds: SiblingBuild[] }) {
       <DialogFooter>
         <DialogDismiss>Not now</DialogDismiss>
         <LinkButton
-          href={getBuildOverviewURL({
-            ...projectParams,
-            buildNumber: nextBuild.number,
-          })}
+          href={getBuildOverviewURL(getBuildParams(nextBuild))}
           autoFocus
         >
           Review {nextBuild.name}

--- a/apps/frontend/src/pages/Build/BuildPage.tsx
+++ b/apps/frontend/src/pages/Build/BuildPage.tsx
@@ -97,8 +97,13 @@ export const BuildPage = ({ params }: { params: BuildParams }) => {
           buildType={data?.project?.build?.type ?? null}
         >
           <BuildDiffProvider params={params} build={build}>
-            <BuildReviewDialogProvider project={data?.project ?? null}>
-              <BuildNextReviewDialogProvider buildNumber={params.buildNumber}>
+            {/*
+             * The next-review prompt wraps the review dialog, not the other
+             * way around: the dialog hosts a review form of its own, outside
+             * `children`, and submitting from there raises the prompt too.
+             */}
+            <BuildNextReviewDialogProvider buildNumber={params.buildNumber}>
+              <BuildReviewDialogProvider project={data?.project ?? null}>
                 <RejectCommentDialogProvider build={build}>
                   <div className="flex h-screen min-h-0 flex-col">
                     {data?.project?.account && (
@@ -134,8 +139,8 @@ export const BuildPage = ({ params }: { params: BuildParams }) => {
                     )}
                   </div>
                 </RejectCommentDialogProvider>
-              </BuildNextReviewDialogProvider>
-            </BuildReviewDialogProvider>
+              </BuildReviewDialogProvider>
+            </BuildNextReviewDialogProvider>
           </BuildDiffProvider>
         </BuildReviewStateProvider>
       </ProjectIgnoreEnabledProvider>

--- a/apps/frontend/src/pages/Build/BuildParams.ts
+++ b/apps/frontend/src/pages/Build/BuildParams.ts
@@ -50,6 +50,23 @@ export function useBuildParams(): BuildParams | null {
   return params;
 }
 
+/**
+ * Parameters of a build that names its own project, rather than of the build
+ * the current route points at. The builds of a single commit can live in
+ * several projects, so a link to one cannot assume the project it is rendered
+ * from.
+ */
+export function getBuildParams(build: {
+  number: number;
+  project: { name: string; account: { slug: string } };
+}): BuildParams {
+  return {
+    accountSlug: build.project.account.slug,
+    projectName: build.project.name,
+    buildNumber: build.number,
+  };
+}
+
 export function getBuildURL(params: BuildParams): string {
   return `${getProjectURL(params)}/builds/${params.buildNumber}${params.diffId ? `/${params.diffId}` : ""}`;
 }

--- a/apps/frontend/src/pages/Build/BuildReviewAction.ts
+++ b/apps/frontend/src/pages/Build/BuildReviewAction.ts
@@ -98,9 +98,9 @@ export function useCreateBuildReviewMutation(
       // Approving or rejecting settles this build, so it's the moment to offer
       // the next one. A neutral comment deliberately leaves the build
       // undecided — sending the reviewer elsewhere would fight that intent.
-      const siblingBuilds = result.data?.createBuildReview.siblingBuilds;
-      if (siblingBuilds && input.event !== BuildReviewEvent.Comment) {
-        promptNextReview(siblingBuilds);
+      const reviewedBuild = result.data?.createBuildReview;
+      if (reviewedBuild && input.event !== BuildReviewEvent.Comment) {
+        promptNextReview(reviewedBuild);
       }
       return result;
     },

--- a/apps/frontend/src/pages/Build/header/BuildHeader.tsx
+++ b/apps/frontend/src/pages/Build/header/BuildHeader.tsx
@@ -242,13 +242,7 @@ export const BuildHeader = memo(
                   {build && build.name !== "default" ? ` • ${build.name}` : ""}
                 </HeadlessLink>
               </Tooltip>
-              {build ? (
-                <BuildSwitcher
-                  accountSlug={props.accountSlug}
-                  projectName={props.projectName}
-                  build={build}
-                />
-              ) : null}
+              {build ? <BuildSwitcher build={build} /> : null}
             </div>
             <div className="flex min-w-0">
               <ProjectLink

--- a/apps/frontend/src/pages/Build/header/BuildSwitcher.tsx
+++ b/apps/frontend/src/pages/Build/header/BuildSwitcher.tsx
@@ -13,7 +13,7 @@ import { Tooltip } from "@/ui/Tooltip";
 import { getBuildDescriptor } from "@/util/build";
 import { lowTextColorClassNames } from "@/util/colors";
 
-import { getBuildOverviewURL } from "../BuildParams";
+import { getBuildOverviewURL, getBuildParams } from "../BuildParams";
 
 const _BuildFragment = graphql(`
   fragment BuildSwitcher_Build on Build {
@@ -22,17 +22,36 @@ const _BuildFragment = graphql(`
     name
     type
     status
+    project {
+      id
+      slug
+      name
+      account {
+        id
+        slug
+      }
+    }
     siblingBuilds {
       id
       number
       name
       type
       status
+      project {
+        id
+        slug
+        name
+        account {
+          id
+          slug
+        }
+      }
     }
   }
 `);
 
 type Build = DocumentType<typeof _BuildFragment>;
+type SwitchableBuild = Build | Build["siblingBuilds"][number];
 
 /**
  * Where a build's review stands, as the icon alone. The full status chip says
@@ -58,22 +77,48 @@ function BuildStatusIcon(props: {
 }
 
 /**
+ * This build's project first — the reviewer is already there — then the others
+ * in alphabetical order, and within a project the builds by name.
+ */
+function compareBuilds(
+  a: SwitchableBuild,
+  b: SwitchableBuild,
+  currentProjectId: string,
+): number {
+  if (a.project.id !== b.project.id) {
+    if (a.project.id === currentProjectId) {
+      return -1;
+    }
+    if (b.project.id === currentProjectId) {
+      return 1;
+    }
+    return a.project.slug.localeCompare(b.project.slug);
+  }
+  return a.name.localeCompare(b.name);
+}
+
+/**
  * Hops between the builds a single commit produced. A commit that runs several
- * suites leaves one build per suite, and the header only names the one being
- * looked at — so without this the others are reachable only through the build
+ * suites leaves one build per suite — and, in a monorepo split over several
+ * Argos projects, one per project — while the header only names the one being
+ * looked at. Without this the others are reachable only through the build
  * list. Renders nothing when the commit produced this build alone.
  */
-export function BuildSwitcher(props: {
-  accountSlug: string;
-  projectName: string;
-  build: Build;
-}) {
-  const { accountSlug, projectName, build } = props;
+export function BuildSwitcher(props: { build: Build }) {
+  const { build } = props;
   if (build.siblingBuilds.length === 0) {
     return null;
   }
   const builds = [build, ...build.siblingBuilds].sort((a, b) =>
-    a.name.localeCompare(b.name),
+    compareBuilds(a, b, build.project.id),
+  );
+  // The build name is what tells the suites of one project apart, but two
+  // projects of a monorepo both call theirs `default` — so the project has to
+  // be named as soon as the commit reaches beyond this one. Named per row
+  // rather than as a section heading: a row is what the reader lands on, and
+  // it has to say where it goes on its own.
+  const showProject = builds.some(
+    (item) => item.project.id !== build.project.id,
   );
   return (
     <MenuRoot>
@@ -88,14 +133,11 @@ export function BuildSwitcher(props: {
           {builds.map((item) => (
             <MenuItem
               key={item.id}
-              href={getBuildOverviewURL({
-                accountSlug,
-                projectName,
-                buildNumber: item.number,
-              })}
+              href={getBuildOverviewURL(getBuildParams(item))}
               icon={<BuildStatusIcon type={item.type} status={item.status} />}
               checked={item.id === build.id}
               textValue={item.name}
+              subtitle={showProject ? item.project.slug : undefined}
             >
               {/*
                * Named by its build name, not its number: on one commit the

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -178,9 +178,8 @@ loggedTest(
   "offers the next build of the commit once a review is submitted",
   async ({ page, auth, team, project }) => {
     await ensureTeamOwner({ team: team.team, user: auth.user });
-    const { defaultBuild, storybookBuild } = await createSiblingBuildsScenario({
-      projectId: project.id,
-    });
+    const { defaultBuild, storybookBuild, docsBuild, docsProject } =
+      await createSiblingBuildsScenario({ projectId: project.id });
 
     await page.goto(
       `/${team.account.slug}/${project.name}/builds/${defaultBuild.number}`,
@@ -188,8 +187,8 @@ loggedTest(
     await page.getByRole("button", { name: "Submit review" }).click();
     await page.getByRole("button", { name: "Approve" }).click();
 
-    // The other build ran on the same commit and nobody has reviewed it, so
-    // finishing this one hands the reviewer straight to it.
+    // Two more builds ran on the same commit and nobody has reviewed them, so
+    // finishing this one hands the reviewer straight to the next.
     //
     // The prompt waits on the review mutation's response, and the server only
     // answers it once the build notifications and the automations have been
@@ -197,15 +196,25 @@ loggedTest(
     const dialog = page.getByRole("dialog", { name: "Review the next build" });
     await expect(dialog).toBeVisible({ timeout: 15_000 });
     await expect(
-      dialog.getByText("One more build ran on this commit"),
+      dialog.getByText("2 more builds ran on this commit"),
     ).toBeVisible();
     // The row carries what the reviewer needs to choose: which build it is,
-    // and where its review stands.
+    // which project it ran in, and where its review stands.
     await expect(
       dialog.getByRole("link", {
-        name: `storybook Build ${storybookBuild.number} Changes detected`,
+        name: `storybook ${team.account.slug}/${project.name} Changes detected`,
       }),
     ).toBeVisible();
+    // The commit reaches beyond this project, and that build is offered with a
+    // link into its own project.
+    await expect(
+      dialog.getByRole("link", {
+        name: `default ${team.account.slug}/${docsProject.name} Changes detected`,
+      }),
+    ).toHaveAttribute(
+      "href",
+      `/${team.account.slug}/${docsProject.name}/builds/${docsBuild.number}/overview`,
+    );
 
     await screenshot(page, "build-next-review-dialog", {
       replacements: {
@@ -262,9 +271,8 @@ loggedTest(
   "header switches between the builds of a commit",
   async ({ page, auth, team, project }) => {
     await ensureTeamOwner({ team: team.team, user: auth.user });
-    const { defaultBuild, storybookBuild } = await createSiblingBuildsScenario({
-      projectId: project.id,
-    });
+    const { defaultBuild, storybookBuild, docsBuild, docsProject } =
+      await createSiblingBuildsScenario({ projectId: project.id });
 
     await page.goto(
       `/${team.account.slug}/${project.name}/builds/${defaultBuild.number}`,
@@ -272,18 +280,25 @@ loggedTest(
     await page.getByRole("button", { name: "Switch build" }).click();
 
     // Every build of the commit is listed with where its review stands, the
-    // one being looked at included. The menu kit is a listbox driven by a
-    // search field, so its rows are options rather than menu items.
+    // one being looked at included, and each names the project it ran in — the
+    // two projects of the commit both call their suite `default`. The menu kit
+    // is a listbox driven by a search field, so its rows are options rather
+    // than menu items.
     const menu = page.getByRole("listbox");
     await expect(
       menu.getByRole("option", {
-        name: `Changes detected ${defaultBuild.name} #${defaultBuild.number}`,
+        name: `Changes detected ${defaultBuild.name} #${defaultBuild.number} ${team.account.slug}/${project.name}`,
       }),
     ).toBeVisible();
-    const storybookItem = menu.getByRole("option", {
-      name: `Changes detected ${storybookBuild.name} #${storybookBuild.number}`,
+    await expect(
+      menu.getByRole("option", {
+        name: `Changes detected ${storybookBuild.name} #${storybookBuild.number} ${team.account.slug}/${project.name}`,
+      }),
+    ).toBeVisible();
+    const docsItem = menu.getByRole("option", {
+      name: `Changes detected ${docsBuild.name} #${docsBuild.number} ${team.account.slug}/${docsProject.name}`,
     });
-    await expect(storybookItem).toBeVisible();
+    await expect(docsItem).toBeVisible();
 
     await screenshot(page, "build-switcher", {
       replacements: {
@@ -291,9 +306,13 @@ loggedTest(
       },
     });
 
-    await storybookItem.click();
+    // Switching lands on the build of the other project, not on a build of
+    // this one that happens to share its number.
+    await docsItem.click();
     await expect(page).toHaveURL(
-      new RegExp(`/builds/${storybookBuild.number}/overview$`),
+      new RegExp(
+        `/${team.account.slug}/${docsProject.name}/builds/${docsBuild.number}/overview$`,
+      ),
     );
   },
 );

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -226,6 +226,39 @@ loggedTest(
 );
 
 loggedTest(
+  "prompts for the next build from the review dialog too",
+  async ({ page, auth, team, project }) => {
+    await ensureTeamOwner({ team: team.team, user: auth.user });
+    const { defaultBuild, storybookBuild } = await createSiblingBuildsScenario({
+      projectId: project.id,
+    });
+
+    await page.goto(
+      `/${team.account.slug}/${project.name}/builds/${defaultBuild.number}`,
+    );
+    await page
+      .getByRole("button", { name: /^(Start review|Browse snapshots)/ })
+      .click();
+    // Marking the build's only change opens the review dialog on its own. That
+    // dialog hosts a review form outside the page's children — it has to reach
+    // the same next-build prompt the header popover does. IconButtons carry no
+    // accessible name, so the thumb icon locates the button.
+    await page.locator("button:has(.lucide-thumbs-up)").first().click();
+    const reviewDialog = page.getByRole("dialog", {
+      name: "Submit your review",
+    });
+    await expect(reviewDialog).toBeVisible();
+
+    await reviewDialog.getByRole("button", { name: "Approve" }).click();
+    const dialog = page.getByRole("dialog", { name: "Review the next build" });
+    await expect(dialog).toBeVisible({ timeout: 15_000 });
+    await expect(
+      dialog.getByRole("link", { name: `Review ${storybookBuild.name}` }),
+    ).toBeVisible();
+  },
+);
+
+loggedTest(
   "header switches between the builds of a commit",
   async ({ page, auth, team, project }) => {
     await ensureTeamOwner({ team: team.team, user: auth.user });


### PR DESCRIPTION
Follow-up to #2488, which stopped at the project boundary.

A monorepo wired to several Argos projects leaves one build per project on a commit. Those are exactly the builds the reviewer still has to go through, and `siblingBuilds` never mentioned them: finishing a review said nothing about the other project, and the header switcher listed only what ran next door.

## What it looks like

The builds of the commit, in two projects — `acme/sparkle` and `acme/sparkle-docs`, both calling their suite `default`:

[![cross-project-build-switcher.png](https://files.argos-ci.com/media/9/d910a2d78c2ce2e45a60043c704c06e0d95fd75a0d679b3d703b30a465f91c7b.webp)](https://app.argos-ci.com/m/9iqagtzgm9uyp5qs529q)

[![cross-project-next-review.png](https://files.argos-ci.com/media/9/1e6675eca62423c1270e22eec672aa0b5503610d86a5857566a5ccadfb220c7e.webp)](https://app.argos-ci.com/m/lw47sysrf8yxbmostbq1)

## What changed

The lookup moves out of the resolver into `build/siblings.ts` and starts from the **commit** rather than from the project: every project that built it, found through `screenshot_buckets.commit` for ordinary builds and through `builds."prHeadCommit"` for pull request ones, whose bucket carries the merge commit instead. A new partial index backs the second half — with no `projectId` to narrow it, that predicate was a sequential scan. **The migration has to run before this deploys.**

Builds now carry their project (new `Build.project` field), so both surfaces link through the sibling's own account and project rather than through the current route.

### Who a project is shown to

Another project only contributes when the viewer is a **member** of it. Being public is deliberately not enough: a commit SHA travels far enough that anyone could otherwise hang a build of their own off someone else's commit and have it offered as the next thing to review. The build's own project stays in scope either way, so a public build page keeps the switcher it has today, and an anonymous visitor never leaves the project they are looking at.

### Two keys that move with the boundary

- Builds are deduplicated per **(project, name)**, not per name. Both projects of a monorepo call their suite `default`, and the name alone would collapse them into one.
- Only the build's own name **in its own project** is excluded. A sibling that shares the name is another suite and is kept — while a re-run of this suite still drops out with it, which is what #2488 fixed.

### Naming the project, only when it matters

The build name is what tells the suites of one project apart, so it stays the row's subject. The project rides underneath — a subtitle in the switcher, a second line in the prompt — and only once the commit reaches past this project, so a single-project commit renders exactly as it does today.

## The crash it also fixes

`ARGOS-BROWSER-K5`: reviewing the last change of a build opens the review dialog by itself, and submitting from there threw `useBuildNextReviewPrompt must be called in BuildNextReviewDialogProvider` — the page went blank on its error boundary instead of recording the review.

`BuildReviewDialogProvider` renders its modal *outside* its own `children`, so the review form it hosts lands wherever the provider sits rather than inside it. It sat outside `BuildNextReviewDialogProvider`, and that form is the one reaching for the prompt. The header popover hosts the same form inside `children`, which is why that path worked and #2488's spec saw nothing. The two are swapped, in its own commit.

## Tests

- `siblings.e2e.test.ts` — 9 cases on the service, covering the member / non-member / public / anonymous splits, the pull request head commit, the branch scope, re-run dedup, and the own-project-first ordering.
- `tests/build.spec.ts` — the seed now builds a second project, so the two existing specs assert a link *into* it, and switching lands on `…/sparkle-docs/builds/7/overview` rather than on a build of this project that shares the number.
- A new spec drives the review dialog end to end. Verified to fail on the previous provider nesting.

Full `pnpm test:integration` (1209) and `tests/build.spec.ts` (21) pass locally, as does `pnpm run static-checks`.

## Left alone

The prompt's primary button still reads `Review default` when the next build is in another project. The row right above it names the project, so I judged the extra words not worth it — easy to change if you disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
