### PR TITLE
chore(backend): add a guarded read-only mode against production data

### DIFF
--- a/.env.prod-ro
+++ b/.env.prod-ro
@@ -1,0 +1,30 @@
+# Runs local development against the PRODUCTION database, read-only.
+#
+#   pnpm run dev:prod-ro
+#
+# Resolved by `op run` — this file is safe to commit, it contains no secrets.
+# The regular `.env` is deliberately NOT loaded in this mode, so this file is
+# the complete environment: anything not listed here is absent on purpose
+# (Resend, Stripe, git-provider apps… their absence is what keeps browsing
+# production data side-effect free). See CONTRIBUTING.md § Running against
+# production data.
+ARGOS_TARGET=prod-ro
+
+# No password in the URL: PG_IAM_AUTH mints a short-lived RDS IAM token per
+# connection from your AWS session (`aws sso login` first). The op:// reference
+# keeps the RDS hostname out of the repository.
+DATABASE_URL=op://argos-dev/argos-prod-ro/DATABASE_URL
+PG_IAM_AUTH=true
+
+SQIDS_ALPHABET=op://argos-dev/argos-prod-ro/SQIDS_ALPHABET
+
+# Production screenshots (public CDN, read via s3:GetObject only).
+AWS_SCREENSHOTS_BUCKET=argos-ci-production
+S3_PUBLIC_IMAGE_BASE_URL=https://files.argos-ci.com/
+
+# Sessions, rate limits and enqueued jobs stay on this machine. The config
+# refuses to boot if these point anywhere else.
+REDIS_URL=redis://localhost:6380/1
+AMQP_URL=amqp://localhost
+
+LOG_LEVEL=info

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,6 +185,63 @@ pnpm run --filter @argos/backend db:migrate:latest
 NODE_ENV=test pnpm run --filter @argos/backend db:reset
 ```
 
+### Running against production data (read-only)
+
+To debug with real data shapes, the app can run locally against the production
+database through the `argos_dev_ro` Postgres role — read-only except for the
+two tables the login flow writes (`user_sessions`, `team_users.lastAuthMethod`).
+
+```sh
+pnpm run dev:prod-ro
+```
+
+The command wraps `pnpm run dev` in `op run --env-file=.env.prod-ro`: no
+secret ever lands on disk or in shell history. It needs three things set up
+once:
+
+- a **1Password item** `argos-prod-ro` in the `argos-dev` vault with the fields
+  referenced by `.env.prod-ro` (`DATABASE_URL` — no password, e.g.
+  `postgresql://argos_dev_ro@<rds-host>:5432/<db>` — and `SQIDS_ALPHABET`);
+- **IAM database authentication enabled on the RDS instance**, which is a
+  separate switch from the `rds_iam` grant on the role. Both are required, and
+  when either is missing RDS answers a perfectly valid token with
+  `password authentication failed for user "argos_dev_ro"`:
+
+  ```sh
+  aws rds describe-db-instances --region us-east-1 \
+    --db-instance-identifier argos-postgres \
+    --query 'DBInstances[0].IAMDatabaseAuthenticationEnabled'
+  ```
+
+- **AWS credentials** for a principal allowed to `rds-db:connect` as
+  `argos_dev_ro` (`arn:aws:rds-db:<region>:<account>:dbuser:<db-resource-id>/argos_dev_ro`).
+  Any principal the SDK can find works — an `aws sso login` session or a
+  configured IAM user. There is no database password at all: `PG_IAM_AUTH=true`
+  signs a short-lived token per connection.
+
+What the mode changes, enforced by the config (`ARGOS_TARGET=prod-ro`):
+
+- your `.env` is **not** loaded, and write-capable third-party credentials
+  (Resend, Stripe, GitHub/GitLab/Google/Slack apps…) must be absent — the
+  database grants make Postgres read-only, these keep everything else
+  side-effect free;
+- the worker refuses to run, and migrations / `knex-scripts` throw;
+- Redis and RabbitMQ must be local (sessions, rate limits and enqueued jobs
+  stay on your machine);
+- conversely, a `DATABASE_URL` pointing at AWS **without** `ARGOS_TARGET=prod-ro`
+  refuses to boot, so the guardrails cannot be forgotten.
+
+**Sign in with an email code** (of an email that exists in production). Resend
+is absent, so the email is never sent — read the code from your local Redis:
+
+```sh
+docker compose exec redis redis-cli -n 1 GET "email_verification:<your-email>"
+```
+
+GitHub/GitLab/Google login would write dev-app OAuth tokens over the
+production rows, and production passkeys are bound to the `argos-ci.com` RP id,
+so neither works here — email code is the only supported method.
+
 ## ✅ Testing your changes
 
 ### Linting

