### PR TITLE
chore(jobs): give every consumer its own AMQP channel

### DIFF
--- a/apps/backend/src/job-core/createJob.ts
+++ b/apps/backend/src/job-core/createJob.ts
@@ -81,53 +81,88 @@ type JobContext = {
   logger: Logger;
 };
 
-// Shared AMQP channels, one per direction, shared across every createJob
-// instance in the process. Keeping channels in singletons keeps the per-
-// connection channel count constant regardless of how many job types we
-// register, which is what stops us tripping RabbitMQ's channel_max limit.
-type ChannelDirection = "publisher" | "consumer";
-const sharedChannels = new Map<ChannelDirection, Promise<Channel>>();
-const sharedChannelLogger = parentLogger.child({ module: "job", shared: true });
+// amqplib emits "error" on a channel before closing it, and an EventEmitter
+// with no "error" listener throws. Termination observers detach theirs as soon
+// as they settle, so keep one attached for the channel's whole life.
+function keepChannelErrorHandled(channel: Channel) {
+  channel.on("error", () => undefined);
+}
 
-function getSharedChannel(direction: ChannelDirection): Promise<Channel> {
-  const existing = sharedChannels.get(direction);
-  if (existing) {
-    return existing;
+// One publisher channel for the whole process: it holds no consumer, so nothing
+// about it grows with the number of registered job types.
+const publisherLogger = parentLogger.child({
+  module: "job",
+  shared: true,
+  channelType: "publisher",
+});
+let publisherChannel: Promise<Channel> | null = null;
+
+function getPublisherChannel(): Promise<Channel> {
+  if (publisherChannel) {
+    return publisherChannel;
   }
-  const channelLogger = sharedChannelLogger.child({ channelType: direction });
   const promise = pRetry(
     async () => {
-      channelLogger.info("Creating shared channel");
+      publisherLogger.info("Creating publisher channel");
       const connection = await connect();
       const channel = await connection.createChannel();
-      // Allow many subscribers (one per job type) without triggering Node's
-      // MaxListenersExceededWarning.
+      keepChannelErrorHandled(channel);
+      // push() attaches a "drain" listener whenever a send is blocked, and
+      // every job in the process publishes through this one channel.
       channel.setMaxListeners(0);
       channel.once("close", () => {
-        channelLogger.info("Shared channel closed");
-        if (sharedChannels.get(direction) === promise) {
-          sharedChannels.delete(direction);
+        publisherLogger.info("Publisher channel closed");
+        if (publisherChannel === promise) {
+          publisherChannel = null;
         }
       });
-      channelLogger.info("Shared channel created");
+      publisherLogger.info("Publisher channel created");
       return channel;
     },
     {
       onFailedAttempt: ({ error, attemptNumber, retriesLeft }) => {
-        channelLogger.info(
+        publisherLogger.info(
           { error, attemptNumber, retriesLeft },
-          "Shared channel creation attempt failed",
+          "Publisher channel creation attempt failed",
         );
       },
     },
   );
-  sharedChannels.set(direction, promise);
+  publisherChannel = promise;
   promise.catch(() => {
-    if (sharedChannels.get(direction) === promise) {
-      sharedChannels.delete(direction);
+    if (publisherChannel === promise) {
+      publisherChannel = null;
     }
   });
   return promise;
+}
+
+/**
+ * Consumers get a channel each.
+ *
+ * A broker caps how many consumers one channel may hold — ours at ten — and
+ * answers a breach with a connection-level 530, which takes down every other
+ * consumer on the connection with it. Sharing a single consumer channel
+ * therefore capped how many job types the worker could register at all, and
+ * crossing that cap broke every job rather than the one registered last.
+ * Channels are the cheap resource here (`channel_max` is 2047), and one
+ * consumer per channel also makes `prefetch` — which applies to the next
+ * consumer started on the channel — unambiguous.
+ */
+async function createConsumerChannel(): Promise<Channel> {
+  const connection = await connect();
+  const channel = await connection.createChannel();
+  keepChannelErrorHandled(channel);
+  return channel;
+}
+
+async function closeChannel(channel: Channel): Promise<void> {
+  try {
+    await channel.close();
+  } catch {
+    // Already closed, which is the usual way out of the consume loop: the
+    // broker or the connection got there first.
+  }
 }
 
 // Track which queues have been asserted on each channel so we only pay the
@@ -157,36 +192,9 @@ function ensureQueueAsserted(
   return promise;
 }
 
-// channel.prefetch with global=false applies to the *next* consumer started
-// on the channel. With a shared consumer channel we have to serialize the
-// prefetch + consume pair per job, otherwise concurrent setup from different
-// jobs can interleave and one job's prefetch ends up applied to another
-// job's consumer.
-const consumerSetupChain = new WeakMap<Channel, Promise<unknown>>();
-
-function runConsumerSetup<T>(
-  channel: Channel,
-  fn: () => Promise<T>,
-): Promise<T> {
-  const previous = consumerSetupChain.get(channel) ?? Promise.resolve();
-  const next = previous.then(fn, fn);
-  consumerSetupChain.set(
-    channel,
-    next.catch(() => undefined),
-  );
-  return next;
-}
-
-// One observer per shared channel exposes its terminal state as a promise
-// instead of each createJob attaching its own close/error listeners.
-const channelTerminations = new WeakMap<Channel, Promise<void>>();
-
+// Resolves when the channel closes, rejects when it errors.
 function observeChannelTermination(channel: Channel): Promise<void> {
-  const existing = channelTerminations.get(channel);
-  if (existing) {
-    return existing;
-  }
-  const promise = new Promise<void>((resolve, reject) => {
+  return new Promise<void>((resolve, reject) => {
     const onClose = () => {
       channel.off("error", onError);
       resolve();
@@ -198,8 +206,6 @@ function observeChannelTermination(channel: Channel): Promise<void> {
     channel.once("close", onClose);
     channel.once("error", onError);
   });
-  channelTerminations.set(channel, promise);
-  return promise;
 }
 
 export const createJob = <TValue extends string | number>(
@@ -224,7 +230,7 @@ export const createJob = <TValue extends string | number>(
   return {
     queue,
     async push(...values) {
-      const channel = await getSharedChannel("publisher");
+      const channel = await getPublisherChannel();
       await ensureQueueAsserted(channel, queue);
       const valuesSet = new Set(values);
       const sendOne = (value: TValue) => {
@@ -276,125 +282,105 @@ export const createJob = <TValue extends string | number>(
         async (): Promise<void> => {
           logger.info("Initialize consuming");
 
-          const channel = await getSharedChannel("consumer");
-          await ensureQueueAsserted(channel, queue);
-          // Retries are published from this channel, so the delay queues have
-          // to exist here. Asserting them during setup surfaces a bad
-          // declaration at startup instead of when a job first fails.
-          await Promise.all(
-            retryLadder.map((tier) =>
-              ensureQueueAsserted(
-                channel,
-                getRetryQueueName(queue, tier),
-                getRetryQueueOptions(queue, tier),
+          const channel = await createConsumerChannel();
+
+          try {
+            await ensureQueueAsserted(channel, queue);
+            // Retries are published from this channel, so the delay queues have
+            // to exist here. Asserting them during setup surfaces a bad
+            // declaration at startup instead of when a job first fails.
+            await Promise.all(
+              retryLadder.map((tier) =>
+                ensureQueueAsserted(
+                  channel,
+                  getRetryQueueName(queue, tier),
+                  getRetryQueueOptions(queue, tier),
+                ),
               ),
-            ),
-          );
+            );
 
-          let consumerTag: string | null = null;
+            // Lets the consume callback signal a fatal error to the outer loop.
+            // The channel goes down with the loop iteration, so the consumer
+            // stops with it and `runForever` re-enters on a fresh one.
+            let signalConsumerFault!: (error: unknown) => void;
+            const consumerFault = new Promise<never>((_, reject) => {
+              signalConsumerFault = reject;
+            });
+            // Prevent an unhandled rejection if the channel terminates first.
+            consumerFault.catch(() => undefined);
 
-          // Lets the consume callback signal a fatal per-consumer error to the
-          // outer loop without taking down the shared channel. Racing this
-          // against channel termination ensures `runForever` re-registers a
-          // fresh consumer for this queue after a cancel.
-          let signalConsumerFault!: (error: unknown) => void;
-          const consumerFault = new Promise<never>((_, reject) => {
-            signalConsumerFault = reject;
-          });
-          // Prevent an unhandled rejection if the channel terminates first.
-          consumerFault.catch(() => undefined);
+            await channel.prefetch(prefetch);
+            logger.info("Consuming queue");
+            await channel.consume(queue, async (msg) => {
+              if (!msg) {
+                return;
+              }
 
-          const { consumerTag: tag } = await runConsumerSetup(
-            channel,
-            async () => {
-              await channel.prefetch(prefetch);
-              logger.info("Consuming queue");
-              return channel.consume(queue, async (msg) => {
-                if (!msg) {
+              try {
+                let payload: Payload<TValue>;
+
+                try {
+                  payload = parseMessage<TValue>(msg.content);
+                } catch (error) {
+                  channel.ack(msg);
+                  logger.error({ error }, "Invalid payload");
                   return;
                 }
 
+                const id = payload.args[0];
+                const consumeLogger = logger.child({ id });
+                const ctx = { logger: consumeLogger };
                 try {
-                  let payload: Payload<TValue>;
+                  await this.run(id, ctx);
+                  channel.ack(msg);
+                } catch (error) {
+                  const tier = getRetryTier(retryLadder, payload.attempts);
 
-                  try {
-                    payload = parseMessage<TValue>(msg.content);
-                  } catch (error) {
+                  if (checkIsRetryable(error) && tier) {
+                    consumeLogger.info(
+                      {
+                        error,
+                        attempts: payload.attempts,
+                        delay: tier.delay,
+                      },
+                      "Retrying job after backoff",
+                    );
+
+                    // Published to the delay queue rather than back to the
+                    // job queue: it waits there for the tier's TTL, then
+                    // RabbitMQ dead-letters it onto the job queue.
+                    channel.sendToQueue(
+                      getRetryQueueName(queue, tier),
+                      serializeMessage({
+                        args: payload.args,
+                        attempts: payload.attempts + 1,
+                      }),
+                      { persistent: true },
+                    );
+
                     channel.ack(msg);
-                    logger.error({ error }, "Invalid payload");
                     return;
                   }
 
-                  const id = payload.args[0];
-                  const consumeLogger = logger.child({ id });
-                  const ctx = { logger: consumeLogger };
-                  try {
-                    await this.run(id, ctx);
-                    channel.ack(msg);
-                  } catch (error) {
-                    const tier = getRetryTier(retryLadder, payload.attempts);
-
-                    if (checkIsRetryable(error) && tier) {
-                      consumeLogger.info(
-                        {
-                          error,
-                          attempts: payload.attempts,
-                          delay: tier.delay,
-                        },
-                        "Retrying job after backoff",
-                      );
-
-                      // Published to the delay queue rather than back to the
-                      // job queue: it waits there for the tier's TTL, then
-                      // RabbitMQ dead-letters it onto the job queue.
-                      channel.sendToQueue(
-                        getRetryQueueName(queue, tier),
-                        serializeMessage({
-                          args: payload.args,
-                          attempts: payload.attempts + 1,
-                        }),
-                        { persistent: true },
-                      );
-
-                      channel.ack(msg);
-                      return;
-                    }
-
-                    channel.ack(msg);
-                    consumeLogger.error(
-                      { error },
-                      "Error while processing job",
-                    );
-                    await pRetry(() =>
-                      consumer.error?.(payload.args[0], error, ctx),
-                    );
-                  }
-                } catch (error) {
-                  logger.info({ error }, "Error when processing message");
-                  if (consumerTag) {
-                    try {
-                      await channel.cancel(consumerTag);
-                    } catch (cancelError) {
-                      logger.info(
-                        { error: cancelError },
-                        "Error while trying to cancel consumer following error",
-                      );
-                    }
-                  }
-                  signalConsumerFault(error);
+                  channel.ack(msg);
+                  consumeLogger.error({ error }, "Error while processing job");
+                  await pRetry(() =>
+                    consumer.error?.(payload.args[0], error, ctx),
+                  );
                 }
-              });
-            },
-          );
-          consumerTag = tag;
+              } catch (error) {
+                logger.info({ error }, "Error when processing message");
+                signalConsumerFault(error);
+              }
+            });
 
-          // Resolves on channel close, rejects on channel error or on a
-          // per-consumer fault signalled from the consume callback. Either
-          // way pRetry / runForever re-enters and re-registers the consumer.
-          await Promise.race([
-            observeChannelTermination(channel),
-            consumerFault,
-          ]);
+            await Promise.race([
+              observeChannelTermination(channel),
+              consumerFault,
+            ]);
+          } finally {
+            await closeChannel(channel);
+          }
         },
         {
           onError: (error) => {


### PR DESCRIPTION
## What happened

Right after [#2506](https://github.com/argos-ci/argos/pull/2506) deployed, the workers started flooding this, and stopped processing jobs:

```
{"level":40,"module":"amqp","error":{"message":"Connection closed: 530 (NOT-ALLOWED) with message
\"NOT_ALLOWED - reached maximum (10) of consumers per channel\""}}
```

#2506 is not at fault beyond arriving last. Since b30aa8ab4 ("perf: mutualize AMQP channels"), every job registers its consumer on **one shared channel**, so the number of job types the worker can register is capped by the broker's `consumer_max_per_channel` — **ten**, on the Amazon MQ broker we run. The ten jobs on `main` filled it exactly, with zero headroom.

Crossing that cap does not fail the job that arrives last. RabbitMQ answers an over-limit `basic.consume` with a **connection-level** 530, so the whole connection goes — the ten healthy consumers and the publisher channel with it. `amqp.ts` reconnects, the `runForever` loops re-register every consumer, and the eleventh trips it again. The worker was not restarting; it was looping, processing nothing, and nothing crashed because `process()` never resolves and `runForever` swallows the error.

The staff gate on the Origin integration did not help: jobs are registered unconditionally in `worker.ts`, so the consumer exists whether or not a message can ever arrive.

## What changed

Consumers get **one channel each**; only the publisher channel stays shared (it holds no consumer, so nothing about it scales with job count). `channel_max` is 2047 against a limit of ten consumers per channel, so channels are the cheap resource to spend.

Two things fall out of it:

- **`runConsumerSetup` is gone.** That WeakMap chain existed only because `channel.prefetch` applies to the *next* consumer started on the channel, so concurrent setup could land one job's prefetch on another job's consumer. One consumer per channel makes it unambiguous.
- **`consumerTag` bookkeeping and the `channel.cancel` on fault are gone.** Closing the channel cancels its consumer, and the unacked message is requeued exactly as before.

A channel error is now also scoped to its own job instead of taking down every consumer in the process.

One addition worth a look: `keepChannelErrorHandled`. `observeChannelTermination` detaches its `error` listener as soon as it settles, and a later `error` on an EventEmitter with no listener *throws* — one permanent no-op listener closes that window.

## Verification

Ran a real `rabbitmq:4.2-alpine` (the production version) with `consumer_max_per_channel = 10` and drove twelve jobs through the actual `createJob` code.

**Before** — the production error, from the broker's own log:

```
[error] operation basic.consume caused a connection exception not_allowed:
        "reached maximum (10) of consumers per channel"
[info]  closing AMQP connection (... duration: '1s')
[info]  accepting AMQP connection ...
```

Ten of twelve jobs consumed, and four connection kills per run at +1s, +2s, +4s — pRetry's backoff, visible in the timestamps. That is the loop from production.

**After** — twelve of twelve, in 0.5s, with no `not_allowed` in the broker log.

- `pnpm test:integration`: 161 files, 1227 tests, all passing.
- `check-types`, `oxlint`, `oxfmt --check`: clean.
- `knip` fails and `storage/checkIfExists.test.ts` fails (an S3 test needing credentials) — both fail identically with this change stashed. Pre-existing.

## For the reviewer

**No guard test, deliberately.** One would need the broker to actually enforce `consumer_max_per_channel`, and CI provisions RabbitMQ through GitHub `services:` — no volume mount, so no `rabbitmq.conf`. I checked whether the image reads the setting from the environment; it does not (`RABBITMQ_CONSUMER_MAX_PER_CHANNEL=10` is silently ignored). In CI such a test would pass on the broken code too, which is worse than no test — it reads as covered when it isn't.

Making it real means moving RabbitMQ out of `services:` into a container CI runs itself, and mounting the same config in `docker-compose.yml`. That is worth doing separately: right now nobody can hit this class of bug locally, because dev and CI both run with the limit at `infinity` while production runs at ten.

**This unblocks re-landing #2506** (reverted in #2518), which needs no change of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
