### PR TITLE
feat(staff): show what each team consumes against its quota

### DIFF
--- a/apps/backend/src/database/models/Subscription.e2e.test.ts
+++ b/apps/backend/src/database/models/Subscription.e2e.test.ts
@@ -111,4 +111,101 @@ describe("Subscription", () => {
       });
     });
   });
+
+  describe("#getPeriodEnd", () => {
+    describe("month interval", () => {
+      it("returns next month's anniversary once this one's has passed", async () => {
+        const subscription = await factory.Subscription.create({
+          startDate: new Date("2021-03-10").toISOString(),
+        });
+        const now = new Date("2023-04-26");
+        expect(subscription.getPeriodEnd(now, "month").toISOString()).toBe(
+          new Date("2023-05-10").toISOString(),
+        );
+      });
+
+      it("returns this month's anniversary before it has passed", async () => {
+        const subscription = await factory.Subscription.create({
+          startDate: new Date("2021-03-10").toISOString(),
+        });
+        const now = new Date("2023-04-05");
+        expect(subscription.getPeriodEnd(now, "month").toISOString()).toBe(
+          new Date("2023-04-10").toISOString(),
+        );
+      });
+
+      it("ends where the next month opens when it has no anniversary", async () => {
+        // Started on the 31st, so February has no such day: the period running
+        // through it closes when March opens rather than overshooting into it.
+        const subscription = await factory.Subscription.create({
+          startDate: new Date("2015-03-31").toISOString(),
+        });
+        const now = new Date("2023-02-15");
+        expect(subscription.getPeriodEnd(now, "month").toISOString()).toBe(
+          new Date(2023, 2, 1).toISOString(),
+        );
+      });
+
+      it("closes exactly where the period after it opens", async () => {
+        // The two have to agree to the millisecond: a gap between them is a day
+        // billed to nobody, an overlap is a day billed twice.
+        const subscription = await factory.Subscription.create({
+          startDate: new Date("2015-03-31").toISOString(),
+        });
+        const end = subscription.getPeriodEnd(new Date("2023-02-15"), "month");
+        const [nextStart] = subscription.getPeriodStarts(
+          new Date(end.getTime() + 1000),
+          "month",
+          1,
+        );
+        expect(nextStart?.toISOString()).toBe(end.toISOString());
+      });
+    });
+
+    describe("year interval", () => {
+      it("returns next year's anniversary once this one's has passed", async () => {
+        const subscription = await factory.Subscription.create({
+          startDate: new Date("2021-03-10").toISOString(),
+        });
+        const now = new Date("2022-04-26");
+        expect(subscription.getPeriodEnd(now, "year").toISOString()).toBe(
+          new Date("2023-03-10").toISOString(),
+        );
+      });
+
+      it("slips a day into a leap year, as the period start does", async () => {
+        // The anniversary is held as a duration from January 1st — 68 days for
+        // March 10th — so February 29th pushes it back a day, and the period
+        // ends one day before Stripe renews it. Pinned rather than corrected:
+        // `getPeriodStarts` reads the anniversary the same way, so an end that
+        // did not slip with it would overlap the period after — the drift has
+        // to be fixed in both at once, or not at all.
+        const subscription = await factory.Subscription.create({
+          startDate: new Date("2021-03-10").toISOString(),
+        });
+        const now = new Date("2023-04-26");
+        expect(subscription.getPeriodEnd(now, "year").toISOString()).toBe(
+          new Date("2024-03-09").toISOString(),
+        );
+        const [nextStart] = subscription.getPeriodStarts(
+          new Date("2024-04-26"),
+          "year",
+          1,
+        );
+        expect(nextStart?.toISOString()).toBe(
+          new Date("2024-03-09").toISOString(),
+        );
+      });
+
+      it("returns this year's anniversary before it has passed", async () => {
+        const subscription = await factory.Subscription.create({
+          startDate: new Date("2021-03-10").toISOString(),
+        });
+        const now = new Date("2023-02-05");
+        expect(subscription.getPeriodEnd(now, "year").toISOString()).toBe(
+          new Date("2023-03-10").toISOString(),
+        );
+      });
+    });
+  });
 });