--- a/apps/backend/knexfile.js
+++ b/apps/backend/knexfile.js
@@ -1,4 +1,13 @@
 import { getKnexConfig } from "./dist/config/database.js";
 import config from "./dist/config/index.js";
 
+// Everything that goes through the knexfile — migrations, knex-scripts
+// (create/drop/truncate/dump) — mutates the database schema or content, and
+// none of it may ever run against production data.
+if (config.get("target") === "prod-ro") {
+  throw new Error(
+    "ARGOS_TARGET=prod-ro: migrations and database scripts are disabled against production data.",
+  );
+}
+
 export default getKnexConfig(config);

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -37,6 +37,7 @@
     "@aws-sdk/client-s3": "^3.1105.0",
     "@aws-sdk/lib-dynamodb": "^3.1105.0",
     "@aws-sdk/lib-storage": "^3.1105.0",
+    "@aws-sdk/rds-signer": "^3.1105.0",
     "@aws-sdk/s3-presigned-post": "^3.1105.0",
     "@aws-sdk/s3-request-presigner": "^3.1105.0",
     "@gitbeaker/rest": "^43.8.0",

--- a/apps/backend/src/config/data-target.test.ts
+++ b/apps/backend/src/config/data-target.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { assertSafeDataTarget } from "./data-target";
+
+const base = {
+  target: "local",
+  env: "development",
+  pgHost: "127.0.0.1",
+  pgUser: "postgres",
+  redisUrl: "redis://localhost:6380/1",
+  amqpUrl: "amqp://localhost",
+  writeCapableSecrets: [],
+} satisfies Parameters<typeof assertSafeDataTarget>[0];
+
+describe("assertSafeDataTarget", () => {
+  it("accepts a local development setup", () => {
+    expect(() => assertSafeDataTarget(base)).not.toThrow();
+  });
+
+  it("accepts production pointing at RDS", () => {
+    expect(() =>
+      assertSafeDataTarget({
+        ...base,
+        env: "production",
+        pgHost: "db.abc123.eu-west-1.rds.amazonaws.com",
+      }),
+    ).not.toThrow();
+  });
+
+  it.each(["development", "test"] as const)(
+    "fails closed when %s reaches an AWS database without prod-ro",
+    (env) => {
+      expect(() =>
+        assertSafeDataTarget({
+          ...base,
+          env,
+          pgHost: "db.abc123.eu-west-1.rds.amazonaws.com",
+        }),
+      ).toThrow(/ARGOS_TARGET/);
+    },
+  );
+
+  describe("with ARGOS_TARGET=prod-ro", () => {
+    const prodRo = {
+      ...base,
+      target: "prod-ro",
+      pgHost: "db.abc123.eu-west-1.rds.amazonaws.com",
+      pgUser: "argos_dev_ro",
+    } satisfies Parameters<typeof assertSafeDataTarget>[0];
+
+    it("accepts the expected setup", () => {
+      expect(() => assertSafeDataTarget(prodRo)).not.toThrow();
+    });
+
+    // The read-only grants live on one role, so connecting as any other — the
+    // application's own role above all — silently removes the write barrier.
+    it.each(["argos", "postgres", "argos_dev"])(
+      "rejects connecting as %s",
+      (pgUser) => {
+        expect(() => assertSafeDataTarget({ ...prodRo, pgUser })).toThrow(
+          /must connect as the read-only role "argos_dev_ro"/,
+        );
+      },
+    );
+
+    it.each(["production", "test"] as const)("rejects NODE_ENV=%s", (env) => {
+      expect(() => assertSafeDataTarget({ ...prodRo, env })).toThrow(
+        /NODE_ENV/,
+      );
+    });
+
+    it("rejects a remote Redis", () => {
+      expect(() =>
+        assertSafeDataTarget({
+          ...prodRo,
+          redisUrl: "redis://prod.cache.amazonaws.com:6379",
+        }),
+      ).toThrow(/REDIS_URL/);
+    });
+
+    it("rejects a remote RabbitMQ", () => {
+      expect(() =>
+        assertSafeDataTarget({
+          ...prodRo,
+          amqpUrl: "amqps://b-1234.mq.eu-west-1.amazonaws.com:5671",
+        }),
+      ).toThrow(/AMQP_URL/);
+    });
+
+    it("rejects an unparsable queue URL rather than letting it through", () => {
+      expect(() =>
+        assertSafeDataTarget({ ...prodRo, amqpUrl: "not a url" }),
+      ).toThrow(/AMQP_URL/);
+    });
+
+    it("rejects write-capable third-party credentials", () => {
+      expect(() =>
+        assertSafeDataTarget({
+          ...prodRo,
+          writeCapableSecrets: ["RESEND_API_KEY", "STRIPE_API_KEY"],
+        }),
+      ).toThrow(/RESEND_API_KEY, STRIPE_API_KEY/);
+    });
+  });
+});

