### PR TITLE
fix(staff): report what a trial consumes in the team directory

### DIFF
--- a/apps/backend/src/database/services/period-usage.ts
+++ b/apps/backend/src/database/services/period-usage.ts
@@ -45,6 +45,15 @@ type AccountPeriodUsage = {
    * whose usage is never billed.
    */
   billingPeriods: BillingPeriodUsage[];
+  /**
+   * Screenshots consumed since the current period opened, billed or not.
+   *
+   * Kept apart from `billingPeriods` because it answers a different question.
+   * That list is what Stripe invoices, so it is empty on a trial — but a trial
+   * is precisely when what a team is consuming is worth watching, since it is
+   * the thing that says whether it will convert.
+   */
+  currentPeriodScreenshotsCount: number;
 };
 
 /**
@@ -580,11 +589,15 @@ export async function getAccountBillings(
     const includedScreenshots =
       subscription.includedScreenshots ?? plan.includedScreenshots;
 
+    // The period holding now, whether or not Stripe bills it.
+    const runningTotals = totals.get(0) ?? EMPTY_TOTALS;
+
     result.set(accountId, {
       plan,
       flatPrice: subscription.flatPrice,
       includedScreenshots,
       periodUsage: {
+        currentPeriodScreenshotsCount: runningTotals.all,
         billingPeriods: accountPeriods
           .filter((period) => checkIsBilledPeriod(period, subscription))
           .map((period) => {

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -258,6 +258,14 @@ export const typeDefs = gql`
     """
     billingPeriods: [TeamStaffBillingPeriod!]!
     """
+    Screenshots consumed since the current period opened, billed or not.
+
+    Apart from \`billingPeriods\` because it answers a different question: that
+    list is what Stripe invoices, so it is empty on a trial — and a trial is
+    precisely when what a team consumes is worth watching.
+    """
+    currentPeriodScreenshotsCount: Int!
+    """
     Share of Storybook screenshots in everything the team ever uploaded, between
     0 and 1. Null when it never uploaded a screenshot at all.
     """
@@ -422,6 +430,12 @@ export const resolvers: IResolvers = {
     },
   },
   TeamStaffPeriodUsage: {
+    currentPeriodScreenshotsCount: async (account, _args, ctx) => {
+      const { periodUsage: usage } =
+        await ctx.loaders.AccountBillingByAccountId.load(account.id);
+      invariant(usage, "period usage resolved for a team that has none");
+      return usage.currentPeriodScreenshotsCount;
+    },
     billingPeriods: async (account, _args, ctx) => {
       const { periodUsage: usage } =
         await ctx.loaders.AccountBillingByAccountId.load(account.id);

--- a/apps/frontend/src/pages/Staff/Teams.tsx
+++ b/apps/frontend/src/pages/Staff/Teams.tsx
@@ -85,6 +85,7 @@ const StaffTeamsQuery = graphql(`
             interval
           }
           periodUsage {
+            currentPeriodScreenshotsCount
             billingPeriods {
               endsAt
               closed
@@ -458,6 +459,12 @@ function PeriodProgress(props: { period: BillingPeriod }) {
  * period, so a lifetime total has nothing to be read against — and this is the
  * figure that says whether the amount in the next invoice is about to move.
  *
+ * Read off the usage rather than off the billing beside it, so a trial reports
+ * what it consumes like everyone else. Stripe never invoices trial usage, so no
+ * billed period is opened for one — but consumption during a trial is the whole
+ * signal for whether it converts, and blanking it was hiding the answer on
+ * exactly the rows the question is asked about.
+ *
  * The quota is named only where it is worth reading. Pro is nearly every row
  * and always includes the same amount, so printing it there would repeat one
  * number down the whole column. What is left is the contracts, where it was
@@ -469,13 +476,16 @@ function ScreenshotsCell(props: {
   billing: TeamBilling | null;
 }) {
   const { team, billing } = props;
+  const { periodUsage } = team.staff;
 
-  // No running period is no consumption to report: a team on a flat plan, on a
-  // granted one, on a trial — whose usage Stripe never bills, so no period is
-  // opened for it — or with no subscription at all.
-  if (!billing?.current) {
+  // Nothing is metered at all: a team on a flat plan, on a granted one, or with
+  // no subscription.
+  if (!periodUsage) {
     return <span className="text-low">—</span>;
   }
+
+  // Usage to read means a usage-based plan was resolved to read it against.
+  invariant(billing, "a team with period usage is billed on a plan");
 
   const { includedScreenshots } = team.staff;
   // Pro includes the same amount on every one of its rows, which is nearly all
@@ -486,10 +496,10 @@ function ScreenshotsCell(props: {
       : includedScreenshots.toLocaleString();
 
   return (
-    <Tooltip content="Consumed since the running period opened, against what the subscription includes in each one. Everything past the quota is billed as overage.">
+    <Tooltip content="Consumed since the running period opened, against what the subscription includes in each one. Everything past the quota is billed as overage — except on a trial, whose usage Stripe never bills.">
       <div>
         <div className="font-medium">
-          {billing.current.period.screenshotsCount.toLocaleString()}
+          {periodUsage.currentPeriodScreenshotsCount.toLocaleString()}
         </div>
         {/* A blank rather than nothing: an empty div collapses, and the count
             would then sit half a line above the amounts beside it. */}

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -127,7 +127,15 @@ async function createBilledTeam(input: {
   planId: string;
   subscriberId: string;
   createdDaysAgo: number;
-  trialEndedDaysAgo: number;
+  /** Days since the trial ended, for a team that converted. */
+  trialEndedDaysAgo?: number;
+  /**
+   * Days until the trial ends, for a team still inside one.
+   *
+   * Stripe never invoices trial usage, so such a team opens no billed period —
+   * which is precisely the row the Screenshots column has to report anyway.
+   */
+  trialEndsInDays?: number;
   /** Where the running period opened, which sets the billing anniversary. */
   periodStartDaysAgo: number;
   /** What the plan costs per month, as Stripe holds it — null when Argos has
@@ -142,6 +150,7 @@ async function createBilledTeam(input: {
    */
   screenshotsInRunningPeriod?: number;
 }): Promise<Account> {
+  const runningTrial = input.trialEndsInDays;
   const { account } = await createTeamAccount({
     slug: input.slug,
     name: input.name,
@@ -164,9 +173,12 @@ async function createBilledTeam(input: {
     createdAt: daysFromNow(-input.createdDaysAgo),
     startDate: daysFromNow(-input.periodStartDaysAgo),
     endDate: null,
-    trialEndDate: daysFromNow(-input.trialEndedDaysAgo),
+    trialEndDate:
+      runningTrial === undefined
+        ? daysFromNow(-(input.trialEndedDaysAgo ?? 0))
+        : daysFromNow(runningTrial),
     paymentMethodFilled: true,
-    status: "active",
+    status: runningTrial === undefined ? "active" : "trialing",
     flatPrice: input.flatPrice,
     includedScreenshots: 35_000,
     additionalScreenshotPrice: 0.005,
@@ -370,6 +382,22 @@ const staffTest = loggedTest.extend<{ pipelineTeams: PipelineTeams }>({
       // so the row has to quote the year — dividing it into a month would
       // report a figure that was never charged. Its previous period predates
       // the subscription row, which is why it has none.
+      // Still inside its trial, and building. Stripe invoices no trial usage, so
+      // this team opens no billed period at all — the two amount columns stay
+      // empty — while the Screenshots column has to report what it consumes,
+      // which is the whole signal for whether it converts.
+      createBilledTeam({
+        ...common,
+        planId: proPlan.id,
+        slug: `${prefix}-trialsonic`,
+        name: "Trialsonic",
+        createdDaysAgo: 10,
+        trialEndsInDays: 4,
+        periodStartDaysAgo: 10,
+        flatPrice: 100,
+        screenshotsByClosedPeriod: [],
+        screenshotsInRunningPeriod: 5_625,
+      }),
       createBilledTeam({
         ...common,
         planId: annualPlan.id,
@@ -417,7 +445,7 @@ staffTest("staff all teams", async ({ page, pipelineTeams }) => {
   await page.goto("/staff/teams");
   await expect(page.getByRole("heading", { name: "All Teams" })).toBeVisible();
   await page.getByRole("searchbox").fill(pipelineTeams.prefix);
-  await expect(page.getByText("Showing 1-8 of 8 teams")).toBeVisible();
+  await expect(page.getByText("Showing 1-9 of 9 teams")).toBeVisible();
 
   // A yearly subscription states its amounts for a year, so the column has to
   // quote the year. Read as a monthly rate this row is a twelfth of itself.
@@ -444,6 +472,14 @@ staffTest("staff all teams", async ({ page, pipelineTeams }) => {
   // what tells a genuine drop from a period that simply opened three days ago.
   await expect(umbrella).toContainText(/\d+ days left/);
 
+  // A trial is invoiced nothing, so it opens no billed period and both amount
+  // columns stay empty — but what it consumes is exactly what says whether it
+  // will convert, so the Screenshots column reports it all the same.
+  const trialsonic = page.getByRole("row", { name: /Trialsonic/ });
+  await expect(trialsonic).toContainText("5,625");
+  await expect(trialsonic).toContainText("trialing");
+  await expect(trialsonic).not.toContainText("$");
+
   await screenshot(page, "staff-all-teams");
 });
 
@@ -452,7 +488,7 @@ staffTest(
   async ({ page, pipelineTeams }) => {
     await page.goto("/staff/teams");
     await page.getByRole("searchbox").fill(pipelineTeams.prefix);
-    await expect(page.getByText("Showing 1-8 of 8 teams")).toBeVisible();
+    await expect(page.getByText("Showing 1-9 of 9 teams")).toBeVisible();
 
     // Narrowing to one interval is what makes the two period columns comparable
     // between rows: a year's amount next to a month's is an order of magnitude.
@@ -465,7 +501,7 @@ staffTest(
     // included: the filter is on how a team is billed, not on whether it pays.
     await page.getByRole("combobox", { name: "Billing interval" }).click();
     await page.getByRole("option", { name: "Monthly" }).click();
-    await expect(page.getByText("Showing 1-7 of 7 teams")).toBeVisible();
+    await expect(page.getByText("Showing 1-8 of 8 teams")).toBeVisible();
     await expect(page.getByRole("row", { name: /Initrode/ })).toBeHidden();
 
     // Ordering and filtering are applied on the server, on two different code
@@ -478,6 +514,7 @@ staffTest(
         "Northwind",
         "Globex",
         "Initech",
+        "Trialsonic",
         "Hexagon",
         "Vandelay",
         "Umbrella",
@@ -491,7 +528,7 @@ staffTest(
   async ({ page, pipelineTeams }) => {
     await page.goto("/staff/teams");
     await page.getByRole("searchbox").fill(pipelineTeams.prefix);
-    await expect(page.getByText("Showing 1-8 of 8 teams")).toBeVisible();
+    await expect(page.getByText("Showing 1-9 of 9 teams")).toBeVisible();
 
     // Ordering by an amount prices every billed team, which takes long enough
     // on real data to look like the click did nothing. Held here so the state
@@ -542,7 +579,7 @@ staffTest("staff trial pipeline", async ({ page, pipelineTeams }) => {
   // only renders once the search has been applied (it runs through
   // `useDeferredValue`, so it lands a render late), which makes it the signal
   // that the table is down to this test's three teams.
-  await expect(page.getByText(/^Showing 3 of \d+ teams$/)).toBeVisible();
+  await expect(page.getByText(/^Showing 4 of \d+ teams$/)).toBeVisible();
   await expect(page.getByText("2d left")).toBeVisible();
   await expect(page.getByText("11d left")).toBeVisible();
 
@@ -558,7 +595,7 @@ staffTest(
       page.getByRole("heading", { name: "Trial pipeline" }),
     ).toBeVisible();
     await page.getByRole("searchbox").fill(pipelineTeams.prefix);
-    await expect(page.getByText(/^Showing 7 of \d+ teams$/)).toBeVisible();
+    await expect(page.getByText(/^Showing 8 of \d+ teams$/)).toBeVisible();
 
     // Soylent uploaded 50k screenshots over its last closed month: 15k past the
     // 35k included, at $0.005, on top of the $100 flat plan. The month still


### PR DESCRIPTION
## The bug

On **All teams**, a team still inside its trial shows an em dash under Screenshots. On **Trials**, the same team shows a figure. Two adjacent tabs, one column name, two answers.

## Why

The two columns never measured the same thing:

- **Trials** reads `staff.screenshotsCount` — `sum((builds.stats->>'total')::int)` over every build the account ever made. A lifetime count, off builds, unrelated to billing.
- **All teams** reads the running **billed** period, off `screenshot_buckets`.

And Stripe never invoices trial usage, so `checkIsBilledPeriod` drops every period that starts before the trial ends. A trialing team therefore has *no* billed period at all — `billingPeriods` comes back empty, and the cell rendered its em dash.

That is correct for the two amount columns: nothing is owed, so nothing is shown. It is wrong for Screenshots, because what a team consumes during its trial is the whole signal for whether it will convert — and the column was blanking it on exactly the rows where the question is asked.

## The change

`TeamStaffPeriodUsage` gains `currentPeriodScreenshotsCount`: what the period holding now has consumed, billed or not. It comes from the same aggregate, before the billed-period filter, so it costs no extra query.

`ScreenshotsCell` reads that instead of the billed period. The em dash now means what it should: nothing is metered at all — a flat plan, a granted one, no subscription.

**The amount columns are untouched.** A trial still shows no money in Last period and Current period, because none is owed. I did not relax `checkIsBilledPeriod`: that would have made the money columns quote figures Stripe never charges, and the server-side amount ordering with them.

## Guard

`staff all teams` now seeds a team inside its trial on a usage-based plan, building into the period it is in, and asserts the row reports its consumption, says `trialing`, and contains no `$`.

Verified it fails without the fix — with `Teams.tsx` reverted the row reads:

```
Trialsonic … trialing Pro 0 — — —
```

The shared fixture gained a team, so the counts other specs assert on moved with it.
