### PR TITLE
chore(db): vacuum screenshot_buckets on inserts, not on dead tuples

### DIFF
--- a/apps/backend/db/migrations/20260822180431_screenshot-buckets-insert-autovacuum.js
+++ b/apps/backend/db/migrations/20260822180431_screenshot-buckets-insert-autovacuum.js
@@ -1,0 +1,49 @@
+/**
+ * Make the billing scan on `screenshot_buckets` actually index-only.
+ *
+ * `screenshot_buckets_projectid_createdat_index` was built to carry the two
+ * counts so the billing window could be answered from the index alone. It was
+ * not: measured in production, that scan reported `Heap Fetches: 163249` on
+ * 235k rows read, and 121k buffer accesses — roughly 950 MB — for 150 sums.
+ *
+ * An index-only scan still has to check visibility, which lives in the row and
+ * not in the index, so it can only skip the table for pages the visibility map
+ * flags as all-visible. Only vacuum sets that flag. This table is almost purely
+ * inserted, so the dead-tuple trigger that normally schedules autovacuum
+ * (0.5% dead here) effectively never fires, and the insert trigger added in
+ * Postgres 13 defaults to `1000 + 0.2 × reltuples` — about 775k inserts on this
+ * table, or once a quarter at the current rate. The pages holding the period
+ * being billed are therefore always the ones never visited.
+ *
+ * The scale factor is set to zero rather than lowered: proportional to the
+ * table, the interval grows as the table does, so the staleness this fixes
+ * would return, worse, as Argos grows. An absolute threshold holds the interval
+ * at roughly two days whatever the row count. A vacuum here costs six seconds
+ * scanning 20% of pages, and skips pages already flagged, so a run every two
+ * days sees only what was written since the last one.
+ *
+ * Measured after a manual `VACUUM (ANALYZE)`: heap fetches 163249 → 1, buffers
+ * 121k → 2.2k, 233 ms → 145 ms. What is left is volume, not visibility.
+ *
+ * @param {import('knex').Knex} knex
+ */
+export const up = async (knex) => {
+  await knex.raw(`
+    ALTER TABLE screenshot_buckets SET (
+      autovacuum_vacuum_insert_scale_factor = 0,
+      autovacuum_vacuum_insert_threshold = 20000
+    )
+  `);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+export const down = async (knex) => {
+  await knex.raw(`
+    ALTER TABLE screenshot_buckets RESET (
+      autovacuum_vacuum_insert_scale_factor,
+      autovacuum_vacuum_insert_threshold
+    )
+  `);
+};

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -2274,7 +2274,8 @@ CREATE TABLE public.screenshot_buckets (
     CONSTRAINT chk_complete_true_screenshotcount_not_null CHECK (((complete = false) OR ("screenshotCount" IS NOT NULL))),
     CONSTRAINT chk_complete_true_storybookscreenshotcount_not_null CHECK (((complete = false) OR ("storybookScreenshotCount" IS NOT NULL))),
     CONSTRAINT screenshot_buckets_mode_check CHECK ((mode = ANY (ARRAY['ci'::text, 'monitoring'::text])))
-);
+)
+WITH (autovacuum_vacuum_insert_scale_factor='0', autovacuum_vacuum_insert_threshold='20000');
 
 
 ALTER TABLE public.screenshot_buckets OWNER TO postgres;
@@ -6777,3 +6778,4 @@ INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('2026081
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260817142631_screenshot-buckets-project-created-index.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260818083531_cursor-origin.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260818120000_builds-prheadcommit-index.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260822180431_screenshot-buckets-insert-autovacuum.js', 1, NOW());


### PR DESCRIPTION
## The problem

`screenshot_buckets_projectid_createdat_index` was added in #2497 to carry the two counts so the billing window could be answered from the index alone. **It never was.** Measured on production, that scan reports:

```
Index Only Scan using screenshot_buckets_projectid_createdat_index
  (actual time=0.012..0.387 rows=789.24 loops=298)
  Heap Fetches: 163249
  Buffers: shared hit=120832 read=734
Execution Time: 233.308 ms
```

163 249 heap fetches, and ~950 MB of buffer traffic, to produce 150 sums.

## Why

An index-only scan still has to check row visibility, and visibility lives in the row — in the heap — not in the index. It can only skip the table for pages the **visibility map** flags as all-visible, and only `VACUUM` sets that flag.

`screenshot_buckets` is almost purely inserted. So:

- the **dead-tuple** trigger that normally schedules autovacuum barely ever fires — the table sits at 19 331 dead tuples for 3 745 796 live, **0.5 %**;
- the **insert** trigger (Postgres 13+) defaults to `1000 + 0.2 × reltuples` ≈ **775 000 inserts**, which at ~235 000 buckets a month is **once a quarter**.

The pages holding the period being billed are therefore, by construction, always the ones vacuum has never visited. The index was doing its job; nothing had told Postgres it was allowed to trust it.

## The fix

Two per-table storage parameters. No data is read, written or rewritten — this only changes when autovacuum considers the table eligible.

```sql
ALTER TABLE screenshot_buckets SET (
  autovacuum_vacuum_insert_scale_factor = 0,
  autovacuum_vacuum_insert_threshold = 20000
);
```

Every ~20 000 inserts instead of ~775 000: roughly every two to three days.

**The scale factor is set to zero on purpose.** Proportional to the table, the interval grows as the table grows — 775k inserts today, 2M at 10M rows — so the staleness this fixes would come back, worse, as Argos grows. An absolute threshold holds the interval at two days whatever the row count.

## What it costs

The manual vacuum took **6.09 s**, scanning 20 % of pages — it skips those already flagged. A run every two days sees only what was written since the last one, so expect well under a second. On an insert-only table most runs have nothing to remove, so Postgres skips the index phase entirely, which is the expensive part.

## Measured

After a manual `VACUUM (ANALYZE) screenshot_buckets`, same query:

| | before | after |
|---|---|---|
| Heap Fetches | 163 249 | **1** |
| Buffers (hit) | 121 556 | **2 210** |
| Execution time | 233 ms | **145 ms** |

The buffer figure matters more than the time: 55× less traffic is load taken off the whole database, not just this query.

## What this does *not* fix

The remaining 145 ms is volume, not visibility — still **235 592 index entries walked** for 151 sums, and the real `getAccountBillings` query does two periods per account with year-long windows for annual subscriptions. That is a daily usage rollup, not a vacuum setting, and it is a separate change.

## Note for whoever deploys

The migration only changes the setting **going forward**. The pages already written stay unflagged until something vacuums them, so run once, by hand, at a quiet moment:

```sql
VACUUM (ANALYZE) screenshot_buckets;
```

It is plain `VACUUM`, not `VACUUM FULL` — `SHARE UPDATE EXCLUSIVE`, reads and writes continue, and it can be interrupted safely.

Separately: the planner estimates 47 rows for 663 on `accounts` in that plan, a 14× error. `ANALYZE accounts, subscriptions, projects;` is worth running too, and is unrelated to this table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
