### PR TITLE
feat(build): rework the snapshot review surface

### DIFF
--- a/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
@@ -377,7 +377,13 @@ function BuildScreenshotHeader(props: {
         disableHoverableContent={false}
         content={props.details}
       >
+        {/* `heading` rather than a bare focusable div: it names the pane, so
+            it is what a screen reader should land on when walking the page —
+            and the level says it sits under the snapshot's name in the bar
+            above, the way `DetailToolbarTitle` states its own. */}
         <div
+          role="heading"
+          aria-level={2}
           tabIndex={0}
           className="underline-emphasis text-xs leading-6 font-medium select-none"
         >

--- a/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
@@ -32,14 +32,17 @@ import {
   fetchBlob,
   ImageActionsMenu,
 } from "@/containers/Build/ScreenshotActions";
+import { useProjectRepositoryUrl } from "@/containers/Project/RepositoryContext";
 import { DocumentType, graphql } from "@/gql";
 import { BuildType, ScreenshotDiffStatus } from "@/gql/graphql";
+import { getBuildURL } from "@/pages/Build/BuildParams";
 import { DiffCommentLayer } from "@/pages/Build/diffComments/DiffCommentLayer";
+import { BranchLink, CommitLink } from "@/pages/Build/GitLink";
 import { ScreenshotCommentLayer } from "@/pages/Build/screenshotComments/ScreenshotCommentLayer";
-import { Code } from "@/ui/Code";
+import { useProjectParams } from "@/pages/Project/ProjectParams";
 import { ImageKitPicture } from "@/ui/ImageKitPicture";
+import { Link } from "@/ui/Link";
 import { MenuItem, MenuSeparator } from "@/ui/menu-kit";
-import { Time } from "@/ui/Time";
 import { Tooltip } from "@/ui/Tooltip";
 import { useObjectRef } from "@/ui/useObjectRef";
 import { useResizeObserver } from "@/ui/useResizeObserver";
@@ -87,8 +90,13 @@ const _BuildFragment = graphql(`
     }
     createdAt
     branch
+    commit
     type
     baseBranch
+    baseBuild {
+      id
+      number
+    }
     baseScreenshotBucket {
       id
       createdAt
@@ -346,35 +354,133 @@ async function createMaskedCompareBlob(props: {
   return canvasToBlob(canvas);
 }
 
+/** Keeps a pane without a header aligned with the one beside it. */
 function BuildScreenshotHeaderPlaceholder() {
-  return <div className="h-10.5" />;
+  return <div className="h-6" />;
 }
 
-const BuildScreenshotHeader = memo(
-  (props: {
-    label: string;
-    gitRef: string | null | undefined;
-    date: string | null;
-  }) => {
-    const { label, gitRef, date } = props;
-    return (
-      <div className="text-low flex shrink-0 flex-col items-center gap-0.5">
-        <div className="flex max-w-full items-center gap-1">
-          <div className="shrink-0 text-xs leading-6 font-medium select-none">
-            {label}
-            {gitRef ? " from" : null}
-          </div>
-          {gitRef && (
-            <Code className="truncate" title={gitRef}>
-              {gitRef}
-            </Code>
-          )}
+/**
+ * The label over a pane, naming which side of the comparison it shows. The
+ * details the line used to spell out — branch, commit, date — live in a hover
+ * card instead, which also has room for what never fit: where the baseline
+ * comes from.
+ */
+function BuildScreenshotHeader(props: {
+  label: string;
+  details: React.ReactNode;
+}) {
+  return (
+    <div className="text-low flex shrink-0 justify-center">
+      <Tooltip
+        variant="info"
+        // The card holds links, so it has to stay hoverable.
+        disableHoverableContent={false}
+        content={props.details}
+      >
+        <div tabIndex={0} className="text-xs leading-6 font-medium select-none">
+          {props.label}
         </div>
-        {date && <Time date={date} className="text-xxs" />}
-      </div>
+      </Tooltip>
+    </div>
+  );
+}
+
+function ScreenshotHeaderDetails(props: { children: React.ReactNode }) {
+  return (
+    <dl className="grid grid-cols-[auto_auto] gap-x-4 gap-y-1 p-0.5 text-xs">
+      {props.children}
+    </dl>
+  );
+}
+
+function ScreenshotHeaderDetail(props: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <dt className="text-low">{props.label}</dt>
+      <dd className="font-medium">{props.children}</dd>
+    </>
+  );
+}
+
+const BaselineScreenshotHeader = memo(
+  (props: { build: BuildFragmentDocument }) => {
+    const { build } = props;
+    if (!build.baseScreenshotBucket) {
+      return <BuildScreenshotHeaderPlaceholder />;
+    }
+    return (
+      <BuildScreenshotHeader
+        label="Baseline"
+        details={<BaselineDetails build={build} />}
+      />
     );
   },
 );
+
+/** Mounted only while the card is open, like every tooltip content. */
+function BaselineDetails(props: { build: BuildFragmentDocument }) {
+  const { build } = props;
+  const params = useProjectParams();
+  invariant(params, "can't be used outside of a project route");
+  const repoUrl = useProjectRepositoryUrl();
+  const { baseScreenshotBucket } = build;
+  invariant(baseScreenshotBucket, "guarded by BaselineScreenshotHeader");
+  return (
+    <ScreenshotHeaderDetails>
+      {build.baseBuild && (
+        <ScreenshotHeaderDetail label="Build">
+          <Link
+            className="font-mono"
+            href={getBuildURL({
+              ...params,
+              buildNumber: build.baseBuild.number,
+            })}
+          >
+            #{build.baseBuild.number}
+          </Link>
+        </ScreenshotHeaderDetail>
+      )}
+      {build.baseBranch && (
+        <ScreenshotHeaderDetail label="Branch">
+          <BranchLink repoUrl={repoUrl} branch={build.baseBranch} />
+        </ScreenshotHeaderDetail>
+      )}
+      <ScreenshotHeaderDetail label="Commit">
+        <CommitLink repoUrl={repoUrl} commit={baseScreenshotBucket.commit} />
+      </ScreenshotHeaderDetail>
+    </ScreenshotHeaderDetails>
+  );
+}
+
+const ChangesScreenshotHeader = memo(
+  (props: { build: BuildFragmentDocument }) => (
+    <BuildScreenshotHeader
+      label="Changes"
+      details={<ChangesDetails build={props.build} />}
+    />
+  ),
+);
+
+/** Mounted only while the card is open, like every tooltip content. */
+function ChangesDetails(props: { build: BuildFragmentDocument }) {
+  const { build } = props;
+  const repoUrl = useProjectRepositoryUrl();
+  return (
+    <ScreenshotHeaderDetails>
+      {build.branch && (
+        <ScreenshotHeaderDetail label="Branch">
+          <BranchLink repoUrl={repoUrl} branch={build.branch} />
+        </ScreenshotHeaderDetail>
+      )}
+      <ScreenshotHeaderDetail label="Commit">
+        <CommitLink repoUrl={repoUrl} commit={build.commit} />
+      </ScreenshotHeaderDetail>
+    </ScreenshotHeaderDetails>
+  );
+}
 
 const MissingScreenshotInfo = memo(
   (props: {
@@ -1249,28 +1355,12 @@ const BuildScreenshots = memo(
               base={{
                 url: diff.baseScreenshot.url,
                 contentType: diff.baseScreenshot.contentType,
-                header: build.baseScreenshotBucket ? (
-                  <BuildScreenshotHeader
-                    label="Baseline"
-                    gitRef={
-                      build.baseBranch ?? build.baseScreenshotBucket.commit
-                    }
-                    date={build.baseScreenshotBucket.createdAt}
-                  />
-                ) : (
-                  <BuildScreenshotHeaderPlaceholder />
-                ),
+                header: <BaselineScreenshotHeader build={build} />,
               }}
               head={{
                 url: diff.compareScreenshot.url,
                 contentType: diff.compareScreenshot.contentType,
-                header: (
-                  <BuildScreenshotHeader
-                    label="Changes"
-                    gitRef={build.branch}
-                    date={build.createdAt}
-                  />
-                ),
+                header: <ChangesScreenshotHeader build={build} />,
               }}
               build={build}
               screenshotDiffId={diff.id}
@@ -1286,15 +1376,7 @@ const BuildScreenshots = memo(
           className="relative flex min-h-0 min-w-0 flex-1 flex-col gap-4 [[hidden]]:hidden"
           hidden={!showBaseline}
         >
-          {build.baseScreenshotBucket ? (
-            <BuildScreenshotHeader
-              label="Baseline"
-              gitRef={build.baseBranch ?? build.baseScreenshotBucket.commit}
-              date={build.baseScreenshotBucket.createdAt}
-            />
-          ) : (
-            <BuildScreenshotHeaderPlaceholder />
-          )}
+          <BaselineScreenshotHeader build={build} />
           <div className="relative flex min-h-0 flex-1 justify-center">
             <ScaleProvider>
               <BaseScreenshot diff={diff} buildId={build.id} />
@@ -1307,27 +1389,11 @@ const BuildScreenshots = memo(
         >
           {blendMode ? (
             <div className="flex shrink-0 justify-center gap-6">
-              {build.baseScreenshotBucket ? (
-                <BuildScreenshotHeader
-                  label="Baseline"
-                  gitRef={build.baseBranch ?? build.baseScreenshotBucket.commit}
-                  date={build.baseScreenshotBucket.createdAt}
-                />
-              ) : (
-                <BuildScreenshotHeaderPlaceholder />
-              )}
-              <BuildScreenshotHeader
-                label="Changes"
-                gitRef={build.branch}
-                date={build.createdAt}
-              />
+              <BaselineScreenshotHeader build={build} />
+              <ChangesScreenshotHeader build={build} />
             </div>
           ) : (
-            <BuildScreenshotHeader
-              label="Changes"
-              gitRef={build.branch}
-              date={build.createdAt}
-            />
+            <ChangesScreenshotHeader build={build} />
           )}
           <div className="relative flex min-h-0 flex-1 justify-center">
             <ScaleProvider>
@@ -1486,7 +1552,6 @@ const useScrollToTop = (
 export function BuildDiffDetail(props: {
   build: BuildFragmentDocument;
   diff: BuildDiffDetailDocument | null;
-  repoUrl: string | null;
   className?: string;
   ref?: React.Ref<HTMLDivElement>;
 }) {

--- a/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
@@ -388,11 +388,24 @@ function BuildScreenshotHeader(props: {
   );
 }
 
-function ScreenshotHeaderDetails(props: { children: React.ReactNode }) {
+/**
+ * What a side of the comparison is, then where it came from.
+ *
+ * The sentence leads because the labels do not explain themselves: a reviewer
+ * meeting "Baseline" for the first time needs to know it is the state being
+ * compared against before a commit sha means anything.
+ */
+function ScreenshotHeaderDetails(props: {
+  description: React.ReactNode;
+  children: React.ReactNode;
+}) {
   return (
-    <dl className="grid grid-cols-[auto_auto] gap-x-4 gap-y-1 p-0.5 text-xs">
-      {props.children}
-    </dl>
+    <div className="max-w-2xs p-0.5 text-xs">
+      <p className="text-low text-balance">{props.description}</p>
+      <dl className="border-t-thin mt-2 grid grid-cols-[auto_auto] gap-x-4 gap-y-1 pt-2">
+        {props.children}
+      </dl>
+    </div>
   );
 }
 
@@ -432,7 +445,7 @@ function BaselineDetails(props: { build: BuildFragmentDocument }) {
   const { baseScreenshotBucket } = build;
   invariant(baseScreenshotBucket, "guarded by BaselineScreenshotHeader");
   return (
-    <ScreenshotHeaderDetails>
+    <ScreenshotHeaderDetails description="The snapshot this build was compared against, kept from the last approved build.">
       {build.baseBuild && (
         <ScreenshotHeaderDetail label="Build">
           <Link
@@ -472,7 +485,7 @@ function ChangesDetails(props: { build: BuildFragmentDocument }) {
   const { build } = props;
   const repoUrl = useProjectRepositoryUrl();
   return (
-    <ScreenshotHeaderDetails>
+    <ScreenshotHeaderDetails description="The snapshot this build captured. Approving it makes it the next baseline.">
       {build.branch && (
         <ScreenshotHeaderDetail label="Branch">
           <BranchLink repoUrl={repoUrl} branch={build.branch} />
@@ -1375,14 +1388,14 @@ const BuildScreenshots = memo(
       }
     }
 
+    const columnClassName =
+      "relative flex min-h-0 min-w-0 flex-1 flex-col gap-2 [[hidden]]:hidden";
+
     return (
       // `pt-2`, not `p-4`: the header row tops out level with the right
       // sidebar's Snapshot/Review tabs, which sit 8px into the same region.
       <div className="flex min-h-0 min-w-0 flex-1 gap-4 px-4 pt-2 pb-4">
-        <div
-          className="relative flex min-h-0 min-w-0 flex-1 flex-col gap-4 [[hidden]]:hidden"
-          hidden={!showBaseline}
-        >
+        <div className={columnClassName} hidden={!showBaseline}>
           <BaselineScreenshotHeader build={build} />
           <div className="relative flex min-h-0 flex-1 justify-center">
             <ScaleProvider>
@@ -1390,10 +1403,7 @@ const BuildScreenshots = memo(
             </ScaleProvider>
           </div>
         </div>
-        <div
-          className="relative flex min-h-0 min-w-0 flex-1 flex-col gap-4 [[hidden]]:hidden"
-          hidden={!showChanges}
-        >
+        <div className={columnClassName} hidden={!showChanges}>
           {blendMode ? (
             <div className="flex shrink-0 justify-center gap-6">
               <BaselineScreenshotHeader build={build} />

--- a/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
@@ -448,19 +448,11 @@ function BaselineDetails(props: { build: BuildFragmentDocument }) {
       )}
       {build.baseBranch && (
         <ScreenshotHeaderDetail label="Branch">
-          <BranchLink
-            repoUrl={repoUrl}
-            branch={build.baseBranch}
-            externalIcon={false}
-          />
+          <BranchLink repoUrl={repoUrl} branch={build.baseBranch} />
         </ScreenshotHeaderDetail>
       )}
       <ScreenshotHeaderDetail label="Commit">
-        <CommitLink
-          repoUrl={repoUrl}
-          commit={baseScreenshotBucket.commit}
-          externalIcon={false}
-        />
+        <CommitLink repoUrl={repoUrl} commit={baseScreenshotBucket.commit} />
       </ScreenshotHeaderDetail>
     </ScreenshotHeaderDetails>
   );
@@ -483,19 +475,11 @@ function ChangesDetails(props: { build: BuildFragmentDocument }) {
     <ScreenshotHeaderDetails>
       {build.branch && (
         <ScreenshotHeaderDetail label="Branch">
-          <BranchLink
-            repoUrl={repoUrl}
-            branch={build.branch}
-            externalIcon={false}
-          />
+          <BranchLink repoUrl={repoUrl} branch={build.branch} />
         </ScreenshotHeaderDetail>
       )}
       <ScreenshotHeaderDetail label="Commit">
-        <CommitLink
-          repoUrl={repoUrl}
-          commit={build.commit}
-          externalIcon={false}
-        />
+        <CommitLink repoUrl={repoUrl} commit={build.commit} />
       </ScreenshotHeaderDetail>
     </ScreenshotHeaderDetails>
   );
@@ -1369,7 +1353,9 @@ const BuildScreenshots = memo(
       invariant(diff.baseScreenshot);
       if (!checkIsImageContentType(diff.compareScreenshot.contentType)) {
         return (
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2 p-4">
+          // `pt-2`, not `p-4`: the header row tops out level with the right
+          // sidebar's Snapshot/Review tabs, which sit 8px into the same region.
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2 px-4 pt-2 pb-4">
             <BuildSnapshotsDiff
               base={{
                 url: diff.baseScreenshot.url,
@@ -1390,7 +1376,9 @@ const BuildScreenshots = memo(
     }
 
     return (
-      <div className="flex min-h-0 min-w-0 flex-1 gap-4 p-4">
+      // `pt-2`, not `p-4`: the header row tops out level with the right
+      // sidebar's Snapshot/Review tabs, which sit 8px into the same region.
+      <div className="flex min-h-0 min-w-0 flex-1 gap-4 px-4 pt-2 pb-4">
         <div
           className="relative flex min-h-0 min-w-0 flex-1 flex-col gap-4 [[hidden]]:hidden"
           hidden={!showBaseline}

--- a/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
@@ -377,7 +377,10 @@ function BuildScreenshotHeader(props: {
         disableHoverableContent={false}
         content={props.details}
       >
-        <div tabIndex={0} className="text-xs leading-6 font-medium select-none">
+        <div
+          tabIndex={0}
+          className="underline-emphasis text-xs leading-6 font-medium select-none"
+        >
           {props.label}
         </div>
       </Tooltip>
@@ -445,11 +448,19 @@ function BaselineDetails(props: { build: BuildFragmentDocument }) {
       )}
       {build.baseBranch && (
         <ScreenshotHeaderDetail label="Branch">
-          <BranchLink repoUrl={repoUrl} branch={build.baseBranch} />
+          <BranchLink
+            repoUrl={repoUrl}
+            branch={build.baseBranch}
+            externalIcon={false}
+          />
         </ScreenshotHeaderDetail>
       )}
       <ScreenshotHeaderDetail label="Commit">
-        <CommitLink repoUrl={repoUrl} commit={baseScreenshotBucket.commit} />
+        <CommitLink
+          repoUrl={repoUrl}
+          commit={baseScreenshotBucket.commit}
+          externalIcon={false}
+        />
       </ScreenshotHeaderDetail>
     </ScreenshotHeaderDetails>
   );
@@ -472,11 +483,19 @@ function ChangesDetails(props: { build: BuildFragmentDocument }) {
     <ScreenshotHeaderDetails>
       {build.branch && (
         <ScreenshotHeaderDetail label="Branch">
-          <BranchLink repoUrl={repoUrl} branch={build.branch} />
+          <BranchLink
+            repoUrl={repoUrl}
+            branch={build.branch}
+            externalIcon={false}
+          />
         </ScreenshotHeaderDetail>
       )}
       <ScreenshotHeaderDetail label="Commit">
-        <CommitLink repoUrl={repoUrl} commit={build.commit} />
+        <CommitLink
+          repoUrl={repoUrl}
+          commit={build.commit}
+          externalIcon={false}
+        />
       </ScreenshotHeaderDetail>
     </ScreenshotHeaderDetails>
   );

--- a/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
@@ -445,7 +445,20 @@ function BaselineDetails(props: { build: BuildFragmentDocument }) {
   const { baseScreenshotBucket } = build;
   invariant(baseScreenshotBucket, "guarded by BaselineScreenshotHeader");
   return (
-    <ScreenshotHeaderDetails description="The snapshot this build was compared against, kept from the last approved build.">
+    <ScreenshotHeaderDetails
+      description={
+        <>
+          The snapshot this build was compared against, kept from the last
+          approved build.{" "}
+          <Link
+            href="https://argos-ci.com/docs/learn/platform-fundamentals/baseline-build"
+            target="_blank"
+          >
+            Learn more
+          </Link>
+        </>
+      }
+    >
       {build.baseBuild && (
         <ScreenshotHeaderDetail label="Build">
           <Link

--- a/apps/frontend/src/containers/Build/BuildDiffDetailToolbar.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetailToolbar.tsx
@@ -14,16 +14,34 @@ import { CommentsEnabledContext } from "./CommentsContext";
 import { CommentsVisibilityToggle } from "./toolbar/CommentsVisibilityToggle";
 import { CommentToolToggle } from "./toolbar/CommentToolToggle";
 import { FitToggle } from "./toolbar/FitToggle";
+import { SettingsButton } from "./toolbar/SettingsButton";
 import { ViewToggle } from "./toolbar/ViewToggle";
 
 interface BuildDiffDetailToolbarProps {
   diff: BuildDiffDetailDocument;
   fitControls?: React.ReactNode;
+  /**
+   * Whether the controls that act on the snapshot itself belong in this bar —
+   * reading its mask, walking its changes, commenting on it. The build page
+   * renders them in the actions bar under the snapshot instead, where what
+   * they act on is; this bar keeps how the pane is laid out.
+   */
+  snapshotControls?: boolean;
   children?: React.ReactNode;
 }
 
+/** Whether the diff has a mask, and so overlay controls to go with it. */
+export function checkDiffHasChangesOverlay(
+  diff: BuildDiffDetailDocument,
+): boolean {
+  return (
+    diff.status === ScreenshotDiffStatus.Changed ||
+    diff.status === ScreenshotDiffStatus.Ignored
+  );
+}
+
 /** Whether point comments can be placed on this diff's changes image. */
-function checkCanCommentOnDiff(diff: BuildDiffDetailDocument): boolean {
+export function checkCanCommentOnDiff(diff: BuildDiffDetailDocument): boolean {
   switch (diff.status) {
     case ScreenshotDiffStatus.Changed:
     case ScreenshotDiffStatus.Ignored:
@@ -52,10 +70,8 @@ function checkCanCommentOnTextDiff(diff: BuildDiffDetailDocument): boolean {
 }
 
 export function BuildDiffDetailToolbar(props: BuildDiffDetailToolbarProps) {
-  const { diff, children, fitControls } = props;
-  const shouldShowToolbarControls =
-    diff.status === ScreenshotDiffStatus.Changed ||
-    diff.status === ScreenshotDiffStatus.Ignored;
+  const { diff, children, fitControls, snapshotControls = true } = props;
+  const showOverlayControls = checkDiffHasChangesOverlay(diff);
 
   const params = useProjectParams();
   invariant(params, "can't be used outside of a project route");
@@ -76,16 +92,18 @@ export function BuildDiffDetailToolbar(props: BuildDiffDetailToolbarProps) {
       <ViewToggle blendEnabled={checkDiffCanBeBlended(diff)} />
       <FitToggle />
       {fitControls}
-      {shouldShowToolbarControls && (
+      {showOverlayControls && (
         <>
           <Separator orientation="vertical" className="mx-1 h-6" />
-          <ChangesOverlayControls />
+          {/* Reading the mask happens next to the snapshot; how it is painted
+              is a preference, and preferences live up here. */}
+          {snapshotControls ? <ChangesOverlayControls /> : <SettingsButton />}
         </>
       )}
       {showComments && (
         <>
           <Separator orientation="vertical" className="mx-1 h-6" />
-          {showCommentTool && <CommentToolToggle />}
+          {showCommentTool && snapshotControls && <CommentToolToggle />}
           <CommentsVisibilityToggle />
         </>
       )}

--- a/apps/frontend/src/containers/Build/ChangesOverlay.tsx
+++ b/apps/frontend/src/containers/Build/ChangesOverlay.tsx
@@ -33,37 +33,47 @@ type Dimensions = { width: number; height: number };
  * Everything a reviewer does with a diff mask, in one cluster: show or hide it,
  * step through the areas it marks, and restyle it.
  *
- * Shared by the build's diff toolbar and the media share page's compare toolbar.
- * The two surfaces run the same engine over comparable images and produce the
- * same kind of answer, so a reviewer who learned the controls on a build finds
- * them — and their shortcuts — unchanged on a before/after pair.
+ * Shared by the build's snapshot actions bar and the media share page's compare
+ * toolbar. The two surfaces run the same engine over comparable images and
+ * produce the same kind of answer, so a reviewer who learned the controls on a
+ * build finds them — and their shortcuts — unchanged on a before/after pair.
  *
  * Renders a fragment rather than its own row: each toolbar owns its separators
  * and spacing.
  */
-export const ChangesOverlayControls = memo(function ChangesOverlayControls() {
-  const { loading } = useBuildDiffHighlighterContext();
-  return (
-    <>
-      <OverlayToggle />
-      {/*
-       * All three enable together, once the changed areas have been detected —
-       * so the group is what is busy until then, not any one button. It also has
-       * to be the group because React Aria drops unknown ARIA props off the DOM
-       * node, `aria-busy` among them, and `ButtonGroup` is a plain div.
-       *
-       * Beyond announcing the wait, this is what makes Argos hold the screenshot
-       * until the answer is in, instead of catching the buttons disabled.
-       */}
-      <ButtonGroup aria-busy={loading}>
-        <GoToPreviousChangesButton />
-        <HighlightButton />
-        <GoToNextChangesButton />
-      </ButtonGroup>
-      <SettingsButton />
-    </>
-  );
-});
+export const ChangesOverlayControls = memo(
+  function ChangesOverlayControls(props: {
+    /**
+     * Whether the overlay style settings belong in this cluster. The build page
+     * keeps them in the top bar instead — how the mask is painted is a
+     * preference about the pane, not something done to the snapshot.
+     */
+    settings?: boolean;
+  }) {
+    const { settings = true } = props;
+    const { loading } = useBuildDiffHighlighterContext();
+    return (
+      <>
+        <OverlayToggle />
+        {/*
+         * All three enable together, once the changed areas have been detected —
+         * so the group is what is busy until then, not any one button. It also has
+         * to be the group because React Aria drops unknown ARIA props off the DOM
+         * node, `aria-busy` among them, and `ButtonGroup` is a plain div.
+         *
+         * Beyond announcing the wait, this is what makes Argos hold the screenshot
+         * until the answer is in, instead of catching the buttons disabled.
+         */}
+        <ButtonGroup aria-busy={loading}>
+          <GoToPreviousChangesButton />
+          <HighlightButton />
+          <GoToNextChangesButton />
+        </ButtonGroup>
+        {settings && <SettingsButton />}
+      </>
+    );
+  },
+);
 
 /**
  * The mask, painted in the reviewer's overlay colour.

--- a/apps/frontend/src/pages/Build/BuildDetailHeader.tsx
+++ b/apps/frontend/src/pages/Build/BuildDetailHeader.tsx
@@ -9,20 +9,15 @@ import {
   DetailToolbarNav,
   DetailToolbarTitle,
 } from "@/containers/Build/toolbar/DetailToolbar";
-import { IgnoreButton } from "@/containers/Build/toolbar/IgnoreButton";
 import {
   NextButton,
   PreviousButton,
 } from "@/containers/Build/toolbar/NavButtons";
-import { BuildType } from "@/gql/graphql";
-import { Separator } from "@/ui/Separator";
 import { Tooltip } from "@/ui/Tooltip";
-import { useEventCallback } from "@/ui/useEventCallback";
 
 import { useProjectParams } from "../Project/ProjectParams";
 import { getTestURL } from "../Test/TestParams";
 import {
-  checkDiffCanBeReviewed,
   Diff,
   useGoToBuildOverview,
   useGoToNextDiff,
@@ -30,24 +25,12 @@ import {
   useHasNextDiff,
   useHasPreviousDiff,
 } from "./BuildDiffState";
-import {
-  useAcknowledgeMarkedDiff,
-  useBuildDiffStatusState,
-} from "./BuildReviewState";
-import { EvaluationStatus } from "./EvaluationStatus";
 import { RightSidebarToggle } from "./RightSidebar";
-import { TrackButtons } from "./TrackButtons";
 
 export const BuildDetailHeader = memo(function BuildDetailHeader(props: {
   diff: Diff;
-  buildType: BuildType | null;
-  isSubsetBuild: boolean;
 }) {
-  const { diff, buildType, isSubsetBuild } = props;
-  const canBeReviewed =
-    buildType !== BuildType.Reference &&
-    checkDiffCanBeReviewed(diff.status, { isSubsetBuild });
-
+  const { diff } = props;
   const params = useProjectParams();
   invariant(params, "can't be used outside of a project route");
 
@@ -79,38 +62,19 @@ export const BuildDetailHeader = memo(function BuildDetailHeader(props: {
       >
         {diff.name}
       </DetailToolbarTitle>
-      <BuildDiffDetailToolbar diff={diff} fitControls={<AriaSnapshotToggle />}>
-        <BuildDetailIgnoreButton diff={diff} />
-        <TrackButtons diff={diff} disabled={!canBeReviewed} />
-        <Separator orientation="vertical" className="mx-1 h-6" />
+      {/* What is about the pane: the view mode, the fit, the overlay's style,
+          comment visibility. Everything that acts on the snapshot itself is in
+          `ScreenshotActionsToolbar`, under it. */}
+      <BuildDiffDetailToolbar
+        diff={diff}
+        snapshotControls={false}
+        fitControls={<AriaSnapshotToggle />}
+      >
         <RightSidebarToggle />
       </BuildDiffDetailToolbar>
     </DetailToolbar>
   );
 });
-
-function BuildDetailIgnoreButton(props: { diff: Diff }) {
-  const { diff } = props;
-
-  const [status, setStatus] = useBuildDiffStatusState({
-    diffId: diff.id,
-    diffGroup: diff.group ?? null,
-  });
-  const [checkIsPending, acknowledge] = useAcknowledgeMarkedDiff();
-
-  const handleIgnoreChange = useEventCallback(() => {
-    if (checkIsPending()) {
-      return;
-    }
-
-    if (status === EvaluationStatus.Pending) {
-      setStatus(EvaluationStatus.Accepted);
-      acknowledge();
-    }
-  });
-
-  return <IgnoreButton diff={diff} onIgnoreChange={handleIgnoreChange} />;
-}
 
 const BuildNavButtons = memo(function BuildNavButtons() {
   const goToNextDiff = useGoToNextDiff();

--- a/apps/frontend/src/pages/Build/BuildWorkspace.tsx
+++ b/apps/frontend/src/pages/Build/BuildWorkspace.tsx
@@ -21,6 +21,7 @@ import { BuildOverview } from "./BuildOverview";
 import { BuildParams } from "./BuildParams";
 import { BuildLeftSidebar } from "./LeftSidebar";
 import { RightSidebar } from "./RightSidebar";
+import { ScreenshotActionsToolbar } from "./ScreenshotActionsToolbar";
 
 const _BuildFragment = graphql(`
   fragment BuildWorkspace_Build on Build {
@@ -118,7 +119,7 @@ export function BuildWorkspace(props: {
         <BuildLeftSidebar build={build} repoUrl={repoUrl} params={params} />
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           <BuildDetailProviders>
-            <Toolbar build={build} />
+            <Toolbar />
             <div className="bg-subtle flex min-h-0 flex-1">
               {(() => {
                 switch (build.status) {
@@ -190,19 +191,14 @@ function BuildDetailProviders(props: { children: React.ReactNode }) {
   );
 }
 
-function Toolbar(props: { build: DocumentType<typeof _BuildFragment> }) {
-  const { build } = props;
+function Toolbar() {
   const { activeDiff } = useBuildDiffState();
   if (!activeDiff) {
     return null;
   }
   return (
     <div className="border-b-thin sticky top-0 z-20 shrink-0 p-2">
-      <BuildDetailHeader
-        diff={activeDiff}
-        buildType={build.type ?? null}
-        isSubsetBuild={build.subset}
-      />
+      <BuildDetailHeader diff={activeDiff} />
     </div>
   );
 }
@@ -216,8 +212,18 @@ function BuildDetail(props: {
   const snapshotType = useAtomValue(snapshotTypeAtom);
   const shownDiff = snapshotType === "aria" && ariaDiff ? ariaDiff : activeDiff;
   return (
-    <div className="flex min-h-0 min-w-0 flex-1">
+    // `relative` so the actions bar can float over the bottom of the pane
+    // rather than scroll away with a full-page snapshot, and `pb-14` to leave
+    // it a gutter of its own instead of covering the foot of the snapshot.
+    <div className="relative flex min-h-0 min-w-0 flex-1 pb-14">
       <BuildDiffDetail build={build} diff={shownDiff} repoUrl={repoUrl} />
+      {activeDiff ? (
+        <ScreenshotActionsToolbar
+          diff={activeDiff}
+          buildType={build.type ?? null}
+          isSubsetBuild={build.subset}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/frontend/src/pages/Build/BuildWorkspace.tsx
+++ b/apps/frontend/src/pages/Build/BuildWorkspace.tsx
@@ -157,9 +157,7 @@ export function BuildWorkspace(props: {
                       return <BuildOverview build={build} repoUrl={repoUrl} />;
                     }
 
-                    return (
-                      build && <BuildDetail build={build} repoUrl={repoUrl} />
-                    );
+                    return build && <BuildDetail build={build} />;
                 }
               })()}
               <RightSidebar
@@ -203,12 +201,9 @@ function Toolbar() {
   );
 }
 
-function BuildDetail(props: {
-  build: DocumentType<typeof _BuildFragment>;
-  repoUrl: string | null;
-}) {
+function BuildDetail(props: { build: DocumentType<typeof _BuildFragment> }) {
   const { activeDiff, ariaDiff } = useBuildDiffState();
-  const { build, repoUrl } = props;
+  const { build } = props;
   const snapshotType = useAtomValue(snapshotTypeAtom);
   const shownDiff = snapshotType === "aria" && ariaDiff ? ariaDiff : activeDiff;
   return (
@@ -216,7 +211,7 @@ function BuildDetail(props: {
     // rather than scroll away with a full-page snapshot, and `pb-14` to leave
     // it a gutter of its own instead of covering the foot of the snapshot.
     <div className="relative flex min-h-0 min-w-0 flex-1 pb-14">
-      <BuildDiffDetail build={build} diff={shownDiff} repoUrl={repoUrl} />
+      <BuildDiffDetail build={build} diff={shownDiff} />
       {activeDiff ? (
         <ScreenshotActionsToolbar
           diff={activeDiff}

--- a/apps/frontend/src/pages/Build/GitLink.tsx
+++ b/apps/frontend/src/pages/Build/GitLink.tsx
@@ -4,20 +4,8 @@ import { Link } from "@/ui/Link";
  * A git branch name linking to the branch on the repository host, or plain
  * monospace text when the repository URL is unknown.
  */
-export function BranchLink(props: {
-  repoUrl: string | null;
-  branch: string;
-  /**
-   * Whether the link carries the external-link icon. Turn it off in tight
-   * quarters (e.g. a hover card): browsers may wrap the icon to a line of its
-   * own next to a long branch name, and no glue character prevents it —
-   * Chromium breaks around an inline SVG even across a no-break space.
-   *
-   * @default true
-   */
-  externalIcon?: boolean;
-}) {
-  const { repoUrl, branch, externalIcon } = props;
+export function BranchLink(props: { repoUrl: string | null; branch: string }) {
+  const { repoUrl, branch } = props;
   if (!repoUrl) {
     return <span className="font-mono">{branch}</span>;
   }
@@ -26,7 +14,6 @@ export function BranchLink(props: {
       className="font-mono"
       href={`${repoUrl}/tree/${branch}`}
       target="_blank"
-      external={externalIcon}
     >
       {branch}
     </Link>
@@ -37,13 +24,8 @@ export function BranchLink(props: {
  * A git commit SHA (shortened) linking to the commit on the repository host, or
  * plain text when the repository URL is unknown.
  */
-export function CommitLink(props: {
-  repoUrl: string | null;
-  commit: string;
-  /** See {@link BranchLink}'s `externalIcon`. */
-  externalIcon?: boolean;
-}) {
-  const { repoUrl, commit, externalIcon } = props;
+export function CommitLink(props: { repoUrl: string | null; commit: string }) {
+  const { repoUrl, commit } = props;
   const shortCommit = commit.slice(0, 7);
   if (!repoUrl) {
     return <>{shortCommit}</>;
@@ -53,7 +35,6 @@ export function CommitLink(props: {
       className="font-mono"
       href={`${repoUrl}/commit/${commit}`}
       target="_blank"
-      external={externalIcon}
     >
       {shortCommit}
     </Link>

--- a/apps/frontend/src/pages/Build/GitLink.tsx
+++ b/apps/frontend/src/pages/Build/GitLink.tsx
@@ -4,8 +4,20 @@ import { Link } from "@/ui/Link";
  * A git branch name linking to the branch on the repository host, or plain
  * monospace text when the repository URL is unknown.
  */
-export function BranchLink(props: { repoUrl: string | null; branch: string }) {
-  const { repoUrl, branch } = props;
+export function BranchLink(props: {
+  repoUrl: string | null;
+  branch: string;
+  /**
+   * Whether the link carries the external-link icon. Turn it off in tight
+   * quarters (e.g. a hover card): browsers may wrap the icon to a line of its
+   * own next to a long branch name, and no glue character prevents it —
+   * Chromium breaks around an inline SVG even across a no-break space.
+   *
+   * @default true
+   */
+  externalIcon?: boolean;
+}) {
+  const { repoUrl, branch, externalIcon } = props;
   if (!repoUrl) {
     return <span className="font-mono">{branch}</span>;
   }
@@ -14,6 +26,7 @@ export function BranchLink(props: { repoUrl: string | null; branch: string }) {
       className="font-mono"
       href={`${repoUrl}/tree/${branch}`}
       target="_blank"
+      external={externalIcon}
     >
       {branch}
     </Link>
@@ -24,8 +37,13 @@ export function BranchLink(props: { repoUrl: string | null; branch: string }) {
  * A git commit SHA (shortened) linking to the commit on the repository host, or
  * plain text when the repository URL is unknown.
  */
-export function CommitLink(props: { repoUrl: string | null; commit: string }) {
-  const { repoUrl, commit } = props;
+export function CommitLink(props: {
+  repoUrl: string | null;
+  commit: string;
+  /** See {@link BranchLink}'s `externalIcon`. */
+  externalIcon?: boolean;
+}) {
+  const { repoUrl, commit, externalIcon } = props;
   const shortCommit = commit.slice(0, 7);
   if (!repoUrl) {
     return <>{shortCommit}</>;
@@ -35,6 +53,7 @@ export function CommitLink(props: { repoUrl: string | null; commit: string }) {
       className="font-mono"
       href={`${repoUrl}/commit/${commit}`}
       target="_blank"
+      external={externalIcon}
     >
       {shortCommit}
     </Link>

--- a/apps/frontend/src/pages/Build/ScreenshotActionsToolbar.tsx
+++ b/apps/frontend/src/pages/Build/ScreenshotActionsToolbar.tsx
@@ -1,0 +1,114 @@
+import { memo, use } from "react";
+
+import {
+  checkCanCommentOnDiff,
+  checkDiffHasChangesOverlay,
+} from "@/containers/Build/BuildDiffDetailToolbar";
+import { ChangesOverlayControls } from "@/containers/Build/ChangesOverlay";
+import { CommentsEnabledContext } from "@/containers/Build/CommentsContext";
+import { CommentToolToggle } from "@/containers/Build/toolbar/CommentToolToggle";
+import { IgnoreButton } from "@/containers/Build/toolbar/IgnoreButton";
+import { useProjectIgnoreEnabled } from "@/containers/Project/IgnoreContext";
+import { useProjectPermission } from "@/containers/Project/PermissionsContext";
+import { BuildType, ProjectPermission } from "@/gql/graphql";
+import { Separator } from "@/ui/Separator";
+import { useEventCallback } from "@/ui/useEventCallback";
+
+import { checkDiffCanBeReviewed, type Diff } from "./BuildDiffState";
+import {
+  useAcknowledgeMarkedDiff,
+  useBuildDiffStatusState,
+} from "./BuildReviewState";
+import { EvaluationStatus } from "./EvaluationStatus";
+import { TrackButtons } from "./TrackButtons";
+
+/**
+ * Everything a reviewer does *to the snapshot in front of them*, as a floating
+ * bar under it: first read the change — show the mask, circle the changed
+ * areas, step through them — then annotate it, then rule on it: ignore, reject,
+ * approve.
+ *
+ * The line is what the control acts on, not what kind of control it is. These
+ * land on the image and get pressed again on every snapshot, so they sit next
+ * to it. What is about the pane rather than the picture — the view mode, the
+ * fit, the overlay's colour, comment visibility — stays in the top bar.
+ *
+ * It floats over the bottom of the pane instead of following the snapshot: a
+ * full-page capture is several thousand pixels tall, and an action bar that
+ * scrolls away is one the reviewer has to go looking for.
+ */
+export const ScreenshotActionsToolbar = memo(
+  function ScreenshotActionsToolbar(props: {
+    diff: Diff;
+    buildType: BuildType | null;
+    isSubsetBuild: boolean;
+  }) {
+    const { diff, buildType, isSubsetBuild } = props;
+    const canBeReviewed =
+      buildType !== BuildType.Reference &&
+      checkDiffCanBeReviewed(diff.status, { isSubsetBuild });
+
+    const commentsEnabled = use(CommentsEnabledContext);
+    const canReview = useProjectPermission(ProjectPermission.Review);
+    const ignoreEnabled = useProjectIgnoreEnabled();
+    const showOverlayControls = checkDiffHasChangesOverlay(diff);
+    // Point comments are placed on the changes image, so the tool only makes
+    // sense where there is one to click.
+    const showCommentTool =
+      commentsEnabled && canReview && checkCanCommentOnDiff(diff);
+    // The ignore button shows whenever the feature does, the verdict buttons
+    // whenever the viewer can review — same as when they lived in the top bar.
+    const showVerdict = canReview || ignoreEnabled;
+
+    if (!showOverlayControls && !showCommentTool && !showVerdict) {
+      return null;
+    }
+
+    return (
+      <div className="pointer-events-none absolute inset-x-0 bottom-4 z-10 flex justify-center">
+        {/* Left to right, the order a snapshot is dealt with: see the change,
+            walk through it, annotate it, then rule on it. The verdict is last,
+            at the end the eye arrives at and under "Submit review". */}
+        <div className="bg-app border-thin pointer-events-auto flex items-center gap-1.5 rounded-full px-2 py-1.5 shadow-md">
+          {showOverlayControls && <ChangesOverlayControls settings={false} />}
+          {showOverlayControls && (showCommentTool || showVerdict) && (
+            <Separator orientation="vertical" className="mx-0.5 h-6" />
+          )}
+          {showCommentTool && <CommentToolToggle />}
+          {showCommentTool && showVerdict && (
+            <Separator orientation="vertical" className="mx-0.5 h-6" />
+          )}
+          {showVerdict && (
+            <>
+              <ScreenshotIgnoreButton diff={diff} />
+              <TrackButtons diff={diff} disabled={!canBeReviewed} />
+            </>
+          )}
+        </div>
+      </div>
+    );
+  },
+);
+
+function ScreenshotIgnoreButton(props: { diff: Diff }) {
+  const { diff } = props;
+
+  const [status, setStatus] = useBuildDiffStatusState({
+    diffId: diff.id,
+    diffGroup: diff.group ?? null,
+  });
+  const [checkIsPending, acknowledge] = useAcknowledgeMarkedDiff();
+
+  const handleIgnoreChange = useEventCallback(() => {
+    if (checkIsPending()) {
+      return;
+    }
+
+    if (status === EvaluationStatus.Pending) {
+      setStatus(EvaluationStatus.Accepted);
+      acknowledge();
+    }
+  });
+
+  return <IgnoreButton diff={diff} onIgnoreChange={handleIgnoreChange} />;
+}

--- a/apps/frontend/src/pages/Build/ScreenshotActionsToolbar.tsx
+++ b/apps/frontend/src/pages/Build/ScreenshotActionsToolbar.tsx
@@ -69,7 +69,7 @@ export const ScreenshotActionsToolbar = memo(
         {/* Left to right, the order a snapshot is dealt with: see the change,
             walk through it, annotate it, then rule on it. The verdict is last,
             at the end the eye arrives at and under "Submit review". */}
-        <div className="bg-app border-thin pointer-events-auto flex items-center gap-1.5 rounded-full px-2 py-1.5 shadow-md">
+        <div className="bg-app border-thin pointer-events-auto flex items-center gap-1.5 rounded-full px-2 py-1.5 shadow-xs">
           {showOverlayControls && <ChangesOverlayControls settings={false} />}
           {showOverlayControls && (showCommentTool || showVerdict) && (
             <Separator orientation="vertical" className="mx-0.5 h-6" />

--- a/apps/frontend/src/pages/Test/index.tsx
+++ b/apps/frontend/src/pages/Test/index.tsx
@@ -432,7 +432,6 @@ function ChangesExplorer(props: {
                 <BuildDiffDetail
                   build={activeChange.stats.lastSeenDiff.build}
                   diff={activeChange.stats.lastSeenDiff}
-                  repoUrl={null}
                 />
               </div>
             </CommentsEnabledContext>

--- a/apps/frontend/src/ui/Link.tsx
+++ b/apps/frontend/src/ui/Link.tsx
@@ -51,10 +51,43 @@ export function HeadlessLink({
         target={target}
         {...props}
       >
-        {children}
-        {isExternal ? <ExternalIndicator /> : null}
+        {isExternal ? <ExternalContent>{children}</ExternalContent> : children}
       </RouterLink>
     </LinkContext>
+  );
+}
+
+/**
+ * The content of an external link, with the indicator icon glued to it.
+ *
+ * Glued, because browsers treat the inline SVG as its own wrap opportunity, so
+ * next to a long label the icon drops to a line of its own — and no glue
+ * character prevents it: Chromium breaks around an atomic inline even across a
+ * no-break space. Sharing a no-wrap span with the label's last characters is
+ * what actually holds: the break opportunity ends up inside the span, where
+ * `nowrap` suppresses it, so the icon only ever wraps together with the tail.
+ * Content that isn't a plain string keeps the plain suffix — there is no tail
+ * to split off.
+ */
+function ExternalContent(props: { children: React.ReactNode }) {
+  const { children } = props;
+  if (typeof children !== "string" || children.length === 0) {
+    return (
+      <>
+        {children}
+        <ExternalIndicator />
+      </>
+    );
+  }
+  const splitAt = Math.max(0, children.length - 3);
+  return (
+    <>
+      {children.slice(0, splitAt)}
+      <span className="whitespace-nowrap">
+        {children.slice(splitAt)}
+        <ExternalIndicator />
+      </span>
+    </>
   );
 }
 
@@ -126,10 +159,7 @@ function FakeLink({
 }) {
   const content =
     isExternal && href ? (
-      <>
-        {children}
-        <ExternalIndicator />
-      </>
+      <ExternalContent>{children}</ExternalContent>
     ) : (
       children
     );

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -110,7 +110,11 @@ buildExamples.forEach((build) => {
       await expect(page).toHaveURL(
         new RegExp(`/builds/${number}/(?!overview)[^/]+$`),
       );
-      await expect(page.getByText("Changes", { exact: true })).toBeVisible();
+      // The pane's own heading, not any of the other places the word appears
+      // (the view-mode button, the sidebar's changes count).
+      await expect(
+        page.getByRole("heading", { name: "Changes", exact: true }),
+      ).toBeVisible();
     }
     await screenshot(page, `build-${build.name}`, {
       replacements: {

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -110,7 +110,7 @@ buildExamples.forEach((build) => {
       await expect(page).toHaveURL(
         new RegExp(`/builds/${number}/(?!overview)[^/]+$`),
       );
-      await expect(page.getByText(`Changes from`)).toBeVisible();
+      await expect(page.getByText("Changes", { exact: true })).toBeVisible();
     }
     await screenshot(page, `build-${build.name}`, {
       replacements: {

--- a/tests/project-tests.spec.ts
+++ b/tests/project-tests.spec.ts
@@ -109,8 +109,11 @@ loggedTest(
     await expect(badge).toBeVisible();
 
     // Ignored changes are part of the default view, and the filter narrows it
-    // down to them.
-    await expect(page.getByRole("heading", { name: /^Changes/ })).toBeVisible();
+    // down to them. `Changes over` rather than `Changes`, which the snapshot
+    // pane's own heading also answers to.
+    await expect(
+      page.getByRole("heading", { name: /^Changes over/ }),
+    ).toBeVisible();
     await page.getByRole("button", { name: "Ignored", exact: true }).click();
     await expect(
       page.getByRole("heading", { name: /^Ignored changes/ }),


### PR DESCRIPTION
Reworks the build review UI so the controls are split by **what they act on**, and the two panes explain themselves.

Takes its design from @jsfez's [`2383700de`](https://github.com/argos-ci/argos/commit/2383700ded2922fd26cd4a5c2c8b3cd73e551ca4) on `feat/review-variant-filter` — the floating bar is that commit's, re-homed onto today's `main` and reordered. The variant filters and the ref badge from that commit are **not** here.

## What changed

**A floating actions bar under the snapshot** (`ScreenshotActionsToolbar`) holding everything a reviewer does *to the snapshot in front of them*, in the order a snapshot is dealt with:

> show changes overlay · prev / highlight / next change · ┃ · move tool / comment tool · ┃ · ignore / reject / approve

It floats over the bottom of the pane rather than following the snapshot: a full-page capture is thousands of pixels tall, and an action bar that scrolls away is one you have to go looking for. Each cluster hides with its own separator (an added snapshot has no overlay cluster, a failure snapshot shows verdicts only), and the bar disappears entirely when nothing applies.

**The top bar keeps what is about the pane**: view mode, fit, aria toggle, the overlay's colour/opacity, comment visibility. `BuildDiffDetailToolbar` gained a `snapshotControls` prop that defaults to the old single-bar layout, so the **test page is untouched** — making it work well there is deliberately a follow-up.

**The pane headers lost their details.** `Baseline from <ref>` + a date is now just **Baseline** / **Changes**, marked with the dotted `underline-emphasis` the app already uses for "hover for details". Hovering opens a card that leads with a sentence saying what that side *is* — the baseline is what the build was compared against, the changes are what it captured and what approving turns into the next baseline — then the git details under a hairline: baseline build (linked), branch and commit for each side, plus a **Learn more** to the [baseline-build guide](https://argos-ci.com/docs/learn/platform-fundamentals/baseline-build). Giving the row of height back to the screenshots was the other half of the point.

**A wrap bug fixed in `ui/Link`, app-wide.** Browsers treat the inline external-link SVG as its own wrap opportunity, so next to a long label (`claude/amqp-consumer-limit-errors-8a4bf7`) the icon dropped to a line of its own. No glue *character* prevents it — Chromium breaks around an atomic inline even across a no-break space, which I verified before giving up on it. External links whose content is a plain string now share a `whitespace-nowrap` span between the icon and the label's last few characters, so the break opportunity lands where `nowrap` suppresses it and the icon can only wrap together with the tail.

## Reviewer notes

- **Baselines will move**, on purpose: the bottom bar is new chrome, the header lost a line, and the panes now start at `pt-2` so the header row sits level with the right sidebar's Snapshot/Review tabs (measured: same top, delta 0).
- `BuildDiffDetail`'s `repoUrl` prop is gone — the cards read the repository from `ProjectRepositoryContext`, which both the build and test routes already provide.
- [`build.spec.ts`](tests/build.spec.ts) used `getByText("Changes from")` as its "diff view loaded" check; it now asserts the exact `Changes` label.
- Verified in the built app (not just types): approve from the bar advances and counts, move↔comment switching, overlay show/hide, next-change zooming to a changed region, both cards in light and dark mode, the placeholder alignment on an orphan build, and the docs link's `target="_blank"` being genuinely clickable rather than sitting under the popup.
- Local gotcha for whoever pulls this: the seeded `penelope-*` diffs carry no width/height, so change navigation and point comments are inert on them — check on a `dummy-*` snapshot. Same on `main`, not caused here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)