--- a/apps/backend/src/database/models/Subscription.ts
+++ b/apps/backend/src/database/models/Subscription.ts
@@ -141,34 +141,63 @@ export class Subscription extends Model {
     interval: SubscriptionInterval,
     count: number,
   ): Date[] {
+    const currentIndex = this.getCurrentPeriodIndex(now, interval);
+
+    return Array.from({ length: count }, (_, index) =>
+      this.getResetDateAt(now, interval, currentIndex + index),
+    );
+  }
+
+  /**
+   * End of the billing period holding `now` — the moment the next one opens,
+   * and the day the included quota resets on.
+   *
+   * The counterpart of `getPeriodStarts`, for the one period whose end cannot
+   * be read off the period after it: the running one has none yet.
+   */
+  getPeriodEnd(now: Date, interval: SubscriptionInterval): Date {
+    // One interval past the current period's own start, walked with the same
+    // anniversary rule — so a period that opened on the 31st still ends where
+    // the next one opens in a 30-day month.
+    return this.getResetDateAt(
+      now,
+      interval,
+      this.getCurrentPeriodIndex(now, interval) - 1,
+    );
+  }
+
+  /**
+   * The anniversary `index` whole intervals back from the one holding `now`.
+   * A negative index walks forward instead, which is what reads the next one.
+   */
+  getResetDateAt(now: Date, interval: SubscriptionInterval, index: number) {
     const startDate = new Date(this.startDate);
     const anniversaryOffset =
       startDate.getTime() - getStartOf(startDate, interval).getTime();
-
-    const getResetDateAt = (index: number) => {
-      const intervalStart = shiftIntervals(
-        getStartOf(now, interval),
-        interval,
-        -index,
-      );
-      const nextIntervalStart = shiftIntervals(intervalStart, interval, 1);
-      // A subscription that started on the 31st has no anniversary in a
-      // 30-day month: it resets when the next interval opens.
-      return new Date(
-        Math.min(
-          intervalStart.getTime() + anniversaryOffset,
-          nextIntervalStart.getTime(),
-        ),
-      );
-    };
-
-    // The period holding `now` opens on this interval's own anniversary once
-    // that anniversary has passed, and on the previous one until then.
-    const currentIndex = getResetDateAt(0).getTime() < now.getTime() ? 0 : 1;
-
-    return Array.from({ length: count }, (_, index) =>
-      getResetDateAt(currentIndex + index),
+    const intervalStart = shiftIntervals(
+      getStartOf(now, interval),
+      interval,
+      -index,
     );
+    const nextIntervalStart = shiftIntervals(intervalStart, interval, 1);
+    // A subscription that started on the 31st has no anniversary in a
+    // 30-day month: it resets when the next interval opens.
+    return new Date(
+      Math.min(
+        intervalStart.getTime() + anniversaryOffset,
+        nextIntervalStart.getTime(),
+      ),
+    );
+  }
+
+  /**
+   * Which anniversary the period holding `now` opened on: this interval's own
+   * once it has passed, and the previous one until then.
+   */
+  getCurrentPeriodIndex(now: Date, interval: SubscriptionInterval): number {
+    return this.getResetDateAt(now, interval, 0).getTime() < now.getTime()
+      ? 0
+      : 1;
   }
 }
 

--- a/apps/backend/src/database/services/period-usage.e2e.test.ts
+++ b/apps/backend/src/database/services/period-usage.e2e.test.ts
@@ -68,6 +68,7 @@ describe("getAccountPeriodUsages", () => {
     expect(usages.get(account.id)).toEqual({
       plan: null,
       flatPrice: null,
+      includedScreenshots: null,
       periodUsage: null,
     });
   });
@@ -91,6 +92,8 @@ describe("getAccountPeriodUsages", () => {
     expect(usages.get(grantedAccount.id)).toEqual({
       plan: expect.objectContaining({ id: usageBasedPlan.id }),
       flatPrice: null,
+      // Nothing is counted against a quota on a plan that is not billed.
+      includedScreenshots: null,
       periodUsage: null,
     });
   });
