### PR TITLE
fix(build): stop naming the build in the next-review button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,28 @@ dependency bumps, and internal fixes no user could ever observe. Do not use
 `style` — the formatter owns formatting, so the type has nothing left to
 describe.
 
+## Comments
+
+**A comment has to say something the code cannot.** A constraint coming from
+elsewhere in the system, a race, a workaround, a decision whose better-looking
+alternative is wrong — those earn their lines, and the codebase is full of
+them on purpose. Everything else is noise a reader wades through and a
+maintainer has to keep true.
+
+So do not write:
+
+- a restatement of the line below it — `// Review the next build` over a
+  button that reads "Review next build";
+- a defence of what is _not_ in the code. An approach considered and dropped
+  belongs in the pull request, where it is read once, not in the file, where
+  it is read forever;
+- an explanation of a name that is already clear, or a banner announcing a
+  section the structure already shows.
+
+Comment the part that is actually surprising, not the whole block around it.
+When the explanation keeps growing, the code usually wants a named function
+instead.
+
 ## TypeScript
 
 - Never use `!` (non-null assertion). Use `invariant` for required values.

--- a/apps/frontend/src/pages/Build/BuildNextReviewDialog.tsx
+++ b/apps/frontend/src/pages/Build/BuildNextReviewDialog.tsx
@@ -197,7 +197,13 @@ function BuildNextReviewDialog(props: { build: ReviewedBuild }) {
           href={getBuildOverviewURL(getBuildParams(nextBuild))}
           autoFocus
         >
-          Review {nextBuild.name}
+          {/*
+           * Unnamed: the rows above are where a build is picked out, and they
+           * have two lines to do it with. Naming the first one here only
+           * raises the question of what the word means — `default` says
+           * nothing, and anything better takes a rule the reader has to infer.
+           */}
+          Review next build
         </LinkButton>
       </DialogFooter>
     </Dialog>

--- a/apps/frontend/src/pages/Build/BuildNextReviewDialog.tsx
+++ b/apps/frontend/src/pages/Build/BuildNextReviewDialog.tsx
@@ -197,12 +197,6 @@ function BuildNextReviewDialog(props: { build: ReviewedBuild }) {
           href={getBuildOverviewURL(getBuildParams(nextBuild))}
           autoFocus
         >
-          {/*
-           * Unnamed: the rows above are where a build is picked out, and they
-           * have two lines to do it with. Naming the first one here only
-           * raises the question of what the word means — `default` says
-           * nothing, and anything better takes a rule the reader has to infer.
-           */}
           Review next build
         </LinkButton>
       </DialogFooter>

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -222,9 +222,7 @@ loggedTest(
       },
     });
 
-    await dialog
-      .getByRole("link", { name: `Review ${storybookBuild.name}` })
-      .click();
+    await dialog.getByRole("link", { name: "Review next build" }).click();
     await expect(page).toHaveURL(
       new RegExp(`/builds/${storybookBuild.number}/overview$`),
     );
@@ -238,7 +236,7 @@ loggedTest(
   "prompts for the next build from the review dialog too",
   async ({ page, auth, team, project }) => {
     await ensureTeamOwner({ team: team.team, user: auth.user });
-    const { defaultBuild, storybookBuild } = await createSiblingBuildsScenario({
+    const { defaultBuild } = await createSiblingBuildsScenario({
       projectId: project.id,
     });
 
@@ -262,7 +260,7 @@ loggedTest(
     const dialog = page.getByRole("dialog", { name: "Review the next build" });
     await expect(dialog).toBeVisible({ timeout: 15_000 });
     await expect(
-      dialog.getByRole("link", { name: `Review ${storybookBuild.name}` }),
+      dialog.getByRole("link", { name: "Review next build" }),
     ).toBeVisible();
   },
 );


### PR DESCRIPTION
Closes ARG-505.

## The problem

The next-review prompt named its call to action after the build it points at — `Review {build.name}`. That word is `default` whenever CI never named the suite, since `default` is what Argos stamps on an unnamed one. A reviewer coming out of one project's build was offered **Review default**, which says nothing about where it goes.

## The fix

The button no longer names anything: **Review next build**.

Nothing takes the name's place, deliberately. The rows above are where a build is picked out, and they have two lines each to do it with — the build name, and the project or the number underneath. Naming the first of them on the button only raises the question of what the word means: `default` says nothing, and anything better (the project it ran in, its number) is a rule the reader has to infer from a single word.

| Before | After |
| --- | --- |
| [![before](https://files.argos-ci.com/media/9/04c8aaf1f7aa6a6b9c3a355729b9142bbf8fd4fe147faa316d90c1badc0e0653.webp)](https://app.argos-ci.com/m/951ijtbhyq2m65dcyw6k) | [![after](https://files.argos-ci.com/media/9/9a85affeadbaadea9e9097c22ab8d27a9ab287562ad6da837227cf78915ece3c.webp)](https://app.argos-ci.com/m/pzlk24geybxstlvyp9yj) |

The reviewer is on `acme/sparkle-docs`, and the next build in line is `acme/sparkle`'s unnamed suite.

## Tests

The two existing next-build specs now assert the static label, and one of them clicks it and follows the navigation, so the button is still covered end to end. No new test: there is no longer a rule to guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)