### PR TITLE
feat(staff): a Revenue tab, read from Stripe invoices

### DIFF
--- a/apps/backend/src/database/services/period-usage.ts
+++ b/apps/backend/src/database/services/period-usage.ts
@@ -201,7 +201,7 @@ async function getScreenshotTotals(
   // a `VALUES` list, and would refuse to join it against `projects."accountId"`.
   const values = buildPeriodValues(periods);
 
-  const rows = (await knex
+  const bucketTotals = knex
     .select("v.accountId", "v.index")
     .select(
       // `screenshotCount` is null until a bucket completes, and the billing
@@ -229,26 +229,42 @@ async function getScreenshotTotals(
     // Bounded in the join rather than only in the aggregate above: the filters
     // there are applied after the rows are read, so on their own the scan still
     // walks every bucket the project ever produced. Each row carries its own
-    // boundary, so this reads `v."from"` rather than one minimum for the whole
-    // batch — a single yearly subscription in the batch would otherwise push
+    // boundaries, so this reads `v."from"` and `v."to"` rather than one minimum
+    // for the whole batch — a single yearly subscription would otherwise push
     // that minimum two years back and unbound everyone else.
+    //
+    // Both ends, not just the lower one: with the upper bound left to the
+    // aggregate's filter, a closed period still read every bucket from its
+    // start through to today and threw the running period's away — roughly
+    // twice the rows, on the table that dominates this query. The pair is also
+    // exactly what `(projectId, createdAt)` indexes, so it reads as one range.
     .leftJoin("screenshot_buckets as sb", (join) => {
       join
         .on("sb.projectId", "p.id")
-        .andOn(knex.raw(`sb."createdAt" >= v."from"`));
+        .andOn(knex.raw(`sb."createdAt" >= v."from"`))
+        .andOn(knex.raw(`sb."createdAt" < v."to"`));
     })
-    .groupBy("v.accountId", "v.index")) as unknown as {
-    accountId: string | number;
-    index: string | number;
-    periodAll: string | number;
-    periodStorybook: string | number;
-  }[];
+    .groupBy("v.accountId", "v.index") as unknown as Promise<
+    {
+      accountId: string | number;
+      index: string | number;
+      periodAll: string | number;
+      periodStorybook: string | number;
+    }[]
+  >;
 
   // Media hangs off a project, like a bucket does, but it still cannot ride the
   // join above: joining two independent one-to-many tables in a single pass
   // multiplies their rows against each other. It is aggregated separately and
   // added in.
-  const mediaUnits = await getMediaUnits(periods);
+  //
+  // Sent together rather than one after the other: neither reads the other's
+  // result, so awaiting them in turn spent the two scans end to end for no
+  // reason. On a directory page this is the whole of the billing wait.
+  const [rows, mediaUnits] = await Promise.all([
+    bucketTotals,
+    getMediaUnits(periods),
+  ]);
 
   const totalsByAccountId = new Map<string, AccountTotals>();
   for (const row of rows) {
@@ -308,7 +324,8 @@ async function getMediaUnits(
       join
         .on("mv.mediaId", "m.id")
         .onNotNull("mv.uploadedAt")
-        .andOn(knex.raw(`mv."uploadedAt" >= v."from"`));
+        .andOn(knex.raw(`mv."uploadedAt" >= v."from"`))
+        .andOn(knex.raw(`mv."uploadedAt" < v."to"`));
     })
     .groupBy("v.accountId", "v.index")) as unknown as {
     accountId: string | number;

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -385,6 +385,55 @@ export const typeDefs = gql`
     yearlyPlans: StaffRevenueSplit!
   }
 
+  "One invoice a contract's worth is read from."
+  type StaffContractInvoice {
+    "Net of tax and credit notes, in the currency's main unit."
+    amount: Float!
+    "The currency it was raised in, counted at parity when not USD."
+    currency: String!
+    "When it was raised."
+    invoicedAt: DateTime!
+    "The stretch it covers, when it states a real one."
+    coveredFrom: DateTime
+    coveredUntil: DateTime
+  }
+
+  """
+  One annual contract in force, and the invoices its rate is read from: the
+  latest annual bill plus whatever was sold on top of it since.
+
+  Listed so the yearly figure can be audited contract by contract — including
+  the contracts that contributed nothing, which the total alone would hide.
+  """
+  type StaffYearlyContract {
+    "The team's slug, which names its pages."
+    slug: String!
+    "The team's display name, when it has one."
+    name: String
+    "The subscription the database knows the contract by."
+    stripeSubscriptionId: String!
+    """
+    The invoices below, added up. Null when none was found, in which case the
+    contract adds nothing to the rate.
+    """
+    amount: Float
+    "The invoices the contract is worth, newest first."
+    invoices: [StaffContractInvoice!]!
+    """
+    True when the invoices found are still awaiting payment. Shown, so a
+    contract in collection is visible, but counted nothing until they clear.
+    """
+    awaitingPayment: Boolean!
+  }
+
+  "What Argos invoiced, and the annual contracts behind the yearly rate."
+  type StaffRevenue {
+    "The window, oldest first and the running month last."
+    months: [StaffRevenueMonth!]!
+    "The contracts behind every month's \`yearlyPlans\`, largest first."
+    yearlyContracts: [StaffYearlyContract!]!
+  }
+
   type StaffTeamConnection implements Connection {
     pageInfo: PageInfo!
     edges: [Team!]!
@@ -416,13 +465,14 @@ export const typeDefs = gql`
     staffTrialPipeline(days: Int! = 30): [Team!]!
     """
     What Argos invoiced over the last \`months\` calendar months, oldest first
-    and the running one last (staff only).
+    and the running one last, with the annual contracts the yearly rate is
+    made of (staff only).
 
     Read from Stripe when asked, never stored: the invoices change behind us as
     they are paid, voided and credited. Every month costs a paginated walk of
     its own, which is what \`months\` is bounded for.
     """
-    staffRevenue(months: Int! = 3): [StaffRevenueMonth!]!
+    staffRevenue(months: Int! = 3): StaffRevenue!
   }
 
   extend type Mutation {

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -346,6 +346,16 @@ export const typeDefs = gql`
     revenue: Float!
     "How many teams contributed."
     teamsCount: Int!
+    """
+    The part of \`revenue\` invoiced in a currency other than US dollars, added
+    in at parity.
+
+    Stripe states each invoice in the currency it was raised in, and converting
+    one into another needs a rate on the day, which nothing here has. So a euro
+    invoice is counted as though it were dollars, and this says how much of the
+    figure rests on that.
+    """
+    foreignRevenue: Float!
   }
 
   """
@@ -408,9 +418,9 @@ export const typeDefs = gql`
     What Argos invoiced over the last \`months\` calendar months, oldest first
     and the running one last (staff only).
 
-    Its own query rather than a field on \`staffTeams\`: it walks Stripe's
-    invoices, so it loads beside the table instead of ahead of it. Every month
-    costs a walk of its own, which is what \`months\` is bounded for.
+    Read from Stripe when asked, never stored: the invoices change behind us as
+    they are paid, voided and credited. Every month costs a paginated walk of
+    its own, which is what \`months\` is bounded for.
     """
     staffRevenue(months: Int! = 3): [StaffRevenueMonth!]!
   }
@@ -606,6 +616,9 @@ export const resolvers: IResolvers = {
     staffRevenue: async (_root, args, ctx) => {
       assertStaff(ctx);
 
+      // Guarded here as well as in the service: this one answers a bad request
+      // with a bad-request error rather than an invariant the client cannot
+      // read.
       if (args.months < 1 || args.months > MAX_MONTHS) {
         throw badUserInput(`\`months\` must be between 1 and ${MAX_MONTHS}.`);
       }

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -7,6 +7,7 @@ import {
   getAccountBillings,
   type AccountBilling,
 } from "@/database/services/period-usage";
+import { getStaffRevenue, MAX_MONTHS } from "@/stripe/revenue";
 
 import type {
   IAccountSubscriptionStatus,
@@ -340,6 +341,40 @@ export const typeDefs = gql`
     CURRENT_PERIOD_DESC
   }
 
+  "What the teams on one billing interval contributed to a month."
+  type StaffRevenueSplit {
+    revenue: Float!
+    "How many teams contributed."
+    teamsCount: Int!
+  }
+
+  """
+  What Argos invoiced over one calendar month.
+
+  Read from the Stripe invoices themselves rather than recomputed from usage, so
+  the amounts carry what Stripe actually charged — negotiated prices, coupons,
+  credit notes — instead of a second pricing engine of ours that would have to
+  agree with the first. Amounts exclude tax, are net of credit notes, and
+  currencies are added at parity.
+  """
+  type StaffRevenueMonth {
+    "The first instant of the month, in UTC — what names it on screen."
+    month: DateTime!
+    "The two splits below, added up."
+    revenue: Float!
+    "What teams billed by the month were invoiced that month."
+    monthlyPlans: StaffRevenueSplit!
+    """
+    What the annual contracts in force are worth per month: their latest invoice
+    over twelve.
+
+    The same on every month, being a rate. Amortizing each annual invoice over
+    the twelve months it covers would be exact, but it would mean reading a year
+    of invoices to report one month — which a request cannot afford.
+    """
+    yearlyPlans: StaffRevenueSplit!
+  }
+
   type StaffTeamConnection implements Connection {
     pageInfo: PageInfo!
     edges: [Team!]!
@@ -369,6 +404,15 @@ export const typeDefs = gql`
     ): StaffTeamConnection!
     "List teams created within the last \`days\` days, newest first (staff only)"
     staffTrialPipeline(days: Int! = 30): [Team!]!
+    """
+    What Argos invoiced over the last \`months\` calendar months, oldest first
+    and the running one last (staff only).
+
+    Its own query rather than a field on \`staffTeams\`: it walks Stripe's
+    invoices, so it loads beside the table instead of ahead of it. Every month
+    costs a walk of its own, which is what \`months\` is bounded for.
+    """
+    staffRevenue(months: Int! = 3): [StaffRevenueMonth!]!
   }
 
   extend type Mutation {
@@ -558,6 +602,15 @@ export const resolvers: IResolvers = {
       ]);
 
       return paginateResult({ result: { total, results }, after, first });
+    },
+    staffRevenue: async (_root, args, ctx) => {
+      assertStaff(ctx);
+
+      if (args.months < 1 || args.months > MAX_MONTHS) {
+        throw badUserInput(`\`months\` must be between 1 and ${MAX_MONTHS}.`);
+      }
+
+      return getStaffRevenue(args.months);
     },
     staffTrialPipeline: async (_root, args, ctx) => {
       assertStaff(ctx);

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -347,13 +347,12 @@ export const typeDefs = gql`
     "How many teams contributed."
     teamsCount: Int!
     """
-    The part of \`revenue\` invoiced in a currency other than US dollars, added
-    in at parity.
+    The part of \`revenue\` invoiced in a currency other than euros, converted
+    at the page's fixed rate.
 
-    Stripe states each invoice in the currency it was raised in, and converting
-    one into another needs a rate on the day, which nothing here has. So a euro
-    invoice is counted as though it were dollars, and this says how much of the
-    figure rests on that.
+    Stripe states each invoice in the currency it was raised in; dollars are
+    brought into euros at a fixed rate rather than the day's, and this says how
+    much of the figure rests on that conversion.
     """
     foreignRevenue: Float!
   }
@@ -364,8 +363,8 @@ export const typeDefs = gql`
   Read from the Stripe invoices themselves rather than recomputed from usage, so
   the amounts carry what Stripe actually charged — negotiated prices, coupons,
   credit notes — instead of a second pricing engine of ours that would have to
-  agree with the first. Amounts exclude tax, are net of credit notes, and
-  currencies are added at parity.
+  agree with the first. Amounts exclude tax, are net of credit notes, and are
+  stated in euros, dollars converted at a fixed rate.
   """
   type StaffRevenueMonth {
     "The first instant of the month, in UTC — what names it on screen."
@@ -374,6 +373,8 @@ export const typeDefs = gql`
     revenue: Float!
     "What teams billed by the month were invoiced that month."
     monthlyPlans: StaffRevenueSplit!
+    "The teams behind \`monthlyPlans\`, largest first — they sum to it."
+    teams: [StaffRevenueMonthTeam!]!
     """
     What the annual contracts in force are worth per month: their latest invoice
     over twelve.
@@ -385,11 +386,27 @@ export const typeDefs = gql`
     yearlyPlans: StaffRevenueSplit!
   }
 
+  "What one team was invoiced over a month, one line of the breakdown."
+  type StaffRevenueMonthTeam {
+    "The team's slug, which names its pages."
+    slug: String!
+    "The team's display name, when it has one."
+    name: String
+    "The Stripe customer the invoices were raised on."
+    stripeCustomerId: String!
+    "What the invoices add up to, in \`currency\`."
+    amount: Float!
+    "The currency the team is invoiced in — null when a month mixes several."
+    currency: String
+    "In euros, like the split it sums into."
+    revenue: Float!
+  }
+
   "One invoice a contract's worth is read from."
   type StaffContractInvoice {
-    "Net of tax and credit notes, in the currency's main unit."
+    "Net of tax and credit notes, in the currency it was raised in."
     amount: Float!
-    "The currency it was raised in, counted at parity when not USD."
+    "The currency it was raised in — the contract's total converts it."
     currency: String!
     "When it was raised."
     invoicedAt: DateTime!
@@ -413,15 +430,16 @@ export const typeDefs = gql`
     "The subscription the database knows the contract by."
     stripeSubscriptionId: String!
     """
-    The invoices below, added up. Null when none was found, in which case the
-    contract adds nothing to the rate.
+    The invoices below added up, in euros. Null when none was found, in which
+    case the contract adds nothing to the rate.
     """
     amount: Float
     "The invoices the contract is worth, newest first."
     invoices: [StaffContractInvoice!]!
     """
-    True when the invoices found are still awaiting payment. Shown, so a
-    contract in collection is visible, but counted nothing until they clear.
+    True when the invoices found are still awaiting payment. Counted all the
+    same — a contract invoice raised is money on its way — and flagged, so
+    collection can be watched.
     """
     awaitingPayment: Boolean!
   }