--- a/apps/backend/src/config/data-target.ts
+++ b/apps/backend/src/config/data-target.ts
@@ -1,0 +1,96 @@
+/**
+ * Guardrails around which data a process is allowed to touch.
+ *
+ * `ARGOS_TARGET=prod-ro` points a local process at the production database
+ * through the read-only `argos_dev_ro` Postgres role (see CONTRIBUTING.md).
+ * The Postgres grants are the hard write barrier; everything here is the
+ * belt-and-braces layer that keeps the *rest* of the process from writing
+ * anywhere production-shaped: jobs must land in local queues, and third-party
+ * credentials that write elsewhere (emails, Stripe, git providers) must be
+ * absent.
+ */
+
+const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+/**
+ * The only Postgres role prod-ro may connect as. Every other role — the
+ * application's own `argos` among them — can write, and the whole mode is
+ * built on the assumption that the database refuses writes on its own.
+ */
+const PROD_RO_ROLE = "argos_dev_ro";
+
+function getHostname(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return "";
+  }
+}
+
+export function assertSafeDataTarget(input: {
+  /** `ARGOS_TARGET`: "local" or "prod-ro". */
+  target: string;
+  /** `NODE_ENV`: "production", "development" or "test". */
+  env: string;
+  pgHost: string;
+  pgUser: string;
+  redisUrl: string;
+  amqpUrl: string;
+  /**
+   * Env-var names of write-capable third-party credentials that differ from
+   * their schema default, i.e. that are actually set.
+   */
+  writeCapableSecrets: string[];
+}): void {
+  if (input.target !== "prod-ro") {
+    // Fail closed: outside production, an AWS-hosted database *is* production
+    // data, and reaching it without the prod-ro guardrails armed means a
+    // hand-assembled environment — exactly the situation that caused writes to
+    // production in the past.
+    if (input.env !== "production" && input.pgHost.endsWith(".amazonaws.com")) {
+      throw new Error(
+        `The database host "${input.pgHost}" is production data, but ARGOS_TARGET is not "prod-ro". ` +
+          `Use \`pnpm run dev:prod-ro\` (see CONTRIBUTING.md) or point DATABASE_URL at a local database.`,
+      );
+    }
+    return;
+  }
+
+  if (input.env !== "development") {
+    throw new Error(
+      `ARGOS_TARGET=prod-ro is a local development mode and cannot run with NODE_ENV=${input.env}.`,
+    );
+  }
+
+  // The read-only grants are what actually makes this mode safe, and they live
+  // on one role. Connecting as anything else — most plausibly the application's
+  // own role, copied out of a production connection string — would leave every
+  // other guardrail here reporting a read-only session that can write.
+  if (input.pgUser !== PROD_RO_ROLE) {
+    throw new Error(
+      `ARGOS_TARGET=prod-ro must connect as the read-only role "${PROD_RO_ROLE}", got "${input.pgUser}". ` +
+        `Check the user in DATABASE_URL.`,
+    );
+  }
+
+  // Jobs enqueued by the web process and session/rate-limit state must stay on
+  // this machine: a production queue would have production workers execute
+  // whatever a local process enqueues.
+  for (const [name, url] of [
+    ["REDIS_URL", input.redisUrl],
+    ["AMQP_URL", input.amqpUrl],
+  ] as const) {
+    if (!LOCAL_HOSTNAMES.has(getHostname(url))) {
+      throw new Error(
+        `ARGOS_TARGET=prod-ro requires ${name} to point at localhost, got "${url}".`,
+      );
+    }
+  }
+
+  if (input.writeCapableSecrets.length > 0) {
+    throw new Error(
+      `ARGOS_TARGET=prod-ro forbids write-capable third-party credentials, remove: ${input.writeCapableSecrets.join(", ")}. ` +
+        `Postgres is read-only in this mode, but these write elsewhere (emails, billing, git providers).`,
+    );
+  }
+}

