### PR TITLE
ci(release): say why the migration task stopped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,16 +258,24 @@ jobs:
             --query 'tasks[0].taskArn' \
             --output text)
 
+          # ECS forgets a stopped task about an hour after it stops. Name it now,
+          # so a run opened the next morning still says what to go looking for.
+          echo "Task: $TASK_ARN (log stream ecs/argos-migrate/${TASK_ARN##*/} in /ecs/argos-migrate)"
+
           aws ecs wait tasks-stopped --cluster "$ECS_CLUSTER" --tasks "$TASK_ARN"
 
-          EXIT_CODE=$(aws ecs describe-tasks \
+          TASK=$(aws ecs describe-tasks \
             --cluster "$ECS_CLUSTER" \
             --tasks "$TASK_ARN" \
-            --query 'tasks[0].containers[0].exitCode' \
-            --output text)
+            --output json)
+
+          # Null rather than a number whenever the container never ran at all,
+          # which the reasons below explain and the migration logs never do.
+          EXIT_CODE=$(jq -r '.tasks[0].containers[0].exitCode // "none"' <<<"$TASK")
 
           if [ "$EXIT_CODE" != "0" ]; then
             echo "Migration task failed with exit code: $EXIT_CODE"
+            jq -r '.tasks[0] | "Stopped reason: \(.stoppedReason // "-")", "Container reason: \(.containers[0].reason // "-")"' <<<"$TASK"
             exit 1
           fi
 


### PR DESCRIPTION
[Run #451](https://github.com/argos-ci/argos/actions/runs/32313871383) failed with `Migration task failed with exit code: None` and nothing else. `None` is a null exit code — the container never ran, so the migrations were never the problem — but the step threw away the task's own account of why. ECS forgets a stopped task about an hour after it stops, so by morning there was nothing left to read.

Nothing in that release touched a migration, and a plain re-run went green: it was a transient ECS startup failure. The cost was an hour of archaeology to establish that.

## What changes

- The task ARN and its CloudWatch log stream name are printed as soon as the task starts, so a run opened the next day still says where to look.
- `describe-tasks` keeps the whole task instead of querying one field out of it — the same call, no extra API round trip.
- `jq` reads the exit code from that JSON, and `// "none"` replaces the bare `None` that `--output text` produced.
- On failure, the same in-memory JSON yields `stoppedReason` and the container's `reason`.

## What it would have said

```
Task: arn:aws:ecs:...:task/argos-production/abc123 (log stream ecs/argos-migrate/abc123 in /ecs/argos-migrate)
Migration task failed with exit code: none
Stopped reason: ResourceInitializationError: unable to pull secrets or registry auth: […]
Container reason: -
```

## Limits

It does not fetch the container's logs. A real SQL failure still reads as `exit code: 1` / `Essential container in task exited`, and you open CloudWatch — but the stream name printed at the top takes you straight to it.

## Testing

The step was extracted and run against a mocked AWS CLI for three cases: success, container-never-started (null exit code, `TaskFailedToStart`), and migration error (exit code 1). Exit statuses and output verified for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)