@@ -129,6 +132,9 @@ describe("getAccountPeriodUsages", () => {
     expect(usages.get(account.id)).toEqual({
       plan: expect.objectContaining({ id: flatPlan.id }),
       flatPrice: null,
+      // Read off the subscription that won, not off the one that lost: the
+      // usage-based one includes a thousand.
+      includedScreenshots: 1_000_000,
       periodUsage: null,
     });
   });
@@ -363,6 +369,7 @@ describe("getAccountPeriodUsages", () => {
     expect(usages.get(noSubscriptionAccount.id)).toEqual({
       plan: null,
       flatPrice: null,
+      includedScreenshots: null,
       periodUsage: null,
     });
   });

--- a/apps/backend/src/database/services/period-usage.ts
+++ b/apps/backend/src/database/services/period-usage.ts
@@ -10,8 +10,24 @@ type BillingPeriodUsage = {
   from: Date;
   /** End of the period, or the moment it was read while still running. */
   to: Date;
+  /**
+   * When the period closes, whether or not it has.
+   *
+   * Distinct from `to`, which stops at the moment a running period was read.
+   * This is the anniversary the next period opens on, and the day the included
+   * quota resets. It cannot be derived outside this module: the boundary
+   * follows the subscription, not the calendar.
+   */
+  endsAt: Date;
   /** False while the period is still accumulating usage. */
   closed: boolean;
+  /**
+   * Screenshots consumed over the period — Storybook ones included, and the
+   * units standalone media uploads are billed as, which is what the overage
+   * below is computed on. So it is above the sum of the period's buckets on a
+   * project that records video.
+   */
+  screenshotsCount: number;
   /**
    * Cost of the screenshots consumed beyond the included quota over the
    * period, in the subscription's currency.
@@ -75,6 +91,14 @@ export type AccountBilling = {
    */
   flatPrice: number | null;
   /**
+   * Screenshots included in each billing period before the overage starts: the
+   * amount the subscription states, and the plan's published one when it
+   * states none — the same fallback `Account.getIncludedScreenshots` meters on.
+   * Null only when there is no plan to fall back to, and for a granted plan,
+   * which counts nothing against a quota.
+   */
+  includedScreenshots: number | null;
+  /**
    * Usage-based billing. Null when the plan is not usage-based: there is no
    * overage to compute and no period to compute it over, which is a different
    * answer from one that consumed nothing.
@@ -111,6 +135,12 @@ type AccountPeriod = {
   index: number;
   from: Date;
   to: Date;
+  /**
+   * When the period closes, which the window above stops short of on the
+   * running one — `to` is the moment it was read. Carried here rather than
+   * recomputed later because it takes the subscription to derive.
+   */
+  endsAt: Date;
 };
 
 /** Screenshots uploaded over one window, split by the way they are billed. */
@@ -430,8 +460,10 @@ export async function getAccountBillings(
         result.set(account.id, {
           plan: forcedPlanById.get(account.forcedPlanId) ?? null,
           // A granted plan is not paid for, so there is no amount to report
-          // even when a leftover subscription still carries one.
+          // even when a leftover subscription still carries one, and no quota
+          // either — nothing is ever counted against it.
           flatPrice: null,
+          includedScreenshots: null,
           periodUsage: null,
         });
       }