--- a/apps/backend/src/config/database.ts
+++ b/apps/backend/src/config/database.ts
@@ -1,6 +1,35 @@
+import { invariant } from "@argos/util/invariant";
+import { Signer } from "@aws-sdk/rds-signer";
 import { Knex } from "knex";
 
 import type { Config } from ".";
+
+/**
+ * Resolve the connection password. With `pg.connection.iamAuth` there is no
+ * stored password: `pg` calls the function for every new pool connection and
+ * gets a freshly signed RDS IAM token (15-minute validity, but only used to
+ * open the connection — established connections are unaffected).
+ */
+function getPassword(config: Config): string | (() => Promise<string>) {
+  if (!config.get("pg.connection.iamAuth")) {
+    return config.get("pg.connection.password") || "";
+  }
+
+  const hostname = config.get("pg.connection.host");
+  const region = hostname.match(/\.([a-z0-9-]+)\.rds\.amazonaws\.com$/)?.[1];
+  invariant(
+    region,
+    `cannot derive an AWS region from Postgres host "${hostname}" — PG_IAM_AUTH expects an RDS endpoint`,
+  );
+
+  const signer = new Signer({
+    hostname,
+    region,
+    port: config.get("pg.connection.port"),
+    username: config.get("pg.connection.user"),
+  });
+  return () => signer.getAuthToken();
+}
 
 /**
  * Get the Knex configuration from the application configuration.
@@ -20,11 +49,13 @@ export function getKnexConfig(config: Config): Knex.Config {
       host: config.get("pg.connection.host"),
       user: config.get("pg.connection.user"),
       port: config.get("pg.connection.port"),
-      password: config.get("pg.connection.password") || "",
+      password: getPassword(config),
       timezone: "utc",
-      ssl: config.get("pg.connection.ssl")
-        ? { rejectUnauthorized: false }
-        : false,
+      // RDS rejects IAM tokens over plaintext connections.
+      ssl:
+        config.get("pg.connection.ssl") || config.get("pg.connection.iamAuth")
+          ? { rejectUnauthorized: false }
+          : false,
     },
   };
 }

--- a/apps/backend/src/config/index.ts
+++ b/apps/backend/src/config/index.ts
@@ -5,11 +5,16 @@ import {
   resolveFromPackageRoot,
   resolveFromRepositoryRoot,
 } from "../util/paths";
+import { assertSafeDataTarget } from "./data-target";
 import { loadDatabaseConfigFromURL } from "./database-url";
 
 const rootDotEnvPath = resolveFromRepositoryRoot(".env");
 
-if (rootDotEnvPath) {
+// Under ARGOS_TARGET=prod-ro the process reads production data, so the
+// developer's `.env` (dev-app secrets, API keys…) must not bleed into it:
+// everything that mode needs is injected explicitly by
+// `op run --env-file=.env.prod-ro` (see `pnpm run dev:prod-ro`).
+if (rootDotEnvPath && process.env["ARGOS_TARGET"] !== "prod-ro") {
   dotenv.config({
     path: rootDotEnvPath,
     quiet: true,
@@ -56,6 +61,12 @@ export function createConfig() {
       format: ["production", "development", "test"],
       default: "development",
       env: "NODE_ENV",
+    },
+    target: {
+      doc: "Which data the process points at. `prod-ro` runs local development against the production database through the read-only `argos_dev_ro` role and arms the guardrails: worker and migrations refuse to run, queues must be local, write-capable third-party credentials must be absent.",
+      format: ["local", "prod-ro"],
+      default: "local",
+      env: "ARGOS_TARGET",
     },
     logLevel: {
       doc: "Log level",
@@ -555,6 +566,12 @@ export function createConfig() {
           format: Number,
           default: 5432,
         },
+        iamAuth: {
+          doc: "Authenticate with short-lived RDS IAM tokens instead of a password. The Postgres role must have `rds_iam` granted, and the process needs AWS credentials (e.g. `aws sso login`).",
+          format: Boolean,
+          default: false,
+          env: "PG_IAM_AUTH",
+        },
       },
     },
     discord: {
@@ -692,6 +709,36 @@ export function createConfig() {
   }
 
   config.validate();
+
+  // Credentials that write *outside* Postgres, so the read-only role cannot
+  // fence them. "Set" means overridden from the schema default.
+  const writeCapableSecrets = (
+    [
+      ["RESEND_API_KEY", "resend.apiKey"],
+      ["STRIPE_API_KEY", "stripe.apiKey"],
+      ["GITHUB_APP_PRIVATE_KEY", "github.privateKey"],
+      ["GITHUB_CLIENT_SECRET", "github.clientSecret"],
+      ["GITHUB_LIGHT_APP_PRIVATE_KEY", "githubLight.privateKey"],
+      ["ORIGIN_APP_PRIVATE_KEY", "origin.privateKey"],
+      ["GITLAB_APP_SECRET", "gitlab.appSecret"],
+      ["GOOGLE_CLIENT_SECRET", "google.clientSecret"],
+      ["SLACK_CLIENT_SECRET", "slack.clientSecret"],
+      ["SLACK_SIGNING_SECRET", "slack.signingSecret"],
+      ["DISCORD_WEBHOOK_URL", "discord.webhookUrl"],
+    ] as const
+  )
+    .filter(([, path]) => config.get(path) !== config.default(path))
+    .map(([name]) => name);
+
+  assertSafeDataTarget({
+    target: config.get("target"),
+    env: config.get("env"),
+    pgHost: config.get("pg.connection.host"),
+    pgUser: config.get("pg.connection.user"),
+    redisUrl: config.get("redis.url"),
+    amqpUrl: config.get("amqp.url"),
+    writeCapableSecrets,
+  });
 
   return config;
 }

--- a/apps/backend/src/processes/proc/web.ts
+++ b/apps/backend/src/processes/proc/web.ts
@@ -28,6 +28,12 @@ const createServer = (requestListener: RequestListener): Server => {
   return createHttpServer(requestListener);
 };
 
+if (config.get("target") === "prod-ro") {
+  logger.warn(
+    "⚠ ARGOS_TARGET=prod-ro — this process reads PRODUCTION data. Postgres writes are limited to the login flow; worker, migrations and third-party credentials are disabled.",
+  );
+}
+
 const app = await createApp();
 const server = createServer(app);
 

--- a/apps/backend/src/processes/proc/worker.ts
+++ b/apps/backend/src/processes/proc/worker.ts
@@ -3,9 +3,11 @@ import { checkExpiringSamlCertificates } from "@/auth/saml-certificate-expiratio
 import { job as automationActionRunJob } from "@/automation/job";
 import { job as buildJob } from "@/build";
 import { job as buildNotificationJob } from "@/build-notification";
+import config from "@/config";
 import { job as deploymentNotificationJob } from "@/deployment-notification";
 import { githubPullRequestJob } from "@/github-pull-request/job";
 import { createJobWorker } from "@/job-core";
+import logger from "@/logger";
 import { mediaDiffJob } from "@/media/diff-job";
 import { purgeExpiredMedia } from "@/media/purge";
 import { notificationMessageJob } from "@/notification/message-job";
@@ -15,6 +17,16 @@ import { originInstallationSyncJob } from "@/origin/synchronize-job";
 import { job as screenshotDiffJob } from "@/screenshot-diff";
 import { job as synchronizeJob } from "@/synchronize";
 import { scheduleCron } from "@/util/cron";
+
+// Even though prod-ro queues are local, every job handler writes to the
+// database and to third parties — nothing a worker does makes sense against
+// production data, so it refuses to run at all.
+if (config.get("target") === "prod-ro") {
+  logger.warn(
+    "ARGOS_TARGET=prod-ro: the worker does not run against production data, exiting.",
+  );
+  process.exit(0);
+}
 
 scheduleCron("saml-certificate-expiration", "0 * * * *", (context) =>
   checkExpiringSamlCertificates(context.date),

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "turbo run watch-build watch-server watch-codegen --concurrency 100",
+    "dev:prod-ro": "op run --env-file=.env.prod-ro -- pnpm run dev",
     "build": "turbo run build",
     "test": "vitest",
     "test:unit": "pnpm run test -c vitest/vitest.unit.config.mts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       '@aws-sdk/lib-storage':
         specifier: ^3.1105.0
         version: 3.1105.0(@aws-sdk/client-s3@3.1105.0)
+      '@aws-sdk/rds-signer':
+        specifier: ^3.1105.0
+        version: 3.1116.0
       '@aws-sdk/s3-presigned-post':
         specifier: ^3.1105.0
         version: 3.1105.0
@@ -1033,36 +1036,80 @@ packages:
     resolution: {integrity: sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.977.9':
+    resolution: {integrity: sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.69':
+    resolution: {integrity: sha512-vpsh9VWmQVC/nsdzf72F2yUMBOFT1aq+hoLseYV03zjVXVHkjqSNJskFRKPFxc3MRFrHNbSSmOwsbYE15u9ecw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.67':
     resolution: {integrity: sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    resolution: {integrity: sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.69':
     resolution: {integrity: sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.972.72':
+    resolution: {integrity: sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.973.12':
     resolution: {integrity: sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    resolution: {integrity: sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.74':
     resolution: {integrity: sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-login@3.972.77':
+    resolution: {integrity: sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.78':
     resolution: {integrity: sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.81':
+    resolution: {integrity: sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.67':
     resolution: {integrity: sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-process@3.972.70':
+    resolution: {integrity: sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.973.11':
     resolution: {integrity: sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    resolution: {integrity: sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.73':
     resolution: {integrity: sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    resolution: {integrity: sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-providers@3.1116.0':
+    resolution: {integrity: sha512-y41rRJ1AWtcJka2YdFQ1BfTf0CZDXizh0VOZLwfUzxI2xhG7n88XXn0N0yvLwI73/tjtXalVy94/N5QCO1lgbg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/dynamodb-codec@3.973.41':
@@ -1097,6 +1144,14 @@ packages:
     resolution: {integrity: sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.44':
+    resolution: {integrity: sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/rds-signer@3.1116.0':
+    resolution: {integrity: sha512-aaCORzUpgNb9oW0HkcY0fdSaXbbDFMhLUN7BkVyLZlxDBbbBi5PrZhUSd7gqOGYPdOmxeR0uNhsY6e5AvwMkkQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/s3-presigned-post@3.1105.0':
     resolution: {integrity: sha512-W2hGeWPibCOdmXGUAITC+56nhxdUojDW+VvsG3ndCi7Gjnw/DQVQvZpSLZPlsWyNP/EqwM26yDEC3QonUbakRg==}
     engines: {node: '>=20.0.0'}
@@ -1109,12 +1164,24 @@ packages:
     resolution: {integrity: sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1103.0':
     resolution: {integrity: sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1116.0':
+    resolution: {integrity: sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.974.2':
     resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.5':
+    resolution: {integrity: sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-dynamodb@3.996.7':
@@ -1125,6 +1192,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.37':
     resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.40':
+    resolution: {integrity: sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.3.0':
@@ -3646,12 +3717,24 @@ packages:
     resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.33.3':
+    resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.4.16':
     resolution: {integrity: sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.6.13':
     resolution: {integrity: sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.7.2':
+    resolution: {integrity: sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.11.3':
+    resolution: {integrity: sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-http-handler@4.9.13':
@@ -3664,6 +3747,10 @@ packages:
 
   '@smithy/types@4.16.1':
     resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.17.2':
+    resolution: {integrity: sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==}
     engines: {node: '>=18.0.0'}
 
   '@socket.io/component-emitter@3.1.2':
@@ -8641,12 +8728,39 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.977.9':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/xml-builder': 3.972.40
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.17.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.69':
+    dependencies:
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.67':
     dependencies:
       '@aws-sdk/core': 3.977.6
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.69':
@@ -8657,6 +8771,16 @@ snapshots:
       '@smithy/fetch-http-handler': 5.6.13
       '@smithy/node-http-handler': 4.9.13
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.973.12':
@@ -8675,6 +8799,22 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-login': 3.972.77
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.74':
     dependencies:
       '@aws-sdk/core': 3.977.6
@@ -8682,6 +8822,15 @@ snapshots:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.78':
@@ -8698,12 +8847,34 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.81':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-ini': 3.973.15
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.67':
     dependencies:
       '@aws-sdk/core': 3.977.6
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.973.11':
@@ -8716,6 +8887,16 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/token-providers': 3.1116.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.73':
     dependencies:
       '@aws-sdk/core': 3.977.6
@@ -8723,6 +8904,34 @@ snapshots:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-providers@3.1116.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-cognito-identity': 3.972.69
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-ini': 3.973.15
+      '@aws-sdk/credential-provider-login': 3.972.77
+      '@aws-sdk/credential-provider-node': 3.972.81
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/dynamodb-codec@3.973.41':
@@ -8784,6 +8993,26 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.44':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/rds-signer@3.1116.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-providers': 3.1116.0
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/s3-presigned-post@3.1105.0':
     dependencies:
       '@aws-sdk/client-s3': 3.1105.0
@@ -8810,6 +9039,13 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1103.0':
     dependencies:
       '@aws-sdk/core': 3.977.6
@@ -8819,9 +9055,23 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/token-providers@3.1116.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.974.2':
     dependencies:
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.5':
+    dependencies:
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/util-dynamodb@3.996.7(@aws-sdk/client-dynamodb@3.1105.0)':
@@ -8832,6 +9082,11 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.37':
     dependencies:
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.40':
+    dependencies:
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.3.0': {}
@@ -11113,6 +11368,11 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@smithy/core@3.33.3':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.4.16':
     dependencies:
       '@smithy/core': 3.31.1
@@ -11123,6 +11383,18 @@ snapshots:
     dependencies:
       '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.7.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.11.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.9.13':
@@ -11138,6 +11410,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.16.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.17.2':
     dependencies:
       tslib: 2.8.1
 

--- a/turbo.json
+++ b/turbo.json
@@ -52,7 +52,19 @@
         "S3_PUBLIC_IMAGE_BASE_URL",
         "AWS_SCREENSHOTS_BUCKET",
         "SQIDS_ALPHABET",
-        "LOG_LEVEL"
+        "LOG_LEVEL",
+        "ARGOS_TARGET",
+        "PG_IAM_AUTH",
+        "REDIS_URL",
+        "AMQP_URL"
+      ],
+      "passThroughEnv": [
+        "AWS_PROFILE",
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN"
       ]
     },
     "//#watch-codegen": {


### PR DESCRIPTION
## Why

Debugging with real data shapes meant hand-assembling a connection string with a production password. That put the password in shell history and clipboards, and — the part that actually causes incidents — left a local dev server able to **write** to production: migrations on boot, workers consuming real jobs, Stripe calls, emails to real customers.

This makes it a supported mode instead of an improvised one.

## How it works

Postgres does the real enforcement, through a read-only role whose only write grants are the two tables the login flow needs:

```sql
CREATE ROLE argos_dev_ro LOGIN;
GRANT pg_read_all_data TO argos_dev_ro;
GRANT INSERT, UPDATE ON public.user_sessions TO argos_dev_ro;
GRANT USAGE ON SEQUENCE public.user_sessions_id_seq TO argos_dev_ro;
GRANT UPDATE ON public.team_users TO argos_dev_ro;
GRANT rds_iam TO argos_dev_ro;
```

Those two tables are all a login writes: `user_sessions` (insert, plus the `lastSeenAt` slide on cache miss) and `team_users.lastAuthMethod`. Email codes, passkey challenges, presence and rate limits are all Redis.

Note `default_transaction_read_only` is deliberately **not** used: it would block the session insert and so the login itself, and it is a `USERSET` GUC any session can turn off — privileges are the real boundary.

`ARGOS_TARGET=prod-ro` then arms the layer that keeps the *rest* of the process from writing anywhere the grants cannot fence:

- worker refuses to start; the knexfile throws, so no migration or `knex-scripts` command can run;
- Redis and RabbitMQ must be local — otherwise a local process could enqueue work that production workers execute;
- write-capable third-party credentials (Resend, Stripe, GitHub/GitLab/Google/Slack, Discord) must be absent;
- `.env` is not loaded at all, so dev-app secrets cannot bleed in;
- the connection must be `argos_dev_ro`. Any other role — the application's own `argos` above all — would leave every guardrail reporting a read-only session that can write.

It fails closed the other way too: a non-production process reaching an AWS database *without* the mode armed refuses to boot.

## Credentials

`pnpm run dev:prod-ro` wraps the dev server in `op run --env-file=.env.prod-ro`, so nothing lands on disk or in shell history. `.env.prod-ro` is committed and holds only `op://` references.

`PG_IAM_AUTH=true` drops the static password entirely: `getKnexConfig` hands `pg` a function, which `pg` awaits once per pooled connection, minting a fresh 15-minute RDS IAM token each time.

## ⚠️ Prerequisite before this works

**IAM database authentication is currently disabled on `argos-postgres`** (`IAMDatabaseAuthenticationEnabled: false`), which is a separate switch from the `rds_iam` grant. Until it is enabled, RDS rejects a perfectly valid token with `password authentication failed for user "argos_dev_ro"`:

```sh
aws rds modify-db-instance --region us-east-1 --db-instance-identifier argos-postgres \
  --enable-iam-database-authentication --apply-immediately
```

The connecting principal also needs `rds-db:connect` on `arn:aws:rds-db:us-east-1:<account>:dbuser:<db-resource-id>/argos_dev_ro`. Missing either produces the same error message.

Alternatively, set a password on the role and drop `PG_IAM_AUTH` — the code already handles that path with no changes.

## Reviewer notes

- **Sign in with an email code.** Resend is absent, so read it from local Redis (`email_verification:<email>`). OAuth would overwrite production access tokens with dev-app ones, and production passkeys are bound to the `argos-ci.com` RP id.
- `pg_read_all_data` really is *all* data, including `github_accounts.accessToken` and every user email. Worth deciding whether that is acceptable on a laptop.
- Unrelated but noticed while verifying: the instance is `PubliclyAccessible: true`.

## Testing

- 14 unit tests on the guard (`data-target.test.ts`).
- Every guardrail exercised against the built backend: worker exits, knexfile throws, each fail-closed branch rejects, web boots and serves with the banner.
- The async-password mechanism verified against a real scram-sha-256 Postgres: connects, called once per pooled connection, and a wrong value is still rejected.
- `pnpm run static-checks` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)