@@ -432,6 +450,12 @@ export const typeDefs = gql`
     months: [StaffRevenueMonth!]!
     "The contracts behind every month's \`yearlyPlans\`, largest first."
     yearlyContracts: [StaffYearlyContract!]!
+    """
+    What GitHub Marketplace brings in a month, in euros, gross of the 5%
+    GitHub keeps. A stated constant, not a reading — GitHub exposes no invoice
+    API — so it is not part of the figures above.
+    """
+    githubMarketplaceMonthlyRevenue: Float!
   }
 
   type StaffTeamConnection implements Connection {

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { factory, setupDatabase } from "@/database/testing";
 
-import { getBilledTeams, getTeamCustomerIds } from "./revenue";
+import { getBilledTeams, getTeamCustomers } from "./revenue";
 
 describe("getBilledTeams", () => {
   beforeEach(async () => {
@@ -113,12 +113,12 @@ describe("getBilledTeams", () => {
   });
 });
 
-describe("getTeamCustomerIds", () => {
+describe("getTeamCustomers", () => {
   beforeEach(async () => {
     await setupDatabase();
   });
 
-  it("keeps a team whose subscription has ended", async () => {
+  it("keeps a team whose subscription has ended, with its names", async () => {
     // Its invoices were still sent, and the month it was invoiced in has to
     // keep them — that departure is exactly what a comparison between two
     // months exists to show.
@@ -139,8 +139,10 @@ describe("getTeamCustomerIds", () => {
       status: "canceled",
     });
 
-    await expect(getTeamCustomerIds()).resolves.toEqual(
-      new Set(["cus_churned"]),
+    await expect(getTeamCustomers()).resolves.toEqual(
+      new Map([
+        ["cus_churned", { slug: account.slug, name: account.name ?? null }],
+      ]),
     );
   });
 
@@ -148,12 +150,12 @@ describe("getTeamCustomerIds", () => {
     // Whatever a personal account was invoiced is not this page's subject.
     await factory.UserAccount.create({ stripeCustomerId: "cus_personal" });
 
-    await expect(getTeamCustomerIds()).resolves.toEqual(new Set());
+    await expect(getTeamCustomers()).resolves.toEqual(new Map());
   });
 
   it("leaves out a team that never reached Stripe", async () => {
     await factory.TeamAccount.create({ stripeCustomerId: null });
 
-    await expect(getTeamCustomerIds()).resolves.toEqual(new Set());
+    await expect(getTeamCustomers()).resolves.toEqual(new Map());
   });
 });

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { factory, setupDatabase } from "@/database/testing";
 
-import { getBilledTeams } from "./revenue";
+import { getBilledTeams, getTeamCustomerIds } from "./revenue";
 
 describe("getBilledTeams", () => {
   beforeEach(async () => {
@@ -110,5 +110,50 @@ describe("getBilledTeams", () => {
 
     expect(teams).toHaveLength(1);
     expect(teams[0]?.interval).toBe("year");
+  });
+});
+
+describe("getTeamCustomerIds", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  it("keeps a team whose subscription has ended", async () => {
+    // Its invoices were still sent, and the month it was invoiced in has to
+    // keep them — that departure is exactly what a comparison between two
+    // months exists to show.
+    const account = await factory.TeamAccount.create({
+      stripeCustomerId: "cus_churned",
+    });
+    const plan = await factory.Plan.create({ usageBased: true });
+    const user = await factory.User.create();
+    await factory.Subscription.create({
+      accountId: account.id,
+      planId: plan.id,
+      currency: "usd",
+      provider: "stripe",
+      stripeSubscriptionId: "sub_churned",
+      subscriberId: user.id,
+      startDate: new Date("2021-01-01").toISOString(),
+      endDate: new Date("2024-01-01").toISOString(),
+      status: "canceled",
+    });
+
+    await expect(getTeamCustomerIds()).resolves.toEqual(
+      new Set(["cus_churned"]),
+    );
+  });
+
+  it("leaves out a personal account", async () => {
+    // Whatever a personal account was invoiced is not this page's subject.
+    await factory.UserAccount.create({ stripeCustomerId: "cus_personal" });
+
+    await expect(getTeamCustomerIds()).resolves.toEqual(new Set());
+  });
+
+  it("leaves out a team that never reached Stripe", async () => {
+    await factory.TeamAccount.create({ stripeCustomerId: null });
+
+    await expect(getTeamCustomerIds()).resolves.toEqual(new Set());
   });
 });

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { factory, setupDatabase } from "@/database/testing";
+
+import { getBilledTeams } from "./revenue";
+
+describe("getBilledTeams", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  let sequence = 0;
+
+  /** A team on a Stripe subscription, as the revenue reader looks for it. */
+  async function createTeam(options: {
+    interval: "month" | "year";
+    status?: "active" | "past_due" | "trialing" | "canceled";
+    /** Set to grant the plan, which bills nothing. */
+    granted?: boolean;
+    /** Teams that never reached Stripe have no customer to match invoices on. */
+    withCustomer?: boolean;
+  }) {
+    sequence += 1;
+    const plan = await factory.Plan.create({
+      usageBased: true,
+      interval: options.interval,
+      includedScreenshots: 1000,
+    });
+    const account = await factory.TeamAccount.create({
+      stripeCustomerId:
+        options.withCustomer === false ? null : `cus_revenue_${sequence}`,
+      forcedPlanId: options.granted ? plan.id : null,
+    });
+    const user = await factory.User.create();
+    await factory.Subscription.create({
+      accountId: account.id,
+      planId: plan.id,
+      currency: "usd",
+      provider: "stripe",
+      stripeSubscriptionId: `sub_revenue_${sequence}`,
+      subscriberId: user.id,
+      startDate: new Date("2021-01-01").toISOString(),
+      status: options.status ?? "active",
+      trialEndDate:
+        options.status === "trialing"
+          ? new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()
+          : null,
+    });
+    return account;
+  }
+
+  it("returns a paying team with the interval it is billed on", async () => {
+    const monthly = await createTeam({ interval: "month" });
+    const yearly = await createTeam({ interval: "year" });
+
+    const teams = await getBilledTeams();
+
+    expect(teams).toHaveLength(2);
+    expect(teams).toContainEqual(
+      expect.objectContaining({ accountId: monthly.id, interval: "month" }),
+    );
+    expect(teams).toContainEqual(
+      expect.objectContaining({ accountId: yearly.id, interval: "year" }),
+    );
+  });
+
+  it("keeps a team whose invoice has not cleared", async () => {
+    // The invoice was raised; whether it is paid is a collection question, and
+    // the invoice is what this reads.
+    const account = await createTeam({ interval: "month", status: "past_due" });
+
+    const teams = await getBilledTeams();
+
+    expect(teams.map((team) => team.accountId)).toEqual([account.id]);
+  });
+
+  it.each([
+    ["a trial, which pays nothing", { status: "trialing" as const }],
+    ["a canceled subscription", { status: "canceled" as const }],
+    ["a granted plan, which bills nothing", { granted: true }],
+    ["a team that never reached Stripe", { withCustomer: false }],
+  ])("drops %s", async (_label, options) => {
+    await createTeam({ interval: "month", ...options });
+
+    await expect(getBilledTeams()).resolves.toEqual([]);
+  });
+
+  it("resolves one row per team when two subscriptions are active", async () => {
+    // Two active subscriptions resolve the highest quota, the same one
+    // `getAccountBillings` picks — so both sides price the same plan.
+    const account = await createTeam({ interval: "month" });
+    const richerPlan = await factory.Plan.create({
+      usageBased: true,
+      interval: "year",
+      includedScreenshots: 1_000_000,
+    });
+    const user = await factory.User.create();
+    await factory.Subscription.create({
+      accountId: account.id,
+      planId: richerPlan.id,
+      currency: "usd",
+      provider: "stripe",
+      stripeSubscriptionId: "sub_revenue_richer",
+      subscriberId: user.id,
+      startDate: new Date("2021-01-01").toISOString(),
+      status: "active",
+    });
+
+    const teams = await getBilledTeams();
+
+    expect(teams).toHaveLength(1);
+    expect(teams[0]?.interval).toBe("year");
+  });
+});

--- a/apps/backend/src/stripe/revenue.test.ts
+++ b/apps/backend/src/stripe/revenue.test.ts
@@ -1,6 +1,12 @@
+import type Stripe from "stripe";
 import { describe, expect, it } from "vitest";
 
-import { getInvoiceRevenue, startOfUTCMonth } from "./revenue";
+import type { ContractInvoiceCandidate } from "./revenue";
+import {
+  findContractInvoices,
+  getInvoiceRevenue,
+  startOfUTCMonth,
+} from "./revenue";
 
 describe("getInvoiceRevenue", () => {
   /** Stripe states amounts in the currency's minor unit. */
@@ -71,6 +77,155 @@ describe("getInvoiceRevenue", () => {
         invoice({ total: 10_000, total_excluding_tax: 10_000, post: 10_000 }),
       ).amount,
     ).toBe(0);
+  });
+});
+
+describe("findContractInvoices", () => {
+  const seconds = (iso: string) => Date.parse(iso) / 1000;
+
+  /** Cases below are the real shapes the yearly book was found to hold. */
+  function candidate(fields: {
+    reason: Stripe.Invoice.BillingReason | null;
+    total: number;
+    /** Each entry is one line's covered stretch. */
+    periods: [string, string][];
+  }): ContractInvoiceCandidate & { total: number } {
+    return {
+      billing_reason: fields.reason,
+      total: fields.total,
+      lines: {
+        data: fields.periods.map(([start, end]) => ({
+          period: { start: seconds(start), end: seconds(end) },
+        })),
+      },
+    };
+  }
+
+  it("picks the year-long conversion invoice over its same-day true-up", () => {
+    // A team converted from monthly to yearly mid-stream: the contract is a
+    // `subscription_update` covering a year, raised alongside a last month of
+    // usage — and behind them, months of cycle invoices from before.
+    const trueUp = candidate({
+      reason: "subscription_update",
+      total: 758_724,
+      periods: [["2026-04-23", "2026-05-23"]],
+    });
+    const contract = candidate({
+      reason: "subscription_update",
+      total: 6_480_000,
+      periods: [["2026-05-23", "2027-05-23"]],
+    });
+    const oldCycle = candidate({
+      reason: "subscription_cycle",
+      total: 745_028,
+      periods: [["2026-03-23", "2026-04-23"]],
+    });
+
+    expect(findContractInvoices([trueUp, contract, oldCycle])).toEqual([
+      contract,
+    ]);
+    expect(findContractInvoices([contract, trueUp, oldCycle])).toEqual([
+      contract,
+    ]);
+  });
+
+  it("adds a partial-period upsell on top of the annual bill", () => {
+    // A contract billed by hand, then upsold mid-year: the upsell covers the
+    // stretch from its sale to the contract's renewal date, and both invoices
+    // are the contract's worth.
+    const upsell = candidate({
+      reason: "manual",
+      total: 3_260_000,
+      periods: [["2026-06-08", "2026-10-31"]],
+    });
+    const annual = candidate({
+      reason: "manual",
+      total: 4_588_994,
+      periods: [["2024-10-30", "2025-10-30"]],
+    });
+
+    expect(findContractInvoices([upsell, annual])).toEqual([upsell, annual]);
+  });
+
+  it("drops an upsell older than the annual bill", () => {
+    // A renewal bakes the upsells sold before it into its own amount.
+    const annual = candidate({
+      reason: "subscription_cycle",
+      total: 1_500_000,
+      periods: [["2026-01-02", "2027-01-02"]],
+    });
+    const bakedIn = candidate({
+      reason: "manual",
+      total: 300_000,
+      periods: [["2025-06-01", "2026-01-02"]],
+    });
+
+    expect(findContractInvoices([annual, bakedIn])).toEqual([annual]);
+  });
+
+  it("keeps only the newest of two year-spanning bills", () => {
+    // A contract replaced mid-stream — a new subscription, or last year's
+    // renewal behind this year's — counts once.
+    const thisYear = candidate({
+      reason: "subscription_create",
+      total: 1_590_000,
+      periods: [["2026-01-02", "2027-01-02"]],
+    });
+    const lastYear = candidate({
+      reason: "subscription_cycle",
+      total: 1_773_605,
+      periods: [["2025-01-03", "2026-01-03"]],
+    });
+
+    expect(findContractInvoices([thisYear, lastYear])).toEqual([thisYear]);
+  });
+
+  it("lets a period-less sales invoice replace the annual bill", () => {
+    // A dashboard invoice often stamps a single day rather than the stretch
+    // the money covers; raised after the annual bill, it re-bills the whole
+    // contract rather than adding to it.
+    const reBilled = candidate({
+      reason: "manual",
+      total: 1_050_000,
+      periods: [["2026-02-12", "2026-02-12"]],
+    });
+    const previous = candidate({
+      reason: "subscription_cycle",
+      total: 1_000_000,
+      periods: [["2025-01-24", "2026-01-24"]],
+    });
+
+    expect(findContractInvoices([reBilled, previous])).toEqual([reBilled]);
+  });
+
+  it("skips the zero invoice a sales-opened subscription starts on", () => {
+    const opening = candidate({
+      reason: "subscription_create",
+      total: 0,
+      periods: [["2026-06-02", "2026-06-17"]],
+    });
+
+    expect(findContractInvoices([opening])).toEqual([]);
+  });
+
+  it("falls back to the newest sales invoice when no bill spans a year", () => {
+    const renewal = candidate({
+      reason: "manual",
+      total: 1_050_000,
+      periods: [["2026-02-12", "2026-02-12"]],
+    });
+
+    expect(findContractInvoices([renewal])).toEqual([renewal]);
+  });
+
+  it("reports nothing when no invoice reads as a contract", () => {
+    const monthlyCycle = candidate({
+      reason: "subscription_cycle",
+      total: 96_000,
+      periods: [["2026-02-23", "2026-03-23"]],
+    });
+
+    expect(findContractInvoices([monthlyCycle])).toEqual([]);
   });
 });
 

--- a/apps/backend/src/stripe/revenue.test.ts
+++ b/apps/backend/src/stripe/revenue.test.ts
@@ -7,12 +7,16 @@ describe("getInvoiceRevenue", () => {
   function invoice(fields: {
     total: number;
     total_excluding_tax?: number | null;
+    taxes?: number[];
+    currency?: string;
     pre?: number;
     post?: number;
   }) {
     return {
+      currency: fields.currency ?? "usd",
       total: fields.total,
       total_excluding_tax: fields.total_excluding_tax ?? null,
+      total_taxes: fields.taxes?.map((amount) => ({ amount })) ?? null,
       pre_payment_credit_notes_amount: fields.pre ?? 0,
       post_payment_credit_notes_amount: fields.post ?? 0,
     };
@@ -24,11 +28,26 @@ describe("getInvoiceRevenue", () => {
       getInvoiceRevenue(
         invoice({ total: 12_000, total_excluding_tax: 10_000 }),
       ),
-    ).toBe(100);
+    ).toEqual({ amount: 100, currency: "usd" });
   });
 
-  it("falls back to the total when no tax is broken out", () => {
-    expect(getInvoiceRevenue(invoice({ total: 10_000 }))).toBe(100);
+  it("takes the listed taxes off when no pre-tax total is stated", () => {
+    // Falling back to the total alone would let the VAT through as revenue.
+    expect(
+      getInvoiceRevenue(invoice({ total: 12_000, taxes: [1_500, 500] })),
+    ).toEqual({ amount: 100, currency: "usd" });
+  });
+
+  it("reports the currency it was raised in", () => {
+    expect(
+      getInvoiceRevenue(
+        invoice({
+          total: 10_000,
+          total_excluding_tax: 10_000,
+          currency: "eur",
+        }),
+      ),
+    ).toEqual({ amount: 100, currency: "eur" });
   });
 
   it("nets out credit notes issued before and after payment", () => {
@@ -42,7 +61,7 @@ describe("getInvoiceRevenue", () => {
           pre: 1_500,
           post: 2_500,
         }),
-      ),
+      ).amount,
     ).toBe(60);
   });
 
@@ -50,7 +69,7 @@ describe("getInvoiceRevenue", () => {
     expect(
       getInvoiceRevenue(
         invoice({ total: 10_000, total_excluding_tax: 10_000, post: 10_000 }),
-      ),
+      ).amount,
     ).toBe(0);
   });
 });

--- a/apps/backend/src/stripe/revenue.test.ts
+++ b/apps/backend/src/stripe/revenue.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { getInvoiceRevenue, startOfUTCMonth } from "./revenue";
+
+describe("getInvoiceRevenue", () => {
+  /** Stripe states amounts in the currency's minor unit. */
+  function invoice(fields: {
+    total: number;
+    total_excluding_tax?: number | null;
+    pre?: number;
+    post?: number;
+  }) {
+    return {
+      total: fields.total,
+      total_excluding_tax: fields.total_excluding_tax ?? null,
+      pre_payment_credit_notes_amount: fields.pre ?? 0,
+      post_payment_credit_notes_amount: fields.post ?? 0,
+    };
+  }
+
+  it("reads the amount excluding tax, in the currency's main unit", () => {
+    // VAT collected for a state is not revenue.
+    expect(
+      getInvoiceRevenue(
+        invoice({ total: 12_000, total_excluding_tax: 10_000 }),
+      ),
+    ).toBe(100);
+  });
+
+  it("falls back to the total when no tax is broken out", () => {
+    expect(getInvoiceRevenue(invoice({ total: 10_000 }))).toBe(100);
+  });
+
+  it("nets out credit notes issued before and after payment", () => {
+    // An invoice refunded after the fact keeps its amount intact, so the
+    // credited half has to be taken off or the total counts money given back.
+    expect(
+      getInvoiceRevenue(
+        invoice({
+          total: 10_000,
+          total_excluding_tax: 10_000,
+          pre: 1_500,
+          post: 2_500,
+        }),
+      ),
+    ).toBe(60);
+  });
+
+  it("reports a fully credited invoice as nothing", () => {
+    expect(
+      getInvoiceRevenue(
+        invoice({ total: 10_000, total_excluding_tax: 10_000, post: 10_000 }),
+      ),
+    ).toBe(0);
+  });
+});
+
+describe("startOfUTCMonth", () => {
+  it("cuts the month in UTC, not where the process happens to run", () => {
+    // The instant below is still July in UTC and already August in Paris. Cut
+    // locally, an invoice stamped here would be filed a month off.
+    const lateJuly = new Date("2026-07-31T23:30:00Z");
+
+    expect(startOfUTCMonth(lateJuly, 0).toISOString()).toBe(
+      "2026-07-01T00:00:00.000Z",
+    );
+  });
+
+  it.each([
+    [0, "2026-08-01T00:00:00.000Z"],
+    [-1, "2026-07-01T00:00:00.000Z"],
+    [-2, "2026-06-01T00:00:00.000Z"],
+  ])("walks %i months back", (offset, expected) => {
+    expect(
+      startOfUTCMonth(new Date("2026-08-22T12:00:00Z"), offset).toISOString(),
+    ).toBe(expected);
+  });
+
+  it("walks back across a year boundary", () => {
+    expect(
+      startOfUTCMonth(new Date("2026-01-15T12:00:00Z"), -2).toISOString(),
+    ).toBe("2025-11-01T00:00:00.000Z");
+  });
+});

--- a/apps/backend/src/stripe/revenue.test.ts
+++ b/apps/backend/src/stripe/revenue.test.ts
@@ -6,6 +6,7 @@ import {
   findContractInvoices,
   getInvoiceRevenue,
   startOfUTCMonth,
+  toEuros,
 } from "./revenue";
 
 describe("getInvoiceRevenue", () => {
@@ -77,6 +78,20 @@ describe("getInvoiceRevenue", () => {
         invoice({ total: 10_000, total_excluding_tax: 10_000, post: 10_000 }),
       ).amount,
     ).toBe(0);
+  });
+});
+
+describe("toEuros", () => {
+  it("brings dollars in at the fixed rate", () => {
+    expect(toEuros({ amount: 1000, currency: "usd" })).toBe(855);
+  });
+
+  it("leaves euros as they are", () => {
+    expect(toEuros({ amount: 1000, currency: "eur" })).toBe(1000);
+  });
+
+  it("keeps an unknown currency at parity, for the foreign caveat to own", () => {
+    expect(toEuros({ amount: 1000, currency: "gbp" })).toBe(1000);
   });
 });
 

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -1,8 +1,8 @@
+import { invariant } from "@argos/util/invariant";
 import type Stripe from "stripe";
 
 import config from "@/config";
-import { Subscription } from "@/database/models";
-import { redisCache } from "@/util/redis";
+import { Account, Subscription } from "@/database/models";
 
 import { stripe } from "./index";
 
@@ -10,6 +10,17 @@ import { stripe } from "./index";
 type StaffRevenueSplit = {
   revenue: number;
   teamsCount: number;
+  /**
+   * The part of `revenue` invoiced in a currency other than US dollars, added
+   * in at parity.
+   *
+   * Stripe states each invoice in the currency it was raised in, and converting
+   * one into another needs a rate on the day, which nothing here has. So a euro
+   * invoice is counted as though it were dollars — the rule the staff pages
+   * already print amounts under — and this says how much of the figure rests on
+   * that, which is the only honest thing to do short of an exchange rate.
+   */
+  foreignRevenue: number;
 };
 
 /** What Argos billed over one calendar month. */
@@ -18,20 +29,15 @@ export type StaffRevenueMonth = {
   month: Date;
   /** The two splits below, added up. */
   revenue: number;
-  /**
-   * What teams billed by the month were invoiced that month — the invoices
-   * themselves, so discounts, credit notes and negotiated amounts are already
-   * in it.
-   */
+  /** What teams billed by the month were invoiced that month. */
   monthlyPlans: StaffRevenueSplit;
   /**
    * What the annual contracts in force are worth per month: their latest
-   * invoice over twelve.
+   * renewal over twelve.
    *
    * The same on every month, being a rate. Amortizing each annual invoice over
    * the twelve months it covers would be exact, but it would mean reading a
-   * year of invoices to report one month — the one thing this cannot afford,
-   * being asked at page load.
+   * year of invoices to report one month.
    */
   yearlyPlans: StaffRevenueSplit;
 };
@@ -39,9 +45,7 @@ export type StaffRevenueMonth = {
 /**
  * Upper bound on the window one call will read.
  *
- * Every month is a walk of its own, so the cost grows with the count asked for
- * — bounded here rather than left to the caller, which is what keeps a request
- * from turning into a hundred round trips.
+ * Every month is a walk of its own, so the cost grows with the count asked for.
  */
 export const MAX_MONTHS = 24;
 
@@ -61,6 +65,48 @@ const PAGE_SIZE = 100;
 /** Months a yearly contract is spread over. */
 const MONTHS_PER_YEAR = 12;
 
+/**
+ * Requests in flight at once.
+ *
+ * The months and the annual contracts are all independent, so nothing here
+ * needs to wait — but Stripe rate-limits per account and the client is built
+ * without retries, so an unbounded fan-out turns a wide account into a 429 that
+ * fails the whole page.
+ */
+const MAX_CONCURRENT_REQUESTS = 8;
+
+/** The currency every amount on the staff pages is printed in. */
+const REPORTING_CURRENCY = "usd";
+
+/**
+ * Why Stripe raised an invoice, for the ones that are a subscription being
+ * billed rather than something invoiced on the side.
+ *
+ * A one-off invoice or an accepted quote is revenue, but it is not what a
+ * column headed by a billing interval reports — and a customer of the Stripe
+ * account that is not an Argos team has no business in this page at all.
+ */
+const SUBSCRIPTION_BILLING_REASONS = new Set<Stripe.Invoice.BillingReason>([
+  "subscription",
+  "subscription_create",
+  "subscription_cycle",
+  "subscription_threshold",
+  "subscription_update",
+]);
+
+/**
+ * The reasons a renewal is raised under, which is the only invoice worth
+ * dividing by twelve.
+ *
+ * Narrower than the set above on purpose: a mid-year proration is real revenue
+ * for the month it lands in, but a twelfth of it is not what the contract is
+ * worth per month.
+ */
+const RENEWAL_BILLING_REASONS = new Set<Stripe.Invoice.BillingReason>([
+  "subscription_create",
+  "subscription_cycle",
+]);
+
 /** The placeholder the config falls back to when no key is configured. */
 const MISSING_API_KEY = "no-api-key";
 
@@ -68,21 +114,27 @@ const MISSING_API_KEY = "no-api-key";
 type BilledTeam = {
   accountId: string;
   stripeCustomerId: string;
+  stripeSubscriptionId: string;
   interval: "month" | "year";
 };
 
 /**
- * Every team with a paying subscription, and the interval it is billed on.
+ * Every team on a paying Stripe subscription, and the interval it is billed on.
  *
- * Reads the subscription the same way `getAccountBillings` does — the highest
- * quota among those active, so an account holding two resolves the same one on
- * both sides. Granted plans are excluded: they bill nothing, so no invoice of
- * theirs exists to find.
+ * Narrower than the subscription `getAccountBillings` resolves, deliberately: a
+ * trial is dropped here where that one keeps it, because a trial is invoiced
+ * nothing and this reads invoices. An account holding both a trial and a paid
+ * subscription can therefore resolve a different plan on the two sides — the
+ * paid one here, which is the one that produced the invoices.
+ *
+ * Granted plans are excluded for the same reason: they bill nothing, so no
+ * invoice of theirs exists to find.
  */
 export async function getBilledTeams(): Promise<BilledTeam[]> {
   const rows = (await Subscription.query()
     .select(
       "subscriptions.accountId",
+      "subscriptions.stripeSubscriptionId",
       "accounts.stripeCustomerId",
       "plan.interval",
     )
@@ -92,10 +144,12 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
     .whereNull("accounts.userId")
     .whereNull("accounts.forcedPlanId")
     .whereNotNull("accounts.stripeCustomerId")
+    // A subscription Argos bills through GitHub raises no Stripe invoice, so
+    // there is nothing to look up for it.
+    .whereNotNull("subscriptions.stripeSubscriptionId")
     .whereRaw("?? < now()", "subscriptions.startDate")
-    // A trial is out: it resolves a plan like a paid subscription and pays
-    // nothing. `past_due` is in — the invoice was raised, whether it clears is
-    // a collection question.
+    // `past_due` is in: the invoice was raised, and whether it clears is a
+    // collection question rather than a revenue one.
     .whereIn("subscriptions.status", ["active", "past_due"])
     .where((query) =>
       query
@@ -106,16 +160,42 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
     .orderBy("subscriptions.accountId")
     .orderBy("plan.includedScreenshots", "DESC")) as unknown as {
     accountId: string | number;
+    stripeSubscriptionId: string;
     stripeCustomerId: string;
     interval: "month" | "year";
   }[];
 
   return rows.map((row) => ({
     accountId: String(row.accountId),
+    stripeSubscriptionId: row.stripeSubscriptionId,
     stripeCustomerId: row.stripeCustomerId,
     interval: row.interval,
   }));
 }
+
+/**
+ * Every Stripe customer that is an Argos team, whether or not it still pays.
+ *
+ * Read over all team accounts rather than over the billed ones: a team that has
+ * since churned keeps the invoices it was already sent, and a month it was
+ * invoiced in would otherwise lose it — which is exactly the revenue a
+ * comparison between two months exists to show. Personal accounts are left out,
+ * so what they may have been invoiced never reaches a page about teams.
+ */
+export async function getTeamCustomerIds(): Promise<Set<string>> {
+  const rows = (await Account.query()
+    .select("stripeCustomerId")
+    .whereNotNull("teamId")
+    .whereNull("userId")
+    .whereNotNull("stripeCustomerId")) as unknown as {
+    stripeCustomerId: string;
+  }[];
+
+  return new Set(rows.map((row) => row.stripeCustomerId));
+}
+
+/** What one invoice contributed, in the currency it was raised in. */
+export type InvoiceRevenue = { amount: number; currency: string };
 
 /**
  * What one invoice contributed to revenue, in the currency's main unit.
@@ -124,32 +204,38 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
  * net of credit notes, because an invoice refunded after the fact keeps its
  * `amount_paid` intact — reading that field alone would count money that was
  * given back.
- *
- * Currencies are added at parity, the rule the staff pages already print
- * amounts under: a euro contract is read as dollars rather than converted.
  */
-export function getInvoiceRevenue(
-  invoice: Pick<
-    Stripe.Invoice,
-    | "total"
-    | "total_excluding_tax"
-    | "pre_payment_credit_notes_amount"
-    | "post_payment_credit_notes_amount"
-  >,
-): number {
-  // Null on invoices Stripe states no tax breakdown for, where the total is
-  // already the whole of it.
-  const excludingTax = invoice.total_excluding_tax ?? invoice.total;
+export function getInvoiceRevenue(invoice: {
+  currency: string;
+  total: number;
+  total_excluding_tax: number | null;
+  /** Only the amounts are read, so the rest of Stripe's shape is not asked for. */
+  total_taxes: { amount: number }[] | null;
+  pre_payment_credit_notes_amount: number;
+  post_payment_credit_notes_amount: number;
+}): InvoiceRevenue {
+  // Null on invoices Stripe states no pre-tax total for. The taxes it lists are
+  // taken off the total instead, rather than letting the tax through as
+  // revenue — falling back to `total` alone would overstate every invoice that
+  // collected VAT, and say nothing about it.
+  const excludingTax =
+    invoice.total_excluding_tax ??
+    invoice.total -
+      (invoice.total_taxes ?? []).reduce((sum, tax) => sum + tax.amount, 0);
+
   const credited =
     invoice.pre_payment_credit_notes_amount +
     invoice.post_payment_credit_notes_amount;
 
-  // Stripe states amounts in the currency's minor unit.
-  return (excludingTax - credited) / 100;
+  return {
+    // Stripe states amounts in the currency's minor unit.
+    amount: (excludingTax - credited) / 100,
+    currency: invoice.currency,
+  };
 }
 
 function createSplit(): StaffRevenueSplit {
-  return { revenue: 0, teamsCount: 0 };
+  return { revenue: 0, teamsCount: 0, foreignRevenue: 0 };
 }
 
 function createMonth(month: Date): StaffRevenueMonth {
@@ -161,14 +247,21 @@ function createMonth(month: Date): StaffRevenueMonth {
   };
 }
 
+/** Add one invoice to a split, tracking what of it was not in dollars. */
+function addToSplit(split: StaffRevenueSplit, revenue: InvoiceRevenue): void {
+  split.revenue += revenue.amount;
+  if (revenue.currency !== REPORTING_CURRENCY) {
+    split.foreignRevenue += revenue.amount;
+  }
+}
+
 /**
  * The first instant of the month `offset` months back, in UTC.
  *
  * Deliberately not the calendar helpers, which work in the process's own
  * timezone: Stripe timestamps every invoice in UTC, so a server running on
  * anything else would cut its months hours away from where Stripe cuts them and
- * file the invoices either side of a boundary in the wrong one. Reading UTC on
- * both sides is what makes the figure independent of where it runs.
+ * file the invoices either side of a boundary in the wrong one.
  */
 export function startOfUTCMonth(date: Date, offset: number): Date {
   return new Date(
@@ -176,65 +269,100 @@ export function startOfUTCMonth(date: Date, offset: number): Date {
   );
 }
 
+/** Run `work` over `items`, never more than `MAX_CONCURRENT_REQUESTS` at once. */
+async function mapWithLimit<Item, Result>(
+  items: Item[],
+  work: (item: Item) => Promise<Result>,
+): Promise<Result[]> {
+  const results: Result[] = Array.from({ length: items.length });
+  let next = 0;
+
+  const runners = Array.from(
+    { length: Math.min(MAX_CONCURRENT_REQUESTS, items.length) },
+    async () => {
+      for (let index = next++; index < items.length; index = next++) {
+        const item = items[index];
+        invariant(item !== undefined, "index is inside the list");
+        results[index] = await work(item);
+      }
+    },
+  );
+
+  await Promise.all(runners);
+  return results;
+}
+
 /**
  * What the annual contracts in force are worth per month.
  *
  * One small request per annual team rather than a year of invoices for
- * everyone: an annual subscription raises one invoice a year, so its latest is
- * what it is worth now, and there are few enough of them to ask in parallel.
+ * everyone: an annual subscription renews once a year, so its latest renewal is
+ * what it is worth now.
  *
- * A contract whose first invoice has not been paid yet counts nothing — it has
+ * Listed by subscription and narrowed to a renewal, not simply the customer's
+ * latest paid invoice: an add-on bought mid-year is the most recent invoice a
+ * customer paid, and a twelfth of it would replace the contract's own amount
+ * with a rounding error.
+ *
+ * A contract whose first renewal has not been paid yet counts nothing — it has
  * been invoiced nothing, which is what this reports.
  */
 async function getYearlyRate(teams: BilledTeam[]): Promise<StaffRevenueSplit> {
   const yearlyTeams = teams.filter((team) => team.interval === "year");
   const split = createSplit();
 
-  const invoices = await Promise.all(
-    yearlyTeams.map(async (team) => {
-      const page = await stripe.invoices.list({
-        customer: team.stripeCustomerId,
-        status: "paid",
-        limit: 1,
-      });
-      return page.data[0] ?? null;
-    }),
-  );
+  const invoices = await mapWithLimit(yearlyTeams, async (team) => {
+    // A handful rather than one: the latest invoice on a subscription can be a
+    // proration, and the renewal is the one behind it.
+    const page = await stripe.invoices.list({
+      subscription: team.stripeSubscriptionId,
+      status: "paid",
+      limit: 10,
+    });
+    return (
+      page.data.find(
+        (invoice) =>
+          invoice.billing_reason !== null &&
+          RENEWAL_BILLING_REASONS.has(invoice.billing_reason),
+      ) ?? null
+    );
+  });
 
   for (const invoice of invoices) {
     if (!invoice) {
       continue;
     }
-    split.revenue += getInvoiceRevenue(invoice) / MONTHS_PER_YEAR;
+    const revenue = getInvoiceRevenue(invoice);
+    addToSplit(split, {
+      amount: revenue.amount / MONTHS_PER_YEAR,
+      currency: revenue.currency,
+    });
     split.teamsCount += 1;
   }
 
   return split;
 }
 
-/** What one month's invoices came to, and how many teams they covered. */
-type MonthTotals = { revenue: number; teamsCount: number };
-
 /**
  * Walk one month's invoices.
  *
  * A chain per month rather than one chain over the whole window, because
  * Stripe's pagination is a cursor: a page cannot be asked for until the one
- * before it has answered, so a single walk over three months is three months of
- * round trips end to end. Split by month they run at once, and the wall clock
- * becomes the longest month rather than their sum — which is also why the split
- * is by month rather than by an arbitrary slice: each chain then knows the
- * bucket its invoices belong to, with nothing left to sort out afterwards.
+ * before it has answered, so a single walk over a year is a year of round trips
+ * end to end. Split by month they run at once, and each chain knows the bucket
+ * its invoices belong to.
  */
 async function readMonth(options: {
   from: Date;
   to: Date;
+  /** Customers that are Argos teams — everything else is not this page's. */
+  teamCustomerIds: Set<string>;
   /** Yearly contracts are reported as a rate, so their invoices are skipped. */
   yearlyCustomerIds: Set<string>;
-}): Promise<MonthTotals> {
-  const { from, to, yearlyCustomerIds } = options;
+}): Promise<StaffRevenueSplit> {
+  const { from, to, teamCustomerIds, yearlyCustomerIds } = options;
+  const split = createSplit();
   const customerIds = new Set<string>();
-  let revenue = 0;
   let count = 0;
 
   for await (const invoice of stripe.invoices.list({
@@ -256,29 +384,44 @@ async function readMonth(options: {
       typeof invoice.customer === "string"
         ? invoice.customer
         : invoice.customer?.id;
-    if (!customerId || yearlyCustomerIds.has(customerId)) {
+    if (!customerId || !teamCustomerIds.has(customerId)) {
+      continue;
+    }
+    if (yearlyCustomerIds.has(customerId)) {
+      continue;
+    }
+    if (
+      invoice.billing_reason === null ||
+      !SUBSCRIPTION_BILLING_REASONS.has(invoice.billing_reason)
+    ) {
       continue;
     }
 
-    revenue += getInvoiceRevenue(invoice);
+    addToSplit(split, getInvoiceRevenue(invoice));
     // A team invoiced twice in one month is one team.
     customerIds.add(customerId);
   }
 
-  return { revenue, teamsCount: customerIds.size };
+  split.teamsCount = customerIds.size;
+  return split;
 }
 
 /**
  * What Argos invoiced over the last `monthCount` calendar months, oldest first
  * and the running one last.
  *
- * Asked of Stripe on every call rather than mirrored into a table: the invoices
- * are the answer, and a copy of them is a second source to keep correct as they
- * are voided, refunded and credited.
+ * Asked of Stripe on every call rather than mirrored into a table or held in a
+ * cache: the invoices are the answer, they change behind us as they are paid,
+ * voided and credited, and a copy of them is a second source to keep correct.
  */
-async function fetchStaffRevenue(
+export async function getStaffRevenue(
   monthCount: number,
 ): Promise<StaffRevenueMonth[]> {
+  invariant(
+    monthCount >= 1 && monthCount <= MAX_MONTHS,
+    `monthCount must be between 1 and ${MAX_MONTHS}`,
+  );
+
   if (config.get("stripe.apiKey") === MISSING_API_KEY) {
     throw new Error(
       "Stripe is not configured, so invoiced revenue cannot be read.",
@@ -292,107 +435,38 @@ async function fetchStaffRevenue(
     startOfUTCMonth(now, index - monthCount + 1),
   );
 
-  const teams = await getBilledTeams();
-  // Only the yearly customers are identified, and the monthly bucket takes
-  // everything else. Matching invoices against the teams billed *today* would
-  // drop the invoices of a team that has since churned — and a month it was
-  // invoiced in would quietly lose it, which is exactly the revenue a
-  // comparison between two months exists to show.
+  const [teams, teamCustomerIds] = await Promise.all([
+    getBilledTeams(),
+    getTeamCustomerIds(),
+  ]);
   const yearlyCustomerIds = new Set(
     teams
       .filter((team) => team.interval === "year")
       .map((team) => team.stripeCustomerId),
   );
 
-  // Every request at once: the months are independent walks, and the yearly
-  // rate is its own set of small ones.
   const reported = starts.slice(0, monthCount);
   const [yearlyRate, totals] = await Promise.all([
     getYearlyRate(teams),
-    Promise.all(
+    mapWithLimit(
       reported.map((from, index) => {
         const to = starts[index + 1];
-        if (!to) {
-          throw new Error("every month reported has a bound");
-        }
-        return readMonth({ from, to, yearlyCustomerIds });
+        invariant(to, "every month reported has a bound");
+        return { from, to };
       }),
+      (window) => readMonth({ ...window, teamCustomerIds, yearlyCustomerIds }),
     ),
   ]);
 
   return reported.map((start, index) => {
     const month = createMonth(start);
     const total = totals[index];
-    if (!total) {
-      throw new Error("every month reported has totals");
-    }
+    invariant(total, "every month reported has totals");
     month.monthlyPlans = total;
-    month.yearlyPlans = yearlyRate;
+    // Copied rather than shared: one object held by every month is one object
+    // a later change can mutate for all of them at once.
+    month.yearlyPlans = { ...yearlyRate };
     month.revenue = total.revenue + yearlyRate.revenue;
     return month;
   });
-}
-
-/**
- * The shape of the cached value, bumped whenever `StaffRevenueMonth` changes.
- *
- * An entry outlives the deploy that changes what this returns, so a field
- * renamed below would otherwise be read back for an hour from a value that no
- * longer has it.
- */
-const CACHE_VERSION = 1;
-
-/** How long a window is served from cache. */
-const CACHE_MAX_AGE = 60 * 60 * 1000;
-
-/**
- * Long enough for the walks to finish while holding the lock.
- *
- * The lock's TTL, not a deadline on the work: expiring early would let a second
- * request start the same walks rather than wait on them, which is the stampede
- * the cache exists to prevent.
- */
-const CACHE_LOCK_TIMEOUT = 60 * 1000;
-
-const staffRevenueStore = redisCache.createStore({
-  fetch: fetchStaffRevenue,
-  /**
-   * Everything the answer is a function of, so no two of them share an entry.
-   *
-   * The deployment above all. Without it the key is global to the Redis
-   * instance and any two apps pointed at one serve each other's totals — which
-   * on a developer's machine is not hypothetical: the end-to-end suite and the
-   * dev server share `redis://localhost:6380/1`.
-   */
-  getCacheKey: (monthCount) => [
-    "staff-revenue",
-    CACHE_VERSION,
-    monthCount,
-    config.get("pg.connection.host"),
-    config.get("pg.connection.database"),
-  ],
-  maxAge: CACHE_MAX_AGE,
-  timeout: CACHE_LOCK_TIMEOUT,
-  // Dates do not survive JSON, and the months carry one each.
-  deserialize: (raw) => {
-    const months = JSON.parse(raw) as (Omit<StaffRevenueMonth, "month"> & {
-      month: string;
-    })[];
-    return months.map((month) => ({ ...month, month: new Date(month.month) }));
-  },
-});
-
-/**
- * What Argos invoiced, from cache.
- *
- * Cached for an hour because the figures move at the pace of an invoice: the
- * complete months behind them cannot change at all, and the running one gains a
- * handful a day. An hour costs no freshness anyone can use, and it is what
- * keeps a page that walks a year of invoices from walking it again on every
- * visit.
- */
-export async function getStaffRevenue(
-  monthCount: number,
-): Promise<StaffRevenueMonth[]> {
-  return staffRevenueStore.get(monthCount);
 }

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -24,7 +24,7 @@ type StaffRevenueSplit = {
 };
 
 /** What Argos billed over one calendar month. */
