### PR TITLE
fix(build): scope local review marks to the account

### DIFF
--- a/apps/frontend/src/pages/Build/BuildReviewState.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewState.tsx
@@ -417,10 +417,17 @@ export function useBuildDiffStatusState(args: {
   return [getDiffStatus(diffId), setDiffStatus] as const;
 }
 
+/**
+ * Local, not-yet-submitted evaluation statuses, persisted per build.
+ *
+ * The key must carry the account slug: project names are only unique within an
+ * account, so two accounts owning a project of the same name would otherwise
+ * share the storage of their same-numbered builds.
+ */
 const diffStatusesFamily = atomFamily(
-  (params: { projectName: string; buildNumber: number }) =>
+  (params: { accountSlug: string; projectName: string; buildNumber: number }) =>
     atomWithStorage<Record<string, EvaluationStatus>>(
-      `${params.projectName}#${params.buildNumber}.review.diffStatuses`,
+      `${params.accountSlug}/${params.projectName}#${params.buildNumber}.review.diffStatuses`,
       {},
     ),
 );
@@ -437,10 +444,11 @@ export function BuildReviewStateProvider(props: {
   const { buildStatus, buildType, params } = props;
   const stableParams = useMemo(
     () => ({
+      accountSlug: params.accountSlug,
       projectName: params.projectName,
       buildNumber: params.buildNumber,
     }),
-    [params.projectName, params.buildNumber],
+    [params.accountSlug, params.projectName, params.buildNumber],
   );
   const [diffStatuses, setDiffStatuses] = useAtom(
     diffStatusesFamily(stableParams),


### PR DESCRIPTION
## What changed

`diffStatusesFamily` in `apps/frontend/src/pages/Build/BuildReviewState.tsx` keyed the reviewer's local, unsubmitted diff marks by `<projectName>#<buildNumber>.review.diffStatuses`. The account slug is now part of the key.

## Why

Project names are only unique *within* an account, and nearly everyone names the project after the repo — so two accounts owning a same-named project shared one localStorage entry for their same-numbered builds.

## Migration: the one-time loss is accepted

Marks stored under the old key are discarded rather than read as a fallback. The reason is stronger than "it's only local data": **the legacy key is ambiguous by construction — that is the bug.** A fallback read could seed a build with the marks of a *different account's* project, which is exactly the contamination this removes. The data is local, unsubmitted and cheap to redo, and the exposure is a single reload for whoever happens to be mid-review when this ships.

## For the reviewer: what the symptom actually was

Worth knowing, because it is not what the title suggests. I wrote a Playwright guard test (two accounts, same project name, same build number, mark a diff in one, assert the other is clean) and **it passed without the fix**. That is a finding, not a bad test:

Diff ids are globally unique DB ids, so one build's marks never resolve against another build's diffs. `useBuildReviewProgression` (the "X / Y reviewed" badge) and `useBuildReviewSummary` both resolve ids against the build's diffs, so they correctly showed `0 / 16`. But `useReviewStatus` does:

```ts
const reviewed = Object.values(diffStatuses).filter((s) => s !== EvaluationStatus.Pending).length;
```

— a raw count of the record, with no check that the entries belong to this build. So the user-visible symptom of the collision was never a stray thumb; it was `expected === reviewed` hitting early and `reviewDialog.show()` popping the submit dialog on a build you had not reviewed.

This PR closes the cross-account path into that count. The unfiltered count itself is still reachable by stale entries (a diff that flips to `Ignored`, or disappears between visits) — left as a follow-up rather than widening this commit.

No guard test was added: the only observable symptom needs a contrived count coincidence between two seeded scenarios, which lands on the wrong side of CLAUDE.md's "not every fix needs a test".

## Verification

- `pnpm run static-checks` — all 11 tasks green.
- Full chromium e2e suite — **103 passed**, including `tests/build.spec.ts:237`, which drives this exact atom end-to-end (mark a diff → storage-backed state reaches `complete` → review dialog opens).
- Confirmed the shipped bundle carries the new key after wiping `dist` — turbo had left both chunk versions in place, which made an earlier check ambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)