### PR TITLE
fix(build): reject reviews targeting another build's screenshot diffs

### DIFF
--- a/apps/backend/src/api/handlers/createReview.e2e.test.ts
+++ b/apps/backend/src/api/handlers/createReview.e2e.test.ts
@@ -306,6 +306,45 @@ describe("createReview", () => {
       });
   });
 
+  test("returns 400 when a snapshot belongs to another build", async ({
+    project,
+    build,
+    screenshotDiffs,
+    scopedPatToken,
+  }) => {
+    const otherBuild = await factory.Build.create({
+      projectId: project.id,
+      conclusion: null,
+    });
+    const screenshots = await factory.Screenshot.createMany(2);
+    const otherDiff = await factory.ScreenshotDiff.create({
+      buildId: otherBuild.id,
+      baseScreenshotId: screenshots[0]!.id,
+      compareScreenshotId: screenshots[1]!.id,
+      score: 0.4,
+    });
+
+    // An agent reviewing with stale ids has to hear about it: a 200 here would
+    // report a review that recorded none of the decisions it sent.
+    await request(app)
+      .post(`/projects/acme/web/builds/${build.number}/reviews`)
+      .set("Authorization", `Bearer ${scopedPatToken}`)
+      .send({
+        event: "APPROVE",
+        snapshots: [
+          { id: screenshotDiffs[0]!.id, conclusion: "APPROVE" },
+          { id: otherDiff.id, conclusion: "APPROVE" },
+        ],
+      })
+      .expect(400)
+      .expect((res) => {
+        expect(res.body.error).toContain(otherDiff.id);
+      });
+
+    const reviews = await BuildReview.query().where({ buildId: build.id });
+    expect(reviews).toHaveLength(0);
+  });
+
   test("returns 400 when neither event nor conclusion is provided", async ({
     build,
     scopedPatToken,

--- a/apps/backend/src/build/createBuildReview.e2e.test.ts
+++ b/apps/backend/src/build/createBuildReview.e2e.test.ts
@@ -1,3 +1,4 @@
+import { invariant } from "@argos/util/invariant";
 import { test as base, describe, expect } from "vitest";
 
 import {
@@ -7,10 +8,12 @@ import {
   BuildReview,
   Comment,
   ScreenshotDiff,
+  ScreenshotDiffReview,
   User,
 } from "@/database/models";
 import { factory } from "@/database/testing";
 import { setupDatabase } from "@/database/testing/util";
+import { HTTPError } from "@/util/error";
 
 import { createBuildReview } from "./createBuildReview";
 
@@ -18,6 +21,7 @@ const test = base.extend<{
   user: User;
   build: Build;
   screenshotDiffs: ScreenshotDiff[];
+  otherBuildScreenshotDiff: ScreenshotDiff;
 }>({
   user: async ({}, use) => {
     await setupDatabase();
@@ -48,6 +52,20 @@ const test = base.extend<{
       },
     ]);
     await use(diffs);
+  },
+  otherBuildScreenshotDiff: async ({}, use) => {
+    const otherBuild = await factory.Build.create({
+      conclusion: "changes-detected",
+      jobStatus: "complete",
+    });
+    const screenshots = await factory.Screenshot.createMany(2);
+    const diff = await factory.ScreenshotDiff.create({
+      buildId: otherBuild.id,
+      baseScreenshotId: screenshots[0]!.id,
+      compareScreenshotId: screenshots[1]!.id,
+      score: 0.5,
+    });
+    await use(diff);
   },
 });
 
@@ -161,6 +179,62 @@ describe("#createBuildReview", () => {
     );
     expect(byDiffId[screenshotDiffs[0]!.id]).toBe("rejected");
     expect(byDiffId[screenshotDiffs[1]!.id]).toBe("approved");
+  });
+
+  test("rejects the review when a reviewed diff belongs to another build", async ({
+    user,
+    build,
+    screenshotDiffs,
+    otherBuildScreenshotDiff,
+  }) => {
+    const error = await createBuildReview({
+      build,
+      userId: user.id,
+      event: "APPROVE",
+      snapshotReviews: [
+        { screenshotDiffId: screenshotDiffs[0]!.id, state: "approved" },
+        { screenshotDiffId: otherBuildScreenshotDiff.id, state: "approved" },
+      ],
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    invariant(error instanceof HTTPError, "expected an HTTP error");
+    expect(error.statusCode).toBe(400);
+    expect(error.message).toContain(otherBuildScreenshotDiff.id);
+
+    // All or nothing: the foreign id poisons the whole review rather than
+    // being dropped, so the valid one is not recorded either.
+    const reviews = await BuildReview.query().where({ buildId: build.id });
+    expect(reviews).toHaveLength(0);
+    const diffReviews = await ScreenshotDiffReview.query().whereIn(
+      "screenshotDiffId",
+      [screenshotDiffs[0]!.id, otherBuildScreenshotDiff.id],
+    );
+    expect(diffReviews).toHaveLength(0);
+  });
+
+  test("rejects the review when a reviewed diff does not exist", async ({
+    user,
+    build,
+  }) => {
+    const error = await createBuildReview({
+      build,
+      userId: user.id,
+      event: "APPROVE",
+      snapshotReviews: [{ screenshotDiffId: "999999999", state: "approved" }],
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    // Used to reach the insert and come back as a foreign-key violation.
+    invariant(error instanceof HTTPError, "expected an HTTP error");
+    expect(error.statusCode).toBe(400);
+
+    const reviews = await BuildReview.query().where({ buildId: build.id });
+    expect(reviews).toHaveLength(0);
   });
 
   test("attaches a comment when a body is provided", async ({

--- a/apps/backend/src/build/createBuildReview.ts
+++ b/apps/backend/src/build/createBuildReview.ts
@@ -15,6 +15,7 @@ import {
   Build,
   BuildReview,
   Comment,
+  ScreenshotDiff,
   ScreenshotDiffReview,
   User,
 } from "@/database/models";
@@ -72,6 +73,59 @@ function getBuildNotificationType(
   }
 }
 
+/**
+ * Number of offending ids named in the error message. A client can send
+ * hundreds of them, and the first few are enough to debug from.
+ */
+const MAX_REPORTED_INVALID_DIFF_IDS = 10;
+
+/**
+ * Check that every reviewed screenshot diff belongs to the build being
+ * reviewed.
+ *
+ * The client picks the diff ids, so nothing stops it from sending another
+ * build's — a frontend bug did exactly that, and the rows landed under the
+ * wrong build's review. Rejecting beats dropping the offending entries
+ * silently: an agent posting to `POST .../builds/{buildNumber}/reviews` with
+ * stale ids would otherwise get a 200 back for a review that recorded none of
+ * the decisions it made.
+ *
+ * Unknown ids fail here too, which is what we want — they used to reach the
+ * insert and come back as a foreign-key violation, i.e. a 500.
+ */
+async function assertSnapshotReviewsBelongToBuild(input: {
+  build: Build;
+  snapshotReviews: { screenshotDiffId: string }[];
+}): Promise<void> {
+  const { build, snapshotReviews } = input;
+
+  if (snapshotReviews.length === 0) {
+    return;
+  }
+
+  const diffIds = Array.from(
+    new Set(snapshotReviews.map((review) => review.screenshotDiffId)),
+  );
+  const buildDiffs = await ScreenshotDiff.query()
+    .select("id")
+    .where("buildId", build.id)
+    .whereIn("id", diffIds);
+
+  if (buildDiffs.length === diffIds.length) {
+    return;
+  }
+
+  const buildDiffIds = new Set(buildDiffs.map((diff) => diff.id));
+  const invalidIds = diffIds.filter((id) => !buildDiffIds.has(id));
+  const reportedIds = invalidIds.slice(0, MAX_REPORTED_INVALID_DIFF_IDS);
+  const omittedCount = invalidIds.length - reportedIds.length;
+
+  throw boom(
+    400,
+    `Some reviewed screenshot diffs do not belong to build ${build.number}: ${reportedIds.join(", ")}${omittedCount > 0 ? ` and ${omittedCount} more` : ""}`,
+  );
+}
+
 export async function createBuildReview(input: {
   build: Build;
   userId: string;
@@ -116,6 +170,8 @@ export async function createBuildReview(input: {
   if (body !== undefined && isCommentTooLarge(body)) {
     throw boom(400, "Comment is too large");
   }
+
+  await assertSnapshotReviewsBelongToBuild({ build, snapshotReviews });
 
   const state = getReviewStateFromEvent(event);
 

--- a/apps/backend/src/graphql/definitions/BuildReview.ts
+++ b/apps/backend/src/graphql/definitions/BuildReview.ts
@@ -25,7 +25,13 @@ import {
   type IResolvers,
 } from "../__generated__/resolver-types";
 import { assertCanViewBuild } from "../buildAccess";
-import { badUserInput, forbidden, notFound, unauthenticated } from "../util";
+import {
+  badUserInput,
+  forbidden,
+  notFound,
+  toGraphQLError,
+  unauthenticated,
+} from "../util";
 import { resolveAgent } from "./Agent";
 
 const { gql } = gqlTag;
@@ -189,16 +195,24 @@ export const resolvers: IResolvers = {
         throw forbidden("You cannot approve or reject this build");
       }
 
-      await createBuildReview({
-        build,
-        userId: auth.user.id,
-        event: parseEvent(input.event),
-        body: (input.body ?? undefined) as JSONContent | undefined,
-        snapshotReviews: input.screenshotDiffReviews.map((diffReviewInput) => ({
-          screenshotDiffId: diffReviewInput.screenshotDiffId,
-          state: parseScreenshotDiffReviewState(diffReviewInput.state),
-        })),
-      });
+      try {
+        // Shared with the REST API — same input validation, so its client
+        // errors have to keep reading as client errors here too.
+        await createBuildReview({
+          build,
+          userId: auth.user.id,
+          event: parseEvent(input.event),
+          body: (input.body ?? undefined) as JSONContent | undefined,
+          snapshotReviews: input.screenshotDiffReviews.map(
+            (diffReviewInput) => ({
+              screenshotDiffId: diffReviewInput.screenshotDiffId,
+              state: parseScreenshotDiffReviewState(diffReviewInput.state),
+            }),
+          ),
+        });
+      } catch (error) {
+        throw toGraphQLError(error);
+      }
 
       return build;
     },

--- a/apps/backend/src/graphql/tests/createBuildReview.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/createBuildReview.e2e.test.ts
@@ -196,6 +196,67 @@ describe("GraphQL createBuildReview mutation", () => {
     expect(reviews).toHaveLength(0);
   });
 
+  test("rejects a review targeting another build's screenshot diff", async ({
+    fixture,
+  }) => {
+    const otherBuild = await factory.Build.create({
+      projectId: fixture.project.id,
+      conclusion: null,
+    });
+    const screenshots = await factory.Screenshot.createMany(2);
+    const otherDiff = await factory.ScreenshotDiff.create({
+      buildId: otherBuild.id,
+      baseScreenshotId: screenshots[0]!.id,
+      compareScreenshotId: screenshots[1]!.id,
+      score: 0.4,
+    });
+
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      {
+        user: fixture.userAccount.user!,
+        account: fixture.userAccount,
+      },
+    );
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: `
+            mutation CreateBuildReview($input: CreateBuildReviewInput!) {
+              createBuildReview(
+                input: $input
+              ) {
+                status
+              }
+            }
+          `,
+        variables: {
+          input: {
+            buildId: fixture.build.id,
+            event: "APPROVE",
+            screenshotDiffReviews: [
+              {
+                screenshotDiffId: fixture.screenshotDiffs[0]!.id,
+                state: "APPROVED",
+              },
+              { screenshotDiffId: otherDiff.id, state: "APPROVED" },
+            ],
+          },
+        },
+      });
+
+    expect(res.body.errors).toBeDefined();
+    expect(res.body.errors[0].message).toContain(otherDiff.id);
+    // A client mistake, not a server fault: it must not page the team.
+    expect(res.body.errors[0].extensions.code).toBe("BAD_USER_INPUT");
+
+    const reviews = await BuildReview.query().where({
+      buildId: fixture.build.id,
+    });
+    expect(reviews).toHaveLength(0);
+  });
+
   test("returns an error if unauthorized", async ({ fixture }) => {
     const userAccount = await factory.UserAccount.create();
     await userAccount.$fetchGraph("user");


### PR DESCRIPTION
## What

`createBuildReview` forwarded `input.screenshotDiffReviews` straight to the insert, creating one `ScreenshotDiffReview` row per entry without checking that each `screenshotDiffId` actually belonged to `input.buildId`.

A frontend bug (fixed in #2515) made the client send another build's diff ids — the rows were inserted happily under the wrong build's review. Separately, an id that existed nowhere reached the insert and came back as a foreign-key violation, i.e. a 500.

This adds the server-side guard. AGENTS.md is explicit that per-object checks belong in the mutation, and the client is not to be trusted here even with the frontend fixed.

## Decision: 400, not silent filtering

Rejecting the whole review, all-or-nothing, rather than dropping the offending entries. The agent/API path drove this:

- An agent posting to `POST /projects/{owner}/{project}/builds/{n}/reviews` with stale or wrong-build snapshot ids would otherwise get a `200` back holding a review that recorded **none** of the decisions it sent — and no way to notice. Filtering makes a client bug invisible on exactly the path that cannot inspect the result.
- It matches what the service already does for bad input (`boom(400, "Invalid comment body")`, `"Comment is too large"`).
- It cleans up the unknown-id case too: a clean 400 instead of a 500.

## Changes

- **`apps/backend/src/build/createBuildReview.ts`** — new `assertSnapshotReviewsBelongToBuild`, called before the transaction. Putting it in the service covers all three callers: the GraphQL mutation, the REST handler, and `autoApproveBuild`. The error names the offending ids (capped at 10) so a caller can map them back to its own input, whether it called them `snapshots` or `screenshotDiffReviews`.
- **`apps/backend/src/graphql/definitions/BuildReview.ts`** — wrapped the `createBuildReview` call in `toGraphQLError`. Without it the service's `HTTPError` reaches Apollo as `INTERNAL_SERVER_ERROR` and pages the team through Sentry for what is a client mistake. This also fixes the same problem for the pre-existing "Invalid comment body" / "Comment is too large" errors on that mutation.

## Tests

- `createBuildReview.e2e.test.ts` — a review mixing one valid diff with another build's is rejected with a 400 and **nothing** is persisted (no `BuildReview`, no `ScreenshotDiffReview`); that is the all-or-nothing assertion. Plus a case for an id that does not exist at all.
- `graphql/tests/createBuildReview.e2e.test.ts` — the mutation path returns `BAD_USER_INPUT`, not a 500.
- `api/handlers/createReview.e2e.test.ts` — the agent path gets a 400 naming the id.

I checked the guard tests earn their place by temporarily disabling the guard: both service tests fail (the foreign-build one because the insert *succeeds* — precisely the bug), then pass again with it restored.

## Verification

- `pnpm run static-checks` clean.
- Full `pnpm test:integration`: 1231/1231.
- The three touched files: 31/31 across three repeat runs.

One note: a single full integration run had one supertest failure whose name I did not capture. Three subsequent full runs passed 1231/1231 and the touched files were stable across repeats, so it looks like a flake elsewhere in the suite — but I cannot point at which test it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)