-export type StaffRevenueMonth = {
+type StaffRevenueMonth = {
   /** The first instant of the month, in UTC — what names it on screen. */
   month: Date;
   /** The two splits below, added up. */
@@ -95,16 +95,28 @@ const SUBSCRIPTION_BILLING_REASONS = new Set<Stripe.Invoice.BillingReason>([
 ]);
 
 /**
- * The reasons a renewal is raised under, which is the only invoice worth
- * dividing by twelve.
+ * A line covering at least this long reads as a year's bill.
  *
- * Narrower than the set above on purpose: a mid-year proration is real revenue
- * for the month it lands in, but a twelfth of it is not what the contract is
- * worth per month.
+ * Under a full year on purpose: an annual invoice raised a few weeks into the
+ * period it covers, or prorated at conversion, still has to read as the
+ * contract — where a monthly cycle or a one-month true-up never comes close.
  */
-const RENEWAL_BILLING_REASONS = new Set<Stripe.Invoice.BillingReason>([
-  "subscription_create",
-  "subscription_cycle",
+const ANNUAL_PERIOD_SECONDS = 300 * 24 * 3600;
+
+/** A day, under which a line's period is a bookkeeping point, not coverage. */
+const DAY_SECONDS = 24 * 3600;
+
+/**
+ * The reasons an invoice is raised by a person rather than by a billing cycle.
+ *
+ * Sales-led contracts are billed this way — a dashboard invoice or an accepted
+ * quote, often carried by no subscription at all — and their line periods are
+ * frequently missing or degenerate, so they cannot be recognized by coverage
+ * the way cycle invoices can.
+ */
+const SALES_LED_BILLING_REASONS = new Set<Stripe.Invoice.BillingReason>([
+  "manual",
+  "quote_accept",
 ]);
 
 /** The placeholder the config falls back to when no key is configured. */
@@ -113,6 +125,8 @@ const MISSING_API_KEY = "no-api-key";
 /** A team Argos bills through Stripe, and how it is billed. */
 type BilledTeam = {
   accountId: string;
+  slug: string;
+  name: string | null;
   stripeCustomerId: string;
   stripeSubscriptionId: string;
   interval: "month" | "year";
@@ -135,6 +149,8 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
     .select(
       "subscriptions.accountId",
       "subscriptions.stripeSubscriptionId",
+      "accounts.slug",
+      "accounts.name",
       "accounts.stripeCustomerId",
       "plan.interval",
     )
@@ -160,6 +176,8 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
     .orderBy("subscriptions.accountId")
     .orderBy("plan.includedScreenshots", "DESC")) as unknown as {
     accountId: string | number;
+    slug: string;
+    name: string | null;
     stripeSubscriptionId: string;
     stripeCustomerId: string;
     interval: "month" | "year";
@@ -167,6 +185,8 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
 
   return rows.map((row) => ({
     accountId: String(row.accountId),
+    slug: row.slug,
+    name: row.name,
     stripeSubscriptionId: row.stripeSubscriptionId,
     stripeCustomerId: row.stripeCustomerId,
     interval: row.interval,
@@ -292,51 +312,232 @@ async function mapWithLimit<Item, Result>(
   return results;
 }
 
-/**
- * What the annual contracts in force are worth per month.
- *
- * One small request per annual team rather than a year of invoices for
- * everyone: an annual subscription renews once a year, so its latest renewal is
- * what it is worth now.
- *
- * Listed by subscription and narrowed to a renewal, not simply the customer's
- * latest paid invoice: an add-on bought mid-year is the most recent invoice a
- * customer paid, and a twelfth of it would replace the contract's own amount
- * with a rounding error.
- *
- * A contract whose first renewal has not been paid yet counts nothing — it has
- * been invoiced nothing, which is what this reports.
- */
-async function getYearlyRate(teams: BilledTeam[]): Promise<StaffRevenueSplit> {
-  const yearlyTeams = teams.filter((team) => team.interval === "year");
-  const split = createSplit();
+/** One invoice a contract's worth is read from. */
+type StaffContractInvoice = {
+  /** Net of tax and credit notes, in the currency's main unit. */
+  amount: number;
+  /** The currency it was raised in, counted at parity when not USD. */
+  currency: string;
+  /** When it was raised. */
+  invoicedAt: Date;
+  /** The stretch it covers, when it states a real one. */
+  coveredFrom: Date | null;
+  coveredUntil: Date | null;
+};
 
-  const invoices = await mapWithLimit(yearlyTeams, async (team) => {
-    // A handful rather than one: the latest invoice on a subscription can be a
-    // proration, and the renewal is the one behind it.
-    const page = await stripe.invoices.list({
-      subscription: team.stripeSubscriptionId,
-      status: "paid",
-      limit: 10,
-    });
+/** One annual contract in force, and the invoices its rate is read from. */
+type StaffYearlyContract = {
+  /** The team's slug, which names its pages. */
+  slug: string;
+  /** The team's display name, when it has one. */
+  name: string | null;
+  /** The subscription the database knows the contract by. */
+  stripeSubscriptionId: string;
+  /**
+   * The invoices below, added up. Null when none was found, in which case the
+   * contract adds nothing to the rate.
+   */
+  amount: number | null;
+  /** The invoices the contract is worth, newest first. */
+  invoices: StaffContractInvoice[];
+  /**
+   * True when the invoices found are still awaiting payment. Shown, so a
+   * contract in collection is visible, but counted nothing until they clear.
+   */
+  awaitingPayment: boolean;
+};
+
+/** The parts of an invoice the contract picker reads. */
+export type ContractInvoiceCandidate = {
+  billing_reason: Stripe.Invoice.BillingReason | null;
+  total: number;
+  lines: { data: { period: { start: number; end: number } }[] };
+};
+
+/** The longest stretch one of the invoice's lines covers, or null. */
+function getCoveredPeriod(
+  invoice: ContractInvoiceCandidate,
+): { start: number; end: number } | null {
+  let longest: { start: number; end: number } | null = null;
+  for (const line of invoice.lines.data) {
+    if (
+      !longest ||
+      line.period.end - line.period.start > longest.end - longest.start
+    ) {
+      longest = line.period;
+    }
+  }
+  // A period under a day is a bookkeeping point, not coverage.
+  return longest && longest.end - longest.start >= DAY_SECONDS ? longest : null;
+}
+
+/** Whether an invoice reads as a contract being billed. */
+function isContractInvoice(invoice: ContractInvoiceCandidate): boolean {
+  if (invoice.total === 0) {
+    // Subscriptions opened by sales to carry a contract start on a zero
+    // invoice; the money is on an invoice of its own.
+    return false;
+  }
+  const period = getCoveredPeriod(invoice);
+  return (
+    (period !== null && period.end - period.start >= ANNUAL_PERIOD_SECONDS) ||
+    (invoice.billing_reason !== null &&
+      SALES_LED_BILLING_REASONS.has(invoice.billing_reason))
+  );
+}
+
+/**
+ * The invoices a contract's worth is read from, among the customer's invoices,
+ * newest first.
+ *
+ * A contract invoice is one that covers about a year — a renewal, a first
+ * year, or a mid-stream conversion, whatever Stripe filed it under — or a
+ * sales-led invoice, whose periods cannot be trusted. Anything else — monthly
+ * cycles from before a conversion, prorations, true-ups — is real revenue but
+ * not what the contract is worth.
+ *
+ * The newest year-spanning bill anchors the contract, and the sales-led
+ * invoices raised on top of it since are read by their period: one covering a
+ * real partial stretch is an upsell, added to the anchor; one with no readable
+ * coverage re-bills the whole contract and replaces it. Upsells older than the
+ * anchor are dropped — a renewal bakes them in. With no year-spanning bill at
+ * all, the newest sales-led invoice is the contract.
+ */
+export function findContractInvoices<Invoice extends ContractInvoiceCandidate>(
+  invoices: Invoice[],
+): Invoice[] {
+  const contracts = invoices.filter(isContractInvoice);
+
+  const annualIndex = contracts.findIndex((invoice) => {
+    const period = getCoveredPeriod(invoice);
     return (
-      page.data.find(
-        (invoice) =>
-          invoice.billing_reason !== null &&
-          RENEWAL_BILLING_REASONS.has(invoice.billing_reason),
-      ) ?? null
+      period !== null && period.end - period.start >= ANNUAL_PERIOD_SECONDS
     );
   });
+  if (annualIndex === -1) {
+    const newest = contracts[0];
+    return newest ? [newest] : [];
+  }
 
-  for (const invoice of invoices) {
-    if (!invoice) {
+  const newerThanAnnual = contracts.slice(0, annualIndex);
+  const replacement = newerThanAnnual.find(
+    (invoice) => getCoveredPeriod(invoice) === null,
+  );
+  if (replacement) {
+    return [replacement];
+  }
+
+  const annual = contracts[annualIndex];
+  invariant(annual, "the index was just found");
+  return [...newerThanAnnual, annual];
+}
+
+/**
+ * One page is all a lookup reads — a hundred invoices of history is years for
+ * any real customer.
+ */
+const INVOICES_PER_CONTRACT_LOOKUP = 100;
+
+/**
+ * The annual contracts in force, each with the invoices it is worth.
+ *
+ * One request per annual team rather than a year of invoices for everyone: an
+ * annual contract is billed a handful of times a year at most, so its latest
+ * contract invoices are what it is worth now.
+ *
+ * Listed by customer, not by subscription: an annual deal is not always billed
+ * through the subscription the database knows. Sales-led contracts arrive as
+ * dashboard or quote invoices carried by no subscription at all, and a team
+ * converted to yearly mid-stream holds its contract on a `subscription_update`
+ * of the old subscription — a subscription lookup misses both.
+ *
+ * A contract with no paid invoice may still have been billed — enterprise
+ * terms run long — so the open invoices are read before concluding nothing,
+ * and reported as awaiting payment. A contract with no invoice at all counts
+ * nothing, which is what this reports — but it is still listed, so a contract
+ * absent from the figure can be seen rather than guessed at.
+ */
+async function getYearlyContracts(
+  teams: BilledTeam[],
+): Promise<StaffYearlyContract[]> {
+  const yearlyTeams = teams.filter((team) => team.interval === "year");
+
+  const contracts = await mapWithLimit(yearlyTeams, async (team) => {
+    const paid = await stripe.invoices.list({
+      customer: team.stripeCustomerId,
+      status: "paid",
+      limit: INVOICES_PER_CONTRACT_LOOKUP,
+    });
+    let awaitingPayment = false;
+    let found = findContractInvoices(paid.data);
+    if (found.length === 0) {
+      const open = await stripe.invoices.list({
+        customer: team.stripeCustomerId,
+        status: "open",
+        limit: INVOICES_PER_CONTRACT_LOOKUP,
+      });
+      found = findContractInvoices(open.data);
+      awaitingPayment = found.length > 0;
+    }
+
+    const invoices = found.map((invoice) => {
+      const revenue = getInvoiceRevenue(invoice);
+      const covered = getCoveredPeriod(invoice);
+      return {
+        amount: revenue.amount,
+        currency: revenue.currency,
+        // Stripe timestamps in whole seconds.
+        invoicedAt: new Date(invoice.created * 1000),
+        coveredFrom: covered ? new Date(covered.start * 1000) : null,
+        coveredUntil: covered ? new Date(covered.end * 1000) : null,
+      };
+    });
+
+    return {
+      slug: team.slug,
+      name: team.name,
+      stripeSubscriptionId: team.stripeSubscriptionId,
+      amount:
+        invoices.length > 0
+          ? invoices.reduce((sum, invoice) => sum + invoice.amount, 0)
+          : null,
+      invoices,
+      awaitingPayment,
+    };
+  });
+
+  // Largest first, the contracts with no invoice found last: the list reads as
+  // the rate's makeup, and a contract adding nothing is the anomaly to end on.
+  return contracts.sort((a, b) => {
+    if (a.amount === null) {
+      return b.amount === null ? 0 : 1;
+    }
+    if (b.amount === null) {
+      return -1;
+    }
+    return b.amount - a.amount;
+  });
+}
+
+/**
+ * What the annual contracts in force are worth per month: each contract's
+ * invoices over twelve, added up.
+ */
+function getYearlyRate(contracts: StaffYearlyContract[]): StaffRevenueSplit {
+  const split = createSplit();
+
+  for (const contract of contracts) {
+    if (contract.invoices.length === 0 || contract.awaitingPayment) {
       continue;
     }
-    const revenue = getInvoiceRevenue(invoice);
-    addToSplit(split, {
-      amount: revenue.amount / MONTHS_PER_YEAR,
-      currency: revenue.currency,
-    });
+    // Invoice by invoice rather than off the summed amount, so a contract
+    // partly billed in another currency keeps that part in the parity caveat.
+    for (const invoice of contract.invoices) {
+      addToSplit(split, {
+        amount: invoice.amount / MONTHS_PER_YEAR,
+        currency: invoice.currency,
+      });
+    }
     split.teamsCount += 1;
   }
 
@@ -406,9 +607,18 @@ async function readMonth(options: {
   return split;
 }
 
+/** What Argos invoiced, and the annual contracts behind the yearly rate. */
+export type StaffRevenue = {
+  /** Oldest first, the running month last. */
+  months: StaffRevenueMonth[];
+  /** The contracts behind every month's `yearlyPlans`, largest first. */
+  yearlyContracts: StaffYearlyContract[];
+};
+
 /**
- * What Argos invoiced over the last `monthCount` calendar months, oldest first
- * and the running one last.
+ * What Argos invoiced over the last `monthCount` calendar months, along with
+ * the annual contracts the yearly rate is made of — one read serving both, so
+ * the list always explains the figure it came with.
  *
  * Asked of Stripe on every call rather than mirrored into a table or held in a
  * cache: the invoices are the answer, they change behind us as they are paid,
@@ -416,7 +626,7 @@ async function readMonth(options: {
  */
 export async function getStaffRevenue(
   monthCount: number,
-): Promise<StaffRevenueMonth[]> {
+): Promise<StaffRevenue> {
   invariant(
     monthCount >= 1 && monthCount <= MAX_MONTHS,
     `monthCount must be between 1 and ${MAX_MONTHS}`,
@@ -446,8 +656,8 @@ export async function getStaffRevenue(
   );
 
   const reported = starts.slice(0, monthCount);
-  const [yearlyRate, totals] = await Promise.all([
-    getYearlyRate(teams),
+  const [yearlyContracts, totals] = await Promise.all([
+    getYearlyContracts(teams),
     mapWithLimit(
       reported.map((from, index) => {
         const to = starts[index + 1];
@@ -457,8 +667,9 @@ export async function getStaffRevenue(
       (window) => readMonth({ ...window, teamCustomerIds, yearlyCustomerIds }),
     ),
   ]);
+  const yearlyRate = getYearlyRate(yearlyContracts);
 
-  return reported.map((start, index) => {
+  const months = reported.map((start, index) => {
     const month = createMonth(start);
     const total = totals[index];
     invariant(total, "every month reported has totals");
@@ -469,4 +680,6 @@ export async function getStaffRevenue(
     month.revenue = total.revenue + yearlyRate.revenue;
     return month;
   });
+
+  return { months, yearlyContracts };
 }

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -11,16 +11,30 @@ type StaffRevenueSplit = {
   revenue: number;
   teamsCount: number;
   /**
-   * The part of `revenue` invoiced in a currency other than US dollars, added
-   * in at parity.
+   * The part of `revenue` invoiced in a currency other than euros, converted
+   * at the page's fixed rate.
    *
-   * Stripe states each invoice in the currency it was raised in, and converting
-   * one into another needs a rate on the day, which nothing here has. So a euro
-   * invoice is counted as though it were dollars — the rule the staff pages
-   * already print amounts under — and this says how much of the figure rests on
-   * that, which is the only honest thing to do short of an exchange rate.
+   * Stripe states each invoice in the currency it was raised in; dollars are
+   * brought into euros at `EUR_PER_USD`, which is fixed rather than the day's
+   * rate — so this says how much of the figure rests on that conversion.
    */
   foreignRevenue: number;
+};
+
+/** What one team was invoiced over a month, one line of the breakdown. */
+type StaffRevenueMonthTeam = {
+  /** The team's slug, which names its pages. */
+  slug: string;
+  /** The team's display name, when it has one. */
+  name: string | null;
+  /** The Stripe customer the invoices were raised on. */
+  stripeCustomerId: string;
+  /** What the invoices add up to, in `currency`. */
+  amount: number;
+  /** The currency the team is invoiced in — null when a month mixes several. */
+  currency: string | null;
+  /** In euros, like the split it sums into. */
+  revenue: number;
 };
 
 /** What Argos billed over one calendar month. */
@@ -31,6 +45,8 @@ type StaffRevenueMonth = {
   revenue: number;
   /** What teams billed by the month were invoiced that month. */
   monthlyPlans: StaffRevenueSplit;
+  /** The teams behind `monthlyPlans`, largest first — they sum to it. */
+  teams: StaffRevenueMonthTeam[];
   /**
    * What the annual contracts in force are worth per month: their latest
    * renewal over twelve.
@@ -75,16 +91,38 @@ const MONTHS_PER_YEAR = 12;
  */
 const MAX_CONCURRENT_REQUESTS = 8;
 
-/** The currency every amount on the staff pages is printed in. */
-const REPORTING_CURRENCY = "usd";
+/** The currency every amount on this page is stated in. */
+const REPORTING_CURRENCY = "eur";
+
+/**
+ * Euros per dollar.
+ *
+ * Fixed rather than fetched: the business is run in euros and this page steers
+ * it, so the figures should move with the book, not with the market — and an
+ * approximate total in the right currency beats an exact one in the wrong one.
+ * ECB said 0.855 on 2026-08-21; update it when the market drifts too far.
+ */
+const EUR_PER_USD = 0.855;
+
+/**
+ * What GitHub Marketplace brings in a month, in dollars, gross of the 5%
+ * GitHub keeps.
+ *
+ * A constant rather than a lookup: the marketplace book is a handful of teams
+ * and barely moves, and GitHub exposes no invoice API to read it from — copy
+ * the statement's total here when it changes. From the 2026-05 statement.
+ */
+const GITHUB_MARKETPLACE_MONTHLY_USD = 1540;
 
 /**
  * Why Stripe raised an invoice, for the ones that are a subscription being
- * billed rather than something invoiced on the side.
+ * billed.
  *
- * A one-off invoice or an accepted quote is revenue, but it is not what a
- * column headed by a billing interval reports — and a customer of the Stripe
- * account that is not an Argos team has no business in this page at all.
+ * Not the whole story for the monthly walk: the odd legacy or partner deal is
+ * billed by hand, month after month, and those invoices carry the sales-led
+ * reasons below instead. The walk takes both; what stays out is `upcoming` —
+ * a preview, not an invoice — and pending-item sweeps, which duplicate what
+ * the cycle will bill.
  */
 const SUBSCRIPTION_BILLING_REASONS = new Set<Stripe.Invoice.BillingReason>([
   "subscription",
@@ -109,10 +147,11 @@ const DAY_SECONDS = 24 * 3600;
 /**
  * The reasons an invoice is raised by a person rather than by a billing cycle.
  *
- * Sales-led contracts are billed this way — a dashboard invoice or an accepted
- * quote, often carried by no subscription at all — and their line periods are
- * frequently missing or degenerate, so they cannot be recognized by coverage
- * the way cycle invoices can.
+ * Sales-led deals are billed this way — a dashboard invoice or an accepted
+ * quote, often carried by no subscription at all — whether the deal is an
+ * annual contract or a legacy team invoiced by hand every month. Their line
+ * periods are frequently missing or degenerate, so they cannot be recognized
+ * by coverage the way cycle invoices can.
  */
 const SALES_LED_BILLING_REASONS = new Set<Stripe.Invoice.BillingReason>([
   "manual",
@@ -193,8 +232,15 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
   }));
 }
 
+/** How a month's breakdown names a team. */
+type TeamCustomer = {
+  slug: string;
+  name: string | null;
+};
+
 /**
- * Every Stripe customer that is an Argos team, whether or not it still pays.
+ * Every Stripe customer that is an Argos team, whether or not it still pays,
+ * with what to call it on screen.
  *
  * Read over all team accounts rather than over the billed ones: a team that has
  * since churned keeps the invoices it was already sent, and a month it was
@@ -202,16 +248,23 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
  * comparison between two months exists to show. Personal accounts are left out,
  * so what they may have been invoiced never reaches a page about teams.
  */
-export async function getTeamCustomerIds(): Promise<Set<string>> {
+export async function getTeamCustomers(): Promise<Map<string, TeamCustomer>> {
   const rows = (await Account.query()
-    .select("stripeCustomerId")
+    .select("stripeCustomerId", "slug", "name")
     .whereNotNull("teamId")
     .whereNull("userId")
     .whereNotNull("stripeCustomerId")) as unknown as {
     stripeCustomerId: string;
+    slug: string;
+    name: string | null;
   }[];
 
-  return new Set(rows.map((row) => row.stripeCustomerId));
+  return new Map(
+    rows.map((row) => [
+      row.stripeCustomerId,
+      { slug: row.slug, name: row.name },
+    ]),
+  );
 }
 
 /** What one invoice contributed, in the currency it was raised in. */
@@ -254,6 +307,17 @@ export function getInvoiceRevenue(invoice: {
   };
 }
 
+/**
+ * An invoice's contribution in euros: dollars at the fixed rate, euros as
+ * they are. A currency this page does not know stays at parity — and lands in
+ * the foreign share, so the caveat covers it either way.
+ */
+export function toEuros(revenue: InvoiceRevenue): number {
+  return revenue.currency === "usd"
+    ? revenue.amount * EUR_PER_USD
+    : revenue.amount;
+}
+
 function createSplit(): StaffRevenueSplit {
   return { revenue: 0, teamsCount: 0, foreignRevenue: 0 };
 }
@@ -263,15 +327,17 @@ function createMonth(month: Date): StaffRevenueMonth {
     month,
     revenue: 0,
     monthlyPlans: createSplit(),
+    teams: [],
     yearlyPlans: createSplit(),
   };
 }
 
-/** Add one invoice to a split, tracking what of it was not in dollars. */
+/** Add one invoice to a split, in euros, tracking what was converted. */
 function addToSplit(split: StaffRevenueSplit, revenue: InvoiceRevenue): void {
-  split.revenue += revenue.amount;
+  const amount = toEuros(revenue);
+  split.revenue += amount;
   if (revenue.currency !== REPORTING_CURRENCY) {
-    split.foreignRevenue += revenue.amount;
+    split.foreignRevenue += amount;
   }
 }
 
@@ -334,15 +400,16 @@ type StaffYearlyContract = {
   /** The subscription the database knows the contract by. */
   stripeSubscriptionId: string;
   /**
-   * The invoices below, added up. Null when none was found, in which case the
-   * contract adds nothing to the rate.
+   * The invoices below added up, in euros. Null when none was found, in which
+   * case the contract adds nothing to the rate.
    */
   amount: number | null;
   /** The invoices the contract is worth, newest first. */
   invoices: StaffContractInvoice[];
   /**
-   * True when the invoices found are still awaiting payment. Shown, so a
-   * contract in collection is visible, but counted nothing until they clear.
+   * True when the invoices found are still awaiting payment. Counted all the
+   * same — a contract invoice raised is money on its way — and flagged, so
+   * collection can be watched.
    */
   awaitingPayment: boolean;
 };
@@ -499,7 +566,7 @@ async function getYearlyContracts(
       stripeSubscriptionId: team.stripeSubscriptionId,
       amount:
         invoices.length > 0
-          ? invoices.reduce((sum, invoice) => sum + invoice.amount, 0)
+          ? invoices.reduce((sum, invoice) => sum + toEuros(invoice), 0)
           : null,
       invoices,
       awaitingPayment,
@@ -527,7 +594,7 @@ function getYearlyRate(contracts: StaffYearlyContract[]): StaffRevenueSplit {
   const split = createSplit();
 
   for (const contract of contracts) {
-    if (contract.invoices.length === 0 || contract.awaitingPayment) {
+    if (contract.invoices.length === 0) {
       continue;
     }
     // Invoice by invoice rather than off the summed amount, so a contract
@@ -557,13 +624,13 @@ async function readMonth(options: {
   from: Date;
   to: Date;
   /** Customers that are Argos teams — everything else is not this page's. */
-  teamCustomerIds: Set<string>;
+  teamCustomers: Map<string, TeamCustomer>;
   /** Yearly contracts are reported as a rate, so their invoices are skipped. */
   yearlyCustomerIds: Set<string>;
-}): Promise<StaffRevenueSplit> {
-  const { from, to, teamCustomerIds, yearlyCustomerIds } = options;
+}): Promise<{ split: StaffRevenueSplit; teams: StaffRevenueMonthTeam[] }> {
+  const { from, to, teamCustomers, yearlyCustomerIds } = options;
   const split = createSplit();
-  const customerIds = new Set<string>();
+  const byCustomer = new Map<string, StaffRevenueMonthTeam>();
   let count = 0;
 
   for await (const invoice of stripe.invoices.list({
@@ -585,7 +652,8 @@ async function readMonth(options: {
       typeof invoice.customer === "string"
         ? invoice.customer
         : invoice.customer?.id;
-    if (!customerId || !teamCustomerIds.has(customerId)) {
+    const team = customerId ? teamCustomers.get(customerId) : undefined;
+    if (!customerId || !team) {
       continue;
     }
     if (yearlyCustomerIds.has(customerId)) {
@@ -593,18 +661,47 @@ async function readMonth(options: {
     }
     if (
       invoice.billing_reason === null ||
-      !SUBSCRIPTION_BILLING_REASONS.has(invoice.billing_reason)
+      (!SUBSCRIPTION_BILLING_REASONS.has(invoice.billing_reason) &&
+        !SALES_LED_BILLING_REASONS.has(invoice.billing_reason))
     ) {
       continue;
     }
 
-    addToSplit(split, getInvoiceRevenue(invoice));
-    // A team invoiced twice in one month is one team.
-    customerIds.add(customerId);
+    const revenue = getInvoiceRevenue(invoice);
+    // A zero invoice — a usage month under the quota, the opening of a
+    // sales-created subscription — is not a team being invoiced: it would fill
+    // the breakdown with empty lines and dilute the per-team average.
+    if (revenue.amount === 0) {
+      continue;
+    }
+    addToSplit(split, revenue);
+
+    // A team invoiced twice in one month is one team, one line deeper.
+    let row = byCustomer.get(customerId);
+    if (!row) {
+      row = {
+        slug: team.slug,
+        name: team.name,
+        stripeCustomerId: customerId,
+        amount: 0,
+        currency: revenue.currency,
+        revenue: 0,
+      };
+      byCustomer.set(customerId, row);
+    }
+    row.amount += revenue.amount;
+    if (row.currency !== revenue.currency) {
+      // Mixed currencies make the original sum meaningless; the euro figure
+      // still holds.
+      row.currency = null;
+    }
+    row.revenue += toEuros(revenue);
   }
 
-  split.teamsCount = customerIds.size;
-  return split;
+  split.teamsCount = byCustomer.size;
+  // Largest first: the breakdown is read to see who made the month.
+  const teams = [...byCustomer.values()].sort((a, b) => b.revenue - a.revenue);
+  return { split, teams };
 }
 
 /** What Argos invoiced, and the annual contracts behind the yearly rate. */
@@ -613,6 +710,11 @@ export type StaffRevenue = {
   months: StaffRevenueMonth[];
   /** The contracts behind every month's `yearlyPlans`, largest first. */
   yearlyContracts: StaffYearlyContract[];
+  /**
+   * What GitHub Marketplace brings in a month, in euros, gross. A stated
+   * constant, not a reading — see `GITHUB_MARKETPLACE_MONTHLY_USD`.
+   */
+  githubMarketplaceMonthlyRevenue: number;
 };
 
 /**
@@ -645,9 +747,9 @@ export async function getStaffRevenue(
     startOfUTCMonth(now, index - monthCount + 1),
   );
 
-  const [teams, teamCustomerIds] = await Promise.all([
+  const [teams, teamCustomers] = await Promise.all([
     getBilledTeams(),
-    getTeamCustomerIds(),
+    getTeamCustomers(),
   ]);
   const yearlyCustomerIds = new Set(
     teams
@@ -664,7 +766,7 @@ export async function getStaffRevenue(
         invariant(to, "every month reported has a bound");
         return { from, to };
       }),
-      (window) => readMonth({ ...window, teamCustomerIds, yearlyCustomerIds }),
+      (window) => readMonth({ ...window, teamCustomers, yearlyCustomerIds }),
     ),
   ]);
   const yearlyRate = getYearlyRate(yearlyContracts);
@@ -673,13 +775,21 @@ export async function getStaffRevenue(
     const month = createMonth(start);
     const total = totals[index];
     invariant(total, "every month reported has totals");
-    month.monthlyPlans = total;
+    month.monthlyPlans = total.split;
+    month.teams = total.teams;
     // Copied rather than shared: one object held by every month is one object
     // a later change can mutate for all of them at once.
     month.yearlyPlans = { ...yearlyRate };
-    month.revenue = total.revenue + yearlyRate.revenue;
+    month.revenue = total.split.revenue + yearlyRate.revenue;
     return month;
   });
 
-  return { months, yearlyContracts };
+  return {
+    months,
+    yearlyContracts,
+    githubMarketplaceMonthlyRevenue: toEuros({
+      amount: GITHUB_MARKETPLACE_MONTHLY_USD,
+      currency: "usd",
+    }),
+  };
 }

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -1,0 +1,398 @@
+import type Stripe from "stripe";
+
+import config from "@/config";
+import { Subscription } from "@/database/models";
+import { redisCache } from "@/util/redis";
+
+import { stripe } from "./index";
+
+/** What the teams on one billing interval contributed to a month. */
+type StaffRevenueSplit = {
+  revenue: number;
+  teamsCount: number;
+};
+
+/** What Argos billed over one calendar month. */
+export type StaffRevenueMonth = {
+  /** The first instant of the month, in UTC — what names it on screen. */
+  month: Date;
+  /** The two splits below, added up. */
+  revenue: number;
+  /**
+   * What teams billed by the month were invoiced that month — the invoices
+   * themselves, so discounts, credit notes and negotiated amounts are already
+   * in it.
+   */
+  monthlyPlans: StaffRevenueSplit;
+  /**
+   * What the annual contracts in force are worth per month: their latest
+   * invoice over twelve.
+   *
+   * The same on every month, being a rate. Amortizing each annual invoice over
+   * the twelve months it covers would be exact, but it would mean reading a
+   * year of invoices to report one month — the one thing this cannot afford,
+   * being asked at page load.
+   */
+  yearlyPlans: StaffRevenueSplit;
+};
+
+/**
+ * Upper bound on the window one call will read.
+ *
+ * Every month is a walk of its own, so the cost grows with the count asked for
+ * — bounded here rather than left to the caller, which is what keeps a request
+ * from turning into a hundred round trips.
+ */
+export const MAX_MONTHS = 24;
+
+/**
+ * Upper bound on the invoices one month's walk will read.
+ *
+ * Reached means a month holds more than this service can read in the time a
+ * page will wait, and the answer is to stop reading Stripe on every request —
+ * not to report the total of however many invoices happened to fit, which would
+ * read as a complete figure while silently missing the rest.
+ */
+const MAX_INVOICES_PER_MONTH = 2000;
+
+/** Page size, which is also Stripe's maximum. */
+const PAGE_SIZE = 100;
+
+/** Months a yearly contract is spread over. */
+const MONTHS_PER_YEAR = 12;
+
+/** The placeholder the config falls back to when no key is configured. */
+const MISSING_API_KEY = "no-api-key";
+
+/** A team Argos bills through Stripe, and how it is billed. */
+type BilledTeam = {
+  accountId: string;
+  stripeCustomerId: string;
+  interval: "month" | "year";
+};
+
+/**
+ * Every team with a paying subscription, and the interval it is billed on.
+ *
+ * Reads the subscription the same way `getAccountBillings` does — the highest
+ * quota among those active, so an account holding two resolves the same one on
+ * both sides. Granted plans are excluded: they bill nothing, so no invoice of
+ * theirs exists to find.
+ */
+export async function getBilledTeams(): Promise<BilledTeam[]> {
+  const rows = (await Subscription.query()
+    .select(
+      "subscriptions.accountId",
+      "accounts.stripeCustomerId",
+      "plan.interval",
+    )
+    .joinRelated("plan")
+    .join("accounts", "accounts.id", "subscriptions.accountId")
+    .whereNotNull("accounts.teamId")
+    .whereNull("accounts.userId")
+    .whereNull("accounts.forcedPlanId")
+    .whereNotNull("accounts.stripeCustomerId")
+    .whereRaw("?? < now()", "subscriptions.startDate")
+    // A trial is out: it resolves a plan like a paid subscription and pays
+    // nothing. `past_due` is in — the invoice was raised, whether it clears is
+    // a collection question.
+    .whereIn("subscriptions.status", ["active", "past_due"])
+    .where((query) =>
+      query
+        .whereNull("subscriptions.endDate")
+        .orWhereRaw("?? >= now()", "subscriptions.endDate"),
+    )
+    .distinctOn("subscriptions.accountId")
+    .orderBy("subscriptions.accountId")
+    .orderBy("plan.includedScreenshots", "DESC")) as unknown as {
+    accountId: string | number;
+    stripeCustomerId: string;
+    interval: "month" | "year";
+  }[];
+
+  return rows.map((row) => ({
+    accountId: String(row.accountId),
+    stripeCustomerId: row.stripeCustomerId,
+    interval: row.interval,
+  }));
+}
+
+/**
+ * What one invoice contributed to revenue, in the currency's main unit.
+ *
+ * Excluding tax, because VAT collected on behalf of a state is not revenue, and
+ * net of credit notes, because an invoice refunded after the fact keeps its
+ * `amount_paid` intact — reading that field alone would count money that was
+ * given back.
+ *
+ * Currencies are added at parity, the rule the staff pages already print
+ * amounts under: a euro contract is read as dollars rather than converted.
+ */
+export function getInvoiceRevenue(
+  invoice: Pick<
+    Stripe.Invoice,
+    | "total"
+    | "total_excluding_tax"
+    | "pre_payment_credit_notes_amount"
+    | "post_payment_credit_notes_amount"
+  >,
+): number {
+  // Null on invoices Stripe states no tax breakdown for, where the total is
+  // already the whole of it.
+  const excludingTax = invoice.total_excluding_tax ?? invoice.total;
+  const credited =
+    invoice.pre_payment_credit_notes_amount +
+    invoice.post_payment_credit_notes_amount;
+
+  // Stripe states amounts in the currency's minor unit.
+  return (excludingTax - credited) / 100;
+}
+
+function createSplit(): StaffRevenueSplit {
+  return { revenue: 0, teamsCount: 0 };
+}
+
+function createMonth(month: Date): StaffRevenueMonth {
+  return {
+    month,
+    revenue: 0,
+    monthlyPlans: createSplit(),
+    yearlyPlans: createSplit(),
+  };
+}
+
+/**
+ * The first instant of the month `offset` months back, in UTC.
+ *
+ * Deliberately not the calendar helpers, which work in the process's own
+ * timezone: Stripe timestamps every invoice in UTC, so a server running on
+ * anything else would cut its months hours away from where Stripe cuts them and
+ * file the invoices either side of a boundary in the wrong one. Reading UTC on
+ * both sides is what makes the figure independent of where it runs.
+ */
+export function startOfUTCMonth(date: Date, offset: number): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + offset, 1),
+  );
+}
+
+/**
+ * What the annual contracts in force are worth per month.
+ *
+ * One small request per annual team rather than a year of invoices for
+ * everyone: an annual subscription raises one invoice a year, so its latest is
+ * what it is worth now, and there are few enough of them to ask in parallel.
+ *
+ * A contract whose first invoice has not been paid yet counts nothing — it has
+ * been invoiced nothing, which is what this reports.
+ */
+async function getYearlyRate(teams: BilledTeam[]): Promise<StaffRevenueSplit> {
+  const yearlyTeams = teams.filter((team) => team.interval === "year");
+  const split = createSplit();
+
+  const invoices = await Promise.all(
+    yearlyTeams.map(async (team) => {
+      const page = await stripe.invoices.list({
+        customer: team.stripeCustomerId,
+        status: "paid",
+        limit: 1,
+      });
+      return page.data[0] ?? null;
+    }),
+  );
+
+  for (const invoice of invoices) {
+    if (!invoice) {
+      continue;
+    }
+    split.revenue += getInvoiceRevenue(invoice) / MONTHS_PER_YEAR;
+    split.teamsCount += 1;
+  }
+
+  return split;
+}
+
+/** What one month's invoices came to, and how many teams they covered. */
+type MonthTotals = { revenue: number; teamsCount: number };
+
+/**
+ * Walk one month's invoices.
+ *
+ * A chain per month rather than one chain over the whole window, because
+ * Stripe's pagination is a cursor: a page cannot be asked for until the one
+ * before it has answered, so a single walk over three months is three months of
+ * round trips end to end. Split by month they run at once, and the wall clock
+ * becomes the longest month rather than their sum — which is also why the split
+ * is by month rather than by an arbitrary slice: each chain then knows the
+ * bucket its invoices belong to, with nothing left to sort out afterwards.
+ */
+async function readMonth(options: {
+  from: Date;
+  to: Date;
+  /** Yearly contracts are reported as a rate, so their invoices are skipped. */
+  yearlyCustomerIds: Set<string>;
+}): Promise<MonthTotals> {
+  const { from, to, yearlyCustomerIds } = options;
+  const customerIds = new Set<string>();
+  let revenue = 0;
+  let count = 0;
+
+  for await (const invoice of stripe.invoices.list({
+    created: {
+      gte: Math.floor(from.getTime() / 1000),
+      lt: Math.floor(to.getTime() / 1000),
+    },
+    status: "paid",
+    limit: PAGE_SIZE,
+  })) {
+    count += 1;
+    if (count > MAX_INVOICES_PER_MONTH) {
+      throw new Error(
+        `More than ${MAX_INVOICES_PER_MONTH} invoices in one month: reading Stripe per request no longer holds.`,
+      );
+    }
+
+    const customerId =
+      typeof invoice.customer === "string"
+        ? invoice.customer
+        : invoice.customer?.id;
+    if (!customerId || yearlyCustomerIds.has(customerId)) {
+      continue;
+    }
+
+    revenue += getInvoiceRevenue(invoice);
+    // A team invoiced twice in one month is one team.
+    customerIds.add(customerId);
+  }
+
+  return { revenue, teamsCount: customerIds.size };
+}
+
+/**
+ * What Argos invoiced over the last `monthCount` calendar months, oldest first
+ * and the running one last.
+ *
+ * Asked of Stripe on every call rather than mirrored into a table: the invoices
+ * are the answer, and a copy of them is a second source to keep correct as they
+ * are voided, refunded and credited.
+ */
+async function fetchStaffRevenue(
+  monthCount: number,
+): Promise<StaffRevenueMonth[]> {
+  if (config.get("stripe.apiKey") === MISSING_API_KEY) {
+    throw new Error(
+      "Stripe is not configured, so invoiced revenue cannot be read.",
+    );
+  }
+
+  const now = new Date();
+  // Oldest first, the running month last. One bound past the end, which is not
+  // itself a month reported: it closes the last window.
+  const starts = Array.from({ length: monthCount + 1 }, (_, index) =>
+    startOfUTCMonth(now, index - monthCount + 1),
+  );
+
+  const teams = await getBilledTeams();
+  // Only the yearly customers are identified, and the monthly bucket takes
+  // everything else. Matching invoices against the teams billed *today* would
+  // drop the invoices of a team that has since churned — and a month it was
+  // invoiced in would quietly lose it, which is exactly the revenue a
+  // comparison between two months exists to show.
+  const yearlyCustomerIds = new Set(
+    teams
+      .filter((team) => team.interval === "year")
+      .map((team) => team.stripeCustomerId),
+  );
+
+  // Every request at once: the months are independent walks, and the yearly
+  // rate is its own set of small ones.
+  const reported = starts.slice(0, monthCount);
+  const [yearlyRate, totals] = await Promise.all([
+    getYearlyRate(teams),
+    Promise.all(
+      reported.map((from, index) => {
+        const to = starts[index + 1];
+        if (!to) {
+          throw new Error("every month reported has a bound");
+        }
+        return readMonth({ from, to, yearlyCustomerIds });
+      }),
+    ),
+  ]);
+
+  return reported.map((start, index) => {
+    const month = createMonth(start);
+    const total = totals[index];
+    if (!total) {
+      throw new Error("every month reported has totals");
+    }
+    month.monthlyPlans = total;
+    month.yearlyPlans = yearlyRate;
+    month.revenue = total.revenue + yearlyRate.revenue;
+    return month;
+  });
+}
+
+/**
+ * The shape of the cached value, bumped whenever `StaffRevenueMonth` changes.
+ *
+ * An entry outlives the deploy that changes what this returns, so a field
+ * renamed below would otherwise be read back for an hour from a value that no
+ * longer has it.
+ */
+const CACHE_VERSION = 1;
+
+/** How long a window is served from cache. */
+const CACHE_MAX_AGE = 60 * 60 * 1000;
+
+/**
+ * Long enough for the walks to finish while holding the lock.
+ *
+ * The lock's TTL, not a deadline on the work: expiring early would let a second
+ * request start the same walks rather than wait on them, which is the stampede
+ * the cache exists to prevent.
+ */
+const CACHE_LOCK_TIMEOUT = 60 * 1000;
+
+const staffRevenueStore = redisCache.createStore({
+  fetch: fetchStaffRevenue,
+  /**
+   * Everything the answer is a function of, so no two of them share an entry.
+   *
+   * The deployment above all. Without it the key is global to the Redis
+   * instance and any two apps pointed at one serve each other's totals — which
+   * on a developer's machine is not hypothetical: the end-to-end suite and the
+   * dev server share `redis://localhost:6380/1`.
+   */
+  getCacheKey: (monthCount) => [
+    "staff-revenue",
+    CACHE_VERSION,
+    monthCount,
+    config.get("pg.connection.host"),
+    config.get("pg.connection.database"),
+  ],
+  maxAge: CACHE_MAX_AGE,
+  timeout: CACHE_LOCK_TIMEOUT,
+  // Dates do not survive JSON, and the months carry one each.
+  deserialize: (raw) => {
+    const months = JSON.parse(raw) as (Omit<StaffRevenueMonth, "month"> & {
+      month: string;
+    })[];
+    return months.map((month) => ({ ...month, month: new Date(month.month) }));
+  },
+});
+
+/**
+ * What Argos invoiced, from cache.
+ *
+ * Cached for an hour because the figures move at the pace of an invoice: the
+ * complete months behind them cannot change at all, and the running one gains a
+ * handful a day. An hour costs no freshness anyone can use, and it is what
+ * keeps a page that walks a year of invoices from walking it again on every
+ * visit.
+ */
+export async function getStaffRevenue(
+  monthCount: number,
+): Promise<StaffRevenueMonth[]> {
+  return staffRevenueStore.get(monthCount);
+}

--- a/apps/frontend/src/pages/Account/Analytics.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.tsx
@@ -19,7 +19,6 @@ import {
 } from "@argos/util/date";
 import { formatDate } from "@argos/util/date-format";
 import { invariant } from "@argos/util/invariant";
-import clsx from "clsx";
 import {
   FileDownIcon,
   GitCompareArrowsIcon,
@@ -47,7 +46,7 @@ import {
 } from "@/gql/graphql";
 import { Badge } from "@/ui/Badge";
 import { Button } from "@/ui/Button";
-import { Card } from "@/ui/Card";
+import { ChartCard } from "@/ui/ChartCard";
 import {
   ChartConfig,
   ChartContainer,
@@ -904,31 +903,6 @@ function Section(props: {
       </div>
       <div className="grid grid-cols-12 gap-6">{props.children}</div>
     </section>
-  );
-}
-
-function ChartCard(props: {
-  className?: string;
-  title: string;
-  description?: React.ReactNode;
-  action?: React.ReactNode;
-  children: React.ReactNode;
-}) {
-  return (
-    <Card className={clsx("flex flex-col", props.className)}>
-      <div className="flex items-start justify-between gap-4 p-5 pb-0">
-        <div>
-          <h3 className="font-semibold">{props.title}</h3>
-          {props.description ? (
-            <p className="text-low text-sm">{props.description}</p>
-          ) : null}
-        </div>
-        {props.action ? <div className="shrink-0">{props.action}</div> : null}
-      </div>
-      <div className="flex min-h-72 flex-1 items-center justify-center p-5">
-        {props.children}
-      </div>
-    </Card>
   );
 }
 

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -471,7 +471,12 @@ function HistoryRow(props: {
   isLast: boolean;
 }) {
   const { month, before, index, isLast } = props;
-  const growth = before ? getGrowth(month.revenue, before.revenue) : null;
+  // On the monthly figure, like every column here: the yearly rate lives in
+  // its own table, and a change diluted by a flat rate would understate every
+  // move.
+  const growth = before
+    ? getGrowth(month.monthlyPlans.revenue, before.monthlyPlans.revenue)
+    : null;
 
   return (
     <tr
@@ -487,12 +492,6 @@ function HistoryRow(props: {
         {formatPrice(month.monthlyPlans.revenue)}
       </td>
       <td className="p-4 text-right text-sm tabular-nums">
-        {formatPrice(month.yearlyPlans.revenue)}
-      </td>
-      <td className="p-4 text-right text-sm font-medium tabular-nums">
-        {formatPrice(month.revenue)}
-      </td>
-      <td className="p-4 text-right text-sm tabular-nums">
         {growth === null ? (
           <span className="text-low">—</span>
         ) : (
@@ -504,6 +503,15 @@ function HistoryRow(props: {
       </td>
       <td className="p-4 text-right text-sm tabular-nums">
         {month.monthlyPlans.teamsCount}
+      </td>
+      <td className="p-4 text-right text-sm tabular-nums">
+        {month.monthlyPlans.teamsCount > 0 ? (
+          formatPrice(
+            month.monthlyPlans.revenue / month.monthlyPlans.teamsCount,
+          )
+        ) : (
+          <span className="text-low">—</span>
+        )}
       </td>
     </tr>
   );
@@ -527,43 +535,59 @@ function RevenueHistory(props: { months: readonly RevenueMonth[] }) {
   const rows = [...complete].reverse();
 
   return (
-    <div className="overflow-x-auto rounded-sm border">
-      <table className="w-full min-w-160 table-fixed border-collapse">
-        <thead>
-          <tr className="text-low border-b text-xs font-semibold">
-            <th className="w-[18%] px-4 py-3 text-left">Month</th>
-            <th className="w-[18%] px-4 py-3 text-right">Monthly plans</th>
-            <th className="w-[18%] px-4 py-3 text-right">Yearly plans</th>
-            <th className="w-[16%] px-4 py-3 text-right">Total</th>
-            <th className="w-[15%] px-4 py-3 text-right">
-              <Tooltip content="Against the month before it. The running month is not listed: being partial, it would read as a drop that is only the calendar.">
-                <span className="underline decoration-dotted underline-offset-2">
-                  Change
-                </span>
-              </Tooltip>
-            </th>
-            <th className="w-[15%] px-4 py-3 text-right">
-              <Tooltip content="Teams invoiced on a monthly plan that month. Annual contracts are a rate rather than a month's invoices, so they are not counted here.">
-                <span className="underline decoration-dotted underline-offset-2">
-                  Teams
-                </span>
-              </Tooltip>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((month, index) => (
-            <HistoryRow
-              key={month.month}
-              month={month}
-              // `rows` runs newest first, so the month before is the next one.
-              before={rows[index + 1] ?? null}
-              index={index}
-              isLast={index === rows.length - 1}
-            />
-          ))}
-        </tbody>
-      </table>
+    <div>
+      <div className="mb-3">
+        <h3 className="font-semibold">Monthly plans</h3>
+      </div>
+      <div className="overflow-x-auto rounded-sm border">
+        <table className="w-full min-w-160 table-fixed border-collapse">
+          <thead>
+            <tr className="text-low border-b text-xs font-semibold">
+              <th className="w-[22%] px-4 py-3 text-left">Month</th>
+              <th className="w-[21%] px-4 py-3 text-right">
+                <Tooltip content="Invoices issued that month, excluding tax and net of credit notes — what Stripe charged, discounts included.">
+                  <span className="underline decoration-dotted underline-offset-2">
+                    Invoiced
+                  </span>
+                </Tooltip>
+              </th>
+              <th className="w-[18%] px-4 py-3 text-right">
+                <Tooltip content="Against the month before it.">
+                  <span className="underline decoration-dotted underline-offset-2">
+                    Change
+                  </span>
+                </Tooltip>
+              </th>
+              <th className="w-[18%] px-4 py-3 text-right">
+                <Tooltip content="Teams invoiced that month.">
+                  <span className="underline decoration-dotted underline-offset-2">
+                    Teams
+                  </span>
+                </Tooltip>
+              </th>
+              <th className="w-[21%] px-4 py-3 text-right">
+                <Tooltip content="The month's invoices over its teams — what the average team was billed.">
+                  <span className="underline decoration-dotted underline-offset-2">
+                    Per team
+                  </span>
+                </Tooltip>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((month, index) => (
+              <HistoryRow
+                key={month.month}
+                month={month}
+                // `rows` runs newest first, so the month before is the next one.
+                before={rows[index + 1] ?? null}
+                index={index}
+                isLast={index === rows.length - 1}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -38,6 +38,7 @@ import { Text } from "@/ui/Text";
 import { Tooltip } from "@/ui/Tooltip";
 
 import { formatPrice } from "./pricing";
+import { getStripeSubscriptionURL } from "./stripe";
 
 /**
  * Asked on its own rather than alongside the team directory: it walks Stripe's
@@ -51,25 +52,41 @@ import { formatPrice } from "./pricing";
 const StaffRevenueQuery = graphql(`
   query StaffRevenue_staffRevenue($months: Int!) {
     staffRevenue(months: $months) {
-      month
-      revenue
-      monthlyPlans {
+      months {
+        month
         revenue
-        teamsCount
-        foreignRevenue
+        monthlyPlans {
+          revenue
+          teamsCount
+          foreignRevenue
+        }
+        yearlyPlans {
+          revenue
+          teamsCount
+          foreignRevenue
+        }
       }
-      yearlyPlans {
-        revenue
-        teamsCount
-        foreignRevenue
+      yearlyContracts {
+        slug
+        name
+        stripeSubscriptionId
+        amount
+        awaitingPayment
+        invoices {
+          amount
+          currency
+          invoicedAt
+          coveredFrom
+          coveredUntil
+        }
       }
     }
   }
 `);
 
-type RevenueMonth = DocumentType<
-  typeof StaffRevenueQuery
->["staffRevenue"][number];
+type RevenueData = DocumentType<typeof StaffRevenueQuery>["staffRevenue"];
+type RevenueMonth = RevenueData["months"][number];
+type YearlyContract = RevenueData["yearlyContracts"][number];
 type Split = RevenueMonth["monthlyPlans"];
 
 /** Months the dedicated page reads — a year, plus the one running. */
@@ -88,7 +105,7 @@ const CURRENT_MONTHLY_HINT =
   "Invoices issued so far this month, excluding tax and net of credit notes. Partial by nature: the month is not over.";
 
 const YEARLY_HINT =
-  "Annual contracts in force: their latest invoice ÷ 12. A rate, so it is the same every month rather than a spike in the renewal month.";
+  "Annual contracts in force: their contract invoices ÷ 12. A rate, so it is the same every month rather than a spike in the renewal month.";
 
 /**
  * Stands in for the hint line while the figures load.
@@ -136,6 +153,24 @@ const AXIS_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
   currency: "USD",
   notation: "compact",
   maximumFractionDigits: 0,
+});
+
+/**
+ * Amounts in the contracts table, with cents.
+ *
+ * The rest of the page rounds to the dollar, but this table exists to be added
+ * up against the yearly figure, and twelfths carry cents — a rounded list
+ * would not sum to its own total.
+ */
+const CONTRACT_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+/** A renewal's date, read in UTC like every other date on the page. */
+const DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+  timeZone: "UTC",
 });
 
 function formatMonth(month: string): string {
@@ -533,11 +568,186 @@ function RevenueHistory(props: { months: readonly RevenueMonth[] }) {
   );
 }
 
+/** One counted invoice, described for the amount's breakdown tooltip. */
+function describeInvoice(invoice: YearlyContract["invoices"][number]): string {
+  const covers =
+    invoice.coveredFrom && invoice.coveredUntil
+      ? `, covers ${DATE_FORMAT.format(new Date(invoice.coveredFrom))} to ${DATE_FORMAT.format(new Date(invoice.coveredUntil))}`
+      : "";
+  return `${CONTRACT_PRICE_FORMAT.format(invoice.amount)} invoiced ${DATE_FORMAT.format(new Date(invoice.invoicedAt))}${covers}.`;
+}
+
+/** One contract, the invoices it is worth and what it adds per month. */
+function ContractRow(props: { contract: YearlyContract; index: number }) {
+  const { contract, index } = props;
+  const newestInvoice = contract.invoices[0] ?? null;
+  const foreignCurrencies = [
+    ...new Set(
+      contract.invoices
+        .filter((invoice) => invoice.currency !== "usd")
+        .map((invoice) => invoice.currency.toUpperCase()),
+    ),
+  ];
+
+  return (
+    <tr className={clsx(index % 2 === 0 ? "bg-app" : "bg-subtle", "border-b")}>
+      <td className="p-4 text-left text-sm font-medium">
+        <Link href={`/${contract.slug}`}>{contract.name ?? contract.slug}</Link>
+      </td>
+      <td className="p-4 text-right text-sm tabular-nums">
+        {contract.amount !== null ? (
+          <>
+            <Tooltip
+              content={
+                <div className="flex flex-col gap-1">
+                  {contract.invoices.map((invoice, invoiceIndex) => (
+                    <div key={invoiceIndex}>{describeInvoice(invoice)}</div>
+                  ))}
+                </div>
+              }
+            >
+              <span className="underline decoration-dotted underline-offset-2">
+                {CONTRACT_PRICE_FORMAT.format(contract.amount)}
+              </span>
+            </Tooltip>
+            {contract.invoices.length > 1 ? (
+              <span className="text-low">
+                {" "}
+                ({contract.invoices.length} invoices)
+              </span>
+            ) : null}
+            {foreignCurrencies.length > 0 ? (
+              <span className="text-low">
+                {" "}
+                ({foreignCurrencies.join(", ")} at parity)
+              </span>
+            ) : null}
+            {contract.awaitingPayment ? (
+              <Tooltip content="The invoice was raised but has not been paid yet, so it counts nothing until it clears.">
+                <span className="text-warning-low underline decoration-dotted underline-offset-2">
+                  {" "}
+                  awaiting payment
+                </span>
+              </Tooltip>
+            ) : null}
+          </>
+        ) : (
+          <Tooltip content="No invoice reading as this contract was found on the customer, so it adds nothing to the yearly figure. Its invoices are worth a look in Stripe.">
+            <span className="text-danger-low underline decoration-dotted underline-offset-2">
+              no invoice found
+            </span>
+          </Tooltip>
+        )}
+      </td>
+      <td className="p-4 text-right text-sm tabular-nums">
+        {contract.amount !== null && !contract.awaitingPayment ? (
+          CONTRACT_PRICE_FORMAT.format(contract.amount / 12)
+        ) : (
+          <span className="text-low">—</span>
+        )}
+      </td>
+      <td className="p-4 text-right text-sm tabular-nums">
+        {newestInvoice ? (
+          DATE_FORMAT.format(new Date(newestInvoice.invoicedAt))
+        ) : (
+          <span className="text-low">—</span>
+        )}
+      </td>
+      <td className="p-4 text-right text-sm">
+        <Link
+          href={getStripeSubscriptionURL(contract.stripeSubscriptionId)}
+          target="_blank"
+        >
+          Stripe
+        </Link>
+      </td>
+    </tr>
+  );
+}
+
+/**
+ * The annual contracts one by one — the makeup of the yearly figure.
+ *
+ * Listed so the figure can be audited: the rate is a sum of twelfths read from
+ * Stripe, and when it looks wrong, the contract at fault can only be found by
+ * seeing each one's renewal — including the contracts that contributed
+ * nothing, which the total alone would hide.
+ */
+function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
+  const { contracts } = props;
+  // Awaiting-payment invoices are listed but not counted, like in the figure.
+  const total = contracts.reduce(
+    (sum, contract) =>
+      sum + (contract.awaitingPayment ? 0 : (contract.amount ?? 0)),
+    0,
+  );
+
+  return (
+    <div className="mt-6">
+      <div className="mb-3">
+        <h3 className="font-semibold">Annual contracts</h3>
+      </div>
+      {contracts.length === 0 ? (
+        <p className="text-low text-sm">No annual contracts in force.</p>
+      ) : (
+        <div className="overflow-x-auto rounded-sm border">
+          <table className="w-full min-w-160 table-fixed border-collapse">
+            <thead>
+              <tr className="text-low border-b text-xs font-semibold">
+                <th className="w-[30%] px-4 py-3 text-left">Team</th>
+                <th className="w-[20%] px-4 py-3 text-right">
+                  <Tooltip content="The contract's invoices added up — its latest annual bill, plus upsells raised on top of it since — excluding tax and net of credit notes.">
+                    <span className="underline decoration-dotted underline-offset-2">
+                      Invoiced
+                    </span>
+                  </Tooltip>
+                </th>
+                <th className="w-[16%] px-4 py-3 text-right">
+                  <Tooltip content="The renewal over twelve — this column adds up to the Yearly plans figure.">
+                    <span className="underline decoration-dotted underline-offset-2">
+                      Per month
+                    </span>
+                  </Tooltip>
+                </th>
+                <th className="w-[18%] px-4 py-3 text-right">Last invoice</th>
+                <th className="w-[16%] px-4 py-3 text-right" />
+              </tr>
+            </thead>
+            <tbody>
+              {contracts.map((contract, index) => (
+                <ContractRow
+                  key={contract.stripeSubscriptionId}
+                  contract={contract}
+                  index={index}
+                />
+              ))}
+            </tbody>
+            <tfoot>
+              <tr className="text-sm font-medium">
+                <td className="p-4 text-left">Total</td>
+                <td className="p-4 text-right tabular-nums">
+                  {CONTRACT_PRICE_FORMAT.format(total)}
+                </td>
+                <td className="p-4 text-right tabular-nums">
+                  {CONTRACT_PRICE_FORMAT.format(total / 12)}
+                </td>
+                <td />
+                <td />
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function StaffRevenuePage() {
   const { data, error } = useQuery(StaffRevenueQuery, {
     variables: { months: PAGE_MONTHS },
   });
-  const months = data?.staffRevenue ?? null;
+  const months = data?.staffRevenue.months ?? null;
+  const contracts = data?.staffRevenue.yearlyContracts ?? null;
 
   // Told rather than reported as a failed figure, as the other staff pages do:
   // a reader without access has no figures to wait for, and three tiles reading
@@ -573,7 +783,7 @@ function StaffRevenuePage() {
         </PageHeaderContent>
       </PageHeader>
       <RevenueCards months={months} error={error ?? null} />
-      {months ? (
+      {months && contracts ? (
         <>
           <ChartCard
             className="mb-6"
@@ -583,6 +793,7 @@ function StaffRevenuePage() {
             <RevenueChart months={months} />
           </ChartCard>
           <RevenueHistory months={months} />
+          <YearlyContracts contracts={contracts} />
         </>
       ) : error ? null : (
         <ChartCard

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { CombinedGraphQLErrors } from "@apollo/client";
 import { useQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
@@ -5,6 +6,7 @@ import { clsx } from "clsx";
 import {
   CalendarCheckIcon,
   CalendarClockIcon,
+  ChevronDownIcon,
   TrendingDownIcon,
   TrendingUpIcon,
 } from "lucide-react";
@@ -15,6 +17,7 @@ import { AuthGuard } from "@/containers/AuthGuard";
 import type { DocumentType } from "@/gql";
 import { graphql } from "@/gql";
 import { Alert, AlertText, AlertTitle } from "@/ui/Alert";
+import { Button, ButtonIcon } from "@/ui/Button";
 import { ChartCard } from "@/ui/ChartCard";
 import type { ChartConfig } from "@/ui/Charts";
 import {
@@ -34,11 +37,9 @@ import {
 import { Link } from "@/ui/Link";
 import { Loader } from "@/ui/Loader";
 import { StatTile } from "@/ui/StatTile";
-import { Text } from "@/ui/Text";
 import { Tooltip } from "@/ui/Tooltip";
 
-import { formatPrice } from "./pricing";
-import { getStripeSubscriptionURL } from "./stripe";
+import { getStripeCustomerURL, getStripeSubscriptionURL } from "./stripe";
 
 /**
  * Asked on its own rather than alongside the team directory: it walks Stripe's
@@ -60,6 +61,14 @@ const StaffRevenueQuery = graphql(`
           teamsCount
           foreignRevenue
         }
+        teams {
+          slug
+          name
+          stripeCustomerId
+          amount
+          currency
+          revenue
+        }
         yearlyPlans {
           revenue
           teamsCount
@@ -80,6 +89,7 @@ const StaffRevenueQuery = graphql(`
           coveredUntil
         }
       }
+      githubMarketplaceMonthlyRevenue
     }
   }
 `);
@@ -98,14 +108,15 @@ const PAGE_MONTHS = 13;
  * Two rather than one because the halves do not answer the same question: the
  * monthly one reports the month's invoices, the yearly one a rate.
  */
-const LAST_MONTHLY_HINT =
-  "Invoices issued last month, excluding tax and net of credit notes — what Stripe charged, discounts included.";
+const LAST_MONTHLY_HINT = "Last month's invoices, ex-tax, net of credit notes.";
 
 const CURRENT_MONTHLY_HINT =
-  "Invoices issued so far this month, excluding tax and net of credit notes. Partial by nature: the month is not over.";
+  "This month's invoices so far, ex-tax, net of credit notes.";
 
 const YEARLY_HINT =
-  "Annual contracts in force: their contract invoices ÷ 12. A rate, so it is the same every month rather than a spike in the renewal month.";
+  "Annual contracts ÷ 12. The same rate every month converted in €.";
+
+const GITHUB_HINT = "Hard coded amount";
 
 /**
  * Stands in for the hint line while the figures load.
@@ -141,16 +152,24 @@ const MONTH_SHORT_FORMAT = new Intl.DateTimeFormat("en-US", {
 });
 
 /**
- * Amounts on the axis, shortened.
- *
- * Fixed to the same locale and currency as `formatPrice` rather than the
- * reader's own: every other figure on the page is printed in US dollars, and an
- * axis that followed the browser would label the same money differently from
- * the cards above it.
+ * Every amount on this page is in euros — the currency the business is run
+ * in — where the other staff pages price plans in dollars. Dollar invoices are
+ * converted server-side at a fixed rate, which the foreign-share caveats own.
  */
+const EUR_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "EUR",
+  maximumFractionDigits: 0,
+});
+
+function formatEuros(amount: number): string {
+  return EUR_PRICE_FORMAT.format(amount);
+}
+
+/** Amounts on the axis, shortened, in the page's euros. */
 const AXIS_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
   style: "currency",
-  currency: "USD",
+  currency: "EUR",
   notation: "compact",
   maximumFractionDigits: 0,
 });
@@ -158,14 +177,25 @@ const AXIS_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
 /**
  * Amounts in the contracts table, with cents.
  *
- * The rest of the page rounds to the dollar, but this table exists to be added
+ * The rest of the page rounds to the euro, but this table exists to be added
  * up against the yearly figure, and twelfths carry cents — a rounded list
  * would not sum to its own total.
  */
 const CONTRACT_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
   style: "currency",
-  currency: "USD",
+  currency: "EUR",
 });
+
+/** An invoice in the currency it was raised in — the audit trail to Stripe. */
+function formatInvoiceAmount(invoice: {
+  amount: number;
+  currency: string;
+}): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: invoice.currency.toUpperCase(),
+  }).format(invoice.amount);
+}
 
 /** A renewal's date, read in UTC like every other date on the page. */
 const DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
@@ -180,12 +210,12 @@ function formatMonth(month: string): string {
 /** The figures behind a half, appended to its tooltip. */
 function getSplitNote(split: Split): string {
   const teams = ` ${split.teamsCount} ${split.teamsCount === 1 ? "team" : "teams"}.`;
-  // Named only when there is some: on an all-dollar month the caveat would be
-  // noise, and on a month with euros in it the reader has to know the total
-  // holds two currencies added at parity.
+  // Named only when there is some: on an all-euro month the caveat would be
+  // noise, and on a month with dollars in it the reader has to know part of
+  // the total went through the fixed rate.
   const foreign =
     split.foreignRevenue > 0
-      ? ` ${formatPrice(split.foreignRevenue)} of it was invoiced in another currency and is counted at parity, not converted.`
+      ? ` ${formatEuros(split.foreignRevenue)} converted from dollars at a fixed rate.`
       : "";
 
   return `${teams}${foreign}`;
@@ -211,7 +241,7 @@ function SplitAmount(props: {
   return (
     <Tooltip content={props.tooltip}>
       <span className="underline decoration-dotted underline-offset-2">
-        {formatPrice(props.amount)} {props.label}
+        {formatEuros(props.amount)} {props.label}
       </span>
     </Tooltip>
   );
@@ -224,22 +254,32 @@ function SplitAmount(props: {
  * computes differently — one reads the month's invoices, the other spreads a
  * year's — so they are what a reader has to be able to take apart.
  */
-function MonthSplit(props: { month: RevenueMonth; monthlyHint: string }) {
-  const { month, monthlyHint } = props;
+function MonthSplit(props: {
+  month: RevenueMonth;
+  monthlyHint: string;
+  github: number | null;
+}) {
+  const { month, monthlyHint, github } = props;
 
   return (
     <>
       <SplitAmount
         amount={month.monthlyPlans.revenue}
-        label="monthly"
+        label="Monthly"
         tooltip={`${monthlyHint}${getSplitNote(month.monthlyPlans)}`}
       />
       {" · "}
       <SplitAmount
         amount={month.yearlyPlans.revenue}
-        label="yearly"
-        tooltip={`${YEARLY_HINT}${getSplitNote(month.yearlyPlans)}`}
+        label="Yearly"
+        tooltip={YEARLY_HINT}
       />
+      {github !== null ? (
+        <>
+          {" · "}
+          <SplitAmount amount={github} label="GitHub" tooltip={GITHUB_HINT} />
+        </>
+      ) : null}
     </>
   );
 }
@@ -254,9 +294,11 @@ function MonthSplit(props: { month: RevenueMonth; monthlyHint: string }) {
 function RevenueCards(props: {
   /** Oldest first, the running month last. Null while loading. */
   months: readonly RevenueMonth[] | null;
+  /** The GitHub Marketplace rate, shown beside each month's split. */
+  github: number | null;
   error: Error | null;
 }) {
-  const { months, error } = props;
+  const { months, github, error } = props;
 
   // The last two are the only ones the cards read, whatever the window.
   const currentMonth = months?.at(-1) ?? null;
@@ -295,14 +337,19 @@ function RevenueCards(props: {
       <StatTile
         data-visual-test="transparent"
         icon={CalendarCheckIcon}
-        color="success"
+        color="primary"
         label="Last month"
         value={readValue(lastMonth?.revenue ?? null)}
         format="currency"
+        currency="EUR"
         hint={
           unavailable ??
           (lastMonth ? (
-            <MonthSplit month={lastMonth} monthlyHint={LAST_MONTHLY_HINT} />
+            <MonthSplit
+              month={lastMonth}
+              monthlyHint={LAST_MONTHLY_HINT}
+              github={github}
+            />
           ) : (
             HINT_PLACEHOLDER
           ))
@@ -311,16 +358,19 @@ function RevenueCards(props: {
       <StatTile
         data-visual-test="transparent"
         icon={CalendarClockIcon}
-        color="primary"
+        // The storybook token is the design system's pink.
+        color="storybook"
         label="Current month"
         value={readValue(currentMonth?.revenue ?? null)}
         format="currency"
+        currency="EUR"
         hint={
           unavailable ??
           (currentMonth ? (
             <MonthSplit
               month={currentMonth}
               monthlyHint={CURRENT_MONTHLY_HINT}
+              github={github}
             />
           ) : (
             HINT_PLACEHOLDER
@@ -338,7 +388,7 @@ function RevenueCards(props: {
           unavailable ??
           (currentMonth && lastMonth && growth !== null ? (
             <Tooltip
-              content={`${formatMonth(currentMonth.month)} at ${formatPrice(currentMonth.revenue)} against ${formatMonth(lastMonth.month)} at ${formatPrice(lastMonth.revenue)}. The running month is still filling, so this starts the month deeply negative and climbs as the invoices land — it is only comparable to the month before it on the last day.`}
+              content={`${formatMonth(currentMonth.month)} (${formatEuros(currentMonth.revenue)}) vs ${formatMonth(lastMonth.month)} (${formatEuros(lastMonth.revenue)}). The running month is still filling.`}
             >
               <span className="underline decoration-dotted underline-offset-2">
                 {formatMonth(currentMonth.month)} vs{" "}
@@ -357,47 +407,41 @@ function RevenueCards(props: {
 }
 
 /**
- * The two series, in a fixed order with fixed colours.
- *
- * Order and colour follow the halves themselves, not their size: the monthly
- * book keeps its colour whether it is the larger half or not, so a month where
- * the two cross over does not repaint the chart.
- *
- * Violet is the app's own accent, which the account analytics already draw
- * their primary series in — the dominant half wears it. Grass is the second
- * because it is far enough from violet on the blue-yellow axis to survive
- * colour blindness: the pair separates by ΔE 28 under deuteranopia and 33 to
- * normal vision. Grass sits just under 3:1 against the light surface, which the
- * legend and the table below relieve.
+ * The series, in a fixed order with fixed colours: the monthly book keeps its
+ * colour whether it is the larger half or not, so a month where the halves
+ * cross over does not repaint the chart. Pink for the monthly book, violet —
+ * the app's accent — for the annual one, grass for the Marketplace rate.
  */
 const CHART_SERIES = [
-  { key: "monthly", label: "Monthly plans", color: "var(--violet-9)" },
-  { key: "yearly", label: "Yearly plans", color: "var(--grass-9)" },
+  { key: "monthly", label: "Monthly plans", color: "var(--pink-9)" },
+  { key: "yearly", label: "Yearly plans", color: "var(--violet-9)" },
+  { key: "github", label: "GitHub Marketplace", color: "var(--grass-9)" },
 ] as const;
 
 const CHART_CONFIG: ChartConfig = {
-  monthly: { label: "Monthly plans", color: "var(--violet-9)" },
-  yearly: { label: "Yearly plans", color: "var(--grass-9)" },
+  monthly: { label: "Monthly plans", color: "var(--pink-9)" },
+  yearly: { label: "Yearly plans", color: "var(--violet-9)" },
+  github: { label: "GitHub Marketplace", color: "var(--grass-9)" },
 };
 
 /**
- * The window as stacked areas, one point per complete month.
+ * The window as stacked areas, one point per month, the running one included.
  *
- * Stacked because the two halves compose the total the cards report, so the
- * height of the band is the figure and its split is where it came from. Areas
- * rather than bars because what is being read here is a trend over a year, and
- * a filled band carries a slope where twelve separate bars make the reader
- * measure heights against each other.
- *
- * The running month is left out, as it is from the table: a partial point
- * dragged the line down every month, which reads as a collapse rather than as a
- * month still filling.
+ * Stacked because the bands compose the business's total, so the height is
+ * the figure and its split is where it came from. Areas rather than bars
+ * because what is being read here is a trend over a year, and a filled band
+ * carries a slope where twelve separate bars make the reader measure heights
+ * against each other.
  */
-function RevenueChart(props: { months: readonly RevenueMonth[] }) {
-  const data = props.months.slice(0, -1).map((month) => ({
+function RevenueChart(props: {
+  months: readonly RevenueMonth[];
+  github: number;
+}) {
+  const data = props.months.map((month) => ({
     month: month.month,
     monthly: month.monthlyPlans.revenue,
     yearly: month.yearlyPlans.revenue,
+    github: props.github,
   }));
 
   return (
@@ -407,6 +451,21 @@ function RevenueChart(props: { months: readonly RevenueMonth[] }) {
       data-visual-test="transparent"
     >
       <AreaChart accessibilityLayer data={data} margin={{ left: 0, right: 8 }}>
+        <defs>
+          {CHART_SERIES.map((series) => (
+            <linearGradient
+              key={series.key}
+              id={`fill-${series.key}`}
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="1"
+            >
+              <stop offset="0%" stopColor={series.color} stopOpacity={0.3} />
+              <stop offset="100%" stopColor={series.color} stopOpacity={0} />
+            </linearGradient>
+          ))}
+        </defs>
         {/* Horizontal only, dashed: the grid is there to read a height against,
             not to be looked at. */}
         <CartesianGrid vertical={false} strokeDasharray="5 5" />
@@ -439,7 +498,7 @@ function RevenueChart(props: { months: readonly RevenueMonth[] }) {
                 invariant(item, "a tooltip always has a datum");
                 return MONTH_YEAR_FORMAT.format(new Date(item.payload.month));
               }}
-              formatter={(value) => formatPrice(Number(value))}
+              valueFormatter={(value) => formatEuros(value)}
             />
           }
         />
@@ -452,8 +511,7 @@ function RevenueChart(props: { months: readonly RevenueMonth[] }) {
             dataKey={series.key}
             type="monotone"
             stackId="revenue"
-            fill={series.color}
-            fillOpacity={0.4}
+            fill={`url(#fill-${series.key})`}
             stroke={series.color}
             isAnimationActive={false}
           />
@@ -467,53 +525,144 @@ function RevenueChart(props: { months: readonly RevenueMonth[] }) {
 function HistoryRow(props: {
   month: RevenueMonth;
   before: RevenueMonth | null;
+  /** The month still running — partial, so it makes no comparison. */
+  isCurrent: boolean;
   index: number;
   isLast: boolean;
 }) {
-  const { month, before, index, isLast } = props;
+  const { month, before, isCurrent, index, isLast } = props;
+  const [isOpened, setIsOpened] = useState(false);
   // On the monthly figure, like every column here: the yearly rate lives in
   // its own table, and a change diluted by a flat rate would understate every
   // move.
-  const growth = before
-    ? getGrowth(month.monthlyPlans.revenue, before.monthlyPlans.revenue)
-    : null;
+  const growth =
+    before && !isCurrent
+      ? getGrowth(month.monthlyPlans.revenue, before.monthlyPlans.revenue)
+      : null;
 
   return (
-    <tr
-      className={clsx(
-        index % 2 === 0 ? "bg-app" : "bg-subtle",
-        !isLast && "border-b",
-      )}
-    >
-      <td className="p-4 text-left text-sm font-medium">
-        {MONTH_YEAR_FORMAT.format(new Date(month.month))}
-      </td>
-      <td className="p-4 text-right text-sm tabular-nums">
-        {formatPrice(month.monthlyPlans.revenue)}
-      </td>
-      <td className="p-4 text-right text-sm tabular-nums">
-        {growth === null ? (
-          <span className="text-low">—</span>
-        ) : (
-          <span className={growth < 0 ? "text-danger-low" : "text-success-low"}>
-            {growth > 0 ? "+" : ""}
-            {Math.round(growth * 100)}%
-          </span>
+    <>
+      <tr
+        className={clsx(
+          index % 2 === 0 ? "bg-app" : "bg-subtle",
+          (!isLast || isOpened) && "border-b",
         )}
-      </td>
-      <td className="p-4 text-right text-sm tabular-nums">
-        {month.monthlyPlans.teamsCount}
-      </td>
-      <td className="p-4 text-right text-sm tabular-nums">
-        {month.monthlyPlans.teamsCount > 0 ? (
-          formatPrice(
-            month.monthlyPlans.revenue / month.monthlyPlans.teamsCount,
-          )
-        ) : (
-          <span className="text-low">—</span>
-        )}
-      </td>
-    </tr>
+      >
+        <td className="p-4 text-left text-sm font-medium">
+          {MONTH_YEAR_FORMAT.format(new Date(month.month))}
+          {isCurrent ? <span className="text-low"> (running)</span> : null}
+        </td>
+        <td className="p-4 text-right text-sm tabular-nums">
+          {formatEuros(month.monthlyPlans.revenue)}
+        </td>
+        <td className="p-4 text-right text-sm tabular-nums">
+          {growth === null ? (
+            <span className="text-low">—</span>
+          ) : (
+            <span
+              className={growth < 0 ? "text-danger-low" : "text-success-low"}
+            >
+              {growth > 0 ? "+" : ""}
+              {Math.round(growth * 100)}%
+            </span>
+          )}
+        </td>
+        <td className="p-4 text-right text-sm tabular-nums">
+          {month.monthlyPlans.teamsCount}
+        </td>
+        <td className="p-4 text-right text-sm tabular-nums">
+          {month.monthlyPlans.teamsCount > 0 ? (
+            formatEuros(
+              month.monthlyPlans.revenue / month.monthlyPlans.teamsCount,
+            )
+          ) : (
+            <span className="text-low">—</span>
+          )}
+        </td>
+        <td className="p-4 text-right text-sm">
+          {month.teams.length > 0 ? (
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={() => setIsOpened((opened) => !opened)}
+            >
+              View details
+              <ButtonIcon position="right">
+                <ChevronDownIcon
+                  className={clsx(
+                    "transition-transform",
+                    isOpened && "rotate-180",
+                  )}
+                />
+              </ButtonIcon>
+            </Button>
+          ) : null}
+        </td>
+      </tr>
+      {isOpened ? (
+        <tr
+          className={clsx(
+            // Inverted from the month's row, like the team directory's detail
+            // rows: the breakdown reads as inside the month, not as a sibling.
+            index % 2 === 0 ? "bg-subtle" : "bg-app",
+            !isLast && "border-b",
+          )}
+        >
+          <td colSpan={6} className="p-4">
+            <div className="bg-app overflow-x-auto rounded-sm border">
+              <table className="w-full table-fixed border-collapse">
+                <thead>
+                  <tr className="text-low border-b text-xs font-semibold">
+                    <th className="w-[40%] px-4 py-2.5 text-left">Team</th>
+                    <th className="w-[22%] px-4 py-2.5 text-right">Invoiced</th>
+                    <th className="w-[22%] px-4 py-2.5 text-right">In euros</th>
+                    <th className="w-[16%] px-4 py-2.5 text-right" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {month.teams.map((team, teamIndex) => (
+                    <tr
+                      key={team.stripeCustomerId}
+                      className={clsx(
+                        "text-sm",
+                        teamIndex !== month.teams.length - 1 && "border-b",
+                      )}
+                    >
+                      <td className="px-4 py-2.5 text-left">
+                        <Link href={`/${team.slug}`}>
+                          {team.name ?? team.slug}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2.5 text-right tabular-nums">
+                        {team.currency !== null ? (
+                          formatInvoiceAmount({
+                            amount: team.amount,
+                            currency: team.currency,
+                          })
+                        ) : (
+                          <span className="text-low">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-2.5 text-right tabular-nums">
+                        {formatEuros(team.revenue)}
+                      </td>
+                      <td className="px-4 py-2.5 text-right">
+                        <Link
+                          href={getStripeCustomerURL(team.stripeCustomerId)}
+                          target="_blank"
+                        >
+                          Stripe
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </td>
+        </tr>
+      ) : null}
+    </>
   );
 }
 
@@ -529,10 +678,7 @@ function HistoryRow(props: {
  */
 function RevenueHistory(props: { months: readonly RevenueMonth[] }) {
   const { months } = props;
-  // The running month is left out: it is partial, so a column comparing it to
-  // complete months would report a drop that is only the calendar.
-  const complete = months.slice(0, -1);
-  const rows = [...complete].reverse();
+  const rows = [...months].reverse();
 
   return (
     <div>
@@ -543,35 +689,24 @@ function RevenueHistory(props: { months: readonly RevenueMonth[] }) {
         <table className="w-full min-w-160 table-fixed border-collapse">
           <thead>
             <tr className="text-low border-b text-xs font-semibold">
-              <th className="w-[22%] px-4 py-3 text-left">Month</th>
-              <th className="w-[21%] px-4 py-3 text-right">
-                <Tooltip content="Invoices issued that month, excluding tax and net of credit notes — what Stripe charged, discounts included.">
+              <th className="w-[16%] px-4 py-3 text-left">Month</th>
+              <th className="w-[18%] px-4 py-3 text-right">
+                <Tooltip content="Ex-tax, net of credit notes.">
                   <span className="underline decoration-dotted underline-offset-2">
                     Invoiced
                   </span>
                 </Tooltip>
               </th>
+              <th className="w-[14%] px-4 py-3 text-right">Change</th>
+              <th className="w-[14%] px-4 py-3 text-right">Teams</th>
               <th className="w-[18%] px-4 py-3 text-right">
-                <Tooltip content="Against the month before it.">
+                <Tooltip content="Monthly revenue per paying team.">
                   <span className="underline decoration-dotted underline-offset-2">
-                    Change
+                    ARPU
                   </span>
                 </Tooltip>
               </th>
-              <th className="w-[18%] px-4 py-3 text-right">
-                <Tooltip content="Teams invoiced that month.">
-                  <span className="underline decoration-dotted underline-offset-2">
-                    Teams
-                  </span>
-                </Tooltip>
-              </th>
-              <th className="w-[21%] px-4 py-3 text-right">
-                <Tooltip content="The month's invoices over its teams — what the average team was billed.">
-                  <span className="underline decoration-dotted underline-offset-2">
-                    Per team
-                  </span>
-                </Tooltip>
-              </th>
+              <th className="w-[20%] px-4 py-3 text-right" />
             </tr>
           </thead>
           <tbody>
@@ -581,6 +716,8 @@ function RevenueHistory(props: { months: readonly RevenueMonth[] }) {
                 month={month}
                 // `rows` runs newest first, so the month before is the next one.
                 before={rows[index + 1] ?? null}
+                // The newest row is the month still running.
+                isCurrent={index === 0}
                 index={index}
                 isLast={index === rows.length - 1}
               />
@@ -598,20 +735,31 @@ function describeInvoice(invoice: YearlyContract["invoices"][number]): string {
     invoice.coveredFrom && invoice.coveredUntil
       ? `, covers ${DATE_FORMAT.format(new Date(invoice.coveredFrom))} to ${DATE_FORMAT.format(new Date(invoice.coveredUntil))}`
       : "";
-  return `${CONTRACT_PRICE_FORMAT.format(invoice.amount)} invoiced ${DATE_FORMAT.format(new Date(invoice.invoicedAt))}${covers}.`;
+  return `${formatInvoiceAmount(invoice)} invoiced ${DATE_FORMAT.format(new Date(invoice.invoicedAt))}${covers}.`;
 }
 
 /** One contract, the invoices it is worth and what it adds per month. */
+/** The contract's invoices in their own currency, when they share one. */
+function getOriginalTotal(
+  contract: YearlyContract,
+): { amount: number; currency: string } | null {
+  const first = contract.invoices[0];
+  if (
+    !first ||
+    contract.invoices.some((invoice) => invoice.currency !== first.currency)
+  ) {
+    return null;
+  }
+  return {
+    amount: contract.invoices.reduce((sum, invoice) => sum + invoice.amount, 0),
+    currency: first.currency,
+  };
+}
+
 function ContractRow(props: { contract: YearlyContract; index: number }) {
   const { contract, index } = props;
   const newestInvoice = contract.invoices[0] ?? null;
-  const foreignCurrencies = [
-    ...new Set(
-      contract.invoices
-        .filter((invoice) => invoice.currency !== "usd")
-        .map((invoice) => invoice.currency.toUpperCase()),
-    ),
-  ];
+  const originalTotal = getOriginalTotal(contract);
 
   return (
     <tr className={clsx(index % 2 === 0 ? "bg-app" : "bg-subtle", "border-b")}>
@@ -631,32 +779,23 @@ function ContractRow(props: { contract: YearlyContract; index: number }) {
               }
             >
               <span className="underline decoration-dotted underline-offset-2">
-                {CONTRACT_PRICE_FORMAT.format(contract.amount)}
+                {originalTotal
+                  ? formatInvoiceAmount(originalTotal)
+                  : CONTRACT_PRICE_FORMAT.format(contract.amount)}
               </span>
             </Tooltip>
-            {contract.invoices.length > 1 ? (
-              <span className="text-low">
-                {" "}
-                ({contract.invoices.length} invoices)
-              </span>
-            ) : null}
-            {foreignCurrencies.length > 0 ? (
-              <span className="text-low">
-                {" "}
-                ({foreignCurrencies.join(", ")} at parity)
-              </span>
-            ) : null}
             {contract.awaitingPayment ? (
-              <Tooltip content="The invoice was raised but has not been paid yet, so it counts nothing until it clears.">
-                <span className="text-warning-low underline decoration-dotted underline-offset-2">
-                  {" "}
-                  awaiting payment
-                </span>
-              </Tooltip>
+              <div>
+                <Tooltip content="Raised, not yet paid. Counted — expected to clear.">
+                  <span className="text-warning-low underline decoration-dotted underline-offset-2">
+                    Awaiting payment
+                  </span>
+                </Tooltip>
+              </div>
             ) : null}
           </>
         ) : (
-          <Tooltip content="No invoice reading as this contract was found on the customer, so it adds nothing to the yearly figure. Its invoices are worth a look in Stripe.">
+          <Tooltip content="Counts nothing.">
             <span className="text-danger-low underline decoration-dotted underline-offset-2">
               no invoice found
             </span>
@@ -664,7 +803,7 @@ function ContractRow(props: { contract: YearlyContract; index: number }) {
         )}
       </td>
       <td className="p-4 text-right text-sm tabular-nums">
-        {contract.amount !== null && !contract.awaitingPayment ? (
+        {contract.amount !== null ? (
           CONTRACT_PRICE_FORMAT.format(contract.amount / 12)
         ) : (
           <span className="text-low">—</span>
@@ -699,10 +838,8 @@ function ContractRow(props: { contract: YearlyContract; index: number }) {
  */
 function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
   const { contracts } = props;
-  // Awaiting-payment invoices are listed but not counted, like in the figure.
   const total = contracts.reduce(
-    (sum, contract) =>
-      sum + (contract.awaitingPayment ? 0 : (contract.amount ?? 0)),
+    (sum, contract) => sum + (contract.amount ?? 0),
     0,
   );
 
@@ -719,15 +856,9 @@ function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
             <thead>
               <tr className="text-low border-b text-xs font-semibold">
                 <th className="w-[30%] px-4 py-3 text-left">Team</th>
-                <th className="w-[20%] px-4 py-3 text-right">
-                  <Tooltip content="The contract's invoices added up — its latest annual bill, plus upsells raised on top of it since — excluding tax and net of credit notes.">
-                    <span className="underline decoration-dotted underline-offset-2">
-                      Invoiced
-                    </span>
-                  </Tooltip>
-                </th>
+                <th className="w-[20%] px-4 py-3 text-right">Invoiced</th>
                 <th className="w-[16%] px-4 py-3 text-right">
-                  <Tooltip content="The renewal over twelve — this column adds up to the Yearly plans figure.">
+                  <Tooltip content="÷ 12, in euros.">
                     <span className="underline decoration-dotted underline-offset-2">
                       Per month
                     </span>
@@ -750,7 +881,11 @@ function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
               <tr className="text-sm font-medium">
                 <td className="p-4 text-left">Total</td>
                 <td className="p-4 text-right tabular-nums">
-                  {CONTRACT_PRICE_FORMAT.format(total)}
+                  <Tooltip content="In euros.">
+                    <span className="underline decoration-dotted underline-offset-2">
+                      {CONTRACT_PRICE_FORMAT.format(total)}
+                    </span>
+                  </Tooltip>
                 </td>
                 <td className="p-4 text-right tabular-nums">
                   {CONTRACT_PRICE_FORMAT.format(total / 12)}
@@ -801,30 +936,26 @@ function StaffRevenuePage() {
       <PageHeader>
         <PageHeaderContent>
           <Heading>Revenue</Heading>
-          <Text slot="headline">
-            What Argos invoiced, month by month, read from Stripe.
-          </Text>
         </PageHeaderContent>
       </PageHeader>
-      <RevenueCards months={months} error={error ?? null} />
-      {months && contracts ? (
+      <RevenueCards
+        months={months}
+        github={data?.staffRevenue.githubMarketplaceMonthlyRevenue ?? null}
+        error={error ?? null}
+      />
+      {data && months && contracts ? (
         <>
-          <ChartCard
-            className="mb-6"
-            title="Invoiced by month"
-            description="Complete months only — the one running is still filling."
-          >
-            <RevenueChart months={months} />
+          <ChartCard className="mb-6" title="Invoiced by month">
+            <RevenueChart
+              months={months}
+              github={data.staffRevenue.githubMarketplaceMonthlyRevenue}
+            />
           </ChartCard>
           <RevenueHistory months={months} />
           <YearlyContracts contracts={contracts} />
         </>
       ) : error ? null : (
-        <ChartCard
-          className="mb-6"
-          title="Invoiced by month"
-          description="Complete months only — the one running is still filling."
-        >
+        <ChartCard className="mb-6" title="Invoiced by month">
           <div className="flex flex-col items-center gap-3 text-center">
             <Loader className="size-8" delay={0} />
             {/* Said rather than left to a spinner: this walks a year of Stripe

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -1,3 +1,4 @@
+import { CombinedGraphQLErrors } from "@apollo/client";
 import { useQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { clsx } from "clsx";
@@ -13,6 +14,7 @@ import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import { AuthGuard } from "@/containers/AuthGuard";
 import type { DocumentType } from "@/gql";
 import { graphql } from "@/gql";
+import { Alert, AlertText, AlertTitle } from "@/ui/Alert";
 import { ChartCard } from "@/ui/ChartCard";
 import type { ChartConfig } from "@/ui/Charts";
 import {
@@ -29,6 +31,7 @@ import {
   PageHeader,
   PageHeaderContent,
 } from "@/ui/Layout";
+import { Link } from "@/ui/Link";
 import { Loader } from "@/ui/Loader";
 import { StatTile } from "@/ui/StatTile";
 import { Text } from "@/ui/Text";
@@ -53,10 +56,12 @@ const StaffRevenueQuery = graphql(`
       monthlyPlans {
         revenue
         teamsCount
+        foreignRevenue
       }
       yearlyPlans {
         revenue
         teamsCount
+        foreignRevenue
       }
     }
   }
@@ -139,7 +144,16 @@ function formatMonth(month: string): string {
 
 /** The figures behind a half, appended to its tooltip. */
 function getSplitNote(split: Split): string {
-  return ` ${split.teamsCount} ${split.teamsCount === 1 ? "team" : "teams"}.`;
+  const teams = ` ${split.teamsCount} ${split.teamsCount === 1 ? "team" : "teams"}.`;
+  // Named only when there is some: on an all-dollar month the caveat would be
+  // noise, and on a month with euros in it the reader has to know the total
+  // holds two currencies added at parity.
+  const foreign =
+    split.foreignRevenue > 0
+      ? ` ${formatPrice(split.foreignRevenue)} of it was invoiced in another currency and is counted at parity, not converted.`
+      : "";
+
+  return `${teams}${foreign}`;
 }
 
 /**
@@ -524,6 +538,29 @@ function StaffRevenuePage() {
     variables: { months: PAGE_MONTHS },
   });
   const months = data?.staffRevenue ?? null;
+
+  // Told rather than reported as a failed figure, as the other staff pages do:
+  // a reader without access has no figures to wait for, and three tiles reading
+  // "unavailable" would send them looking for an outage. Every other failure
+  // stays on the tiles, where it does not take the page down with it.
+  const isForbidden =
+    error !== undefined &&
+    CombinedGraphQLErrors.is(error) &&
+    error.errors.some((item) => item.extensions?.code === "FORBIDDEN");
+
+  if (isForbidden) {
+    return (
+      <PageContainer>
+        <Alert>
+          <AlertTitle>Access restricted</AlertTitle>
+          <AlertText>This page is only available to staff users.</AlertText>
+          <AlertText>
+            <Link href="/teams">Go to your teams</Link>
+          </AlertText>
+        </Alert>
+      </PageContainer>
+    );
+  }
 
   return (
     <PageContainer>

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -1,0 +1,582 @@
+import { useQuery } from "@apollo/client/react";
+import { invariant } from "@argos/util/invariant";
+import { clsx } from "clsx";
+import {
+  CalendarCheckIcon,
+  CalendarClockIcon,
+  TrendingDownIcon,
+  TrendingUpIcon,
+} from "lucide-react";
+import { Helmet } from "react-helmet";
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+
+import { AuthGuard } from "@/containers/AuthGuard";
+import type { DocumentType } from "@/gql";
+import { graphql } from "@/gql";
+import { ChartCard } from "@/ui/ChartCard";
+import type { ChartConfig } from "@/ui/Charts";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/ui/Charts";
+import { Heading } from "@/ui/Heading";
+import {
+  Page,
+  PageContainer,
+  PageHeader,
+  PageHeaderContent,
+} from "@/ui/Layout";
+import { Loader } from "@/ui/Loader";
+import { StatTile } from "@/ui/StatTile";
+import { Text } from "@/ui/Text";
+import { Tooltip } from "@/ui/Tooltip";
+
+import { formatPrice } from "./pricing";
+
+/**
+ * Asked on its own rather than alongside the team directory: it walks Stripe's
+ * invoices, so the two load beside each other, each with its own skeleton, and
+ * a slow answer never holds a row of the table back.
+ *
+ * Every month costs a walk of its own, which is why the count is asked for
+ * rather than fixed: the band above the directory wants three, the page that
+ * charts a year wants twelve, and neither should pay for the other.
+ */
+const StaffRevenueQuery = graphql(`
+  query StaffRevenue_staffRevenue($months: Int!) {
+    staffRevenue(months: $months) {
+      month
+      revenue
+      monthlyPlans {
+        revenue
+        teamsCount
+      }
+      yearlyPlans {
+        revenue
+        teamsCount
+      }
+    }
+  }
+`);
+
+type RevenueMonth = DocumentType<
+  typeof StaffRevenueQuery
+>["staffRevenue"][number];
+type Split = RevenueMonth["monthlyPlans"];
+
+/** Months the dedicated page reads — a year, plus the one running. */
+const PAGE_MONTHS = 13;
+
+/**
+ * How each half is arrived at, one tooltip each.
+ *
+ * Two rather than one because the halves do not answer the same question: the
+ * monthly one reports the month's invoices, the yearly one a rate.
+ */
+const LAST_MONTHLY_HINT =
+  "Invoices issued last month, excluding tax and net of credit notes — what Stripe charged, discounts included.";
+
+const CURRENT_MONTHLY_HINT =
+  "Invoices issued so far this month, excluding tax and net of credit notes. Partial by nature: the month is not over.";
+
+const YEARLY_HINT =
+  "Annual contracts in force: their latest invoice ÷ 12. A rate, so it is the same every month rather than a spike in the renewal month.";
+
+/**
+ * Stands in for the hint line while the figures load.
+ *
+ * `StatTile` only reserves that line's height when it is given a hint at all,
+ * and blanks its content on its own while loading. Handing it nothing until the
+ * data lands drops the line entirely, so the card grows under the reader the
+ * moment it arrives.
+ */
+const HINT_PLACEHOLDER = " ";
+
+/**
+ * The month an amount covers, named.
+ *
+ * Read in UTC, which is where the server cut the month — formatting in the
+ * reader's own zone would name the month before it for anyone west of
+ * Greenwich.
+ */
+const MONTH_FORMAT = new Intl.DateTimeFormat("en-US", {
+  month: "long",
+  timeZone: "UTC",
+});
+
+const MONTH_YEAR_FORMAT = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  year: "numeric",
+  timeZone: "UTC",
+});
+
+const MONTH_SHORT_FORMAT = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  timeZone: "UTC",
+});
+
+/**
+ * Amounts on the axis, shortened.
+ *
+ * Fixed to the same locale and currency as `formatPrice` rather than the
+ * reader's own: every other figure on the page is printed in US dollars, and an
+ * axis that followed the browser would label the same money differently from
+ * the cards above it.
+ */
+const AXIS_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  notation: "compact",
+  maximumFractionDigits: 0,
+});
+
+function formatMonth(month: string): string {
+  return MONTH_FORMAT.format(new Date(month));
+}
+
+/** The figures behind a half, appended to its tooltip. */
+function getSplitNote(split: Split): string {
+  return ` ${split.teamsCount} ${split.teamsCount === 1 ? "team" : "teams"}.`;
+}
+
+/**
+ * How the figure moved between two months, or null when there is nothing to
+ * divide by.
+ *
+ * A month that invoiced nothing is a real answer, but it makes no ratio, and
+ * reporting the growth as infinite would say less than saying nothing.
+ */
+function getGrowth(month: number, before: number): number | null {
+  return before === 0 ? null : (month - before) / before;
+}
+
+/** One half of the amount, with the tooltip that explains that half alone. */
+function SplitAmount(props: {
+  amount: number;
+  label: string;
+  tooltip: string;
+}) {
+  return (
+    <Tooltip content={props.tooltip}>
+      <span className="underline decoration-dotted underline-offset-2">
+        {formatPrice(props.amount)} {props.label}
+      </span>
+    </Tooltip>
+  );
+}
+
+/**
+ * Where a month's amount comes from, under the amount.
+ *
+ * The two intervals rather than any other cut: they are the two things this
+ * computes differently — one reads the month's invoices, the other spreads a
+ * year's — so they are what a reader has to be able to take apart.
+ */
+function MonthSplit(props: { month: RevenueMonth; monthlyHint: string }) {
+  const { month, monthlyHint } = props;
+
+  return (
+    <>
+      <SplitAmount
+        amount={month.monthlyPlans.revenue}
+        label="monthly"
+        tooltip={`${monthlyHint}${getSplitNote(month.monthlyPlans)}`}
+      />
+      {" · "}
+      <SplitAmount
+        amount={month.yearlyPlans.revenue}
+        label="yearly"
+        tooltip={`${YEARLY_HINT}${getSplitNote(month.yearlyPlans)}`}
+      />
+    </>
+  );
+}
+
+/**
+ * The three headline figures, rendered from whatever window was read.
+ *
+ * Takes the months rather than fetching them, so the band above the directory
+ * and the page that charts a year draw the same cards off one query each rather
+ * than asking twice.
+ */
+function RevenueCards(props: {
+  /** Oldest first, the running month last. Null while loading. */
+  months: readonly RevenueMonth[] | null;
+  error: Error | null;
+}) {
+  const { months, error } = props;
+
+  // The last two are the only ones the cards read, whatever the window.
+  const currentMonth = months?.at(-1) ?? null;
+  const lastMonth = months?.at(-2) ?? null;
+  const growth =
+    currentMonth && lastMonth
+      ? getGrowth(currentMonth.revenue, lastMonth.revenue)
+      : null;
+
+  // An em dash on all three rather than a band that disappears: the figures
+  // failing to load is worth seeing on a page whose whole subject is what they
+  // report, and it must not take the directory down with it.
+  //
+  // The reason is carried rather than swallowed. This reads a third party at
+  // request time, so it fails in ways only its message explains — a key missing
+  // a permission, a rate limit, a key in the wrong mode — and this page is
+  // staff-only, so there is nobody here to protect from the detail.
+  const unavailable = error ? (
+    <Tooltip content={error.message}>
+      <span className="underline decoration-dotted underline-offset-2">
+        unavailable
+      </span>
+    </Tooltip>
+  ) : null;
+
+  /** `undefined` draws the skeleton, `null` an em dash. */
+  const readValue = (value: number | null) => {
+    if (error) {
+      return null;
+    }
+    return months ? value : undefined;
+  };
+
+  return (
+    <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <StatTile
+        data-visual-test="transparent"
+        icon={CalendarCheckIcon}
+        color="success"
+        label="Last month"
+        value={readValue(lastMonth?.revenue ?? null)}
+        format="currency"
+        hint={
+          unavailable ??
+          (lastMonth ? (
+            <MonthSplit month={lastMonth} monthlyHint={LAST_MONTHLY_HINT} />
+          ) : (
+            HINT_PLACEHOLDER
+          ))
+        }
+      />
+      <StatTile
+        data-visual-test="transparent"
+        icon={CalendarClockIcon}
+        color="primary"
+        label="Current month"
+        value={readValue(currentMonth?.revenue ?? null)}
+        format="currency"
+        hint={
+          unavailable ??
+          (currentMonth ? (
+            <MonthSplit
+              month={currentMonth}
+              monthlyHint={CURRENT_MONTHLY_HINT}
+            />
+          ) : (
+            HINT_PLACEHOLDER
+          ))
+        }
+      />
+      <StatTile
+        data-visual-test="transparent"
+        icon={growth !== null && growth < 0 ? TrendingDownIcon : TrendingUpIcon}
+        color={growth !== null && growth < 0 ? "warning" : "success"}
+        label="Month over month"
+        value={readValue(growth)}
+        format="percent"
+        hint={
+          unavailable ??
+          (currentMonth && lastMonth && growth !== null ? (
+            <Tooltip
+              content={`${formatMonth(currentMonth.month)} at ${formatPrice(currentMonth.revenue)} against ${formatMonth(lastMonth.month)} at ${formatPrice(lastMonth.revenue)}. The running month is still filling, so this starts the month deeply negative and climbs as the invoices land — it is only comparable to the month before it on the last day.`}
+            >
+              <span className="underline decoration-dotted underline-offset-2">
+                {formatMonth(currentMonth.month)} vs{" "}
+                {formatMonth(lastMonth.month)}
+              </span>
+            </Tooltip>
+          ) : months ? (
+            "nothing to compare"
+          ) : (
+            HINT_PLACEHOLDER
+          ))
+        }
+      />
+    </div>
+  );
+}
+
+/**
+ * The two series, in a fixed order with fixed colours.
+ *
+ * Order and colour follow the halves themselves, not their size: the monthly
+ * book keeps its colour whether it is the larger half or not, so a month where
+ * the two cross over does not repaint the chart.
+ *
+ * Violet is the app's own accent, which the account analytics already draw
+ * their primary series in — the dominant half wears it. Grass is the second
+ * because it is far enough from violet on the blue-yellow axis to survive
+ * colour blindness: the pair separates by ΔE 28 under deuteranopia and 33 to
+ * normal vision. Grass sits just under 3:1 against the light surface, which the
+ * legend and the table below relieve.
+ */
+const CHART_SERIES = [
+  { key: "monthly", label: "Monthly plans", color: "var(--violet-9)" },
+  { key: "yearly", label: "Yearly plans", color: "var(--grass-9)" },
+] as const;
+
+const CHART_CONFIG: ChartConfig = {
+  monthly: { label: "Monthly plans", color: "var(--violet-9)" },
+  yearly: { label: "Yearly plans", color: "var(--grass-9)" },
+};
+
+/**
+ * The window as stacked areas, one point per complete month.
+ *
+ * Stacked because the two halves compose the total the cards report, so the
+ * height of the band is the figure and its split is where it came from. Areas
+ * rather than bars because what is being read here is a trend over a year, and
+ * a filled band carries a slope where twelve separate bars make the reader
+ * measure heights against each other.
+ *
+ * The running month is left out, as it is from the table: a partial point
+ * dragged the line down every month, which reads as a collapse rather than as a
+ * month still filling.
+ */
+function RevenueChart(props: { months: readonly RevenueMonth[] }) {
+  const data = props.months.slice(0, -1).map((month) => ({
+    month: month.month,
+    monthly: month.monthlyPlans.revenue,
+    yearly: month.yearlyPlans.revenue,
+  }));
+
+  return (
+    <ChartContainer
+      config={CHART_CONFIG}
+      className="h-full w-full"
+      data-visual-test="transparent"
+    >
+      <AreaChart accessibilityLayer data={data} margin={{ left: 0, right: 8 }}>
+        {/* Horizontal only, dashed: the grid is there to read a height against,
+            not to be looked at. */}
+        <CartesianGrid vertical={false} strokeDasharray="5 5" />
+        <XAxis
+          dataKey="month"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={12}
+          tickFormatter={(value: string) =>
+            MONTH_SHORT_FORMAT.format(new Date(value))
+          }
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          // Wide enough for the longest compact amount. Left to itself under a
+          // negative margin, the axis cropped its own labels and printed
+          // "8 k $US" where it meant "$38K".
+          width={56}
+          tickFormatter={(value: number) => AXIS_PRICE_FORMAT.format(value)}
+        />
+        <ChartTooltip
+          isAnimationActive={false}
+          content={
+            <ChartTooltipContent
+              // The month is read off the datum rather than off the label:
+              // Recharts hands the label over as a node, not as the value.
+              labelFormatter={(_label, payload) => {
+                const item = payload[0];
+                invariant(item, "a tooltip always has a datum");
+                return MONTH_YEAR_FORMAT.format(new Date(item.payload.month));
+              }}
+              formatter={(value) => formatPrice(Number(value))}
+            />
+          }
+        />
+        {/* Two series, so a legend is not optional: identity must not rest on
+            colour alone. */}
+        <ChartLegend content={<ChartLegendContent />} />
+        {CHART_SERIES.map((series) => (
+          <Area
+            key={series.key}
+            dataKey={series.key}
+            type="monotone"
+            stackId="revenue"
+            fill={series.color}
+            fillOpacity={0.4}
+            stroke={series.color}
+            isAnimationActive={false}
+          />
+        ))}
+      </AreaChart>
+    </ChartContainer>
+  );
+}
+
+/** Month over month down the history, so a trend can be read off the column. */
+function HistoryRow(props: {
+  month: RevenueMonth;
+  before: RevenueMonth | null;
+  index: number;
+  isLast: boolean;
+}) {
+  const { month, before, index, isLast } = props;
+  const growth = before ? getGrowth(month.revenue, before.revenue) : null;
+
+  return (
+    <tr
+      className={clsx(
+        index % 2 === 0 ? "bg-app" : "bg-subtle",
+        !isLast && "border-b",
+      )}
+    >
+      <td className="p-4 text-left text-sm font-medium">
+        {MONTH_YEAR_FORMAT.format(new Date(month.month))}
+      </td>
+      <td className="p-4 text-right text-sm tabular-nums">
+        {formatPrice(month.monthlyPlans.revenue)}
+      </td>
+      <td className="p-4 text-right text-sm tabular-nums">
+        {formatPrice(month.yearlyPlans.revenue)}
+      </td>
+      <td className="p-4 text-right text-sm font-medium tabular-nums">
+        {formatPrice(month.revenue)}
+      </td>
+      <td className="p-4 text-right text-sm tabular-nums">
+        {growth === null ? (
+          <span className="text-low">—</span>
+        ) : (
+          <span className={growth < 0 ? "text-danger-low" : "text-success-low"}>
+            {growth > 0 ? "+" : ""}
+            {Math.round(growth * 100)}%
+          </span>
+        )}
+      </td>
+      <td className="p-4 text-right text-sm tabular-nums">
+        {month.monthlyPlans.teamsCount}
+      </td>
+    </tr>
+  );
+}
+
+/**
+ * The window, month by month.
+ *
+ * The reason this page exists rather than the band alone: three cards say where
+ * revenue stands, a column says which way it has been going — and the months
+ * are already read to draw the cards, so the table costs nothing more.
+ *
+ * Newest first, like every other staff table: the rows people read are the
+ * recent ones.
+ */
+function RevenueHistory(props: { months: readonly RevenueMonth[] }) {
+  const { months } = props;
+  // The running month is left out: it is partial, so a column comparing it to
+  // complete months would report a drop that is only the calendar.
+  const complete = months.slice(0, -1);
+  const rows = [...complete].reverse();
+
+  return (
+    <div className="overflow-x-auto rounded-sm border">
+      <table className="w-full min-w-160 table-fixed border-collapse">
+        <thead>
+          <tr className="text-low border-b text-xs font-semibold">
+            <th className="w-[18%] px-4 py-3 text-left">Month</th>
+            <th className="w-[18%] px-4 py-3 text-right">Monthly plans</th>
+            <th className="w-[18%] px-4 py-3 text-right">Yearly plans</th>
+            <th className="w-[16%] px-4 py-3 text-right">Total</th>
+            <th className="w-[15%] px-4 py-3 text-right">
+              <Tooltip content="Against the month before it. The running month is not listed: being partial, it would read as a drop that is only the calendar.">
+                <span className="underline decoration-dotted underline-offset-2">
+                  Change
+                </span>
+              </Tooltip>
+            </th>
+            <th className="w-[15%] px-4 py-3 text-right">
+              <Tooltip content="Teams invoiced on a monthly plan that month. Annual contracts are a rate rather than a month's invoices, so they are not counted here.">
+                <span className="underline decoration-dotted underline-offset-2">
+                  Teams
+                </span>
+              </Tooltip>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((month, index) => (
+            <HistoryRow
+              key={month.month}
+              month={month}
+              // `rows` runs newest first, so the month before is the next one.
+              before={rows[index + 1] ?? null}
+              index={index}
+              isLast={index === rows.length - 1}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function StaffRevenuePage() {
+  const { data, error } = useQuery(StaffRevenueQuery, {
+    variables: { months: PAGE_MONTHS },
+  });
+  const months = data?.staffRevenue ?? null;
+
+  return (
+    <PageContainer>
+      <PageHeader>
+        <PageHeaderContent>
+          <Heading>Revenue</Heading>
+          <Text slot="headline">
+            What Argos invoiced, month by month, read from Stripe.
+          </Text>
+        </PageHeaderContent>
+      </PageHeader>
+      <RevenueCards months={months} error={error ?? null} />
+      {months ? (
+        <>
+          <ChartCard
+            className="mb-6"
+            title="Invoiced by month"
+            description="Complete months only — the one running is still filling."
+          >
+            <RevenueChart months={months} />
+          </ChartCard>
+          <RevenueHistory months={months} />
+        </>
+      ) : error ? null : (
+        <ChartCard
+          className="mb-6"
+          title="Invoiced by month"
+          description="Complete months only — the one running is still filling."
+        >
+          <div className="flex flex-col items-center gap-3 text-center">
+            <Loader className="size-8" delay={0} />
+            {/* Said rather than left to a spinner: this walks a year of Stripe
+                invoices, which is seconds rather than the moment a spinner
+                usually stands for — and knowing why it is slow is the
+                difference between waiting and reloading. */}
+            <div className="text-low max-w-sm text-sm">
+              Reading {PAGE_MONTHS} months of invoices from Stripe. Nothing is
+              stored, so this takes a few seconds the first time each hour.
+            </div>
+          </div>
+        </ChartCard>
+      )}
+    </PageContainer>
+  );
+}
+
+export function Component() {
+  return (
+    <Page>
+      <Helmet>
+        <title>Staff Revenue</title>
+      </Helmet>
+      <AuthGuard>{() => <StaffRevenuePage />}</AuthGuard>
+    </Page>
+  );
+}

--- a/apps/frontend/src/pages/Staff/index.tsx
+++ b/apps/frontend/src/pages/Staff/index.tsx
@@ -19,6 +19,7 @@ export function Component() {
       <TabLinkList className="px-4" aria-label="Staff navigation">
         <TabLink href="teams">All teams</TabLink>
         <TabLink href="trials">Trials</TabLink>
+        <TabLink href="revenue">Revenue</TabLink>
       </TabLinkList>
       <hr className="border-t" />
       <TabLinkPanel className="flex flex-1 flex-col">

--- a/apps/frontend/src/pages/Staff/stripe.ts
+++ b/apps/frontend/src/pages/Staff/stripe.ts
@@ -6,3 +6,8 @@
 export function getStripeCustomerURL(stripeCustomerId: string) {
   return `https://dashboard.stripe.com/customers/${stripeCustomerId}`;
 }
+
+/** The subscription page in the dashboard, where its invoices are listed. */
+export function getStripeSubscriptionURL(stripeSubscriptionId: string) {
+  return `https://dashboard.stripe.com/subscriptions/${stripeSubscriptionId}`;
+}

--- a/apps/frontend/src/router.tsx
+++ b/apps/frontend/src/router.tsx
@@ -281,6 +281,11 @@ export const router: ReturnType<typeof createBrowserRouter> =
                   HydrateFallback,
                   lazy: () => import("./pages/Staff/Trials"),
                 },
+                {
+                  path: "revenue",
+                  HydrateFallback,
+                  lazy: () => import("./pages/Staff/Revenue"),
+                },
               ],
             },
             {

--- a/apps/frontend/src/ui/ChartCard.tsx
+++ b/apps/frontend/src/ui/ChartCard.tsx
@@ -1,0 +1,37 @@
+import { clsx } from "clsx";
+
+import { Card } from "./Card";
+
+/**
+ * A chart on its own surface, with a title above it.
+ *
+ * The white card is what separates a plot from the page around it: an axis
+ * drawn straight onto the app background reads as part of the layout rather
+ * than as a figure. The minimum height keeps a card that is still loading the
+ * same size as one that has drawn, so a dashboard does not reflow under the
+ * reader as its charts arrive.
+ */
+export function ChartCard(props: {
+  className?: string;
+  title: string;
+  description?: React.ReactNode;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card className={clsx("flex flex-col", props.className)}>
+      <div className="flex items-start justify-between gap-4 p-5 pb-0">
+        <div>
+          <h3 className="font-semibold">{props.title}</h3>
+          {props.description ? (
+            <p className="text-low text-sm">{props.description}</p>
+          ) : null}
+        </div>
+        {props.action ? <div className="shrink-0">{props.action}</div> : null}
+      </div>
+      <div className="flex min-h-72 flex-1 items-center justify-center p-5">
+        {props.children}
+      </div>
+    </Card>
+  );
+}

--- a/apps/frontend/src/ui/Charts.tsx
+++ b/apps/frontend/src/ui/Charts.tsx
@@ -125,6 +125,7 @@ export function ChartTooltipContent({
   labelFormatter,
   labelClassName,
   formatter,
+  valueFormatter,
   color,
   nameKey,
   labelKey,
@@ -137,6 +138,11 @@ export function ChartTooltipContent({
     payload?: any[] | undefined;
     nameKey?: string;
     labelKey?: string;
+    /**
+     * Formats each row's value (and the Total), keeping the indicator and
+     * series label — where `formatter` replaces the whole row.
+     */
+    valueFormatter?: (value: number) => React.ReactNode;
   }) {
   const { config } = useChart();
 
@@ -252,7 +258,9 @@ export function ChartTooltipContent({
                     </div>
                     {item.value && (
                       <span className="text-default font-medium tabular-nums">
-                        {item.value.toLocaleString()}
+                        {valueFormatter && typeof item.value === "number"
+                          ? valueFormatter(item.value)
+                          : item.value.toLocaleString()}
                       </span>
                     )}
                   </div>
@@ -264,7 +272,9 @@ export function ChartTooltipContent({
         {payload.length > 1 && (
           <div className="mt-1 flex w-full justify-between border-t pt-1 font-bold">
             <span>Total</span>
-            <span>{sum.toLocaleString()}</span>
+            <span>
+              {valueFormatter ? valueFormatter(sum) : sum.toLocaleString()}
+            </span>
           </div>
         )}
       </div>

--- a/apps/frontend/src/ui/StatTile.tsx
+++ b/apps/frontend/src/ui/StatTile.tsx
@@ -18,8 +18,10 @@ type StatTileProps = ComponentPropsWithRef<"div"> & {
   color: StatTileColor;
   label: string;
   value: number | null | undefined;
-  /** `currency` renders US dollars — the currency Argos reports revenue in. */
+  /** `currency` renders money, US dollars unless `currency` says otherwise. */
   format?: "number" | "percent" | "currency";
+  /** ISO code for `format="currency"` — the staff pages price in USD, the revenue page in EUR. */
+  currency?: string;
   hint?: React.ReactNode;
   visual?: React.ReactNode;
 };
@@ -37,6 +39,7 @@ export function StatTile({
   label,
   value,
   format = "number",
+  currency = "USD",
   hint,
   visual,
   ...rest
@@ -71,7 +74,7 @@ export function StatTile({
               value={value}
               format={{
                 style: "currency",
-                currency: "USD",
+                currency,
                 maximumFractionDigits: 0,
               }}
             />

--- a/playwright.config.mts
+++ b/playwright.config.mts
@@ -107,6 +107,12 @@ const config = defineConfig({
     env: {
       NODE_ENV: "test",
       CSP_SCRIPT_SRC: `${getCSPScriptHash()},'unsafe-eval'`,
+      // The staff revenue band reads Stripe's invoices at request time. Left to
+      // the key in `.env`, the suite would call Stripe on every run of the
+      // staff page — a third party in the way of the tests, and a figure that
+      // changes under the visual baseline. Unset, the band reports itself
+      // unavailable, which is both true here and stable.
+      STRIPE_API_KEY: "no-api-key",
     },
   },
 });

--- a/playwright.config.mts
+++ b/playwright.config.mts
@@ -107,11 +107,10 @@ const config = defineConfig({
     env: {
       NODE_ENV: "test",
       CSP_SCRIPT_SRC: `${getCSPScriptHash()},'unsafe-eval'`,
-      // The staff revenue band reads Stripe's invoices at request time. Left to
-      // the key in `.env`, the suite would call Stripe on every run of the
-      // staff page — a third party in the way of the tests, and a figure that
-      // changes under the visual baseline. Unset, the band reports itself
-      // unavailable, which is both true here and stable.
+      // The staff revenue page reads Stripe's invoices at request time. Left to
+      // the key in `.env`, the suite would call a third party on every run, and
+      // its figures would move under the visual baseline. Unset, the page
+      // reports itself unavailable, which is both true here and stable.
       STRIPE_API_KEY: "no-api-key",
     },
   },

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -621,6 +621,11 @@ staffTest(
 );
 
 loggedTest("staff pages are refused to regular users", async ({ page }) => {
-  await page.goto("/staff/trials");
-  await expect(page.getByText("Access restricted")).toBeVisible();
+  // Every staff page, not just one: each owns its own query, so each has to
+  // turn the refusal into something a reader can act on rather than into a
+  // figure that failed to load.
+  for (const path of ["/staff/teams", "/staff/trials", "/staff/revenue"]) {
+    await page.goto(path);
+    await expect(page.getByText("Access restricted")).toBeVisible();
+  }
 });

--- a/turbo.json
+++ b/turbo.json
@@ -52,7 +52,9 @@
         "S3_PUBLIC_IMAGE_BASE_URL",
         "AWS_SCREENSHOTS_BUCKET",
         "SQIDS_ALPHABET",
-        "LOG_LEVEL"
+        "LOG_LEVEL",
+        "STRIPE_API_KEY",
+        "TZ"
       ]
     },
     "//#watch-codegen": {


### PR DESCRIPTION
A **Revenue** tab under Staff: what Argos invoiced, month by month, read from Stripe.

## Why the invoices, and not our own numbers

Argos does not price its own subscriptions. It sends usage as meter events and Stripe invoices it. Recomputing revenue from `screenshot_buckets` therefore means running a second pricing engine that has to agree with the first — and it did not: the flat price was guessed from a hardcoded table when Stripe had not been asked for it, euro contracts were read at parity, no price history existed so a renegotiation applied retroactively, and coupons, credit notes and proration were invisible entirely.

Reading the invoices removes all of it. An invoice has a date, an amount, a currency and a customer, so a calendar month is a sum with no rule left to agree on. Churn stops being invisible too: a team that left keeps the invoices it was already sent.

Nothing is stored. Invoices get voided, refunded and credited, so a local copy is a second source to keep correct forever — and the questions this page asks are answered by Stripe in a few round trips.

## The figures

**Monthly plans** are the month's invoices, excluding tax and net of credit notes.

**Annual contracts** report their latest invoice over twelve. A closed annual period is up to a year old and its overage lands on a single invoice up to a year away, so neither belongs under a heading that says "per month". It is a rate, so it reads the same on every month.

**Month over month** compares the running month to the last complete one. It therefore starts each month deeply negative and climbs as the invoices land — deliberate, and said in the tooltip. The chart and the table leave the running month out for the opposite reason: a partial point beside complete ones reads as a collapse rather than as a month still filling.

## Speed

Stripe's pagination is a cursor, so one walk over a year is a year of round trips end to end. Each month is its own walk and they run together, which also means each chain knows the bucket its invoices belong to. Cached for an hour: complete months cannot change, and the running one gains a handful of invoices a day.

The cache key carries the month count **and the deployment**. Without that, two apps pointed at one Redis serve each other's totals — which on a developer machine is not hypothetical, since the end-to-end suite and the dev server share `redis://localhost:6380/1`.

## Its own tab, not a band above the directory

Both were built. The band lost: the directory answers what a team is, this answers how Argos is doing, and putting them together invited a reconciliation that cannot work — the band reads invoices while the columns beside it price accumulated usage, so they never add up. A tab also has room for the year of history, which is the part worth having.

## Two fixes that came out of the same work

`turbo.json` — `watch-server` declares the environment it receives, and Turbo runs tasks in strict mode. `STRIPE_API_KEY` was not on the list, so passing it on the command line never reached the dev server: it silently fell back to the test-mode key in `.env`, which matches no production customer and totals zero without erroring. `TZ` was missing for the same reason.

`period-usage.ts` — the bucket totals and the media units read nothing of each other and were awaited in turn. The bucket join was also bounded at its lower end only, so a closed period read every bucket from its start through to today and discarded the running period's: roughly twice the rows on the table that dominates that query.

## Tests

Stripe is not mocked. `getInvoiceRevenue` and the UTC month boundaries are covered case by case, `getBilledTeams` runs against a real database — trials, granted plans, `past_due`, a team that never reached Stripe, two active subscriptions at once. The pagination itself has no test: it cannot be reached without a mock, and a mock there would assert what I assumed Stripe does.

The end-to-end suite runs with Stripe deliberately unconfigured, so the band reports itself unavailable rather than calling a third party on every run and moving the visual baseline with real invoices.

## Draft

Opened as a draft: the figures have been read against production, but nobody other than me has looked at whether this is the revenue view you want.