@@ -481,6 +513,10 @@ export async function getAccountBillings(
       result.set(account.id, {
         plan: subscription?.plan ?? null,
         flatPrice: subscription?.flatPrice ?? null,
+        includedScreenshots:
+          subscription?.includedScreenshots ??
+          subscription?.plan?.includedScreenshots ??
+          null,
         periodUsage: null,
       });
       continue;
@@ -492,6 +528,10 @@ export async function getAccountBillings(
       subscription.plan.interval,
       READ_PERIOD_COUNT,
     );
+    const runningPeriodEnd = subscription.getPeriodEnd(
+      now,
+      subscription.plan.interval,
+    );
     periodsByAccountId.set(
       account.id,
       starts.map((from, index) => ({
@@ -499,6 +539,9 @@ export async function getAccountBillings(
         index,
         from,
         to: starts[index - 1] ?? now,
+        // A closed period ends exactly where the next one opens. The running
+        // one has no next period yet, so its end comes off the anniversary.
+        endsAt: starts[index - 1] ?? runningPeriodEnd,
       })),
     );
   }
@@ -530,9 +573,17 @@ export async function getAccountBillings(
         0,
     };
 
+    // Stripe states the quota on the subscription when its price carries the
+    // metadata, and nothing when it does not — a GitHub subscription included.
+    // The plan's own quota is what the account is metered against in that case,
+    // so it is what the overage below has to be computed on too.
+    const includedScreenshots =
+      subscription.includedScreenshots ?? plan.includedScreenshots;
+
     result.set(accountId, {
       plan,
       flatPrice: subscription.flatPrice,
+      includedScreenshots,
       periodUsage: {
         billingPeriods: accountPeriods
           .filter((period) => checkIsBilledPeriod(period, subscription))
@@ -540,23 +591,21 @@ export async function getAccountBillings(
             const periodTotals = totals.get(period.index) ?? EMPTY_TOTALS;
             // The included quota resets at every period, so the overage is
             // computed period by period rather than off a running total.
-            const additional =
-              subscription.includedScreenshots === null
-                ? null
-                : computeAdditionalScreenshots({
-                    neutral: periodTotals.all - periodTotals.storybook,
-                    storybook: periodTotals.storybook,
-                    included: subscription.includedScreenshots,
-                  });
+            const additional = computeAdditionalScreenshots({
+              neutral: periodTotals.all - periodTotals.storybook,
+              storybook: periodTotals.storybook,
+              included: includedScreenshots,
+            });
 
             return {
               from: period.from,
               to: period.to,
+              endsAt: period.endsAt,
               closed: period.index > 0,
-              additionalScreenshotCost: additional
-                ? additional.neutral * price.neutral +
-                  additional.storybook * price.storybook
-                : 0,
+              screenshotsCount: periodTotals.all,
+              additionalScreenshotCost:
+                additional.neutral * price.neutral +
+                additional.storybook * price.storybook,
             };
           }),
       },

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -231,8 +231,20 @@ export const typeDefs = gql`
     from: DateTime!
     "End of the period, or now while it is still running."
     to: DateTime!
+    """
+    When the period closes, whether or not it has. Unlike \`to\`, this does not
+    stop at the moment a running period was read: it is the anniversary the next
+    period opens on, which follows the subscription rather than the calendar.
+    """
+    endsAt: DateTime!
     "False while the period is still accumulating usage."
     closed: Boolean!
+    """
+    Screenshots consumed over the period — Storybook ones included, and the
+    units standalone media uploads are billed as. So it runs above the sum of
+    the period's buckets on a project that records video.
+    """
+    screenshotsCount: Int!
     "Cost of the screenshots consumed beyond the included quota, this period."
     additionalScreenshotsCost: Float!
   }
@@ -283,6 +295,13 @@ export const typeDefs = gql`
     reading the amount.
     """
     flatPrice: Float
+    """
+    Screenshots included in each billing period before the overage starts: the
+    amount the subscription states, and the plan's published one when it states
+    none. Null only when there is no plan to fall back to, and for a granted
+    plan, which counts nothing against a quota.
+    """
+    includedScreenshots: Int
     "Billing usage. Null when the team is not on a usage-based plan."
     periodUsage: TeamStaffPeriodUsage
   }
@@ -387,6 +406,12 @@ export const resolvers: IResolvers = {
       );
       return billing.flatPrice;
     },
+    includedScreenshots: async (account, _args, ctx) => {
+      const billing = await ctx.loaders.AccountBillingByAccountId.load(
+        account.id,
+      );
+      return billing.includedScreenshots;
+    },
     // Resolves to the account rather than to the usage itself: the Storybook
     // mix below costs a scan of the account's whole history, so it is left to
     // its own resolver and only runs when a document actually selects it.
@@ -404,7 +429,9 @@ export const resolvers: IResolvers = {
       return usage.billingPeriods.map((period) => ({
         from: period.from,
         to: period.to,
+        endsAt: period.endsAt,
         closed: period.closed,
+        screenshotsCount: period.screenshotsCount,
         additionalScreenshotsCost: period.additionalScreenshotCost,
       }));
     },

--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -763,6 +763,7 @@ function createAccountActivationByAccountIdLoader() {
 const EMPTY_ACCOUNT_BILLING: AccountBilling = {
   plan: null,
   flatPrice: null,
+  includedScreenshots: null,
   periodUsage: null,
 };
 

--- a/apps/frontend/src/containers/ImageAvatar.tsx
+++ b/apps/frontend/src/containers/ImageAvatar.tsx
@@ -8,6 +8,10 @@ export function ImageAvatar(props: {
 }) {
   const { ref, ...rest } = props;
   return (
-    <img ref={ref} {...rest} className={clsx(rest.className, "rounded-full")} />
+    <img
+      ref={ref}
+      {...rest}
+      className={clsx(rest.className, "shrink-0 rounded-full")}
+    />
   );
 }

--- a/apps/frontend/src/containers/InitialAvatar.tsx
+++ b/apps/frontend/src/containers/InitialAvatar.tsx
@@ -13,7 +13,7 @@ export function InitialAvatar(props: {
       ref={ref}
       className={clsx(
         props.className,
-        "relative flex items-center justify-center rounded-full select-none",
+        "relative flex shrink-0 items-center justify-center rounded-full select-none",
       )}
       style={{
         backgroundColor: props.color,

--- a/apps/frontend/src/pages/Staff/Teams.tsx
+++ b/apps/frontend/src/pages/Staff/Teams.tsx
@@ -39,7 +39,12 @@ import { Time } from "@/ui/Time";
 import { Tooltip } from "@/ui/Tooltip";
 
 import { getAccountURL } from "../Account/AccountParams";
-import { formatPrice, getPeriodFlatPrice, type PricedPlan } from "./pricing";
+import {
+  formatPrice,
+  getPeriodFlatPrice,
+  PRO_PLAN_NAME,
+  type PricedPlan,
+} from "./pricing";
 import { getStripeCustomerURL } from "./stripe";
 
 const StaffTeamsQuery = graphql(`
@@ -72,6 +77,7 @@ const StaffTeamsQuery = graphql(`
         stripeCustomerId
         staff {
           flatPrice
+          includedScreenshots
           plan {
             id
             name
@@ -80,9 +86,9 @@ const StaffTeamsQuery = graphql(`
           }
           periodUsage {
             billingPeriods {
-              from
-              to
+              endsAt
               closed
+              screenshotsCount
               additionalScreenshotsCost
             }
           }
@@ -417,28 +423,81 @@ function getAmountHint(team: TeamItem, billing: TeamBilling): string {
 }
 
 /**
- * How far into the running period the team is.
+ * How much of the running period is left.
  *
  * The running period is partial by construction, so it reads lower than the one
- * before it whatever the team is doing. How far in it is tells a genuine drop
- * from a period that simply opened three days ago.
+ * before it whatever the team is doing. What is left of it tells a genuine drop
+ * from a period that simply opened three days ago — and, unlike a count from the
+ * start, it also says when the figure beside it becomes comparable.
  *
- * Counted from the period's own start rather than shown as a fraction: a
- * running period's `to` is the moment it was read, and its end is derived server
- * side from a subscription anniversary this page cannot reproduce. Neutralized
- * for visual tests — it moves every day, and the table would rebaseline
- * overnight.
+ * Read off `endsAt` rather than the period's `to`, which on a running period is
+ * only the moment it was read: the real end follows the subscription's
+ * anniversary. Neutralized for visual tests — it moves every day, and the table
+ * would rebaseline overnight.
  */
 function PeriodProgress(props: { period: BillingPeriod }) {
-  const days = diffInCalendarDays(
-    new Date(props.period.to),
-    new Date(props.period.from),
+  // Floored: a period read moments past its own end has not rolled over yet,
+  // and a negative count reads as a bug rather than as a boundary.
+  const remaining = Math.max(
+    0,
+    diffInCalendarDays(new Date(props.period.endsAt), new Date()),
   );
 
   return (
     <div className="text-low text-xs" data-visual-test="transparent">
-      {days === 1 ? "1 day in" : `${days} days in`}
+      {remaining === 1 ? "1 day left" : `${remaining} days left`}
     </div>
+  );
+}
+
+/**
+ * What the running period has consumed, against what the subscription includes
+ * in each one.
+ *
+ * The running period rather than the whole history: the quota resets at every
+ * period, so a lifetime total has nothing to be read against — and this is the
+ * figure that says whether the amount in the next invoice is about to move.
+ *
+ * The quota is named only where it is worth reading. Pro is nearly every row
+ * and always includes the same amount, so printing it there would repeat one
+ * number down the whole column. What is left is the contracts, where it was
+ * negotiated — and where it is the only thing that makes the count above it
+ * mean anything.
+ */
+function ScreenshotsCell(props: {
+  team: TeamItem;
+  billing: TeamBilling | null;
+}) {
+  const { team, billing } = props;
+
+  // No running period is no consumption to report: a team on a flat plan, on a
+  // granted one, on a trial — whose usage Stripe never bills, so no period is
+  // opened for it — or with no subscription at all.
+  if (!billing?.current) {
+    return <span className="text-low">—</span>;
+  }
+
+  const { includedScreenshots } = team.staff;
+  // Pro includes the same amount on every one of its rows, which is nearly all
+  // of them, so naming it there would repeat one figure down the column.
+  const quota =
+    includedScreenshots === null || billing.plan.name === PRO_PLAN_NAME
+      ? null
+      : includedScreenshots.toLocaleString();
+
+  return (
+    <Tooltip content="Consumed since the running period opened, against what the subscription includes in each one. Everything past the quota is billed as overage.">
+      <div>
+        <div className="font-medium">
+          {billing.current.period.screenshotsCount.toLocaleString()}
+        </div>
+        {/* A blank rather than nothing: an empty div collapses, and the count
+            would then sit half a line above the amounts beside it. */}
+        <div className="text-low text-xs">
+          {quota === null ? <>&nbsp;</> : `/ ${quota}`}
+        </div>
+      </div>
+    </Tooltip>
   );
 }
 
@@ -676,6 +735,11 @@ function StaffTeamRow(props: {
         <td className="p-4 text-right text-sm tabular-nums">
           {team.membersCount}
         </td>
+        {/* Before the two amounts rather than after: the row reads as what the
+            team is, then what it consumed, then what that comes to. */}
+        <td className="p-4 text-right text-sm tabular-nums">
+          <ScreenshotsCell team={team} billing={billing} />
+        </td>
         <BilledPeriodCells team={team} billing={billing} />
         <td className="p-4 text-right text-sm">
           <div className="flex items-center justify-end gap-3 whitespace-nowrap">
@@ -707,7 +771,7 @@ function StaffTeamRow(props: {
               : `bg-app ${isLast ? "" : "border-b"}`
           }
         >
-          <td colSpan={8} className="border-t px-4 py-3">
+          <td colSpan={9} className="border-t px-4 py-3">
             {detailsError ? (
               <div className="text-danger-low text-sm">
                 Failed to load team details.
@@ -812,7 +876,7 @@ function StaffTeamsTable(props: {
           isBusy && "opacity-65",
         )}
       >
-        <table className="w-full min-w-300 table-fixed border-collapse">
+        <table className="w-full min-w-312 table-fixed border-collapse">
           {/* Widths live on the headers rather than in a `colgroup`: the
             positional mapping broke silently whenever a column moved. */}
           <thead>
@@ -823,7 +887,7 @@ function StaffTeamsTable(props: {
                 activeSortKey={sortKey}
                 direction={sortDirection}
                 onSort={onSort}
-                className="w-[22%] text-left"
+                className="w-[16%] text-left"
               />
               <SortHeader
                 label="Created"
@@ -833,15 +897,25 @@ function StaffTeamsTable(props: {
                 onSort={onSort}
                 className="w-[11%] text-left"
               />
-              <th className="w-[12%] px-4 py-3 text-left">Subscription</th>
+              <th className="w-[8%] px-4 py-3 text-left">Subscription</th>
               <SortHeader
                 label="Members"
                 sortKey="members"
                 activeSortKey={sortKey}
                 direction={sortDirection}
                 onSort={onSort}
-                className="w-[7%] text-right"
+                className="w-[8%] text-right"
               />
+              {/* Not sortable, unlike the amounts beside it: the ordering would
+                  have to be computed over every candidate the way theirs is,
+                  and nothing has asked to read the directory that way yet. */}
+              <th className="w-[9%] px-4 py-3 text-right">
+                <Tooltip content="Consumed since the running period opened, against what the subscription includes in each one. It resets when the period closes.">
+                  <span className="underline decoration-dotted underline-offset-2">
+                    Screenshots
+                  </span>
+                </Tooltip>
+              </th>
               {/* Two periods rather than one: a single settled figure says what a
                 team is worth, the pair says which way it is going. */}
               <SortHeader
@@ -850,7 +924,7 @@ function StaffTeamsTable(props: {
                 activeSortKey={sortKey}
                 direction={sortDirection}
                 onSort={onSort}
-                className="w-[11%] text-right"
+                className="w-[9%] text-right"
               />
               <SortHeader
                 label="Current period"
@@ -860,7 +934,7 @@ function StaffTeamsTable(props: {
                 onSort={onSort}
                 className="w-[11%] text-right"
               />
-              <th className="w-[16%] px-4 py-3 text-right">Links</th>
+              <th className="w-[18%] px-4 py-3 text-right">Links</th>
               <th className="w-[10%] px-4 py-3 text-right">Actions</th>
             </tr>
           </thead>

--- a/apps/frontend/src/ui/Layout.tsx
+++ b/apps/frontend/src/ui/Layout.tsx
@@ -15,7 +15,7 @@ export function PageHeader(props: ComponentPropsWithRef<"div">) {
         <div
           {...props}
           className={clsx(
-            "mb-6 flex items-end justify-between gap-x-4",
+            "mb-6 flex flex-wrap justify-between items-end gap-x-4 gap-y-3",
             props.className,
           )}
         />

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -135,14 +135,24 @@ async function createBilledTeam(input: {
   flatPrice: number | null;
   /** Screenshots uploaded during each closed period, most recent first. */
   screenshotsByClosedPeriod: number[];
+  /**
+   * Screenshots uploaded since the running period opened, which is what the
+   * Screenshots column reports. Left out where the team has yet to build into
+   * the period it is in — a real state, and the one that reads as zero.
+   */
+  screenshotsInRunningPeriod?: number;
 }): Promise<Account> {
   const { account } = await createTeamAccount({
     slug: input.slug,
     name: input.name,
   });
-  await account
-    .$query()
-    .patch({ createdAt: daysFromNow(-input.createdDaysAgo) });
+  await account.$query().patch({
+    createdAt: daysFromNow(-input.createdDaysAgo),
+    // A billed team reached checkout, so it has a Stripe customer and its row
+    // carries the third link. Without one the Links column renders two links
+    // out of three and never reaches the width it needs.
+    stripeCustomerId: `cus_${input.slug}`,
+  });
 
   const subscription = await Subscription.query().insertAndFetch({
     planId: input.planId,
@@ -179,18 +189,25 @@ async function createBilledTeam(input: {
     name: "usage",
   });
 
-  // One build per closed period, rather than a bare bucket: the Screenshots
-  // column is summed off build stats while billing reads the buckets, and in
-  // real data every bucket comes from a build. Sequential because the build
-  // number is resolved with a `max(number) + 1` sub-query.
-  for (const [
-    index,
-    screenshotCount,
-  ] of input.screenshotsByClosedPeriod.entries()) {
-    // Index 0 is the period still running, so the closed ones start at 1.
-    const periodStart = periodStarts[index + 1];
+  // Index 0 is the period still running, so the closed ones start at 1.
+  const volumes = [
+    ...(input.screenshotsInRunningPeriod === undefined
+      ? []
+      : [{ index: 0, screenshotCount: input.screenshotsInRunningPeriod }]),
+    ...input.screenshotsByClosedPeriod.map((screenshotCount, index) => ({
+      index: index + 1,
+      screenshotCount,
+    })),
+  ];
+
+  // One build per period, rather than a bare bucket: the Screenshots column is
+  // summed off build stats while billing reads the buckets, and in real data
+  // every bucket comes from a build. Sequential because the build number is
+  // resolved with a `max(number) + 1` sub-query.
+  for (const { index, screenshotCount } of volumes) {
+    const periodStart = periodStarts[index];
     if (!periodStart) {
-      throw new Error("missing closed period");
+      throw new Error("missing period");
     }
     const createdAt = new Date(periodStart.getTime() + 3_600_000).toISOString();
     const bucket = await ScreenshotBucket.query().insertAndFetch({
@@ -316,6 +333,9 @@ const staffTest = loggedTest.extend<{ pipelineTeams: PipelineTeams }>({
         periodStartDaysAgo: 14,
         flatPrice: 100,
         screenshotsByClosedPeriod: [50_000, 40_000],
+        // Well inside the 35k quota with half the period still to run: the
+        // column says so long before the invoice does.
+        screenshotsInRunningPeriod: 12_340,
       }),
       // A contract whose amount Argos has not read yet: the row falls back to
       // the guess for its plan rather than to the cheapest plan we sell.
@@ -342,6 +362,9 @@ const staffTest = loggedTest.extend<{ pipelineTeams: PipelineTeams }>({
         flatPrice: 750,
         periodStartDaysAgo: 9,
         screenshotsByClosedPeriod: [60_000],
+        // Already 6k past the quota, which is the whole point of the column:
+        // the running amount has started moving with days still left on it.
+        screenshotsInRunningPeriod: 41_000,
       }),
       // Billed by the year. Stripe states both halves of the amount for a year,
       // so the row has to quote the year — dividing it into a month would
@@ -401,6 +424,25 @@ staffTest("staff all teams", async ({ page, pipelineTeams }) => {
   await expect(page.getByRole("row", { name: /Initrode/ })).toContainText(
     "$12,000",
   );
+
+  // Soylent is 12,340 into the 35k this month, well inside it — so the running
+  // amount is still the flat price alone. On Pro, which includes the same
+  // 35k on every row, the quota itself is left unsaid.
+  const soylent = page.getByRole("row", { name: /Soylent/ });
+  await expect(soylent).toContainText("12,340");
+  await expect(soylent).not.toContainText("35,000");
+
+  // Umbrella is on a contract, so its quota is named — and it is 6k past it
+  // with days still to run: $750 flat plus $30 of overage, which is the figure
+  // the column exists to explain.
+  const umbrella = page.getByRole("row", { name: /Umbrella/ });
+  await expect(umbrella).toContainText("41,000");
+  await expect(umbrella).toContainText("/ 35,000");
+  await expect(umbrella).toContainText("$780");
+
+  // The running period is partial by construction, so what is left of it is
+  // what tells a genuine drop from a period that simply opened three days ago.
+  await expect(umbrella).toContainText(/\d+ days left/);
 
   await screenshot(page, "staff-all-teams");
 });
@@ -520,7 +562,8 @@ staffTest(
 
     // Soylent uploaded 50k screenshots over its last closed month: 15k past the
     // 35k included, at $0.005, on top of the $100 flat plan. The month still
-    // running holds nothing, so reading that one instead would print $100.
+    // running holds 12,340, well inside the quota, so reading that one instead
+    // would print $100.
     await expect(page.getByText("$175")).toBeVisible();
     // Umbrella is on Enterprise: same 60k over the same quota, but its
     // contract is $750, read from the subscription rather than assumed. The row


### PR DESCRIPTION
The team directory gains a Screenshots column: what the running period has consumed, with the included quota under it on the contracts. Pro is left unsaid — it includes the same amount on every row.

The period countdown now says what is left rather than how far in, which needs the period's real end: `to` stops at the moment a running period was read, so `Subscription.getPeriodEnd` walks the anniversary forward instead.

The quota it is all read against is the one the account is actually metered on — the subscription's, falling back to the plan's — so the overage is computed on that too rather than skipped when Stripe states none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)