### PR TITLE
fix(build): load the snapshots of the build you jump to

### DIFF
--- a/apps/frontend/src/pages/Build/BuildNextReviewDialog.tsx
+++ b/apps/frontend/src/pages/Build/BuildNextReviewDialog.tsx
@@ -1,4 +1,4 @@
-import { createContext, use, useEffect, useMemo } from "react";
+import { createContext, use, useMemo } from "react";
 import { invariant } from "@argos/util/invariant";
 import { clsx } from "clsx";
 
@@ -89,10 +89,9 @@ export function useBuildNextReviewPrompt(): ContextValue {
 }
 
 export function BuildNextReviewDialogProvider(props: {
-  buildNumber: number;
   children: React.ReactNode;
 }) {
-  const { buildNumber, children } = props;
+  const { children } = props;
   const dialog = useDialogValueState<ReviewedBuild | null>(null);
 
   const promptNextReview = useEventCallback((build: ReviewedBuild) => {
@@ -103,15 +102,8 @@ export function BuildNextReviewDialogProvider(props: {
   });
   const value = useMemo(() => ({ promptNextReview }), [promptNextReview]);
 
-  // The prompt belongs to the build that was just reviewed. Jumping to another
-  // build keeps this provider mounted (same route, different param), so close
-  // the dialog by hand — otherwise it outlives the navigation and keeps
-  // offering the previous build's siblings.
-  const close = useEventCallback(() => dialog.onOpenChange(false));
-  useEffect(() => {
-    close();
-  }, [buildNumber, close]);
-
+  // The prompt belongs to the build that was just reviewed, and it does not
+  // outlive it: jumping to one of the siblings remounts the build page.
   return (
     <>
       {dialog.value ? (

--- a/apps/frontend/src/pages/Build/BuildPage.tsx
+++ b/apps/frontend/src/pages/Build/BuildPage.tsx
@@ -102,7 +102,7 @@ export const BuildPage = ({ params }: { params: BuildParams }) => {
              * way around: the dialog hosts a review form of its own, outside
              * `children`, and submitting from there raises the prompt too.
              */}
-            <BuildNextReviewDialogProvider buildNumber={params.buildNumber}>
+            <BuildNextReviewDialogProvider>
               <BuildReviewDialogProvider project={data?.project ?? null}>
                 <RejectCommentDialogProvider build={build}>
                   <div className="flex h-screen min-h-0 flex-col">

--- a/apps/frontend/src/pages/Build/BuildParams.ts
+++ b/apps/frontend/src/pages/Build/BuildParams.ts
@@ -67,6 +67,16 @@ export function getBuildParams(build: {
   };
 }
 
+/**
+ * Identity of a build, independent of the snapshot being looked at. Keys the
+ * build page: React reuses a route component across a param change, and
+ * everything the page holds — the screenshot list, the filters, the snapshot
+ * it opened on — belongs to one build.
+ */
+export function getBuildKey(params: BuildParams): string {
+  return `${params.accountSlug}/${params.projectName}/${params.buildNumber}`;
+}
+
 export function getBuildURL(params: BuildParams): string {
   return `${getProjectURL(params)}/builds/${params.buildNumber}${params.diffId ? `/${params.diffId}` : ""}`;
 }

--- a/apps/frontend/src/pages/Build/index.tsx
+++ b/apps/frontend/src/pages/Build/index.tsx
@@ -7,7 +7,11 @@ import { BuildHotkeysDialogStateProvider } from "@/containers/Build/BuildHotkeys
 
 import { BuildNotFound } from "./BuildNotFound";
 import { BuildPage } from "./BuildPage";
-import { getBuildOverviewURL, useBuildParams } from "./BuildParams";
+import {
+  getBuildKey,
+  getBuildOverviewURL,
+  useBuildParams,
+} from "./BuildParams";
 
 export function Component() {
   const params = useBuildParams();
@@ -34,7 +38,13 @@ export function Component() {
         <title>{`Build ${params.buildNumber} • ${params.projectName}`}</title>
       </Helmet>
       <BuildHotkeysDialogStateProvider>
-        <BuildPage params={params} />
+        {/*
+         * Keyed by the build, not by the route: jumping from one build of a
+         * commit to the next (the next-review prompt, the build switcher)
+         * stays on the same route, and React would keep the page mounted with
+         * the previous build's screenshot list, filters and prompts.
+         */}
+        <BuildPage key={getBuildKey(params)} params={params} />
         <BuildHotkeysDialog env="build" />
       </BuildHotkeysDialogStateProvider>
     </>

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -1,6 +1,9 @@
 import { expect } from "@playwright/test";
 
-import { BuildReview } from "../apps/backend/src/database/models";
+import {
+  BuildReview,
+  ScreenshotDiff,
+} from "../apps/backend/src/database/models";
 import {
   BuildScenario,
   createFallbackBaselineScenario,
@@ -231,6 +234,20 @@ loggedTest(
     // The prompt belongs to the build it was raised on: it must not survive
     // the jump and keep pointing at the build the reviewer just left.
     await expect(dialog).toBeHidden();
+
+    // Landing on the next build means reviewing *its* snapshots: starting the
+    // review has to open a snapshot of the build being looked at, not one the
+    // previous build left in the list.
+    const storybookDiff = await ScreenshotDiff.query()
+      .findOne({ buildId: storybookBuild.id })
+      .throwIfNotFound();
+    await page
+      .getByRole("button", { name: /^(Start review|Browse snapshots)/ })
+      .click();
+    await expect(page).toHaveURL(
+      new RegExp(`/builds/${storybookBuild.number}/${storybookDiff.id}$`),
+    );
+    await expect(page.getByRole("heading", { name: "home.png" })).toBeVisible();
   },
 );
 


### PR DESCRIPTION
Fixes ARG-506.

## The bug

Jumping from one build of a commit to another — the next-review prompt, the header build switcher — stays on the same route, so React keeps the build page mounted and reuses its state. The screenshot list is fetched once per mount and stops paginating once the last page has landed, so it never refetched: the page showed the new build with the snapshots of the build just left.

That is worse than a stale list. Starting the review opened one of those snapshots, and the review submitted from there carried their diff ids — `useGetReviewedDiffStatuses` builds `screenshotDiffReviews` from that list. Active filters were a second casualty: `FilterChips` asserts every active filter key exists among the current build's diffs, so switching to a build without that value threw.

**Before** — Build 2 (`storybook`), reached from the prompt, showing `home.png`, which belongs to build 1. Even the comment box targets it:

[![before](https://files.argos-ci.com/media/9/7194f40aa4af2d25ce70f199301115576b00a1257f9d5bbc88da2665567bc800.webp)](https://app.argos-ci.com/m/u362fxcjy9s272imlaag)

**After** — same flow, showing `button.png`, build 2's own snapshot:

[![after](https://files.argos-ci.com/media/9/dfb119474319b03b6283ac1720f00bb095ccb2f3c262af495c6fbb0168ede60a.webp)](https://app.argos-ci.com/m/l9jners6wkjlfipgu19q)

<sub>The two sibling builds in the seed share a snapshot name, so for these captures build 2's snapshot was renamed locally — otherwise both screenshots look the same and prove nothing.</sub>

## The fix

Key the build page by the build it shows — `account/project/buildNumber`, deliberately not the snapshot, so navigating between snapshots stays a re-render. One mount is now one build: the screenshot list, the filters, the search, the snapshot it opened on and the prompts all reset together. It also subsumes the manual "close the next-review dialog when the build number changes" effect, which is gone.

## Tests

The existing next-review flow test in `tests/build.spec.ts` now asserts that starting the review on the build it jumped to opens *that* build's snapshot. It fails without the fix — verified: it navigated to the previous build's diff id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
