### PR TITLE
feat(staff): add a Revenue page, read from a Stripe invoice mirror

### DIFF
--- a/apps/backend/db/migrations/20260823065836_stripe-invoices.js
+++ b/apps/backend/db/migrations/20260823065836_stripe-invoices.js
@@ -4,7 +4,13 @@
  * Kept in sync by the Stripe webhooks plus a reconciliation sweep, so the page
  * costs a query instead of a paginated walk of Stripe on every view. Only the
  * fields the revenue arithmetic reads are mirrored; the invoice itself stays
- * in Stripe. Amounts are in the currency's minor unit, as Stripe states them.
+ * in Stripe. Amounts are in the currency's minor unit, as Stripe states them —
+ * 32-bit on purpose: the cap is ~21M in minor units, three orders of magnitude
+ * above the largest invoice ever raised, and staying `integer` keeps the
+ * values plain numbers where `bigint` would come back from pg as strings.
+ *
+ * `stripe_invoice_syncs` records each completed sweep, so the reader can tell
+ * a window the mirror never covered from a quiet one.
  *
  * @param {import('knex').Knex} knex
  */
@@ -25,12 +31,22 @@ export const up = async (knex) => {
     table.integer("total").notNullable();
     table.integer("totalExcludingTax");
     table.integer("totalTaxesAmount");
-    table.integer("prePaymentCreditNotesAmount").notNullable();
-    table.integer("postPaymentCreditNotesAmount").notNullable();
+    // The credit notes' ex-tax totals added up — ex-tax like the base they are
+    // taken off, where the invoice's own rollup fields are tax-inclusive.
+    table.integer("creditedAmountExcludingTax").notNullable();
     // The longest stretch one of the invoice's lines covers, resolved at
     // ingest — what tells an annual bill from a true-up.
     table.dateTime("periodStart");
     table.dateTime("periodEnd");
+  });
+
+  await knex.schema.createTable("stripe_invoice_syncs", (table) => {
+    table.bigIncrements("id").primary();
+    table.dateTime("createdAt").notNullable();
+    table.dateTime("updatedAt").notNullable();
+    // The window the sweep read, and when it finished reading it.
+    table.dateTime("sinceDate").notNullable();
+    table.dateTime("completedAt").notNullable();
   });
 };
 
@@ -38,5 +54,6 @@ export const up = async (knex) => {
  * @param {import('knex').Knex} knex
  */
 export const down = async (knex) => {
+  await knex.schema.dropTable("stripe_invoice_syncs");
   await knex.schema.dropTable("stripe_invoices");
 };

--- a/apps/backend/db/migrations/20260823065836_stripe-invoices.js
+++ b/apps/backend/db/migrations/20260823065836_stripe-invoices.js
@@ -1,0 +1,42 @@
+/**
+ * Mirror of the Stripe invoices the revenue page reads.
+ *
+ * Kept in sync by the Stripe webhooks plus a reconciliation sweep, so the page
+ * costs a query instead of a paginated walk of Stripe on every view. Only the
+ * fields the revenue arithmetic reads are mirrored; the invoice itself stays
+ * in Stripe. Amounts are in the currency's minor unit, as Stripe states them.
+ *
+ * @param {import('knex').Knex} knex
+ */
+export const up = async (knex) => {
+  await knex.schema.createTable("stripe_invoices", (table) => {
+    table.bigIncrements("id").primary();
+    table.dateTime("createdAt").notNullable();
+    table.dateTime("updatedAt").notNullable();
+    table.string("stripeInvoiceId").notNullable();
+    table.unique("stripeInvoiceId");
+    table.string("stripeCustomerId").notNullable().index();
+    table.string("stripeSubscriptionId");
+    // Stripe's own `created`, which is what files an invoice into a month.
+    table.dateTime("stripeCreatedAt").notNullable().index();
+    table.string("status").notNullable();
+    table.string("billingReason");
+    table.string("currency").notNullable();
+    table.integer("total").notNullable();
+    table.integer("totalExcludingTax");
+    table.integer("totalTaxesAmount");
+    table.integer("prePaymentCreditNotesAmount").notNullable();
+    table.integer("postPaymentCreditNotesAmount").notNullable();
+    // The longest stretch one of the invoice's lines covers, resolved at
+    // ingest — what tells an annual bill from a true-up.
+    table.dateTime("periodStart");
+    table.dateTime("periodEnd");
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+export const down = async (knex) => {
+  await knex.schema.dropTable("stripe_invoices");
+};

--- a/apps/backend/db/migrations/20260823133757_github-plan-prices.js
+++ b/apps/backend/db/migrations/20260823133757_github-plan-prices.js
@@ -1,0 +1,24 @@
+/**
+ * The Marketplace listing's monthly price, copied onto the GitHub plans.
+ *
+ * GitHub exposes no seller invoice API, so the marketplace book is priced by
+ * plan: the revenue page multiplies the active marketplace subscriptions by
+ * this price. Kept current by the `github-marketplace-prices` cron; null on
+ * plans that are not marketplace listings.
+ *
+ * @param {import('knex').Knex} knex
+ */
+export const up = async (knex) => {
+  await knex.schema.alterTable("plans", (table) => {
+    table.integer("githubMonthlyPriceCents");
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+export const down = async (knex) => {
+  await knex.schema.alterTable("plans", (table) => {
+    table.dropColumn("githubMonthlyPriceCents");
+  });
+};

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict o4yY6kzuLNk2D1yhBasUoDQXc8fl7t4BaBXbo3R8dYyaf1tg57N27yueaEx5yhC
+\restrict 8YyqcMJ0I5XNZcsHVmCWOSWmeYiDRSWndBgMnDgf5deA7M7wg7w92yaObvxLpdi
 
 -- Dumped from database version 18.4
 -- Dumped by pg_dump version 18.6 (Homebrew)
@@ -2091,6 +2091,7 @@ CREATE TABLE public.plans (
     "fineGrainedAccessControlIncluded" boolean DEFAULT false NOT NULL,
     "interval" text DEFAULT 'month'::text NOT NULL,
     "samlIncluded" boolean DEFAULT false NOT NULL,
+    "githubMonthlyPriceCents" integer,
     CONSTRAINT plans_interval_check CHECK (("interval" = ANY (ARRAY['month'::text, 'year'::text])))
 );
 
@@ -6629,7 +6630,7 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-\unrestrict o4yY6kzuLNk2D1yhBasUoDQXc8fl7t4BaBXbo3R8dYyaf1tg57N27yueaEx5yhC
+\unrestrict 8YyqcMJ0I5XNZcsHVmCWOSWmeYiDRSWndBgMnDgf5deA7M7wg7w92yaObvxLpdi
 
 -- Knex migrations
 
@@ -6881,3 +6882,4 @@ INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('2026081
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260818120000_builds-prheadcommit-index.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260822180431_screenshot-buckets-insert-autovacuum.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260823065836_stripe-invoices.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260823133757_github-plan-prices.js', 1, NOW());

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -2,10 +2,10 @@
 -- PostgreSQL database dump
 --
 
-\restrict WdPASFUugdXgFTLqh4lGiG1SQRrRqudKcouqrkd2RN5BOKGILfTHRiDdHgaTnsN
+\restrict 4zZG6Hoe1K3ZBDrHabFPUGq365Inj9r7dt9THx8frPwftlzfV3Wfyai1eXJJuqm
 
 -- Dumped from database version 18.4
--- Dumped by pg_dump version 18.6 (Homebrew)
+-- Dumped by pg_dump version 18.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -498,8 +498,8 @@ CREATE TABLE public.build_shards (
     "updatedAt" timestamp with time zone NOT NULL,
     "buildId" bigint NOT NULL,
     index integer,
-    metadata jsonb,
-    nonce character varying(255)
+    nonce character varying(255),
+    metadata jsonb
 );
 
 
@@ -1059,7 +1059,7 @@ ALTER SEQUENCE public.github_installations_id_seq OWNED BY public.github_install
 --
 
 CREATE TABLE public.github_pull_requests (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     "createdAt" timestamp with time zone NOT NULL,
     "updatedAt" timestamp with time zone NOT NULL,
     "commentDeleted" boolean DEFAULT false NOT NULL,
@@ -1465,7 +1465,7 @@ CREATE TABLE public.media (
     visibility character varying(255) DEFAULT 'team'::character varying NOT NULL,
     "shareToken" character varying(255) NOT NULL,
     branch character varying(255),
-    CONSTRAINT media_state_check CHECK (((state IS NULL) OR ((state)::text = ANY ((ARRAY['before'::character varying, 'after'::character varying])::text[]))))
+    CONSTRAINT media_state_check CHECK (((state IS NULL) OR ((state)::text = ANY (ARRAY[('before'::character varying)::text, ('after'::character varying)::text]))))
 );
 
 
@@ -2083,7 +2083,7 @@ CREATE TABLE public.plans (
     "createdAt" timestamp with time zone NOT NULL,
     "updatedAt" timestamp with time zone NOT NULL,
     name character varying(255) NOT NULL,
-    "includedScreenshots" integer CONSTRAINT "plans_screenshotsLimitPerMonth_not_null" NOT NULL,
+    "includedScreenshots" integer NOT NULL,
     "githubPlanId" integer,
     "stripeProductId" character varying(255),
     "usageBased" boolean NOT NULL,
@@ -2217,12 +2217,12 @@ CREATE TABLE public.projects (
     "summaryCheck" text DEFAULT 'auto'::text NOT NULL,
     "autoApprovedBranchGlob" character varying(255),
     "defaultUserLevel" text,
-    "autoIgnore" jsonb,
     "deploymentProdBranchGlob" character varying(255),
     "deploymentEnabled" boolean DEFAULT true NOT NULL,
     "deploymentAuth" text DEFAULT 'domain-private'::text NOT NULL,
     "githubActionsOidcEnabled" boolean DEFAULT false NOT NULL,
     "tokenlessAuthEnabled" boolean DEFAULT false NOT NULL,
+    "autoIgnore" jsonb,
     "ignoreConfig" jsonb,
     "buildNumber" integer DEFAULT 0 NOT NULL,
     "originRepositoryId" bigint,
@@ -2542,6 +2542,42 @@ ALTER SEQUENCE public.staff_team_contacts_id_seq OWNED BY public.staff_team_cont
 
 
 --
+-- Name: stripe_invoice_syncs; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.stripe_invoice_syncs (
+    id bigint NOT NULL,
+    "createdAt" timestamp with time zone NOT NULL,
+    "updatedAt" timestamp with time zone NOT NULL,
+    "sinceDate" timestamp with time zone NOT NULL,
+    "completedAt" timestamp with time zone NOT NULL
+);
+
+
+ALTER TABLE public.stripe_invoice_syncs OWNER TO postgres;
+
+--
+-- Name: stripe_invoice_syncs_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.stripe_invoice_syncs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.stripe_invoice_syncs_id_seq OWNER TO postgres;
+
+--
+-- Name: stripe_invoice_syncs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.stripe_invoice_syncs_id_seq OWNED BY public.stripe_invoice_syncs.id;
+
+
+--
 -- Name: stripe_invoices; Type: TABLE; Schema: public; Owner: postgres
 --
 
@@ -2559,8 +2595,7 @@ CREATE TABLE public.stripe_invoices (
     total integer NOT NULL,
     "totalExcludingTax" integer,
     "totalTaxesAmount" integer,
-    "prePaymentCreditNotesAmount" integer NOT NULL,
-    "postPaymentCreditNotesAmount" integer NOT NULL,
+    "creditedAmountExcludingTax" integer NOT NULL,
     "periodStart" timestamp with time zone,
     "periodEnd" timestamp with time zone
 );
@@ -3539,6 +3574,13 @@ ALTER TABLE ONLY public.staff_team_contacts ALTER COLUMN id SET DEFAULT nextval(
 
 
 --
+-- Name: stripe_invoice_syncs id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.stripe_invoice_syncs ALTER COLUMN id SET DEFAULT nextval('public.stripe_invoice_syncs_id_seq'::regclass);
+
+
+--
 -- Name: stripe_invoices id; Type: DEFAULT; Schema: public; Owner: postgres
 --
 
@@ -4406,6 +4448,14 @@ ALTER TABLE ONLY public.staff_team_contacts
 
 
 --
+-- Name: stripe_invoice_syncs stripe_invoice_syncs_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.stripe_invoice_syncs
+    ADD CONSTRAINT stripe_invoice_syncs_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: stripe_invoices stripe_invoices_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
@@ -4627,22 +4677,6 @@ ALTER TABLE ONLY public.user_sessions
 
 ALTER TABLE ONLY public.user_sessions
     ADD CONSTRAINT user_sessions_tokenhash_unique UNIQUE ("tokenHash");
-
-
---
--- Name: users users_email_unique; Type: CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.users
-    ADD CONSTRAINT users_email_unique UNIQUE (email);
-
-
---
--- Name: users users_gitlabuserid_unique; Type: CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.users
-    ADD CONSTRAINT users_gitlabuserid_unique UNIQUE ("gitlabUserId");
 
 
 --
@@ -6630,7 +6664,7 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-\unrestrict WdPASFUugdXgFTLqh4lGiG1SQRrRqudKcouqrkd2RN5BOKGILfTHRiDdHgaTnsN
+\unrestrict 4zZG6Hoe1K3ZBDrHabFPUGq365Inj9r7dt9THx8frPwftlzfV3Wfyai1eXJJuqm
 
 -- Knex migrations
 

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -2,10 +2,10 @@
 -- PostgreSQL database dump
 --
 
-\restrict TecscV4OH9SRouor5Q7L4FIpo5MhEM4uJOqgz5ASGa8paVh5IRkikkvzMULtmGW
+\restrict 0KSt2lgqlUkuV5WztXjn0UKwvjseeNWDsiTBs6oXqUIRWNnt2ilIvBUPJI6zJbU
 
 -- Dumped from database version 18.4
--- Dumped by pg_dump version 18.4 (Homebrew)
+-- Dumped by pg_dump version 18.6 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -498,8 +498,8 @@ CREATE TABLE public.build_shards (
     "updatedAt" timestamp with time zone NOT NULL,
     "buildId" bigint NOT NULL,
     index integer,
-    nonce character varying(255),
-    metadata jsonb
+    metadata jsonb,
+    nonce character varying(255)
 );
 
 
@@ -1059,7 +1059,7 @@ ALTER SEQUENCE public.github_installations_id_seq OWNED BY public.github_install
 --
 
 CREATE TABLE public.github_pull_requests (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     "createdAt" timestamp with time zone NOT NULL,
     "updatedAt" timestamp with time zone NOT NULL,
     "commentDeleted" boolean DEFAULT false NOT NULL,
@@ -1465,7 +1465,7 @@ CREATE TABLE public.media (
     visibility character varying(255) DEFAULT 'team'::character varying NOT NULL,
     "shareToken" character varying(255) NOT NULL,
     branch character varying(255),
-    CONSTRAINT media_state_check CHECK (((state IS NULL) OR ((state)::text = ANY (ARRAY[('before'::character varying)::text, ('after'::character varying)::text]))))
+    CONSTRAINT media_state_check CHECK (((state IS NULL) OR ((state)::text = ANY ((ARRAY['before'::character varying, 'after'::character varying])::text[]))))
 );
 
 
@@ -2083,7 +2083,7 @@ CREATE TABLE public.plans (
     "createdAt" timestamp with time zone NOT NULL,
     "updatedAt" timestamp with time zone NOT NULL,
     name character varying(255) NOT NULL,
-    "includedScreenshots" integer NOT NULL,
+    "includedScreenshots" integer CONSTRAINT "plans_screenshotsLimitPerMonth_not_null" NOT NULL,
     "githubPlanId" integer,
     "stripeProductId" character varying(255),
     "usageBased" boolean NOT NULL,
@@ -2216,12 +2216,12 @@ CREATE TABLE public.projects (
     "summaryCheck" text DEFAULT 'auto'::text NOT NULL,
     "autoApprovedBranchGlob" character varying(255),
     "defaultUserLevel" text,
+    "autoIgnore" jsonb,
     "deploymentProdBranchGlob" character varying(255),
     "deploymentEnabled" boolean DEFAULT true NOT NULL,
     "deploymentAuth" text DEFAULT 'domain-private'::text NOT NULL,
     "githubActionsOidcEnabled" boolean DEFAULT false NOT NULL,
     "tokenlessAuthEnabled" boolean DEFAULT false NOT NULL,
-    "autoIgnore" jsonb,
     "ignoreConfig" jsonb,
     "buildNumber" integer DEFAULT 0 NOT NULL,
     "originRepositoryId" bigint,
@@ -2538,6 +2538,54 @@ ALTER SEQUENCE public.staff_team_contacts_id_seq OWNER TO postgres;
 --
 
 ALTER SEQUENCE public.staff_team_contacts_id_seq OWNED BY public.staff_team_contacts.id;
+
+
+--
+-- Name: stripe_invoices; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.stripe_invoices (
+    id bigint NOT NULL,
+    "createdAt" timestamp with time zone NOT NULL,
+    "updatedAt" timestamp with time zone NOT NULL,
+    "stripeInvoiceId" character varying(255) NOT NULL,
+    "stripeCustomerId" character varying(255) NOT NULL,
+    "stripeSubscriptionId" character varying(255),
+    "stripeCreatedAt" timestamp with time zone NOT NULL,
+    status character varying(255) NOT NULL,
+    "billingReason" character varying(255),
+    currency character varying(255) NOT NULL,
+    total integer NOT NULL,
+    "totalExcludingTax" integer,
+    "totalTaxesAmount" integer,
+    "prePaymentCreditNotesAmount" integer NOT NULL,
+    "postPaymentCreditNotesAmount" integer NOT NULL,
+    "periodStart" timestamp with time zone,
+    "periodEnd" timestamp with time zone
+);
+
+
+ALTER TABLE public.stripe_invoices OWNER TO postgres;
+
+--
+-- Name: stripe_invoices_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.stripe_invoices_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.stripe_invoices_id_seq OWNER TO postgres;
+
+--
+-- Name: stripe_invoices_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.stripe_invoices_id_seq OWNED BY public.stripe_invoices.id;
 
 
 --
@@ -3490,6 +3538,13 @@ ALTER TABLE ONLY public.staff_team_contacts ALTER COLUMN id SET DEFAULT nextval(
 
 
 --
+-- Name: stripe_invoices id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.stripe_invoices ALTER COLUMN id SET DEFAULT nextval('public.stripe_invoices_id_seq'::regclass);
+
+
+--
 -- Name: subscriptions id; Type: DEFAULT; Schema: public; Owner: postgres
 --
 
@@ -4350,6 +4405,22 @@ ALTER TABLE ONLY public.staff_team_contacts
 
 
 --
+-- Name: stripe_invoices stripe_invoices_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.stripe_invoices
+    ADD CONSTRAINT stripe_invoices_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: stripe_invoices stripe_invoices_stripeinvoiceid_unique; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.stripe_invoices
+    ADD CONSTRAINT stripe_invoices_stripeinvoiceid_unique UNIQUE ("stripeInvoiceId");
+
+
+--
 -- Name: subscriptions subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
@@ -4555,6 +4626,22 @@ ALTER TABLE ONLY public.user_sessions
 
 ALTER TABLE ONLY public.user_sessions
     ADD CONSTRAINT user_sessions_tokenhash_unique UNIQUE ("tokenHash");
+
+
+--
+-- Name: users users_email_unique; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_email_unique UNIQUE (email);
+
+
+--
+-- Name: users users_gitlabuserid_unique; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_gitlabuserid_unique UNIQUE ("gitlabUserId");
 
 
 --
@@ -5330,6 +5417,20 @@ CREATE INDEX screenshots_screenshotbucketid_index ON public.screenshots USING bt
 --
 
 CREATE INDEX screenshots_testid_index ON public.screenshots USING btree ("testId");
+
+
+--
+-- Name: stripe_invoices_stripecreatedat_index; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX stripe_invoices_stripecreatedat_index ON public.stripe_invoices USING btree ("stripeCreatedAt");
+
+
+--
+-- Name: stripe_invoices_stripecustomerid_index; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX stripe_invoices_stripecustomerid_index ON public.stripe_invoices USING btree ("stripeCustomerId");
 
 
 --
@@ -6528,7 +6629,7 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-\unrestrict TecscV4OH9SRouor5Q7L4FIpo5MhEM4uJOqgz5ASGa8paVh5IRkikkvzMULtmGW
+\unrestrict 0KSt2lgqlUkuV5WztXjn0UKwvjseeNWDsiTBs6oXqUIRWNnt2ilIvBUPJI6zJbU
 
 -- Knex migrations
 
@@ -6779,3 +6880,4 @@ INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('2026081
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260818083531_cursor-origin.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260818120000_builds-prheadcommit-index.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260822180431_screenshot-buckets-insert-autovacuum.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260823065836_stripe-invoices.js', 1, NOW());

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict 0KSt2lgqlUkuV5WztXjn0UKwvjseeNWDsiTBs6oXqUIRWNnt2ilIvBUPJI6zJbU
+\restrict o4yY6kzuLNk2D1yhBasUoDQXc8fl7t4BaBXbo3R8dYyaf1tg57N27yueaEx5yhC
 
 -- Dumped from database version 18.4
 -- Dumped by pg_dump version 18.6 (Homebrew)
@@ -6629,7 +6629,7 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-\unrestrict 0KSt2lgqlUkuV5WztXjn0UKwvjseeNWDsiTBs6oXqUIRWNnt2ilIvBUPJI6zJbU
+\unrestrict o4yY6kzuLNk2D1yhBasUoDQXc8fl7t4BaBXbo3R8dYyaf1tg57N27yueaEx5yhC
 
 -- Knex migrations
 

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict 8YyqcMJ0I5XNZcsHVmCWOSWmeYiDRSWndBgMnDgf5deA7M7wg7w92yaObvxLpdi
+\restrict WdPASFUugdXgFTLqh4lGiG1SQRrRqudKcouqrkd2RN5BOKGILfTHRiDdHgaTnsN
 
 -- Dumped from database version 18.4
 -- Dumped by pg_dump version 18.6 (Homebrew)
@@ -6630,7 +6630,7 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-\unrestrict 8YyqcMJ0I5XNZcsHVmCWOSWmeYiDRSWndBgMnDgf5deA7M7wg7w92yaObvxLpdi
+\unrestrict WdPASFUugdXgFTLqh4lGiG1SQRrRqudKcouqrkd2RN5BOKGILfTHRiDdHgaTnsN
 
 -- Knex migrations
 

--- a/apps/backend/src/database/models/Plan.ts
+++ b/apps/backend/src/database/models/Plan.ts
@@ -19,6 +19,7 @@ export class Plan extends Model {
           name: { type: "string" },
           includedScreenshots: { type: "number" },
           githubPlanId: { type: ["number", "null"] },
+          githubMonthlyPriceCents: { type: ["number", "null"] },
           stripeProductId: { type: ["string", "null"] },
           usageBased: { type: "boolean" },
           githubSsoIncluded: { type: "boolean" },
@@ -33,6 +34,13 @@ export class Plan extends Model {
   name!: string;
   includedScreenshots!: number;
   githubPlanId!: number | null;
+  /**
+   * The Marketplace listing's monthly price, copied here by the
+   * `github-marketplace-prices` cron — GitHub exposes no seller invoices, so
+   * the price times the active subscriptions is what the marketplace book is
+   * worth. Null on plans that are not marketplace listings.
+   */
+  githubMonthlyPriceCents!: number | null;
   stripeProductId!: string | null;
   usageBased!: boolean;
   githubSsoIncluded!: boolean;

--- a/apps/backend/src/database/models/StripeInvoice.ts
+++ b/apps/backend/src/database/models/StripeInvoice.ts
@@ -1,0 +1,69 @@
+import { Model } from "../util/model";
+import { timestampsSchema } from "../util/schemas";
+
+/**
+ * Mirror of a Stripe invoice — the fields the revenue page reads.
+ *
+ * Kept in sync by the Stripe webhooks plus a reconciliation sweep
+ * (`stripe/bin/sync-stripe-invoices.ts`); the invoice itself stays in Stripe.
+ * Amounts are in the currency's minor unit, as Stripe states them.
+ */
+export class StripeInvoice extends Model {
+  static override tableName = "stripe_invoices";
+
+  static override jsonSchema = {
+    allOf: [
+      timestampsSchema,
+      {
+        type: "object",
+        required: [
+          "stripeInvoiceId",
+          "stripeCustomerId",
+          "stripeCreatedAt",
+          "status",
+          "currency",
+          "total",
+          "prePaymentCreditNotesAmount",
+          "postPaymentCreditNotesAmount",
+        ],
+        properties: {
+          stripeInvoiceId: { type: "string" },
+          stripeCustomerId: { type: "string" },
+          stripeSubscriptionId: { type: ["string", "null"] },
+          stripeCreatedAt: { type: "string" },
+          status: { type: "string" },
+          billingReason: { type: ["string", "null"] },
+          currency: { type: "string" },
+          total: { type: "number" },
+          totalExcludingTax: { type: ["number", "null"] },
+          totalTaxesAmount: { type: ["number", "null"] },
+          prePaymentCreditNotesAmount: { type: "number" },
+          postPaymentCreditNotesAmount: { type: "number" },
+          periodStart: { type: ["string", "null"] },
+          periodEnd: { type: ["string", "null"] },
+        },
+      },
+    ],
+  };
+
+  stripeInvoiceId!: string;
+  stripeCustomerId!: string;
+  stripeSubscriptionId!: string | null;
+  /** Stripe's own `created`, which is what files an invoice into a month. */
+  stripeCreatedAt!: string;
+  status!: string;
+  billingReason!: string | null;
+  currency!: string;
+  total!: number;
+  totalExcludingTax!: number | null;
+  /** The listed taxes added up — the fallback when no pre-tax total is stated. */
+  totalTaxesAmount!: number | null;
+  prePaymentCreditNotesAmount!: number;
+  postPaymentCreditNotesAmount!: number;
+  /**
+   * The longest stretch one of the invoice's lines covers, resolved at
+   * ingest — what tells an annual bill from a true-up.
+   */
+  periodStart!: string | null;
+  periodEnd!: string | null;
+}

--- a/apps/backend/src/database/models/StripeInvoice.ts
+++ b/apps/backend/src/database/models/StripeInvoice.ts
@@ -23,8 +23,7 @@ export class StripeInvoice extends Model {
           "status",
           "currency",
           "total",
-          "prePaymentCreditNotesAmount",
-          "postPaymentCreditNotesAmount",
+          "creditedAmountExcludingTax",
         ],
         properties: {
           stripeInvoiceId: { type: "string" },
@@ -37,8 +36,7 @@ export class StripeInvoice extends Model {
           total: { type: "number" },
           totalExcludingTax: { type: ["number", "null"] },
           totalTaxesAmount: { type: ["number", "null"] },
-          prePaymentCreditNotesAmount: { type: "number" },
-          postPaymentCreditNotesAmount: { type: "number" },
+          creditedAmountExcludingTax: { type: "number" },
           periodStart: { type: ["string", "null"] },
           periodEnd: { type: ["string", "null"] },
         },
@@ -58,8 +56,11 @@ export class StripeInvoice extends Model {
   totalExcludingTax!: number | null;
   /** The listed taxes added up — the fallback when no pre-tax total is stated. */
   totalTaxesAmount!: number | null;
-  prePaymentCreditNotesAmount!: number;
-  postPaymentCreditNotesAmount!: number;
+  /**
+   * The credit notes' ex-tax totals added up — ex-tax like the base they are
+   * taken off, where the invoice's own rollup fields are tax-inclusive.
+   */
+  creditedAmountExcludingTax!: number;
   /**
    * The longest stretch one of the invoice's lines covers, resolved at
    * ingest — what tells an annual bill from a true-up.

--- a/apps/backend/src/database/models/StripeInvoiceSync.ts
+++ b/apps/backend/src/database/models/StripeInvoiceSync.ts
@@ -1,0 +1,32 @@
+import { Model } from "../util/model";
+import { timestampsSchema } from "../util/schemas";
+
+/**
+ * One completed reconciliation sweep of the Stripe invoice mirror.
+ *
+ * The reader's coverage proof: the revenue page refuses a window older than
+ * the deepest `sinceDate` ever swept, so a mirror that was never backfilled
+ * reports an operator-actionable error instead of zeros that read as figures.
+ */
+export class StripeInvoiceSync extends Model {
+  static override tableName = "stripe_invoice_syncs";
+
+  static override jsonSchema = {
+    allOf: [
+      timestampsSchema,
+      {
+        type: "object",
+        required: ["sinceDate", "completedAt"],
+        properties: {
+          sinceDate: { type: "string" },
+          completedAt: { type: "string" },
+        },
+      },
+    ],
+  };
+
+  /** The start of the window the sweep read. */
+  sinceDate!: string;
+  /** When it finished reading it. */
+  completedAt!: string;
+}

--- a/apps/backend/src/database/models/index.ts
+++ b/apps/backend/src/database/models/index.ts
@@ -56,6 +56,7 @@ export * from "./ScreenshotDiffReview";
 export * from "./SlackChannel";
 export * from "./SlackInstallation";
 export * from "./StaffTeamContact";
+export * from "./StripeInvoice";
 export * from "./Subscription";
 export * from "./Team";
 export * from "./TeamDomain";

--- a/apps/backend/src/database/models/index.ts
+++ b/apps/backend/src/database/models/index.ts
@@ -57,6 +57,7 @@ export * from "./SlackChannel";
 export * from "./SlackInstallation";
 export * from "./StaffTeamContact";
 export * from "./StripeInvoice";
+export * from "./StripeInvoiceSync";
 export * from "./Subscription";
 export * from "./Team";
 export * from "./TeamDomain";

--- a/apps/backend/src/database/services/period-usage.ts
+++ b/apps/backend/src/database/services/period-usage.ts
@@ -201,7 +201,7 @@ async function getScreenshotTotals(
   // a `VALUES` list, and would refuse to join it against `projects."accountId"`.
   const values = buildPeriodValues(periods);
 
-  const rows = (await knex
+  const bucketTotals = knex
     .select("v.accountId", "v.index")
     .select(
       // `screenshotCount` is null until a bucket completes, and the billing
@@ -229,26 +229,42 @@ async function getScreenshotTotals(
     // Bounded in the join rather than only in the aggregate above: the filters
     // there are applied after the rows are read, so on their own the scan still
     // walks every bucket the project ever produced. Each row carries its own
-    // boundary, so this reads `v."from"` rather than one minimum for the whole
-    // batch — a single yearly subscription in the batch would otherwise push
+    // boundaries, so this reads `v."from"` and `v."to"` rather than one minimum
+    // for the whole batch — a single yearly subscription would otherwise push
     // that minimum two years back and unbound everyone else.
+    //
+    // Both ends, not just the lower one: with the upper bound left to the
+    // aggregate's filter, a closed period still read every bucket from its
+    // start through to today and threw the running period's away — roughly
+    // twice the rows, on the table that dominates this query. The pair is also
+    // exactly what `(projectId, createdAt)` indexes, so it reads as one range.
     .leftJoin("screenshot_buckets as sb", (join) => {
       join
         .on("sb.projectId", "p.id")
-        .andOn(knex.raw(`sb."createdAt" >= v."from"`));
+        .andOn(knex.raw(`sb."createdAt" >= v."from"`))
+        .andOn(knex.raw(`sb."createdAt" < v."to"`));
     })
-    .groupBy("v.accountId", "v.index")) as unknown as {
-    accountId: string | number;
-    index: string | number;
-    periodAll: string | number;
-    periodStorybook: string | number;
-  }[];
+    .groupBy("v.accountId", "v.index") as unknown as Promise<
+    {
+      accountId: string | number;
+      index: string | number;
+      periodAll: string | number;
+      periodStorybook: string | number;
+    }[]
+  >;
 
   // Media hangs off a project, like a bucket does, but it still cannot ride the
   // join above: joining two independent one-to-many tables in a single pass
   // multiplies their rows against each other. It is aggregated separately and
   // added in.
-  const mediaUnits = await getMediaUnits(periods);
+  //
+  // Sent together rather than one after the other: neither reads the other's
+  // result, so awaiting them in turn spent the two scans end to end for no
+  // reason. On a directory page this is the whole of the billing wait.
+  const [rows, mediaUnits] = await Promise.all([
+    bucketTotals,
+    getMediaUnits(periods),
+  ]);
 
   const totalsByAccountId = new Map<string, AccountTotals>();
   for (const row of rows) {
@@ -308,7 +324,8 @@ async function getMediaUnits(
       join
         .on("mv.mediaId", "m.id")
         .onNotNull("mv.uploadedAt")
-        .andOn(knex.raw(`mv."uploadedAt" >= v."from"`));
+        .andOn(knex.raw(`mv."uploadedAt" >= v."from"`))
+        .andOn(knex.raw(`mv."uploadedAt" < v."to"`));
     })
     .groupBy("v.accountId", "v.index")) as unknown as {
     accountId: string | number;

--- a/apps/backend/src/database/testing/factory.ts
+++ b/apps/backend/src/database/testing/factory.ts
@@ -140,6 +140,22 @@ export const Subscription = defineFactory(models.Subscription, () => ({
   status: "active" as const,
 }));
 
+export const StripeInvoice = defineFactory(models.StripeInvoice, () => ({
+  stripeInvoiceId: FactoryGirl.sequence("stripeInvoice.id", (n) => `in_${n}`),
+  stripeCustomerId: FactoryGirl.sequence(
+    "stripeInvoice.customer",
+    (n) => `cus_invoice_${n}`,
+  ),
+  stripeCreatedAt: new Date("2026-01-15").toISOString(),
+  status: "paid",
+  billingReason: "subscription_cycle",
+  currency: "usd",
+  total: 10_000,
+  totalExcludingTax: 10_000,
+  prePaymentCreditNotesAmount: 0,
+  postPaymentCreditNotesAmount: 0,
+}));
+
 export const TeamAccount = defineFactory(models.Account, () => ({
   teamId: Team.associate("id") as unknown as string,
   name: FactoryGirl.sequence("account.slug", (n) => `Account ${n}`),

--- a/apps/backend/src/database/testing/factory.ts
+++ b/apps/backend/src/database/testing/factory.ts
@@ -152,9 +152,16 @@ export const StripeInvoice = defineFactory(models.StripeInvoice, () => ({
   currency: "usd",
   total: 10_000,
   totalExcludingTax: 10_000,
-  prePaymentCreditNotesAmount: 0,
-  postPaymentCreditNotesAmount: 0,
+  creditedAmountExcludingTax: 0,
 }));
+
+export const StripeInvoiceSync = defineFactory(
+  models.StripeInvoiceSync,
+  () => ({
+    sinceDate: new Date("2024-01-01").toISOString(),
+    completedAt: new Date().toISOString(),
+  }),
+);
 
 export const TeamAccount = defineFactory(models.Account, () => ({
   teamId: Team.associate("id") as unknown as string,

--- a/apps/backend/src/github/bin/sync-github-marketplace-prices.ts
+++ b/apps/backend/src/github/bin/sync-github-marketplace-prices.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import { callbackify } from "node:util";
+
+import logger from "@/logger";
+
+import { syncGithubMarketplacePlanPrices } from "../marketplace";
+
+/**
+ * The recurring refresh runs as the `github-marketplace-prices` cron in the
+ * worker; this hand-run form exists to price the plans right after a deploy
+ * rather than waiting for the next pass.
+ */
+const main = callbackify(async () => {
+  const count = await syncGithubMarketplacePlanPrices();
+  logger.info(`${count} plans priced from the Marketplace listing`);
+});
+
+main((err) => {
+  if (err) {
+    throw err;
+  }
+});

--- a/apps/backend/src/github/bin/sync-github-marketplace-prices.ts
+++ b/apps/backend/src/github/bin/sync-github-marketplace-prices.ts
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-import { callbackify } from "node:util";
-
 import logger from "@/logger";
 
 import { syncGithubMarketplacePlanPrices } from "../marketplace";
@@ -10,13 +8,8 @@ import { syncGithubMarketplacePlanPrices } from "../marketplace";
  * worker; this hand-run form exists to price the plans right after a deploy
  * rather than waiting for the next pass.
  */
-const main = callbackify(async () => {
-  const count = await syncGithubMarketplacePlanPrices();
-  logger.info(`${count} plans priced from the Marketplace listing`);
-});
+const count = await syncGithubMarketplacePlanPrices();
+logger.info(`${count} plans priced from the Marketplace listing`);
 
-main((err) => {
-  if (err) {
-    throw err;
-  }
-});
+// The database pool would hold the process open otherwise.
+process.exit(0);

--- a/apps/backend/src/github/marketplace.ts
+++ b/apps/backend/src/github/marketplace.ts
@@ -17,6 +17,13 @@ export async function syncGithubMarketplacePlanPrices(): Promise<number> {
     per_page: 100,
   });
 
+  // An empty listing is a listing that could not be read, not one that lost
+  // every plan: `whereNotIn` over an empty set matches everything, so clearing
+  // on it would wipe the prices the figures are built from.
+  if (plans.length === 0) {
+    return 0;
+  }
+
   // Cleared first: a plan the listing no longer carries has no price any more,
   // and leaving the last one known would keep pricing its subscribers off a
   // tariff that does not exist.

--- a/apps/backend/src/github/marketplace.ts
+++ b/apps/backend/src/github/marketplace.ts
@@ -17,6 +17,17 @@ export async function syncGithubMarketplacePlanPrices(): Promise<number> {
     per_page: 100,
   });
 
+  // Cleared first: a plan the listing no longer carries has no price any more,
+  // and leaving the last one known would keep pricing its subscribers off a
+  // tariff that does not exist.
+  await Plan.query()
+    .patch({ githubMonthlyPriceCents: null })
+    .whereNotNull("githubPlanId")
+    .whereNotIn(
+      "githubPlanId",
+      plans.map((listingPlan) => listingPlan.id),
+    );
+
   let count = 0;
   for (const listingPlan of plans) {
     count += await Plan.query()

--- a/apps/backend/src/github/marketplace.ts
+++ b/apps/backend/src/github/marketplace.ts
@@ -1,0 +1,27 @@
+import { Plan } from "@/database/models";
+
+import { getAppOctokit } from "./client";
+
+/**
+ * Copy the Marketplace listing's plan prices onto the plans table.
+ *
+ * GitHub exposes no seller invoice API, so the marketplace book cannot be
+ * mirrored the way the Stripe one is: what exists is the listing's plans and
+ * their current prices, which the revenue page multiplies the active
+ * marketplace subscriptions by. A price change rewrites how past months are
+ * priced — accepted, marketplace prices barely ever move.
+ */
+export async function syncGithubMarketplacePlanPrices(): Promise<number> {
+  const octokit = getAppOctokit({ app: "main", proxy: false });
+  const plans = await octokit.paginate("GET /marketplace_listing/plans", {
+    per_page: 100,
+  });
+
+  let count = 0;
+  for (const listingPlan of plans) {
+    count += await Plan.query()
+      .patch({ githubMonthlyPriceCents: listingPlan.monthly_price_in_cents })
+      .where("githubPlanId", listingPlan.id);
+  }
+  return count;
+}

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -385,6 +385,55 @@ export const typeDefs = gql`
     yearlyPlans: StaffRevenueSplit!
   }
 
+  "One invoice a contract's worth is read from."
+  type StaffContractInvoice {
+    "Net of tax and credit notes, in the currency's main unit."
+    amount: Float!
+    "The currency it was raised in, counted at parity when not USD."
+    currency: String!
+    "When it was raised."
+    invoicedAt: DateTime!
+    "The stretch it covers, when it states a real one."
+    coveredFrom: DateTime
+    coveredUntil: DateTime
+  }
+
+  """
+  One annual contract in force, and the invoices its rate is read from: the
+  latest annual bill plus whatever was sold on top of it since.
+
+  Listed so the yearly figure can be audited contract by contract — including
+  the contracts that contributed nothing, which the total alone would hide.
+  """
+  type StaffYearlyContract {
+    "The team's slug, which names its pages."
+    slug: String!
+    "The team's display name, when it has one."
+    name: String
+    "The subscription the database knows the contract by."
+    stripeSubscriptionId: String!
+    """
+    The invoices below, added up. Null when none was found, in which case the
+    contract adds nothing to the rate.
+    """
+    amount: Float
+    "The invoices the contract is worth, newest first."
+    invoices: [StaffContractInvoice!]!
+    """
+    True when the invoices found are still awaiting payment. Shown, so a
+    contract in collection is visible, but counted nothing until they clear.
+    """
+    awaitingPayment: Boolean!
+  }
+
+  "What Argos invoiced, and the annual contracts behind the yearly rate."
+  type StaffRevenue {
+    "The window, oldest first and the running month last."
+    months: [StaffRevenueMonth!]!
+    "The contracts behind every month's \`yearlyPlans\`, largest first."
+    yearlyContracts: [StaffYearlyContract!]!
+  }
+
   type StaffTeamConnection implements Connection {
     pageInfo: PageInfo!
     edges: [Team!]!
@@ -416,13 +465,14 @@ export const typeDefs = gql`
     staffTrialPipeline(days: Int! = 30): [Team!]!
     """
     What Argos invoiced over the last \`months\` calendar months, oldest first
-    and the running one last (staff only).
+    and the running one last, with the annual contracts the yearly rate is
+    made of (staff only).
 
     Read from Stripe when asked, never stored: the invoices change behind us as
     they are paid, voided and credited. Every month costs a paginated walk of
     its own, which is what \`months\` is bounded for.
     """
-    staffRevenue(months: Int! = 3): [StaffRevenueMonth!]!
+    staffRevenue(months: Int! = 3): StaffRevenue!
   }
 
   extend type Mutation {

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -346,6 +346,16 @@ export const typeDefs = gql`
     revenue: Float!
     "How many teams contributed."
     teamsCount: Int!
+    """
+    The part of \`revenue\` invoiced in a currency other than US dollars, added
+    in at parity.
+
+    Stripe states each invoice in the currency it was raised in, and converting
+    one into another needs a rate on the day, which nothing here has. So a euro
+    invoice is counted as though it were dollars, and this says how much of the
+    figure rests on that.
+    """
+    foreignRevenue: Float!
   }
 
   """
@@ -408,9 +418,9 @@ export const typeDefs = gql`
     What Argos invoiced over the last \`months\` calendar months, oldest first
     and the running one last (staff only).
 
-    Its own query rather than a field on \`staffTeams\`: it walks Stripe's
-    invoices, so it loads beside the table instead of ahead of it. Every month
-    costs a walk of its own, which is what \`months\` is bounded for.
+    Read from Stripe when asked, never stored: the invoices change behind us as
+    they are paid, voided and credited. Every month costs a paginated walk of
+    its own, which is what \`months\` is bounded for.
     """
     staffRevenue(months: Int! = 3): [StaffRevenueMonth!]!
   }
@@ -606,6 +616,9 @@ export const resolvers: IResolvers = {
     staffRevenue: async (_root, args, ctx) => {
       assertStaff(ctx);
 
+      // Guarded here as well as in the service: this one answers a bad request
+      // with a bad-request error rather than an invariant the client cannot
+      // read.
       if (args.months < 1 || args.months > MAX_MONTHS) {
         throw badUserInput(`\`months\` must be between 1 and ${MAX_MONTHS}.`);
       }

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -7,6 +7,7 @@ import {
   getAccountBillings,
   type AccountBilling,
 } from "@/database/services/period-usage";
+import { getStaffRevenue, MAX_MONTHS } from "@/stripe/revenue";
 
 import type {
   IAccountSubscriptionStatus,
@@ -340,6 +341,40 @@ export const typeDefs = gql`
     CURRENT_PERIOD_DESC
   }
 
+  "What the teams on one billing interval contributed to a month."
+  type StaffRevenueSplit {
+    revenue: Float!
+    "How many teams contributed."
+    teamsCount: Int!
+  }
+
+  """
+  What Argos invoiced over one calendar month.
+
+  Read from the Stripe invoices themselves rather than recomputed from usage, so
+  the amounts carry what Stripe actually charged — negotiated prices, coupons,
+  credit notes — instead of a second pricing engine of ours that would have to
+  agree with the first. Amounts exclude tax, are net of credit notes, and
+  currencies are added at parity.
+  """
+  type StaffRevenueMonth {
+    "The first instant of the month, in UTC — what names it on screen."
+    month: DateTime!
+    "The two splits below, added up."
+    revenue: Float!
+    "What teams billed by the month were invoiced that month."
+    monthlyPlans: StaffRevenueSplit!
+    """
+    What the annual contracts in force are worth per month: their latest invoice
+    over twelve.
+
+    The same on every month, being a rate. Amortizing each annual invoice over
+    the twelve months it covers would be exact, but it would mean reading a year
+    of invoices to report one month — which a request cannot afford.
+    """
+    yearlyPlans: StaffRevenueSplit!
+  }
+
   type StaffTeamConnection implements Connection {
     pageInfo: PageInfo!
     edges: [Team!]!
@@ -369,6 +404,15 @@ export const typeDefs = gql`
     ): StaffTeamConnection!
     "List teams created within the last \`days\` days, newest first (staff only)"
     staffTrialPipeline(days: Int! = 30): [Team!]!
+    """
+    What Argos invoiced over the last \`months\` calendar months, oldest first
+    and the running one last (staff only).
+
+    Its own query rather than a field on \`staffTeams\`: it walks Stripe's
+    invoices, so it loads beside the table instead of ahead of it. Every month
+    costs a walk of its own, which is what \`months\` is bounded for.
+    """
+    staffRevenue(months: Int! = 3): [StaffRevenueMonth!]!
   }
 
   extend type Mutation {
@@ -558,6 +602,15 @@ export const resolvers: IResolvers = {
       ]);
 
       return paginateResult({ result: { total, results }, after, first });
+    },
+    staffRevenue: async (_root, args, ctx) => {
+      assertStaff(ctx);
+
+      if (args.months < 1 || args.months > MAX_MONTHS) {
+        throw badUserInput(`\`months\` must be between 1 and ${MAX_MONTHS}.`);
+      }
+
+      return getStaffRevenue(args.months);
     },
     staffTrialPipeline: async (_root, args, ctx) => {
       assertStaff(ctx);

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -451,9 +451,9 @@ export const typeDefs = gql`
     "The invoices the contract is worth, newest first."
     invoices: [StaffContractInvoice!]!
     """
-    True when every invoice found is still awaiting payment. Counted all the
-    same — a contract invoice raised is money on its way — and flagged, so
-    collection can be watched.
+    True when any invoice found is still awaiting payment — the unpaid
+    renewal beside a settled upsell is exactly the one worth watching.
+    Counted all the same: a contract invoice raised is money on its way.
     """
     awaitingPayment: Boolean!
   }

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -7,7 +7,11 @@ import {
   getAccountBillings,
   type AccountBilling,
 } from "@/database/services/period-usage";
-import { getStaffRevenue, MAX_MONTHS } from "@/stripe/revenue";
+import {
+  getStaffRevenue,
+  MAX_MONTHS,
+  MirrorCoverageError,
+} from "@/stripe/revenue";
 
 import type {
   IAccountSubscriptionStatus,
@@ -17,7 +21,7 @@ import type {
 } from "../__generated__/resolver-types";
 import type { Context } from "../context";
 import type { AccountActivation } from "../loaders";
-import { badUserInput, forbidden, unauthenticated } from "../util";
+import { badUserInput, forbidden, notFound, unauthenticated } from "../util";
 import { paginateResult } from "./PageInfo";
 
 /** Every staff entry point opens with this — the check lives in one place. */
@@ -407,11 +411,13 @@ export const typeDefs = gql`
     amount: Float!
     "The currency it was raised in — the contract's total converts it."
     currency: String!
+    "True while it is raised but not yet cleared."
+    awaitingPayment: Boolean!
     "When it was raised."
     invoicedAt: DateTime!
-    "The stretch it covers, when it states a real one."
-    coveredFrom: DateTime
-    coveredUntil: DateTime
+    "The stretch its money pays for, after the next bill clipped it."
+    coveredFrom: DateTime!
+    coveredUntil: DateTime!
   }
 
   """
@@ -426,17 +432,20 @@ export const typeDefs = gql`
     slug: String!
     "The team's display name, when it has one."
     name: String
-    "The subscription the database knows the contract by."
-    stripeSubscriptionId: String!
+    "The Stripe customer the contract is billed on."
+    stripeCustomerId: String!
     """
-    The invoices below added up, in euros. Null when none was found, in which
-    case the contract adds nothing to the rate.
+    The invoices below added up, in euros. Null when the team is billed yearly
+    but no invoice of its contract could be found — an anomaly worth seeing
+    rather than hiding.
     """
     amount: Float
+    "What the contract contributes to the running month, in euros."
+    monthlyRevenue: Float!
     "The invoices the contract is worth, newest first."
     invoices: [StaffContractInvoice!]!
     """
-    True when the invoices found are still awaiting payment. Counted all the
+    True when every invoice found is still awaiting payment. Counted all the
     same — a contract invoice raised is money on its way — and flagged, so
     collection can be watched.
     """
@@ -698,7 +707,17 @@ export const resolvers: IResolvers = {
         throw badUserInput(`\`months\` must be between 1 and ${MAX_MONTHS}.`);
       }
 
-      return getStaffRevenue(args.months);
+      try {
+        return await getStaffRevenue(args.months);
+      } catch (error) {
+        // A mirror not backfilled, or one the sweep stopped reconciling, is an
+        // operator state the page is built to report — not a fault to page
+        // the on-call over, which a bare error reaching Sentry would be.
+        if (error instanceof MirrorCoverageError) {
+          throw notFound(error.message);
+        }
+        throw error;
+      }
     },
     staffTrialPipeline: async (_root, args, ctx) => {
       assertStaff(ctx);

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -347,13 +347,12 @@ export const typeDefs = gql`
     "How many teams contributed."
     teamsCount: Int!
     """
-    The part of \`revenue\` invoiced in a currency other than US dollars, added
-    in at parity.
+    The part of \`revenue\` invoiced in a currency other than euros, converted
+    at the page's fixed rate.
 
-    Stripe states each invoice in the currency it was raised in, and converting
-    one into another needs a rate on the day, which nothing here has. So a euro
-    invoice is counted as though it were dollars, and this says how much of the
-    figure rests on that.
+    Stripe states each invoice in the currency it was raised in; dollars are
+    brought into euros at a fixed rate rather than the day's, and this says how
+    much of the figure rests on that conversion.
     """
     foreignRevenue: Float!
   }
@@ -364,8 +363,8 @@ export const typeDefs = gql`
   Read from the Stripe invoices themselves rather than recomputed from usage, so
   the amounts carry what Stripe actually charged — negotiated prices, coupons,
   credit notes — instead of a second pricing engine of ours that would have to
-  agree with the first. Amounts exclude tax, are net of credit notes, and
-  currencies are added at parity.
+  agree with the first. Amounts exclude tax, are net of credit notes, and are
+  stated in euros, dollars converted at a fixed rate.
   """
   type StaffRevenueMonth {
     "The first instant of the month, in UTC — what names it on screen."
@@ -374,6 +373,8 @@ export const typeDefs = gql`
     revenue: Float!
     "What teams billed by the month were invoiced that month."
     monthlyPlans: StaffRevenueSplit!
+    "The teams behind \`monthlyPlans\`, largest first — they sum to it."
+    teams: [StaffRevenueMonthTeam!]!
     """
     What the annual contracts in force are worth per month: their latest invoice
     over twelve.
@@ -385,11 +386,27 @@ export const typeDefs = gql`
     yearlyPlans: StaffRevenueSplit!
   }
 
+  "What one team was invoiced over a month, one line of the breakdown."
+  type StaffRevenueMonthTeam {
+    "The team's slug, which names its pages."
+    slug: String!
+    "The team's display name, when it has one."
+    name: String
+    "The Stripe customer the invoices were raised on."
+    stripeCustomerId: String!
+    "What the invoices add up to, in \`currency\`."
+    amount: Float!
+    "The currency the team is invoiced in — null when a month mixes several."
+    currency: String
+    "In euros, like the split it sums into."
+    revenue: Float!
+  }
+
   "One invoice a contract's worth is read from."
   type StaffContractInvoice {
-    "Net of tax and credit notes, in the currency's main unit."
+    "Net of tax and credit notes, in the currency it was raised in."
     amount: Float!
-    "The currency it was raised in, counted at parity when not USD."
+    "The currency it was raised in — the contract's total converts it."
     currency: String!
     "When it was raised."
     invoicedAt: DateTime!
@@ -413,15 +430,16 @@ export const typeDefs = gql`
     "The subscription the database knows the contract by."
     stripeSubscriptionId: String!
     """
-    The invoices below, added up. Null when none was found, in which case the
-    contract adds nothing to the rate.
+    The invoices below added up, in euros. Null when none was found, in which
+    case the contract adds nothing to the rate.
     """
     amount: Float
     "The invoices the contract is worth, newest first."
     invoices: [StaffContractInvoice!]!
     """
-    True when the invoices found are still awaiting payment. Shown, so a
-    contract in collection is visible, but counted nothing until they clear.
+    True when the invoices found are still awaiting payment. Counted all the
+    same — a contract invoice raised is money on its way — and flagged, so
+    collection can be watched.
     """
     awaitingPayment: Boolean!
   }
@@ -432,6 +450,12 @@ export const typeDefs = gql`
     months: [StaffRevenueMonth!]!
     "The contracts behind every month's \`yearlyPlans\`, largest first."
     yearlyContracts: [StaffYearlyContract!]!
+    """
+    What GitHub Marketplace brings in a month, in euros, gross of the 5%
+    GitHub keeps. A stated constant, not a reading — GitHub exposes no invoice
+    API — so it is not part of the figures above.
+    """
+    githubMarketplaceMonthlyRevenue: Float!
   }
 
   type StaffTeamConnection implements Connection {

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -451,8 +451,9 @@ export const typeDefs = gql`
     yearlyContracts: [StaffYearlyContract!]!
     """
     What GitHub Marketplace brings in a month, in euros, gross of the 5%
-    GitHub keeps. A stated constant, not a reading — GitHub exposes no invoice
-    API — so it is not part of the figures above.
+    GitHub keeps: the active marketplace subscriptions at their plans' list
+    prices, since GitHub exposes no seller invoice API. Not part of the
+    figures above.
     """
     githubMarketplaceMonthlyRevenue: Float!
   }

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -387,6 +387,12 @@ export const typeDefs = gql`
     never moves once written.
     """
     yearlyPlans: StaffRevenueSplit!
+    """
+    What GitHub Marketplace brought in over the month: the subscriptions
+    running then, at their plans' list prices. Beside the two above rather
+    than inside them — GitHub bills it, and \`revenue\` never counts it.
+    """
+    githubPlans: StaffRevenueSplit!
   }
 
   "What one team was invoiced over a month, one line of the breakdown."
@@ -458,13 +464,6 @@ export const typeDefs = gql`
     months: [StaffRevenueMonth!]!
     "The contracts behind every month's \`yearlyPlans\`, largest first."
     yearlyContracts: [StaffYearlyContract!]!
-    """
-    What GitHub Marketplace brings in a month, in euros, gross of the 5%
-    GitHub keeps: the active marketplace subscriptions at their plans' list
-    prices, since GitHub exposes no seller invoice API. Not part of the
-    figures above.
-    """
-    githubMarketplaceMonthlyRevenue: Float!
   }
 
   type StaffTeamConnection implements Connection {

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -376,12 +376,13 @@ export const typeDefs = gql`
     "The teams behind \`monthlyPlans\`, largest first — they sum to it."
     teams: [StaffRevenueMonthTeam!]!
     """
-    What the annual contracts in force are worth per month: their latest invoice
-    over twelve.
+    What the annual contracts in force are worth per month: their contract
+    invoices over twelve.
 
-    The same on every month, being a rate. Amortizing each annual invoice over
-    the twelve months it covers would be exact, but it would mean reading a year
-    of invoices to report one month — which a request cannot afford.
+    The same on every month, being a rate — amortizing each invoice over the
+    exact months it covers would be more precise, and the mirror now makes it
+    affordable, but a flat rate is what the page's readers asked to compare
+    months against.
     """
     yearlyPlans: StaffRevenueSplit!
   }
@@ -492,11 +493,12 @@ export const typeDefs = gql`
     and the running one last, with the annual contracts the yearly rate is
     made of (staff only).
 
-    Read from Stripe when asked, never stored: the invoices change behind us as
-    they are paid, voided and credited. Every month costs a paginated walk of
-    its own, which is what \`months\` is bounded for.
+    Read from the \`stripe_invoices\` mirror, which the Stripe webhooks keep
+    current and a reconciliation sweep backs up — a window the mirror was
+    never backfilled for is refused rather than reported as zeros. The staff
+    revenue page is the only consumer today.
     """
-    staffRevenue(months: Int! = 3): StaffRevenue!
+    staffRevenue(months: Int!): StaffRevenue!
   }
 
   extend type Mutation {

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -376,13 +376,11 @@ export const typeDefs = gql`
     "The teams behind \`monthlyPlans\`, largest first — they sum to it."
     teams: [StaffRevenueMonthTeam!]!
     """
-    What the annual contracts in force are worth per month: their contract
-    invoices over twelve.
-
-    The same on every month, being a rate — amortizing each invoice over the
-    exact months it covers would be more precise, and the mirror now makes it
-    affordable, but a flat rate is what the page's readers asked to compare
-    months against.
+    What the annual contracts contributed to the month: their invoices
+    amortized, day by day, over the stretch each one pays for — the monthly
+    equivalent of the annual book. A renewal weighs on the twelve months it
+    covers, an upsell on the stretch it was sold for, and a month's figure
+    never moves once written.
     """
     yearlyPlans: StaffRevenueSplit!
   }

--- a/apps/backend/src/processes/proc/worker.ts
+++ b/apps/backend/src/processes/proc/worker.ts
@@ -15,6 +15,8 @@ import { notificationWorkflowJob } from "@/notification/workflow-job";
 import { originPullRequestJob } from "@/origin-pull-request/job";
 import { originInstallationSyncJob } from "@/origin/synchronize-job";
 import { job as screenshotDiffJob } from "@/screenshot-diff";
+import { checkIsStripeConfigured } from "@/stripe";
+import { syncStripeInvoices } from "@/stripe/invoice-mirror";
 import { job as synchronizeJob } from "@/synchronize";
 import { scheduleCron } from "@/util/cron";
 
@@ -38,6 +40,17 @@ scheduleCron("saml-certificate-expiration", "0 * * * *", (context) =>
 scheduleCron("media-retention", "15 * * * *", (context) =>
   purgeExpiredMedia(context.date),
 );
+
+// The safety net under the invoice webhooks: re-reads a window wide enough to
+// catch anything a missed delivery left behind. Daily, because the webhooks
+// are the live path — the sweep only has to beat an operator noticing.
+scheduleCron("stripe-invoice-sync", "45 4 * * *", async (context) => {
+  if (!checkIsStripeConfigured()) {
+    return;
+  }
+  const since = new Date(context.date.getTime() - 35 * 24 * 3600 * 1000);
+  await syncStripeInvoices({ since });
+});
 
 createJobWorker(
   automationActionRunJob,

--- a/apps/backend/src/processes/proc/worker.ts
+++ b/apps/backend/src/processes/proc/worker.ts
@@ -6,6 +6,7 @@ import { job as buildNotificationJob } from "@/build-notification";
 import config from "@/config";
 import { job as deploymentNotificationJob } from "@/deployment-notification";
 import { githubPullRequestJob } from "@/github-pull-request/job";
+import { syncGithubMarketplacePlanPrices } from "@/github/marketplace";
 import { createJobWorker } from "@/job-core";
 import logger from "@/logger";
 import { mediaDiffJob } from "@/media/diff-job";
@@ -50,6 +51,15 @@ scheduleCron("stripe-invoice-sync", "45 4 * * *", async (context) => {
   }
   const since = new Date(context.date.getTime() - 35 * 24 * 3600 * 1000);
   await syncStripeInvoices({ since });
+});
+
+// The Marketplace listing's prices, onto the plans — what the revenue page
+// multiplies the active marketplace subscriptions by.
+scheduleCron("github-marketplace-prices", "35 4 * * *", async () => {
+  if (!config.get("github.appId")) {
+    return;
+  }
+  await syncGithubMarketplacePlanPrices();
 });
 
 createJobWorker(

--- a/apps/backend/src/stripe/bin/sync-stripe-invoices.ts
+++ b/apps/backend/src/stripe/bin/sync-stripe-invoices.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import { callbackify } from "node:util";
+
+import logger from "@/logger";
+
+import { syncStripeInvoices } from "../invoice-mirror";
+
+/**
+ * Days swept, from the command line.
+ *
+ * Defaults shallow, for the recurring reconciliation under the webhooks; the
+ * one-off backfill passes a deep window instead — 760 covers the 24 months the
+ * revenue page can be asked for, with a margin.
+ */
+const days = Number(process.argv[2] ?? 35);
+
+const main = callbackify(async () => {
+  if (!Number.isFinite(days) || days <= 0) {
+    throw new Error(`Not a number of days: ${process.argv[2]}`);
+  }
+  const since = new Date(Date.now() - days * 24 * 3600 * 1000);
+  const count = await syncStripeInvoices({ since });
+  logger.info(`${count} invoices mirrored since ${since.toISOString()}`);
+});
+
+main((err) => {
+  if (err) {
+    throw err;
+  }
+});

--- a/apps/backend/src/stripe/bin/sync-stripe-invoices.ts
+++ b/apps/backend/src/stripe/bin/sync-stripe-invoices.ts
@@ -10,9 +10,10 @@ import { syncStripeInvoices } from "../invoice-mirror";
  *
  * The recurring reconciliation runs as the `stripe-invoice-sync` cron in the
  * worker; this hand-run form exists for the one-off backfill and for repairs.
- * The backfill passes a deep window — 760 covers the 24 months the revenue
- * page can be asked for, with a margin — and the recorded sweep is what lets
- * the page report that far back.
+ * The backfill passes a deep window — 1200 covers the 24 months the revenue
+ * page can be asked for plus the year of contracts still paying for its first
+ * months, with a margin — and the recorded sweep is what lets the page report
+ * that far back.
  */
 const days = Number(process.argv[2] ?? 35);
 

--- a/apps/backend/src/stripe/bin/sync-stripe-invoices.ts
+++ b/apps/backend/src/stripe/bin/sync-stripe-invoices.ts
@@ -8,9 +8,11 @@ import { syncStripeInvoices } from "../invoice-mirror";
 /**
  * Days swept, from the command line.
  *
- * Defaults shallow, for the recurring reconciliation under the webhooks; the
- * one-off backfill passes a deep window instead — 760 covers the 24 months the
- * revenue page can be asked for, with a margin.
+ * The recurring reconciliation runs as the `stripe-invoice-sync` cron in the
+ * worker; this hand-run form exists for the one-off backfill and for repairs.
+ * The backfill passes a deep window — 760 covers the 24 months the revenue
+ * page can be asked for, with a margin — and the recorded sweep is what lets
+ * the page report that far back.
  */
 const days = Number(process.argv[2] ?? 35);
 

--- a/apps/backend/src/stripe/bin/sync-stripe-invoices.ts
+++ b/apps/backend/src/stripe/bin/sync-stripe-invoices.ts
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-import { callbackify } from "node:util";
-
 import logger from "@/logger";
 
 import { syncStripeInvoices } from "../invoice-mirror";
@@ -17,17 +15,13 @@ import { syncStripeInvoices } from "../invoice-mirror";
  */
 const days = Number(process.argv[2] ?? 35);
 
-const main = callbackify(async () => {
-  if (!Number.isFinite(days) || days <= 0) {
-    throw new Error(`Not a number of days: ${process.argv[2]}`);
-  }
-  const since = new Date(Date.now() - days * 24 * 3600 * 1000);
-  const count = await syncStripeInvoices({ since });
-  logger.info(`${count} invoices mirrored since ${since.toISOString()}`);
-});
+if (!Number.isFinite(days) || days <= 0) {
+  throw new Error(`Not a number of days: ${process.argv[2]}`);
+}
 
-main((err) => {
-  if (err) {
-    throw err;
-  }
-});
+const since = new Date(Date.now() - days * 24 * 3600 * 1000);
+const count = await syncStripeInvoices({ since });
+logger.info(`${count} invoices mirrored since ${since.toISOString()}`);
+
+// The database pool would hold the process open otherwise.
+process.exit(0);

--- a/apps/backend/src/stripe/index.ts
+++ b/apps/backend/src/stripe/index.ts
@@ -15,7 +15,7 @@ import {
 import { sendNotification } from "@/notification";
 import { redisLock } from "@/util/redis";
 
-import { deleteStripeInvoice, upsertStripeInvoice } from "./invoice-mirror";
+import { deleteStripeInvoice, refreshStripeInvoice } from "./invoice-mirror";
 
 export type { Stripe };
 
@@ -180,7 +180,8 @@ function getPlanProductIdFromStripeSubscription(
   return product.id;
 }
 
-function timestampToISOString(date: number): string {
+/** Stripe timestamps in whole seconds. */
+export function timestampToISOString(date: number): string {
   return new Date(date * 1000).toISOString();
 }
 
@@ -188,6 +189,16 @@ export const stripe = new Stripe(config.get("stripe.apiKey"), {
   apiVersion: "2026-07-29.dahlia",
   typescript: true,
 });
+
+/**
+ * Whether a real Stripe key is configured, next to the client it guards.
+ *
+ * Compared against the schema's own default rather than a re-spelled literal,
+ * so renaming the placeholder cannot silently turn the check off.
+ */
+export function checkIsStripeConfigured(): boolean {
+  return config.get("stripe.apiKey") !== config.default("stripe.apiKey");
+}
 
 async function createArgosSubscriptionFromCheckoutSession({
   account,
@@ -881,6 +892,44 @@ export async function handleStripeEvent({
   data,
   type,
 }: Pick<Stripe.Event, "data" | "type">): Promise<void> {
+  // Every invoice or credit-note event is only a signal to re-read the
+  // invoice from the API, never a payload to trust: Stripe guarantees no
+  // delivery order and retries for days, so a payload is a snapshot of
+  // unknown age — and it embeds at most ten invoice lines anyway. Handling
+  // the whole families by prefix also keeps an over-ticked event type on the
+  // dashboard endpoint from landing in the throwing default case below.
+  //
+  // The endpoint needs at least: invoice.created, invoice.updated,
+  // invoice.finalized, invoice.paid, invoice.voided,
+  // invoice.marked_uncollectible, invoice.deleted, credit_note.created,
+  // credit_note.updated, credit_note.voided.
+  if (type === "invoice.deleted") {
+    const invoice = data.object as Stripe.Invoice;
+    if (invoice.id) {
+      await deleteStripeInvoice(invoice.id);
+    }
+    return;
+  }
+  if (type.startsWith("invoice.")) {
+    const invoice = data.object as Stripe.Invoice;
+    // An `invoice.upcoming` preview has no id, and nothing to mirror.
+    if (invoice.id) {
+      await refreshStripeInvoice(invoice.id);
+    }
+    return;
+  }
+  if (type.startsWith("credit_note.")) {
+    const creditNote = data.object as Stripe.CreditNote;
+    const invoiceId =
+      typeof creditNote.invoice === "string"
+        ? creditNote.invoice
+        : creditNote.invoice?.id;
+    if (invoiceId) {
+      await refreshStripeInvoice(invoiceId);
+    }
+    return;
+  }
+
   switch (type) {
     case "payment_method.attached": {
       const paymentMethod = data.object as Stripe.PaymentMethod;
@@ -1020,42 +1069,6 @@ export async function handleStripeEvent({
           });
         })(),
       ]);
-      return;
-    }
-
-    case "invoice.created":
-    case "invoice.updated":
-    case "invoice.finalized":
-    case "invoice.paid":
-    case "invoice.voided":
-    case "invoice.marked_uncollectible": {
-      const invoice = data.object as Stripe.Invoice;
-      await upsertStripeInvoice(invoice);
-      return;
-    }
-
-    case "invoice.deleted": {
-      const invoice = data.object as Stripe.Invoice;
-      if (invoice.id) {
-        await deleteStripeInvoice(invoice.id);
-      }
-      return;
-    }
-
-    // A credit note changes its invoice's credited amounts, but Stripe sends
-    // no invoice.updated for it — the invoice has to be re-read.
-    case "credit_note.created":
-    case "credit_note.updated":
-    case "credit_note.voided": {
-      const creditNote = data.object as Stripe.CreditNote;
-      const invoiceId =
-        typeof creditNote.invoice === "string"
-          ? creditNote.invoice
-          : creditNote.invoice?.id;
-      if (invoiceId) {
-        const invoice = await stripe.invoices.retrieve(invoiceId);
-        await upsertStripeInvoice(invoice);
-      }
       return;
     }
 

--- a/apps/backend/src/stripe/index.ts
+++ b/apps/backend/src/stripe/index.ts
@@ -15,6 +15,8 @@ import {
 import { sendNotification } from "@/notification";
 import { redisLock } from "@/util/redis";
 
+import { deleteStripeInvoice, upsertStripeInvoice } from "./invoice-mirror";
+
 export type { Stripe };
 
 async function getPlanFromStripeProductId(stripeProductId: string) {
@@ -1018,6 +1020,42 @@ export async function handleStripeEvent({
           });
         })(),
       ]);
+      return;
+    }
+
+    case "invoice.created":
+    case "invoice.updated":
+    case "invoice.finalized":
+    case "invoice.paid":
+    case "invoice.voided":
+    case "invoice.marked_uncollectible": {
+      const invoice = data.object as Stripe.Invoice;
+      await upsertStripeInvoice(invoice);
+      return;
+    }
+
+    case "invoice.deleted": {
+      const invoice = data.object as Stripe.Invoice;
+      if (invoice.id) {
+        await deleteStripeInvoice(invoice.id);
+      }
+      return;
+    }
+
+    // A credit note changes its invoice's credited amounts, but Stripe sends
+    // no invoice.updated for it — the invoice has to be re-read.
+    case "credit_note.created":
+    case "credit_note.updated":
+    case "credit_note.voided": {
+      const creditNote = data.object as Stripe.CreditNote;
+      const invoiceId =
+        typeof creditNote.invoice === "string"
+          ? creditNote.invoice
+          : creditNote.invoice?.id;
+      if (invoiceId) {
+        const invoice = await stripe.invoices.retrieve(invoiceId);
+        await upsertStripeInvoice(invoice);
+      }
       return;
     }
 

--- a/apps/backend/src/stripe/invoice-mirror.ts
+++ b/apps/backend/src/stripe/invoice-mirror.ts
@@ -1,0 +1,105 @@
+import type Stripe from "stripe";
+
+import { StripeInvoice } from "@/database/models";
+
+import { stripe } from "./index";
+
+/**
+ * What a Stripe invoice becomes in the mirror, or null for the ones not worth
+ * a row: a draft is not an invoice yet — it changes freely and gets deleted —
+ * and it will be mirrored when finalization makes it one.
+ */
+function buildStripeInvoiceRow(invoice: Stripe.Invoice) {
+  const customerId =
+    typeof invoice.customer === "string"
+      ? invoice.customer
+      : invoice.customer?.id;
+  if (!invoice.id || !invoice.status || invoice.status === "draft") {
+    return null;
+  }
+  if (!customerId) {
+    return null;
+  }
+
+  const subscription = invoice.parent?.subscription_details?.subscription;
+
+  // The longest stretch one of the invoice's lines covers — resolved here
+  // rather than at read time, so the reader never needs the lines back.
+  let period: { start: number; end: number } | null = null;
+  for (const line of invoice.lines.data) {
+    if (
+      !period ||
+      line.period.end - line.period.start > period.end - period.start
+    ) {
+      period = line.period;
+    }
+  }
+
+  return {
+    stripeInvoiceId: invoice.id,
+    stripeCustomerId: customerId,
+    stripeSubscriptionId:
+      typeof subscription === "string"
+        ? subscription
+        : (subscription?.id ?? null),
+    // Stripe timestamps in whole seconds.
+    stripeCreatedAt: new Date(invoice.created * 1000).toISOString(),
+    status: invoice.status,
+    billingReason: invoice.billing_reason,
+    currency: invoice.currency,
+    total: invoice.total,
+    totalExcludingTax: invoice.total_excluding_tax,
+    totalTaxesAmount:
+      invoice.total_taxes === null
+        ? null
+        : invoice.total_taxes.reduce((sum, tax) => sum + tax.amount, 0),
+    prePaymentCreditNotesAmount: invoice.pre_payment_credit_notes_amount,
+    postPaymentCreditNotesAmount: invoice.post_payment_credit_notes_amount,
+    periodStart: period ? new Date(period.start * 1000).toISOString() : null,
+    periodEnd: period ? new Date(period.end * 1000).toISOString() : null,
+  };
+}
+
+/**
+ * Write one invoice into the mirror, idempotently: webhooks arrive more than
+ * once and out of order, and the reconciliation sweep re-reads what the
+ * webhooks already wrote.
+ */
+export async function upsertStripeInvoice(
+  invoice: Stripe.Invoice,
+): Promise<void> {
+  const row = buildStripeInvoiceRow(invoice);
+  if (!row) {
+    return;
+  }
+  await StripeInvoice.query().insert(row).onConflict("stripeInvoiceId").merge();
+}
+
+/** Forget an invoice Stripe deleted — only drafts can be, but be thorough. */
+export async function deleteStripeInvoice(
+  stripeInvoiceId: string,
+): Promise<void> {
+  await StripeInvoice.query().delete().where({ stripeInvoiceId });
+}
+
+/**
+ * Re-read a window of invoices from Stripe into the mirror.
+ *
+ * The safety net under the webhooks: a webhook missed during a downtime, or a
+ * subscription created before the mirror existed, is caught by the next sweep.
+ * Used both for the initial backfill (a deep window) and the recurring
+ * reconciliation (a shallow one).
+ */
+export async function syncStripeInvoices(options: {
+  since: Date;
+}): Promise<number> {
+  let count = 0;
+  for await (const invoice of stripe.invoices.list({
+    created: { gte: Math.floor(options.since.getTime() / 1000) },
+    limit: 100,
+  })) {
+    await upsertStripeInvoice(invoice);
+    count += 1;
+  }
+  return count;
+}

--- a/apps/backend/src/stripe/invoice-mirror.ts
+++ b/apps/backend/src/stripe/invoice-mirror.ts
@@ -1,78 +1,201 @@
 import type Stripe from "stripe";
 
-import { StripeInvoice } from "@/database/models";
+import { StripeInvoice, StripeInvoiceSync } from "@/database/models";
 
-import { stripe } from "./index";
+import { stripe, timestampToISOString } from "./index";
 
 /**
- * What a Stripe invoice becomes in the mirror, or null for the ones not worth
- * a row: a draft is not an invoice yet — it changes freely and gets deleted —
- * and it will be mirrored when finalization makes it one.
+ * The columns a conflicting upsert refreshes — everything but `createdAt`,
+ * which records when the mirror first saw the invoice and must survive
+ * updates.
  */
-function buildStripeInvoiceRow(invoice: Stripe.Invoice) {
-  const customerId =
-    typeof invoice.customer === "string"
-      ? invoice.customer
-      : invoice.customer?.id;
-  if (!invoice.id || !invoice.status || invoice.status === "draft") {
-    return null;
-  }
-  if (!customerId) {
-    return null;
-  }
+const MERGE_COLUMNS = [
+  "updatedAt",
+  "stripeCustomerId",
+  "stripeSubscriptionId",
+  "stripeCreatedAt",
+  "status",
+  "billingReason",
+  "currency",
+  "total",
+  "totalExcludingTax",
+  "totalTaxesAmount",
+  "creditedAmountExcludingTax",
+  "periodStart",
+  "periodEnd",
+];
 
-  const subscription = invoice.parent?.subscription_details?.subscription;
+/** How many rows a sweep writes per statement. */
+const BATCH_SIZE = 100;
 
-  // The longest stretch one of the invoice's lines covers — resolved here
-  // rather than at read time, so the reader never needs the lines back.
+/**
+ * The longest stretch one of the invoice's lines covers.
+ *
+ * Paginated when the embedded page is not the whole list: Stripe embeds at
+ * most ten lines in a payload, and the year-long line of a conversion invoice
+ * can sit past them — resolving from the first page alone would file the
+ * contract as a true-up.
+ */
+async function resolveCoveredPeriod(
+  invoice: Stripe.Invoice & { id: string },
+): Promise<{ start: number; end: number } | null> {
   let period: { start: number; end: number } | null = null;
-  for (const line of invoice.lines.data) {
+  const consider = (line: { period: { start: number; end: number } }) => {
     if (
       !period ||
       line.period.end - line.period.start > period.end - period.start
     ) {
       period = line.period;
     }
+  };
+
+  if (invoice.lines.has_more) {
+    for await (const line of stripe.invoices.listLineItems(invoice.id, {
+      limit: 100,
+    })) {
+      consider(line);
+    }
+  } else {
+    for (const line of invoice.lines.data) {
+      consider(line);
+    }
+  }
+  return period;
+}
+
+/**
+ * What the invoice's credit notes gave back, ex-tax.
+ *
+ * Read from the credit notes themselves rather than from the invoice's
+ * pre/post_payment_credit_notes_amount rollups: those are tax-INCLUSIVE
+ * totals, and subtracting them from the ex-tax base would take the credited
+ * VAT off twice — a fully refunded taxed invoice would report negative.
+ */
+async function resolveCreditedAmount(
+  invoice: Stripe.Invoice & { id: string },
+): Promise<number> {
+  if (
+    invoice.pre_payment_credit_notes_amount +
+      invoice.post_payment_credit_notes_amount ===
+    0
+  ) {
+    return 0;
   }
 
+  let credited = 0;
+  for await (const creditNote of stripe.creditNotes.list({
+    invoice: invoice.id,
+    limit: 100,
+  })) {
+    if (creditNote.status === "void") {
+      continue;
+    }
+    // The rare note stating no ex-tax total falls back to its tax-inclusive
+    // one — conservative, and bounded by how rare it is.
+    credited += creditNote.total_excluding_tax ?? creditNote.total;
+  }
+  return credited;
+}
+
+/**
+ * What a Stripe invoice becomes in the mirror, or null for the ones not worth
+ * a row: a draft is not an invoice yet — it changes freely and gets deleted —
+ * and it will be mirrored when finalization makes it one.
+ */
+async function buildStripeInvoiceRow(invoice: Stripe.Invoice) {
+  const customerId =
+    typeof invoice.customer === "string"
+      ? invoice.customer
+      : invoice.customer?.id;
+  const invoiceId = invoice.id;
+  if (!invoiceId || !invoice.status || invoice.status === "draft") {
+    return null;
+  }
+  if (!customerId) {
+    return null;
+  }
+
+  const identified = Object.assign(invoice, { id: invoiceId });
+  const subscription = invoice.parent?.subscription_details?.subscription;
+  const [period, creditedAmountExcludingTax] = await Promise.all([
+    resolveCoveredPeriod(identified),
+    resolveCreditedAmount(identified),
+  ]);
+
   return {
-    stripeInvoiceId: invoice.id,
+    stripeInvoiceId: invoiceId,
     stripeCustomerId: customerId,
     stripeSubscriptionId:
       typeof subscription === "string"
         ? subscription
         : (subscription?.id ?? null),
-    // Stripe timestamps in whole seconds.
-    stripeCreatedAt: new Date(invoice.created * 1000).toISOString(),
+    stripeCreatedAt: timestampToISOString(invoice.created),
     status: invoice.status,
     billingReason: invoice.billing_reason,
     currency: invoice.currency,
     total: invoice.total,
     totalExcludingTax: invoice.total_excluding_tax,
     totalTaxesAmount:
-      invoice.total_taxes === null
+      invoice.total_taxes == null
         ? null
         : invoice.total_taxes.reduce((sum, tax) => sum + tax.amount, 0),
-    prePaymentCreditNotesAmount: invoice.pre_payment_credit_notes_amount,
-    postPaymentCreditNotesAmount: invoice.post_payment_credit_notes_amount,
-    periodStart: period ? new Date(period.start * 1000).toISOString() : null,
-    periodEnd: period ? new Date(period.end * 1000).toISOString() : null,
+    creditedAmountExcludingTax,
+    periodStart: period ? timestampToISOString(period.start) : null,
+    periodEnd: period ? timestampToISOString(period.end) : null,
   };
 }
 
+type StripeInvoiceRow = NonNullable<
+  Awaited<ReturnType<typeof buildStripeInvoiceRow>>
+>;
+
 /**
- * Write one invoice into the mirror, idempotently: webhooks arrive more than
- * once and out of order, and the reconciliation sweep re-reads what the
- * webhooks already wrote.
+ * Write invoices into the mirror, idempotently: webhooks arrive more than
+ * once, and the reconciliation sweep re-reads what they already wrote.
  */
-export async function upsertStripeInvoice(
-  invoice: Stripe.Invoice,
+async function upsertStripeInvoiceRows(
+  rows: StripeInvoiceRow[],
 ): Promise<void> {
-  const row = buildStripeInvoiceRow(invoice);
-  if (!row) {
+  if (rows.length === 0) {
     return;
   }
-  await StripeInvoice.query().insert(row).onConflict("stripeInvoiceId").merge();
+  await StripeInvoice.query()
+    .insert(rows)
+    .onConflict("stripeInvoiceId")
+    .merge(MERGE_COLUMNS);
+}
+
+/**
+ * Re-read one invoice from Stripe into the mirror.
+ *
+ * Always a fresh retrieve, never the webhook's payload: Stripe guarantees no
+ * event ordering and retries deliveries for days, so a payload is a snapshot
+ * of unknown age — writing it could regress a paid row to open. The current
+ * state, re-read on every signal, cannot.
+ */
+export async function refreshStripeInvoice(
+  stripeInvoiceId: string,
+): Promise<void> {
+  let invoice: Stripe.Invoice;
+  try {
+    invoice = await stripe.invoices.retrieve(stripeInvoiceId);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "resource_missing"
+    ) {
+      // Deleted between the signal and the read — only drafts can be.
+      await deleteStripeInvoice(stripeInvoiceId);
+      return;
+    }
+    throw error;
+  }
+
+  const row = await buildStripeInvoiceRow(invoice);
+  if (row) {
+    await upsertStripeInvoiceRows([row]);
+  }
 }
 
 /** Forget an invoice Stripe deleted — only drafts can be, but be thorough. */
@@ -83,23 +206,81 @@ export async function deleteStripeInvoice(
 }
 
 /**
- * Re-read a window of invoices from Stripe into the mirror.
+ * Re-read a window of invoices from Stripe into the mirror, and record having
+ * done so.
  *
- * The safety net under the webhooks: a webhook missed during a downtime, or a
- * subscription created before the mirror existed, is caught by the next sweep.
+ * The safety net under the webhooks, in three passes: the invoices created in
+ * the window; the invoices — however old — whose credit notes were issued in
+ * the window; and the mirrored rows still in a non-terminal status from before
+ * the window, which a missed webhook may have left behind (an open invoice
+ * paid or voided late). The completed window is recorded, which is how the
+ * revenue reader proves the months it reports were ever covered.
+ *
  * Used both for the initial backfill (a deep window) and the recurring
- * reconciliation (a shallow one).
+ * reconciliation cron (a shallow one).
  */
 export async function syncStripeInvoices(options: {
   since: Date;
 }): Promise<number> {
+  const gte = Math.floor(options.since.getTime() / 1000);
+  const seen = new Set<string>();
   let count = 0;
+
+  let batch: StripeInvoiceRow[] = [];
+  const flush = async () => {
+    await upsertStripeInvoiceRows(batch);
+    count += batch.length;
+    batch = [];
+  };
+
   for await (const invoice of stripe.invoices.list({
-    created: { gte: Math.floor(options.since.getTime() / 1000) },
+    created: { gte },
     limit: 100,
   })) {
-    await upsertStripeInvoice(invoice);
+    const row = await buildStripeInvoiceRow(invoice);
+    if (!row) {
+      continue;
+    }
+    seen.add(row.stripeInvoiceId);
+    batch.push(row);
+    if (batch.length >= BATCH_SIZE) {
+      await flush();
+    }
+  }
+  await flush();
+
+  for await (const creditNote of stripe.creditNotes.list({
+    created: { gte },
+    limit: 100,
+  })) {
+    const invoiceId =
+      typeof creditNote.invoice === "string"
+        ? creditNote.invoice
+        : creditNote.invoice?.id;
+    if (!invoiceId || seen.has(invoiceId)) {
+      continue;
+    }
+    seen.add(invoiceId);
+    await refreshStripeInvoice(invoiceId);
     count += 1;
   }
+
+  const unsettled = await StripeInvoice.query()
+    .select("stripeInvoiceId")
+    .whereIn("status", ["open", "uncollectible"])
+    .where("stripeCreatedAt", "<", options.since.toISOString());
+  for (const row of unsettled) {
+    if (seen.has(row.stripeInvoiceId)) {
+      continue;
+    }
+    await refreshStripeInvoice(row.stripeInvoiceId);
+    count += 1;
+  }
+
+  await StripeInvoiceSync.query().insert({
+    sinceDate: options.since.toISOString(),
+    completedAt: new Date().toISOString(),
+  });
+
   return count;
 }

--- a/apps/backend/src/stripe/invoice-mirror.ts
+++ b/apps/backend/src/stripe/invoice-mirror.ts
@@ -241,6 +241,12 @@ export async function syncStripeInvoices(options: {
     if (!row) {
       continue;
     }
+    // A page Stripe hands over twice — a cursor resumed, a listing drifting
+    // under us — would put one invoice in a batch twice, and Postgres refuses
+    // to update the same row twice in one statement.
+    if (seen.has(row.stripeInvoiceId)) {
+      continue;
+    }
     seen.add(row.stripeInvoiceId);
     batch.push(row);
     if (batch.length >= BATCH_SIZE) {

--- a/apps/backend/src/stripe/invoice-mirror.ts
+++ b/apps/backend/src/stripe/invoice-mirror.ts
@@ -1,6 +1,7 @@
 import type Stripe from "stripe";
 
 import { StripeInvoice, StripeInvoiceSync } from "@/database/models";
+import { redisLock } from "@/util/redis";
 
 import { stripe, timestampToISOString } from "./index";
 
@@ -27,6 +28,15 @@ const MERGE_COLUMNS = [
 
 /** How many rows a sweep writes per statement. */
 const BATCH_SIZE = 100;
+
+/**
+ * How far before its window a sweep re-reads the invoices left unsettled.
+ *
+ * A year covers any collection worth chasing; past that an invoice still open
+ * is one nobody expects to clear, and re-reading it nightly for ever buys
+ * nothing.
+ */
+const UNSETTLED_LOOKBACK_MS = 365 * 24 * 3600 * 1000;
 
 /**
  * The longest stretch one of the invoice's lines covers.
@@ -170,10 +180,22 @@ async function upsertStripeInvoiceRows(
  *
  * Always a fresh retrieve, never the webhook's payload: Stripe guarantees no
  * event ordering and retries deliveries for days, so a payload is a snapshot
- * of unknown age — writing it could regress a paid row to open. The current
- * state, re-read on every signal, cannot.
+ * of unknown age — writing it could regress a paid row to open.
+ *
+ * Under a lock on the invoice, because reading current state is only enough
+ * while one reader runs at a time: two events delivered together would
+ * otherwise read in one order and write in the other, and the older read
+ * landing second would put the row back where it had already left.
  */
 export async function refreshStripeInvoice(
+  stripeInvoiceId: string,
+): Promise<void> {
+  await redisLock.acquire(["stripe-invoice", stripeInvoiceId], () =>
+    readStripeInvoiceIntoMirror(stripeInvoiceId),
+  );
+}
+
+async function readStripeInvoiceIntoMirror(
   stripeInvoiceId: string,
 ): Promise<void> {
   let invoice: Stripe.Invoice;
@@ -271,9 +293,17 @@ export async function syncStripeInvoices(options: {
     count += 1;
   }
 
+  // Bounded below as well as above: an invoice written off in practice but
+  // never voided in Stripe stays non-terminal for ever, and re-reading every
+  // one of them would add a round trip a night forever, none of which can
+  // change anything.
+  const unsettledFrom = new Date(
+    options.since.getTime() - UNSETTLED_LOOKBACK_MS,
+  );
   const unsettled = await StripeInvoice.query()
     .select("stripeInvoiceId")
     .whereIn("status", ["open", "uncollectible"])
+    .where("stripeCreatedAt", ">=", unsettledFrom.toISOString())
     .where("stripeCreatedAt", "<", options.since.toISOString());
   for (const row of unsettled) {
     if (seen.has(row.stripeInvoiceId)) {

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { factory, setupDatabase } from "@/database/testing";
 
-import { getBilledTeams, getTeamCustomerIds } from "./revenue";
+import { getBilledTeams, getTeamCustomers } from "./revenue";
 
 describe("getBilledTeams", () => {
   beforeEach(async () => {
@@ -113,12 +113,12 @@ describe("getBilledTeams", () => {
   });
 });
 
-describe("getTeamCustomerIds", () => {
+describe("getTeamCustomers", () => {
   beforeEach(async () => {
     await setupDatabase();
   });
 
-  it("keeps a team whose subscription has ended", async () => {
+  it("keeps a team whose subscription has ended, with its names", async () => {
     // Its invoices were still sent, and the month it was invoiced in has to
     // keep them — that departure is exactly what a comparison between two
     // months exists to show.
@@ -139,8 +139,10 @@ describe("getTeamCustomerIds", () => {
       status: "canceled",
     });
 
-    await expect(getTeamCustomerIds()).resolves.toEqual(
-      new Set(["cus_churned"]),
+    await expect(getTeamCustomers()).resolves.toEqual(
+      new Map([
+        ["cus_churned", { slug: account.slug, name: account.name ?? null }],
+      ]),
     );
   });
 
@@ -148,12 +150,12 @@ describe("getTeamCustomerIds", () => {
     // Whatever a personal account was invoiced is not this page's subject.
     await factory.UserAccount.create({ stripeCustomerId: "cus_personal" });
 
-    await expect(getTeamCustomerIds()).resolves.toEqual(new Set());
+    await expect(getTeamCustomers()).resolves.toEqual(new Map());
   });
 
   it("leaves out a team that never reached Stripe", async () => {
     await factory.TeamAccount.create({ stripeCustomerId: null });
 
-    await expect(getTeamCustomerIds()).resolves.toEqual(new Set());
+    await expect(getTeamCustomers()).resolves.toEqual(new Map());
   });
 });

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -8,7 +8,6 @@ import {
   getStaffRevenue,
   getTeamCustomers,
   startOfUTCMonth,
-  toEuros,
 } from "./revenue";
 
 let sequence = 0;
@@ -169,13 +168,24 @@ describe("getStaffRevenue", () => {
 
   it("refuses a window the mirror never covered", async () => {
     // Months nobody backfilled would report zeros that read as real figures.
-    await expect(getStaffRevenue(2)).rejects.toThrow(/does not cover/);
+    await expect(getStaffRevenue(2)).rejects.toThrow(/never swept deep enough/);
 
     // A sweep exists but is too shallow for the window asked.
     await factory.StripeInvoiceSync.create({
       sinceDate: new Date().toISOString(),
     });
-    await expect(getStaffRevenue(2)).rejects.toThrow(/does not cover/);
+    await expect(getStaffRevenue(2)).rejects.toThrow(/never swept deep enough/);
+  });
+
+  it("refuses figures from a mirror nothing reconciles any more", async () => {
+    // Deep enough, but the sweep stopped running: what it holds has drifted
+    // from Stripe by however long it has been silent.
+    await factory.StripeInvoiceSync.create({
+      sinceDate: new Date("2020-01-01").toISOString(),
+      completedAt: new Date(Date.now() - 30 * 24 * 3600 * 1000).toISOString(),
+    });
+
+    await expect(getStaffRevenue(2)).rejects.toThrow(/has not been swept/);
   });
 
   it("reports the window from the mirror, split by interval", async () => {
@@ -197,8 +207,8 @@ describe("getStaffRevenue", () => {
     const churned = await factory.TeamAccount.create({
       stripeCustomerId: "cus_staff_churned",
     });
-    // A churned yearly team: its old annual bill must not spike a month.
-    await factory.TeamAccount.create({
+    // A team that has left keeps paying for the months its contract bought.
+    const churnedYearly = await factory.TeamAccount.create({
       stripeCustomerId: "cus_staff_churned_yearly",
     });
 
@@ -226,6 +236,7 @@ describe("getStaffRevenue", () => {
       total: 0,
       totalExcludingTax: 0,
     });
+    // Billed by hand, a month at a time — a legacy deal, not a contract.
     await factory.StripeInvoice.create({
       stripeCustomerId: "cus_staff_churned",
       stripeCreatedAt: lastMonth.toISOString(),
@@ -233,6 +244,8 @@ describe("getStaffRevenue", () => {
       currency: "eur",
       total: 20_000,
       totalExcludingTax: 20_000,
+      periodStart: startOfUTCMonth(now, -1).toISOString(),
+      periodEnd: startOfUTCMonth(now, 0).toISOString(),
     });
     // Not an Argos team: not this page's.
     await factory.StripeInvoice.create({
@@ -241,6 +254,18 @@ describe("getStaffRevenue", () => {
       currency: "eur",
       total: 99_900,
       totalExcludingTax: 99_900,
+    });
+    // The term before this one: last month is paid for by it, so the months
+    // before a renewal must not fall to zero.
+    await factory.StripeInvoice.create({
+      stripeCustomerId: "cus_staff_yearly",
+      stripeCreatedAt: startOfUTCMonth(now, -12).toISOString(),
+      billingReason: "subscription_cycle",
+      currency: "eur",
+      total: 120_000,
+      totalExcludingTax: 120_000,
+      periodStart: startOfUTCMonth(now, -12).toISOString(),
+      periodEnd: startOfUTCMonth(now, 0).toISOString(),
     });
     // The annual contract, covering twelve months from this month's start.
     await factory.StripeInvoice.create({
@@ -272,8 +297,8 @@ describe("getStaffRevenue", () => {
       currency: "eur",
       total: 480_000,
       totalExcludingTax: 480_000,
-      periodStart: startOfUTCMonth(now, -13).toISOString(),
-      periodEnd: startOfUTCMonth(now, -1).toISOString(),
+      periodStart: startOfUTCMonth(now, -1).toISOString(),
+      periodEnd: startOfUTCMonth(now, 11).toISOString(),
     });
 
     const result = await getStaffRevenue(2);
@@ -292,72 +317,50 @@ describe("getStaffRevenue", () => {
       [yearly.slug, 300],
       [churned.slug, 200],
     ]);
-    // The contract's coverage starts this month, so last month gets none of
-    // it — amortized figures never move once a month is written.
-    expect(last.yearlyPlans).toEqual({
-      revenue: 0,
-      teamsCount: 0,
-      foreignRevenue: 0,
-    });
-    expect(last.revenue).toBe(1000);
+    // Two contracts pay for last month: the term before this team's newest
+    // renewal — a contract does not begin at whichever bill is latest — and
+    // the churned team's, which keeps paying for the months it bought
+    // whatever its subscription says today.
+    expect(last.yearlyPlans.teamsCount).toBe(2);
+    expect(last.yearlyPlans.revenue).toBeGreaterThan(0);
+    expect(last.revenue).toBe(1000 + last.yearlyPlans.revenue);
 
-    // The contract invoice lands in the running month, but an annual bill is
-    // amortized over its coverage, never counted as the month's own revenue.
+    // The running month is only as long as it has been, so a contract's share
+    // of it is as partial as the invoices beside it.
     expect(current.monthlyPlans.revenue).toBe(100);
     expect(current.teams).toHaveLength(1);
-    const DAY = 24 * 3600 * 1000;
-    const coveredDays =
-      (startOfUTCMonth(now, 12).getTime() - startOfUTCMonth(now, 0).getTime()) /
-      DAY;
-    const currentMonthDays =
-      (startOfUTCMonth(now, 1).getTime() - startOfUTCMonth(now, 0).getTime()) /
-      DAY;
+    const elapsed = now.getTime() - startOfUTCMonth(now, 0).getTime();
+    const currentTerm =
+      startOfUTCMonth(now, 12).getTime() - startOfUTCMonth(now, 0).getTime();
+    const churnedTerm =
+      startOfUTCMonth(now, 11).getTime() - startOfUTCMonth(now, -1).getTime();
     expect(current.yearlyPlans.revenue).toBeCloseTo(
-      (1200 * currentMonthDays) / coveredDays,
-      8,
+      (1200 * elapsed) / currentTerm + (4800 * elapsed) / churnedTerm,
+      3,
     );
-    expect(current.yearlyPlans.teamsCount).toBe(1);
+    expect(current.yearlyPlans.teamsCount).toBe(2);
 
-    expect(result.yearlyContracts).toHaveLength(1);
-    const contract = result.yearlyContracts[0];
+    // Both contracts are in force, largest first, each with the invoice its
+    // figure is read from.
+    expect(
+      result.yearlyContracts.map((contract) => [
+        contract.slug,
+        contract.amount,
+      ]),
+    ).toEqual([
+      [churnedYearly.slug, 4800],
+      [yearly.slug, 1200],
+    ]);
+    const contract = result.yearlyContracts[1];
     invariant(contract);
-    expect(contract.amount).toBe(1200);
     expect(contract.awaitingPayment).toBe(false);
     expect(contract.invoices).toHaveLength(1);
-  });
-
-  it("prices the marketplace book from the active GitHub subscriptions", async () => {
-    await factory.StripeInvoiceSync.create();
-    const plan = await factory.Plan.create({
-      usageBased: false,
-      githubMonthlyPriceCents: 10_000,
-    });
-    const account = await factory.TeamAccount.create({});
-    const user = await factory.User.create();
-    await factory.Subscription.create({
-      accountId: account.id,
-      planId: plan.id,
-      provider: "github",
-      subscriberId: user.id,
-      startDate: new Date("2021-01-01").toISOString(),
-      status: "active",
-    });
-    // An unpriced plan — not a marketplace listing — counts nothing.
-    const unpriced = await factory.Plan.create({ usageBased: true });
-    const other = await factory.TeamAccount.create({});
-    await factory.Subscription.create({
-      accountId: other.id,
-      planId: unpriced.id,
-      provider: "github",
-      subscriberId: user.id,
-      startDate: new Date("2021-01-01").toISOString(),
-      status: "active",
-    });
-
-    const result = await getStaffRevenue(1);
-
-    expect(result.githubMarketplaceMonthlyRevenue).toBe(
-      toEuros({ amount: 100, currency: "usd" }),
+    // A whole month of it, not the part of the running month that has gone by.
+    const runningMonth =
+      startOfUTCMonth(now, 1).getTime() - startOfUTCMonth(now, 0).getTime();
+    expect(contract.monthlyRevenue).toBeCloseTo(
+      (1200 * runningMonth) / currentTerm,
+      3,
     );
   });
 
@@ -388,17 +391,10 @@ describe("getStaffRevenue", () => {
     expect(contract.awaitingPayment).toBe(true);
     const month = result.months[0];
     invariant(month);
-    const DAY = 24 * 3600 * 1000;
-    const coveredDays =
-      (startOfUTCMonth(now, 12).getTime() - startOfUTCMonth(now, 0).getTime()) /
-      DAY;
-    const monthDays =
-      (startOfUTCMonth(now, 1).getTime() - startOfUTCMonth(now, 0).getTime()) /
-      DAY;
-    expect(month.yearlyPlans.revenue).toBeCloseTo(
-      (1200 * monthDays) / coveredDays,
-      8,
-    );
+    const elapsed = now.getTime() - startOfUTCMonth(now, 0).getTime();
+    const term =
+      startOfUTCMonth(now, 12).getTime() - startOfUTCMonth(now, 0).getTime();
+    expect(month.yearlyPlans.revenue).toBeCloseTo((1200 * elapsed) / term, 3);
     expect(month.yearlyPlans.teamsCount).toBe(1);
   });
 });

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { factory, setupDatabase } from "@/database/testing";
 
-import { getBilledTeams } from "./revenue";
+import { getBilledTeams, getTeamCustomerIds } from "./revenue";
 
 describe("getBilledTeams", () => {
   beforeEach(async () => {
@@ -110,5 +110,50 @@ describe("getBilledTeams", () => {
 
     expect(teams).toHaveLength(1);
     expect(teams[0]?.interval).toBe("year");
+  });
+});
+
+describe("getTeamCustomerIds", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  it("keeps a team whose subscription has ended", async () => {
+    // Its invoices were still sent, and the month it was invoiced in has to
+    // keep them — that departure is exactly what a comparison between two
+    // months exists to show.
+    const account = await factory.TeamAccount.create({
+      stripeCustomerId: "cus_churned",
+    });
+    const plan = await factory.Plan.create({ usageBased: true });
+    const user = await factory.User.create();
+    await factory.Subscription.create({
+      accountId: account.id,
+      planId: plan.id,
+      currency: "usd",
+      provider: "stripe",
+      stripeSubscriptionId: "sub_churned",
+      subscriberId: user.id,
+      startDate: new Date("2021-01-01").toISOString(),
+      endDate: new Date("2024-01-01").toISOString(),
+      status: "canceled",
+    });
+
+    await expect(getTeamCustomerIds()).resolves.toEqual(
+      new Set(["cus_churned"]),
+    );
+  });
+
+  it("leaves out a personal account", async () => {
+    // Whatever a personal account was invoiced is not this page's subject.
+    await factory.UserAccount.create({ stripeCustomerId: "cus_personal" });
+
+    await expect(getTeamCustomerIds()).resolves.toEqual(new Set());
+  });
+
+  it("leaves out a team that never reached Stripe", async () => {
+    await factory.TeamAccount.create({ stripeCustomerId: null });
+
+    await expect(getTeamCustomerIds()).resolves.toEqual(new Set());
   });
 });

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -408,6 +408,59 @@ describe("getStaffRevenue", () => {
     expect(result.yearlyContracts).toHaveLength(1);
   });
 
+  it("never spreads a contract for more than it was raised for", async () => {
+    // The invariant the arithmetic rests on: an invoice pays for its own term
+    // at its own rate, so what it puts into the months of a window can only
+    // ever be a part of what it was raised for — a term cut short by an early
+    // renewal delivers less, never the same amount faster.
+    const now = new Date();
+    await factory.StripeInvoiceSync.create({
+      sinceDate: new Date("2020-01-01").toISOString(),
+    });
+    await createTeam({
+      interval: "year",
+      stripeCustomerId: "cus_staff_early",
+    });
+    // A year's contract, then a renewal five months in: the first term is cut
+    // short, and five months of it is all it can ever have delivered.
+    await factory.StripeInvoice.create({
+      stripeCustomerId: "cus_staff_early",
+      stripeCreatedAt: startOfUTCMonth(now, -11).toISOString(),
+      billingReason: "subscription_cycle",
+      currency: "eur",
+      total: 1_200_000,
+      totalExcludingTax: 1_200_000,
+      periodStart: startOfUTCMonth(now, -11).toISOString(),
+      periodEnd: startOfUTCMonth(now, 1).toISOString(),
+    });
+    await factory.StripeInvoice.create({
+      stripeCustomerId: "cus_staff_early",
+      stripeCreatedAt: startOfUTCMonth(now, -6).toISOString(),
+      billingReason: "subscription_cycle",
+      currency: "eur",
+      total: 2_400_000,
+      totalExcludingTax: 2_400_000,
+      periodStart: startOfUTCMonth(now, -6).toISOString(),
+      periodEnd: startOfUTCMonth(now, 6).toISOString(),
+    });
+
+    const result = await getStaffRevenue(12);
+
+    const spread = result.months.reduce(
+      (sum, month) => sum + month.yearlyPlans.revenue,
+      0,
+    );
+    // Both invoices come to €36,000; a window of twelve months can hold only
+    // part of that, and the first term must contribute at its own rate — a
+    // fifth of €12,000 over five months, not the whole of it.
+    expect(spread).toBeLessThan(36_000);
+    const firstTermRate = 12_000 / 12;
+    const monthsOfFirstTerm = result.months.slice(0, 5);
+    for (const month of monthsOfFirstTerm) {
+      expect(month.yearlyPlans.revenue).toBeLessThan(firstTermRate * 1.2);
+    }
+  });
+
   it("reports an open annual invoice as awaiting payment, counted", async () => {
     const now = new Date();
     await factory.StripeInvoiceSync.create();

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -241,7 +241,7 @@ describe("getStaffRevenue", () => {
       total: 99_900,
       totalExcludingTax: 99_900,
     });
-    // The annual contract, covering from this month on.
+    // The annual contract, covering twelve months from this month's start.
     await factory.StripeInvoice.create({
       stripeCustomerId: "cus_staff_yearly",
       stripeCreatedAt: startOfUTCMonth(now, 0).toISOString(),
@@ -291,17 +291,31 @@ describe("getStaffRevenue", () => {
       [yearly.slug, 300],
       [churned.slug, 200],
     ]);
+    // The contract's coverage starts this month, so last month gets none of
+    // it — amortized figures never move once a month is written.
     expect(last.yearlyPlans).toEqual({
-      revenue: 100,
-      teamsCount: 1,
+      revenue: 0,
+      teamsCount: 0,
       foreignRevenue: 0,
     });
-    expect(last.revenue).toBe(1100);
+    expect(last.revenue).toBe(1000);
 
     // The contract invoice lands in the running month, but an annual bill is
-    // reported as the rate, never as the month's own revenue.
+    // amortized over its coverage, never counted as the month's own revenue.
     expect(current.monthlyPlans.revenue).toBe(100);
     expect(current.teams).toHaveLength(1);
+    const DAY = 24 * 3600 * 1000;
+    const coveredDays =
+      (startOfUTCMonth(now, 12).getTime() - startOfUTCMonth(now, 0).getTime()) /
+      DAY;
+    const currentMonthDays =
+      (startOfUTCMonth(now, 1).getTime() - startOfUTCMonth(now, 0).getTime()) /
+      DAY;
+    expect(current.yearlyPlans.revenue).toBeCloseTo(
+      (1200 * currentMonthDays) / coveredDays,
+      8,
+    );
+    expect(current.yearlyPlans.teamsCount).toBe(1);
 
     expect(result.yearlyContracts).toHaveLength(1);
     const contract = result.yearlyContracts[0];
@@ -338,10 +352,17 @@ describe("getStaffRevenue", () => {
     expect(contract.awaitingPayment).toBe(true);
     const month = result.months[0];
     invariant(month);
-    expect(month.yearlyPlans).toEqual({
-      revenue: 100,
-      teamsCount: 1,
-      foreignRevenue: 0,
-    });
+    const DAY = 24 * 3600 * 1000;
+    const coveredDays =
+      (startOfUTCMonth(now, 12).getTime() - startOfUTCMonth(now, 0).getTime()) /
+      DAY;
+    const monthDays =
+      (startOfUTCMonth(now, 1).getTime() - startOfUTCMonth(now, 0).getTime()) /
+      DAY;
+    expect(month.yearlyPlans.revenue).toBeCloseTo(
+      (1200 * monthDays) / coveredDays,
+      8,
+    );
+    expect(month.yearlyPlans.teamsCount).toBe(1);
   });
 });

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -10,50 +10,55 @@ import {
   startOfUTCMonth,
 } from "./revenue";
 
+let sequence = 0;
+
+/** A team on a Stripe subscription, as the revenue reader looks for it. */
+async function createTeam(options: {
+  interval: "month" | "year";
+  status?: "active" | "past_due" | "trialing" | "canceled";
+  endDate?: string;
+  /** Set to grant the plan, which bills nothing. */
+  granted?: boolean;
+  /** Teams that never reached Stripe have no customer to match invoices on. */
+  withCustomer?: boolean;
+  stripeCustomerId?: string;
+}) {
+  sequence += 1;
+  const plan = await factory.Plan.create({
+    usageBased: true,
+    interval: options.interval,
+    includedScreenshots: 1000,
+  });
+  const account = await factory.TeamAccount.create({
+    stripeCustomerId:
+      options.withCustomer === false
+        ? null
+        : (options.stripeCustomerId ?? `cus_revenue_${sequence}`),
+    forcedPlanId: options.granted ? plan.id : null,
+  });
+  const user = await factory.User.create();
+  await factory.Subscription.create({
+    accountId: account.id,
+    planId: plan.id,
+    currency: "usd",
+    provider: "stripe",
+    stripeSubscriptionId: `sub_revenue_${sequence}`,
+    subscriberId: user.id,
+    startDate: new Date("2021-01-01").toISOString(),
+    endDate: options.endDate ?? null,
+    status: options.status ?? "active",
+    trialEndDate:
+      options.status === "trialing"
+        ? new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()
+        : null,
+  });
+  return account;
+}
+
 describe("getBilledTeams", () => {
   beforeEach(async () => {
     await setupDatabase();
   });
-
-  let sequence = 0;
-
-  /** A team on a Stripe subscription, as the revenue reader looks for it. */
-  async function createTeam(options: {
-    interval: "month" | "year";
-    status?: "active" | "past_due" | "trialing" | "canceled";
-    /** Set to grant the plan, which bills nothing. */
-    granted?: boolean;
-    /** Teams that never reached Stripe have no customer to match invoices on. */
-    withCustomer?: boolean;
-  }) {
-    sequence += 1;
-    const plan = await factory.Plan.create({
-      usageBased: true,
-      interval: options.interval,
-      includedScreenshots: 1000,
-    });
-    const account = await factory.TeamAccount.create({
-      stripeCustomerId:
-        options.withCustomer === false ? null : `cus_revenue_${sequence}`,
-      forcedPlanId: options.granted ? plan.id : null,
-    });
-    const user = await factory.User.create();
-    await factory.Subscription.create({
-      accountId: account.id,
-      planId: plan.id,
-      currency: "usd",
-      provider: "stripe",
-      stripeSubscriptionId: `sub_revenue_${sequence}`,
-      subscriberId: user.id,
-      startDate: new Date("2021-01-01").toISOString(),
-      status: options.status ?? "active",
-      trialEndDate:
-        options.status === "trialing"
-          ? new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()
-          : null,
-    });
-    return account;
-  }
 
   it("returns a paying team with the interval it is billed on", async () => {
     const monthly = await createTeam({ interval: "month" });
@@ -128,21 +133,11 @@ describe("getTeamCustomers", () => {
     // Its invoices were still sent, and the month it was invoiced in has to
     // keep them — that departure is exactly what a comparison between two
     // months exists to show.
-    const account = await factory.TeamAccount.create({
-      stripeCustomerId: "cus_churned",
-    });
-    const plan = await factory.Plan.create({ usageBased: true });
-    const user = await factory.User.create();
-    await factory.Subscription.create({
-      accountId: account.id,
-      planId: plan.id,
-      currency: "usd",
-      provider: "stripe",
-      stripeSubscriptionId: "sub_churned",
-      subscriberId: user.id,
-      startDate: new Date("2021-01-01").toISOString(),
-      endDate: new Date("2024-01-01").toISOString(),
+    const account = await createTeam({
+      interval: "month",
       status: "canceled",
+      endDate: new Date("2024-01-01").toISOString(),
+      stripeCustomerId: "cus_churned",
     });
 
     await expect(getTeamCustomers()).resolves.toEqual(
@@ -171,39 +166,15 @@ describe("getStaffRevenue", () => {
     await setupDatabase();
   });
 
-  let sequence = 0;
+  it("refuses a window the mirror never covered", async () => {
+    // Months nobody backfilled would report zeros that read as real figures.
+    await expect(getStaffRevenue(2)).rejects.toThrow(/does not cover/);
 
-  /** A team billed through Stripe, with the subscription the reader expects. */
-  async function createBilledTeam(options: {
-    interval: "month" | "year";
-    stripeCustomerId: string;
-  }) {
-    sequence += 1;
-    const plan = await factory.Plan.create({
-      usageBased: true,
-      interval: options.interval,
-      includedScreenshots: 1000,
+    // A sweep exists but is too shallow for the window asked.
+    await factory.StripeInvoiceSync.create({
+      sinceDate: new Date().toISOString(),
     });
-    const account = await factory.TeamAccount.create({
-      stripeCustomerId: options.stripeCustomerId,
-    });
-    const user = await factory.User.create();
-    await factory.Subscription.create({
-      accountId: account.id,
-      planId: plan.id,
-      currency: "usd",
-      provider: "stripe",
-      stripeSubscriptionId: `sub_staff_revenue_${sequence}`,
-      subscriberId: user.id,
-      startDate: new Date("2021-01-01").toISOString(),
-      status: "active",
-    });
-    return account;
-  }
-
-  it("refuses to report from an empty mirror", async () => {
-    // Zeros from a mirror nobody backfilled would read as real figures.
-    await expect(getStaffRevenue(2)).rejects.toThrow(/mirror is empty/);
+    await expect(getStaffRevenue(2)).rejects.toThrow(/does not cover/);
   });
 
   it("reports the window from the mirror, split by interval", async () => {
@@ -212,17 +183,22 @@ describe("getStaffRevenue", () => {
       startOfUTCMonth(now, -1).getTime() + 5 * 24 * 3600 * 1000,
     );
 
-    const monthly = await createBilledTeam({
+    await factory.StripeInvoiceSync.create();
+    const monthly = await createTeam({
       interval: "month",
       stripeCustomerId: "cus_staff_monthly",
     });
-    await createBilledTeam({
+    const yearly = await createTeam({
       interval: "year",
       stripeCustomerId: "cus_staff_yearly",
     });
     // A churned team keeps the invoices it was already sent.
     const churned = await factory.TeamAccount.create({
       stripeCustomerId: "cus_staff_churned",
+    });
+    // A churned yearly team: its old annual bill must not spike a month.
+    await factory.TeamAccount.create({
+      stripeCustomerId: "cus_staff_churned_yearly",
     });
 
     await factory.StripeInvoice.create({
@@ -265,16 +241,38 @@ describe("getStaffRevenue", () => {
       total: 99_900,
       totalExcludingTax: 99_900,
     });
-    // The annual contract, covering today.
+    // The annual contract, covering from this month on.
     await factory.StripeInvoice.create({
       stripeCustomerId: "cus_staff_yearly",
-      stripeCreatedAt: startOfUTCMonth(now, -6).toISOString(),
-      billingReason: "subscription_cycle",
+      stripeCreatedAt: startOfUTCMonth(now, 0).toISOString(),
+      billingReason: "subscription_update",
       currency: "eur",
       total: 120_000,
       totalExcludingTax: 120_000,
-      periodStart: startOfUTCMonth(now, -6).toISOString(),
-      periodEnd: startOfUTCMonth(now, 6).toISOString(),
+      periodStart: startOfUTCMonth(now, 0).toISOString(),
+      periodEnd: startOfUTCMonth(now, 12).toISOString(),
+    });
+    // The same team's monthly bill from before its conversion: history the
+    // present interval must not erase.
+    await factory.StripeInvoice.create({
+      stripeCustomerId: "cus_staff_yearly",
+      stripeCreatedAt: lastMonth.toISOString(),
+      billingReason: "subscription_cycle",
+      currency: "eur",
+      total: 30_000,
+      totalExcludingTax: 30_000,
+    });
+    // A churned yearly team's old renewal: an annual bill is never a month's
+    // revenue, whoever it belongs to now.
+    await factory.StripeInvoice.create({
+      stripeCustomerId: "cus_staff_churned_yearly",
+      stripeCreatedAt: lastMonth.toISOString(),
+      billingReason: "subscription_cycle",
+      currency: "eur",
+      total: 480_000,
+      totalExcludingTax: 480_000,
+      periodStart: startOfUTCMonth(now, -13).toISOString(),
+      periodEnd: startOfUTCMonth(now, -1).toISOString(),
     });
 
     const result = await getStaffRevenue(2);
@@ -284,12 +282,13 @@ describe("getStaffRevenue", () => {
     invariant(last && current);
 
     expect(last.monthlyPlans).toEqual({
-      revenue: 700,
-      teamsCount: 2,
+      revenue: 1000,
+      teamsCount: 3,
       foreignRevenue: 0,
     });
     expect(last.teams.map((team) => [team.slug, team.revenue])).toEqual([
       [monthly.slug, 500],
+      [yearly.slug, 300],
       [churned.slug, 200],
     ]);
     expect(last.yearlyPlans).toEqual({
@@ -297,8 +296,10 @@ describe("getStaffRevenue", () => {
       teamsCount: 1,
       foreignRevenue: 0,
     });
-    expect(last.revenue).toBe(800);
+    expect(last.revenue).toBe(1100);
 
+    // The contract invoice lands in the running month, but an annual bill is
+    // reported as the rate, never as the month's own revenue.
     expect(current.monthlyPlans.revenue).toBe(100);
     expect(current.teams).toHaveLength(1);
 
@@ -312,7 +313,8 @@ describe("getStaffRevenue", () => {
 
   it("reports an open annual invoice as awaiting payment, counted", async () => {
     const now = new Date();
-    await createBilledTeam({
+    await factory.StripeInvoiceSync.create();
+    await createTeam({
       interval: "year",
       stripeCustomerId: "cus_staff_open",
     });

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -502,10 +502,16 @@ describe("getStaffRevenue", () => {
     expect(last.githubPlans.revenue).toBe(
       toEuros({ amount: 200, currency: "usd" }),
     );
-    // The one that left is gone from this month, and only from this one.
+    // The one that left is gone from this month, and only from this one —
+    // and what the month has earned so far is the share of it gone by, like
+    // the two figures beside it.
     expect(current.githubPlans.teamsCount).toBe(1);
-    expect(current.githubPlans.revenue).toBe(
-      toEuros({ amount: 100, currency: "usd" }),
+    const monthMs =
+      startOfUTCMonth(now, 1).getTime() - startOfUTCMonth(now, 0).getTime();
+    const elapsed = now.getTime() - startOfUTCMonth(now, 0).getTime();
+    expect(current.githubPlans.revenue).toBeCloseTo(
+      toEuros({ amount: 100 * (elapsed / monthMs), currency: "usd" }),
+      3,
     );
     // Never inside the figure the cards report.
     expect(current.revenue).toBe(

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -364,6 +364,50 @@ describe("getStaffRevenue", () => {
     );
   });
 
+  it("lists a contract that ran out mid-month, so the table adds up", async () => {
+    // It paid for the days before it ended, so it is in the month's figure —
+    // and a table that left it out would come up short against the card it
+    // exists to explain.
+    const now = new Date();
+    await factory.StripeInvoiceSync.create({
+      sinceDate: new Date("2020-01-01").toISOString(),
+    });
+    await createTeam({
+      interval: "year",
+      stripeCustomerId: "cus_staff_expired",
+    });
+    const endedOn = new Date(
+      startOfUTCMonth(now, 0).getTime() + 10 * 24 * 3600 * 1000,
+    );
+    await factory.StripeInvoice.create({
+      stripeCustomerId: "cus_staff_expired",
+      stripeCreatedAt: startOfUTCMonth(now, -12).toISOString(),
+      billingReason: "subscription_cycle",
+      currency: "eur",
+      total: 120_000,
+      totalExcludingTax: 120_000,
+      periodStart: startOfUTCMonth(now, -12).toISOString(),
+      periodEnd: endedOn.toISOString(),
+    });
+
+    const result = await getStaffRevenue(1);
+
+    const month = result.months[0];
+    invariant(month);
+    const listed = result.yearlyContracts.reduce(
+      (sum, contract) => sum + contract.monthlyRevenue,
+      0,
+    );
+    // The table reports whole months and the month is still running, so the
+    // figure it explains is the smaller of the two — never the other way
+    // round, which would mean a contributor missing from the list.
+    expect(listed).toBeGreaterThanOrEqual(month.yearlyPlans.revenue);
+    expect(
+      result.yearlyContracts.map((contract) => contract.slug),
+    ).toContainEqual(expect.any(String));
+    expect(result.yearlyContracts).toHaveLength(1);
+  });
+
   it("reports an open annual invoice as awaiting payment, counted", async () => {
     const now = new Date();
     await factory.StripeInvoiceSync.create();

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -8,6 +8,7 @@ import {
   getStaffRevenue,
   getTeamCustomers,
   startOfUTCMonth,
+  toEuros,
 } from "./revenue";
 
 let sequence = 0;
@@ -323,6 +324,41 @@ describe("getStaffRevenue", () => {
     expect(contract.amount).toBe(1200);
     expect(contract.awaitingPayment).toBe(false);
     expect(contract.invoices).toHaveLength(1);
+  });
+
+  it("prices the marketplace book from the active GitHub subscriptions", async () => {
+    await factory.StripeInvoiceSync.create();
+    const plan = await factory.Plan.create({
+      usageBased: false,
+      githubMonthlyPriceCents: 10_000,
+    });
+    const account = await factory.TeamAccount.create({});
+    const user = await factory.User.create();
+    await factory.Subscription.create({
+      accountId: account.id,
+      planId: plan.id,
+      provider: "github",
+      subscriberId: user.id,
+      startDate: new Date("2021-01-01").toISOString(),
+      status: "active",
+    });
+    // An unpriced plan — not a marketplace listing — counts nothing.
+    const unpriced = await factory.Plan.create({ usageBased: true });
+    const other = await factory.TeamAccount.create({});
+    await factory.Subscription.create({
+      accountId: other.id,
+      planId: unpriced.id,
+      provider: "github",
+      subscriberId: user.id,
+      startDate: new Date("2021-01-01").toISOString(),
+      status: "active",
+    });
+
+    const result = await getStaffRevenue(1);
+
+    expect(result.githubMarketplaceMonthlyRevenue).toBe(
+      toEuros({ amount: 100, currency: "usd" }),
+    );
   });
 
   it("reports an open annual invoice as awaiting payment, counted", async () => {

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -1,8 +1,14 @@
+import { invariant } from "@argos/util/invariant";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { factory, setupDatabase } from "@/database/testing";
 
-import { getBilledTeams, getTeamCustomers } from "./revenue";
+import {
+  getBilledTeams,
+  getStaffRevenue,
+  getTeamCustomers,
+  startOfUTCMonth,
+} from "./revenue";
 
 describe("getBilledTeams", () => {
   beforeEach(async () => {
@@ -157,5 +163,183 @@ describe("getTeamCustomers", () => {
     await factory.TeamAccount.create({ stripeCustomerId: null });
 
     await expect(getTeamCustomers()).resolves.toEqual(new Map());
+  });
+});
+
+describe("getStaffRevenue", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  let sequence = 0;
+
+  /** A team billed through Stripe, with the subscription the reader expects. */
+  async function createBilledTeam(options: {
+    interval: "month" | "year";
+    stripeCustomerId: string;
+  }) {
+    sequence += 1;
+    const plan = await factory.Plan.create({
+      usageBased: true,
+      interval: options.interval,
+      includedScreenshots: 1000,
+    });
+    const account = await factory.TeamAccount.create({
+      stripeCustomerId: options.stripeCustomerId,
+    });
+    const user = await factory.User.create();
+    await factory.Subscription.create({
+      accountId: account.id,
+      planId: plan.id,
+      currency: "usd",
+      provider: "stripe",
+      stripeSubscriptionId: `sub_staff_revenue_${sequence}`,
+      subscriberId: user.id,
+      startDate: new Date("2021-01-01").toISOString(),
+      status: "active",
+    });
+    return account;
+  }
+
+  it("refuses to report from an empty mirror", async () => {
+    // Zeros from a mirror nobody backfilled would read as real figures.
+    await expect(getStaffRevenue(2)).rejects.toThrow(/mirror is empty/);
+  });
+
+  it("reports the window from the mirror, split by interval", async () => {
+    const now = new Date();
+    const lastMonth = new Date(
+      startOfUTCMonth(now, -1).getTime() + 5 * 24 * 3600 * 1000,
+    );
+
+    const monthly = await createBilledTeam({
+      interval: "month",
+      stripeCustomerId: "cus_staff_monthly",
+    });
+    await createBilledTeam({
+      interval: "year",
+      stripeCustomerId: "cus_staff_yearly",
+    });
+    // A churned team keeps the invoices it was already sent.
+    const churned = await factory.TeamAccount.create({
+      stripeCustomerId: "cus_staff_churned",
+    });
+
+    await factory.StripeInvoice.create({
+      stripeCustomerId: "cus_staff_monthly",
+      stripeCreatedAt: lastMonth.toISOString(),
+      billingReason: "subscription_cycle",
+      currency: "eur",
+      total: 50_000,
+      totalExcludingTax: 50_000,
+    });
+    await factory.StripeInvoice.create({
+      stripeCustomerId: "cus_staff_monthly",
+      stripeCreatedAt: now.toISOString(),
+      billingReason: "manual",
+      currency: "eur",
+      total: 10_000,
+      totalExcludingTax: 10_000,
+    });
+    // A zero invoice is not a team being invoiced.
+    await factory.StripeInvoice.create({
+      stripeCustomerId: "cus_staff_monthly",
+      stripeCreatedAt: lastMonth.toISOString(),
+      currency: "eur",
+      total: 0,
+      totalExcludingTax: 0,
+    });
+    await factory.StripeInvoice.create({
+      stripeCustomerId: "cus_staff_churned",
+      stripeCreatedAt: lastMonth.toISOString(),
+      billingReason: "manual",
+      currency: "eur",
+      total: 20_000,
+      totalExcludingTax: 20_000,
+    });
+    // Not an Argos team: not this page's.
+    await factory.StripeInvoice.create({
+      stripeCustomerId: "cus_staff_random",
+      stripeCreatedAt: lastMonth.toISOString(),
+      currency: "eur",
+      total: 99_900,
+      totalExcludingTax: 99_900,
+    });
+    // The annual contract, covering today.
+    await factory.StripeInvoice.create({
+      stripeCustomerId: "cus_staff_yearly",
+      stripeCreatedAt: startOfUTCMonth(now, -6).toISOString(),
+      billingReason: "subscription_cycle",
+      currency: "eur",
+      total: 120_000,
+      totalExcludingTax: 120_000,
+      periodStart: startOfUTCMonth(now, -6).toISOString(),
+      periodEnd: startOfUTCMonth(now, 6).toISOString(),
+    });
+
+    const result = await getStaffRevenue(2);
+
+    expect(result.months).toHaveLength(2);
+    const [last, current] = result.months;
+    invariant(last && current);
+
+    expect(last.monthlyPlans).toEqual({
+      revenue: 700,
+      teamsCount: 2,
+      foreignRevenue: 0,
+    });
+    expect(last.teams.map((team) => [team.slug, team.revenue])).toEqual([
+      [monthly.slug, 500],
+      [churned.slug, 200],
+    ]);
+    expect(last.yearlyPlans).toEqual({
+      revenue: 100,
+      teamsCount: 1,
+      foreignRevenue: 0,
+    });
+    expect(last.revenue).toBe(800);
+
+    expect(current.monthlyPlans.revenue).toBe(100);
+    expect(current.teams).toHaveLength(1);
+
+    expect(result.yearlyContracts).toHaveLength(1);
+    const contract = result.yearlyContracts[0];
+    invariant(contract);
+    expect(contract.amount).toBe(1200);
+    expect(contract.awaitingPayment).toBe(false);
+    expect(contract.invoices).toHaveLength(1);
+  });
+
+  it("reports an open annual invoice as awaiting payment, counted", async () => {
+    const now = new Date();
+    await createBilledTeam({
+      interval: "year",
+      stripeCustomerId: "cus_staff_open",
+    });
+    await factory.StripeInvoice.create({
+      stripeCustomerId: "cus_staff_open",
+      stripeCreatedAt: now.toISOString(),
+      status: "open",
+      billingReason: "manual",
+      currency: "eur",
+      total: 120_000,
+      totalExcludingTax: 120_000,
+      periodStart: startOfUTCMonth(now, 0).toISOString(),
+      periodEnd: startOfUTCMonth(now, 12).toISOString(),
+    });
+
+    const result = await getStaffRevenue(1);
+
+    const contract = result.yearlyContracts[0];
+    invariant(contract);
+    expect(contract.amount).toBe(1200);
+    expect(contract.awaitingPayment).toBe(true);
+    const month = result.months[0];
+    invariant(month);
+    expect(month.yearlyPlans).toEqual({
+      revenue: 100,
+      teamsCount: 1,
+      foreignRevenue: 0,
+    });
   });
 });

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { factory, setupDatabase } from "@/database/testing";
+
+import { getBilledTeams } from "./revenue";
+
+describe("getBilledTeams", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  let sequence = 0;
+
+  /** A team on a Stripe subscription, as the revenue reader looks for it. */
+  async function createTeam(options: {
+    interval: "month" | "year";
+    status?: "active" | "past_due" | "trialing" | "canceled";
+    /** Set to grant the plan, which bills nothing. */
+    granted?: boolean;
+    /** Teams that never reached Stripe have no customer to match invoices on. */
+    withCustomer?: boolean;
+  }) {
+    sequence += 1;
+    const plan = await factory.Plan.create({
+      usageBased: true,
+      interval: options.interval,
+      includedScreenshots: 1000,
+    });
+    const account = await factory.TeamAccount.create({
+      stripeCustomerId:
+        options.withCustomer === false ? null : `cus_revenue_${sequence}`,
+      forcedPlanId: options.granted ? plan.id : null,
+    });
+    const user = await factory.User.create();
+    await factory.Subscription.create({
+      accountId: account.id,
+      planId: plan.id,
+      currency: "usd",
+      provider: "stripe",
+      stripeSubscriptionId: `sub_revenue_${sequence}`,
+      subscriberId: user.id,
+      startDate: new Date("2021-01-01").toISOString(),
+      status: options.status ?? "active",
+      trialEndDate:
+        options.status === "trialing"
+          ? new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()
+          : null,
+    });
+    return account;
+  }
+
+  it("returns a paying team with the interval it is billed on", async () => {
+    const monthly = await createTeam({ interval: "month" });
+    const yearly = await createTeam({ interval: "year" });
+
+    const teams = await getBilledTeams();
+
+    expect(teams).toHaveLength(2);
+    expect(teams).toContainEqual(
+      expect.objectContaining({ accountId: monthly.id, interval: "month" }),
+    );
+    expect(teams).toContainEqual(
+      expect.objectContaining({ accountId: yearly.id, interval: "year" }),
+    );
+  });
+
+  it("keeps a team whose invoice has not cleared", async () => {
+    // The invoice was raised; whether it is paid is a collection question, and
+    // the invoice is what this reads.
+    const account = await createTeam({ interval: "month", status: "past_due" });
+
+    const teams = await getBilledTeams();
+
+    expect(teams.map((team) => team.accountId)).toEqual([account.id]);
+  });
+
+  it.each([
+    ["a trial, which pays nothing", { status: "trialing" as const }],
+    ["a canceled subscription", { status: "canceled" as const }],
+    ["a granted plan, which bills nothing", { granted: true }],
+    ["a team that never reached Stripe", { withCustomer: false }],
+  ])("drops %s", async (_label, options) => {
+    await createTeam({ interval: "month", ...options });
+
+    await expect(getBilledTeams()).resolves.toEqual([]);
+  });
+
+  it("resolves one row per team when two subscriptions are active", async () => {
+    // Two active subscriptions resolve the highest quota, the same one
+    // `getAccountBillings` picks — so both sides price the same plan.
+    const account = await createTeam({ interval: "month" });
+    const richerPlan = await factory.Plan.create({
+      usageBased: true,
+      interval: "year",
+      includedScreenshots: 1_000_000,
+    });
+    const user = await factory.User.create();
+    await factory.Subscription.create({
+      accountId: account.id,
+      planId: richerPlan.id,
+      currency: "usd",
+      provider: "stripe",
+      stripeSubscriptionId: "sub_revenue_richer",
+      subscriberId: user.id,
+      startDate: new Date("2021-01-01").toISOString(),
+      status: "active",
+    });
+
+    const teams = await getBilledTeams();
+
+    expect(teams).toHaveLength(1);
+    expect(teams[0]?.interval).toBe("year");
+  });
+});

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -8,6 +8,7 @@ import {
   getStaffRevenue,
   getTeamCustomers,
   startOfUTCMonth,
+  toEuros,
 } from "./revenue";
 
 let sequence = 0;
@@ -459,6 +460,57 @@ describe("getStaffRevenue", () => {
     for (const month of monthsOfFirstTerm) {
       expect(month.yearlyPlans.revenue).toBeLessThan(firstTermRate * 1.2);
     }
+  });
+
+  it("prices each month's marketplace book from the subscriptions it ran", async () => {
+    const now = new Date();
+    await factory.StripeInvoiceSync.create({
+      sinceDate: new Date("2020-01-01").toISOString(),
+    });
+    const plan = await factory.Plan.create({
+      usageBased: false,
+      githubMonthlyPriceCents: 10_000,
+    });
+    const user = await factory.User.create();
+
+    async function subscribe(options: { endDate?: string; planId?: string }) {
+      const account = await factory.TeamAccount.create({});
+      await factory.Subscription.create({
+        accountId: account.id,
+        planId: options.planId ?? plan.id,
+        provider: "github",
+        subscriberId: user.id,
+        startDate: startOfUTCMonth(now, -6).toISOString(),
+        endDate: options.endDate ?? null,
+        status: "active",
+      });
+    }
+
+    // One still running, and one that left when this month opened: the months
+    // it ran through earned what it was subscribed for, whatever it does now.
+    await subscribe({});
+    await subscribe({ endDate: startOfUTCMonth(now, 0).toISOString() });
+    // An unpriced plan is not a marketplace listing, so it counts nothing.
+    const unpriced = await factory.Plan.create({ usageBased: true });
+    await subscribe({ planId: unpriced.id });
+
+    const result = await getStaffRevenue(2);
+    const [last, current] = result.months;
+    invariant(last && current);
+
+    expect(last.githubPlans.teamsCount).toBe(2);
+    expect(last.githubPlans.revenue).toBe(
+      toEuros({ amount: 200, currency: "usd" }),
+    );
+    // The one that left is gone from this month, and only from this one.
+    expect(current.githubPlans.teamsCount).toBe(1);
+    expect(current.githubPlans.revenue).toBe(
+      toEuros({ amount: 100, currency: "usd" }),
+    );
+    // Never inside the figure the cards report.
+    expect(current.revenue).toBe(
+      current.monthlyPlans.revenue + current.yearlyPlans.revenue,
+    );
   });
 
   it("reports an open annual invoice as awaiting payment, counted", async () => {

--- a/apps/backend/src/stripe/revenue.test.ts
+++ b/apps/backend/src/stripe/revenue.test.ts
@@ -1,6 +1,12 @@
+import type Stripe from "stripe";
 import { describe, expect, it } from "vitest";
 
-import { getInvoiceRevenue, startOfUTCMonth } from "./revenue";
+import type { ContractInvoiceCandidate } from "./revenue";
+import {
+  findContractInvoices,
+  getInvoiceRevenue,
+  startOfUTCMonth,
+} from "./revenue";
 
 describe("getInvoiceRevenue", () => {
   /** Stripe states amounts in the currency's minor unit. */
@@ -71,6 +77,155 @@ describe("getInvoiceRevenue", () => {
         invoice({ total: 10_000, total_excluding_tax: 10_000, post: 10_000 }),
       ).amount,
     ).toBe(0);
+  });
+});
+
+describe("findContractInvoices", () => {
+  const seconds = (iso: string) => Date.parse(iso) / 1000;
+
+  /** Cases below are the real shapes the yearly book was found to hold. */
+  function candidate(fields: {
+    reason: Stripe.Invoice.BillingReason | null;
+    total: number;
+    /** Each entry is one line's covered stretch. */
+    periods: [string, string][];
+  }): ContractInvoiceCandidate & { total: number } {
+    return {
+      billing_reason: fields.reason,
+      total: fields.total,
+      lines: {
+        data: fields.periods.map(([start, end]) => ({
+          period: { start: seconds(start), end: seconds(end) },
+        })),
+      },
+    };
+  }
+
+  it("picks the year-long conversion invoice over its same-day true-up", () => {
+    // A team converted from monthly to yearly mid-stream: the contract is a
+    // `subscription_update` covering a year, raised alongside a last month of
+    // usage — and behind them, months of cycle invoices from before.
+    const trueUp = candidate({
+      reason: "subscription_update",
+      total: 758_724,
+      periods: [["2026-04-23", "2026-05-23"]],
+    });
+    const contract = candidate({
+      reason: "subscription_update",
+      total: 6_480_000,
+      periods: [["2026-05-23", "2027-05-23"]],
+    });
+    const oldCycle = candidate({
+      reason: "subscription_cycle",
+      total: 745_028,
+      periods: [["2026-03-23", "2026-04-23"]],
+    });
+
+    expect(findContractInvoices([trueUp, contract, oldCycle])).toEqual([
+      contract,
+    ]);
+    expect(findContractInvoices([contract, trueUp, oldCycle])).toEqual([
+      contract,
+    ]);
+  });
+
+  it("adds a partial-period upsell on top of the annual bill", () => {
+    // A contract billed by hand, then upsold mid-year: the upsell covers the
+    // stretch from its sale to the contract's renewal date, and both invoices
+    // are the contract's worth.
+    const upsell = candidate({
+      reason: "manual",
+      total: 3_260_000,
+      periods: [["2026-06-08", "2026-10-31"]],
+    });
+    const annual = candidate({
+      reason: "manual",
+      total: 4_588_994,
+      periods: [["2024-10-30", "2025-10-30"]],
+    });
+
+    expect(findContractInvoices([upsell, annual])).toEqual([upsell, annual]);
+  });
+
+  it("drops an upsell older than the annual bill", () => {
+    // A renewal bakes the upsells sold before it into its own amount.
+    const annual = candidate({
+      reason: "subscription_cycle",
+      total: 1_500_000,
+      periods: [["2026-01-02", "2027-01-02"]],
+    });
+    const bakedIn = candidate({
+      reason: "manual",
+      total: 300_000,
+      periods: [["2025-06-01", "2026-01-02"]],
+    });
+
+    expect(findContractInvoices([annual, bakedIn])).toEqual([annual]);
+  });
+
+  it("keeps only the newest of two year-spanning bills", () => {
+    // A contract replaced mid-stream — a new subscription, or last year's
+    // renewal behind this year's — counts once.
+    const thisYear = candidate({
+      reason: "subscription_create",
+      total: 1_590_000,
+      periods: [["2026-01-02", "2027-01-02"]],
+    });
+    const lastYear = candidate({
+      reason: "subscription_cycle",
+      total: 1_773_605,
+      periods: [["2025-01-03", "2026-01-03"]],
+    });
+
+    expect(findContractInvoices([thisYear, lastYear])).toEqual([thisYear]);
+  });
+
+  it("lets a period-less sales invoice replace the annual bill", () => {
+    // A dashboard invoice often stamps a single day rather than the stretch
+    // the money covers; raised after the annual bill, it re-bills the whole
+    // contract rather than adding to it.
+    const reBilled = candidate({
+      reason: "manual",
+      total: 1_050_000,
+      periods: [["2026-02-12", "2026-02-12"]],
+    });
+    const previous = candidate({
+      reason: "subscription_cycle",
+      total: 1_000_000,
+      periods: [["2025-01-24", "2026-01-24"]],
+    });
+
+    expect(findContractInvoices([reBilled, previous])).toEqual([reBilled]);
+  });
+
+  it("skips the zero invoice a sales-opened subscription starts on", () => {
+    const opening = candidate({
+      reason: "subscription_create",
+      total: 0,
+      periods: [["2026-06-02", "2026-06-17"]],
+    });
+
+    expect(findContractInvoices([opening])).toEqual([]);
+  });
+
+  it("falls back to the newest sales invoice when no bill spans a year", () => {
+    const renewal = candidate({
+      reason: "manual",
+      total: 1_050_000,
+      periods: [["2026-02-12", "2026-02-12"]],
+    });
+
+    expect(findContractInvoices([renewal])).toEqual([renewal]);
+  });
+
+  it("reports nothing when no invoice reads as a contract", () => {
+    const monthlyCycle = candidate({
+      reason: "subscription_cycle",
+      total: 96_000,
+      periods: [["2026-02-23", "2026-03-23"]],
+    });
+
+    expect(findContractInvoices([monthlyCycle])).toEqual([]);
   });
 });
 

--- a/apps/backend/src/stripe/revenue.test.ts
+++ b/apps/backend/src/stripe/revenue.test.ts
@@ -1,4 +1,3 @@
-import type Stripe from "stripe";
 import { describe, expect, it } from "vitest";
 
 import type { ContractInvoiceCandidate } from "./revenue";
@@ -13,8 +12,8 @@ describe("getInvoiceRevenue", () => {
   /** Stripe states amounts in the currency's minor unit. */
   function invoice(fields: {
     total: number;
-    total_excluding_tax?: number | null;
-    taxes?: number[];
+    totalExcludingTax?: number | null;
+    totalTaxesAmount?: number | null;
     currency?: string;
     pre?: number;
     post?: number;
@@ -22,26 +21,24 @@ describe("getInvoiceRevenue", () => {
     return {
       currency: fields.currency ?? "usd",
       total: fields.total,
-      total_excluding_tax: fields.total_excluding_tax ?? null,
-      total_taxes: fields.taxes?.map((amount) => ({ amount })) ?? null,
-      pre_payment_credit_notes_amount: fields.pre ?? 0,
-      post_payment_credit_notes_amount: fields.post ?? 0,
+      totalExcludingTax: fields.totalExcludingTax ?? null,
+      totalTaxesAmount: fields.totalTaxesAmount ?? null,
+      prePaymentCreditNotesAmount: fields.pre ?? 0,
+      postPaymentCreditNotesAmount: fields.post ?? 0,
     };
   }
 
   it("reads the amount excluding tax, in the currency's main unit", () => {
     // VAT collected for a state is not revenue.
     expect(
-      getInvoiceRevenue(
-        invoice({ total: 12_000, total_excluding_tax: 10_000 }),
-      ),
+      getInvoiceRevenue(invoice({ total: 12_000, totalExcludingTax: 10_000 })),
     ).toEqual({ amount: 100, currency: "usd" });
   });
 
   it("takes the listed taxes off when no pre-tax total is stated", () => {
     // Falling back to the total alone would let the VAT through as revenue.
     expect(
-      getInvoiceRevenue(invoice({ total: 12_000, taxes: [1_500, 500] })),
+      getInvoiceRevenue(invoice({ total: 12_000, totalTaxesAmount: 2_000 })),
     ).toEqual({ amount: 100, currency: "usd" });
   });
 
@@ -50,7 +47,7 @@ describe("getInvoiceRevenue", () => {
       getInvoiceRevenue(
         invoice({
           total: 10_000,
-          total_excluding_tax: 10_000,
+          totalExcludingTax: 10_000,
           currency: "eur",
         }),
       ),
@@ -64,7 +61,7 @@ describe("getInvoiceRevenue", () => {
       getInvoiceRevenue(
         invoice({
           total: 10_000,
-          total_excluding_tax: 10_000,
+          totalExcludingTax: 10_000,
           pre: 1_500,
           post: 2_500,
         }),
@@ -75,7 +72,7 @@ describe("getInvoiceRevenue", () => {
   it("reports a fully credited invoice as nothing", () => {
     expect(
       getInvoiceRevenue(
-        invoice({ total: 10_000, total_excluding_tax: 10_000, post: 10_000 }),
+        invoice({ total: 10_000, totalExcludingTax: 10_000, post: 10_000 }),
       ).amount,
     ).toBe(0);
   });
@@ -96,23 +93,18 @@ describe("toEuros", () => {
 });
 
 describe("findContractInvoices", () => {
-  const seconds = (iso: string) => Date.parse(iso) / 1000;
-
   /** Cases below are the real shapes the yearly book was found to hold. */
   function candidate(fields: {
-    reason: Stripe.Invoice.BillingReason | null;
+    reason: string | null;
     total: number;
-    /** Each entry is one line's covered stretch. */
-    periods: [string, string][];
+    /** The stretch the invoice covers, as the mirror resolved it at ingest. */
+    period: [string, string] | null;
   }): ContractInvoiceCandidate & { total: number } {
     return {
-      billing_reason: fields.reason,
+      billingReason: fields.reason,
       total: fields.total,
-      lines: {
-        data: fields.periods.map(([start, end]) => ({
-          period: { start: seconds(start), end: seconds(end) },
-        })),
-      },
+      periodStart: fields.period ? fields.period[0] : null,
+      periodEnd: fields.period ? fields.period[1] : null,
     };
   }
 
@@ -123,17 +115,17 @@ describe("findContractInvoices", () => {
     const trueUp = candidate({
       reason: "subscription_update",
       total: 758_724,
-      periods: [["2026-04-23", "2026-05-23"]],
+      period: ["2026-04-23", "2026-05-23"],
     });
     const contract = candidate({
       reason: "subscription_update",
       total: 6_480_000,
-      periods: [["2026-05-23", "2027-05-23"]],
+      period: ["2026-05-23", "2027-05-23"],
     });
     const oldCycle = candidate({
       reason: "subscription_cycle",
       total: 745_028,
-      periods: [["2026-03-23", "2026-04-23"]],
+      period: ["2026-03-23", "2026-04-23"],
     });
 
     expect(findContractInvoices([trueUp, contract, oldCycle])).toEqual([
@@ -151,12 +143,12 @@ describe("findContractInvoices", () => {
     const upsell = candidate({
       reason: "manual",
       total: 3_260_000,
-      periods: [["2026-06-08", "2026-10-31"]],
+      period: ["2026-06-08", "2026-10-31"],
     });
     const annual = candidate({
       reason: "manual",
       total: 4_588_994,
-      periods: [["2024-10-30", "2025-10-30"]],
+      period: ["2024-10-30", "2025-10-30"],
     });
 
     expect(findContractInvoices([upsell, annual])).toEqual([upsell, annual]);
@@ -167,12 +159,12 @@ describe("findContractInvoices", () => {
     const annual = candidate({
       reason: "subscription_cycle",
       total: 1_500_000,
-      periods: [["2026-01-02", "2027-01-02"]],
+      period: ["2026-01-02", "2027-01-02"],
     });
     const bakedIn = candidate({
       reason: "manual",
       total: 300_000,
-      periods: [["2025-06-01", "2026-01-02"]],
+      period: ["2025-06-01", "2026-01-02"],
     });
 
     expect(findContractInvoices([annual, bakedIn])).toEqual([annual]);
@@ -184,12 +176,12 @@ describe("findContractInvoices", () => {
     const thisYear = candidate({
       reason: "subscription_create",
       total: 1_590_000,
-      periods: [["2026-01-02", "2027-01-02"]],
+      period: ["2026-01-02", "2027-01-02"],
     });
     const lastYear = candidate({
       reason: "subscription_cycle",
       total: 1_773_605,
-      periods: [["2025-01-03", "2026-01-03"]],
+      period: ["2025-01-03", "2026-01-03"],
     });
 
     expect(findContractInvoices([thisYear, lastYear])).toEqual([thisYear]);
@@ -202,12 +194,12 @@ describe("findContractInvoices", () => {
     const reBilled = candidate({
       reason: "manual",
       total: 1_050_000,
-      periods: [["2026-02-12", "2026-02-12"]],
+      period: ["2026-02-12", "2026-02-12"],
     });
     const previous = candidate({
       reason: "subscription_cycle",
       total: 1_000_000,
-      periods: [["2025-01-24", "2026-01-24"]],
+      period: ["2025-01-24", "2026-01-24"],
     });
 
     expect(findContractInvoices([reBilled, previous])).toEqual([reBilled]);
@@ -217,7 +209,7 @@ describe("findContractInvoices", () => {
     const opening = candidate({
       reason: "subscription_create",
       total: 0,
-      periods: [["2026-06-02", "2026-06-17"]],
+      period: ["2026-06-02", "2026-06-17"],
     });
 
     expect(findContractInvoices([opening])).toEqual([]);
@@ -227,7 +219,7 @@ describe("findContractInvoices", () => {
     const renewal = candidate({
       reason: "manual",
       total: 1_050_000,
-      periods: [["2026-02-12", "2026-02-12"]],
+      period: null,
     });
 
     expect(findContractInvoices([renewal])).toEqual([renewal]);
@@ -237,7 +229,7 @@ describe("findContractInvoices", () => {
     const monthlyCycle = candidate({
       reason: "subscription_cycle",
       total: 96_000,
-      periods: [["2026-02-23", "2026-03-23"]],
+      period: ["2026-02-23", "2026-03-23"],
     });
 
     expect(findContractInvoices([monthlyCycle])).toEqual([]);

--- a/apps/backend/src/stripe/revenue.test.ts
+++ b/apps/backend/src/stripe/revenue.test.ts
@@ -7,12 +7,16 @@ describe("getInvoiceRevenue", () => {
   function invoice(fields: {
     total: number;
     total_excluding_tax?: number | null;
+    taxes?: number[];
+    currency?: string;
     pre?: number;
     post?: number;
   }) {
     return {
+      currency: fields.currency ?? "usd",
       total: fields.total,
       total_excluding_tax: fields.total_excluding_tax ?? null,
+      total_taxes: fields.taxes?.map((amount) => ({ amount })) ?? null,
       pre_payment_credit_notes_amount: fields.pre ?? 0,
       post_payment_credit_notes_amount: fields.post ?? 0,
     };
@@ -24,11 +28,26 @@ describe("getInvoiceRevenue", () => {
       getInvoiceRevenue(
         invoice({ total: 12_000, total_excluding_tax: 10_000 }),
       ),
-    ).toBe(100);
+    ).toEqual({ amount: 100, currency: "usd" });
   });
 
-  it("falls back to the total when no tax is broken out", () => {
-    expect(getInvoiceRevenue(invoice({ total: 10_000 }))).toBe(100);
+  it("takes the listed taxes off when no pre-tax total is stated", () => {
+    // Falling back to the total alone would let the VAT through as revenue.
+    expect(
+      getInvoiceRevenue(invoice({ total: 12_000, taxes: [1_500, 500] })),
+    ).toEqual({ amount: 100, currency: "usd" });
+  });
+
+  it("reports the currency it was raised in", () => {
+    expect(
+      getInvoiceRevenue(
+        invoice({
+          total: 10_000,
+          total_excluding_tax: 10_000,
+          currency: "eur",
+        }),
+      ),
+    ).toEqual({ amount: 100, currency: "eur" });
   });
 
   it("nets out credit notes issued before and after payment", () => {
@@ -42,7 +61,7 @@ describe("getInvoiceRevenue", () => {
           pre: 1_500,
           post: 2_500,
         }),
-      ),
+      ).amount,
     ).toBe(60);
   });
 
@@ -50,7 +69,7 @@ describe("getInvoiceRevenue", () => {
     expect(
       getInvoiceRevenue(
         invoice({ total: 10_000, total_excluding_tax: 10_000, post: 10_000 }),
-      ),
+      ).amount,
     ).toBe(0);
   });
 });

--- a/apps/backend/src/stripe/revenue.test.ts
+++ b/apps/backend/src/stripe/revenue.test.ts
@@ -1,11 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import type { ContractInvoiceCandidate } from "./revenue";
 import {
-  findContractInvoices,
-  getAmortizedCoverage,
+  classifyInvoice,
   getInvoiceRevenue,
-  getYearlyMonthSplits,
   startOfUTCMonth,
   toEuros,
 } from "./revenue";
@@ -97,255 +94,131 @@ describe("toEuros", () => {
   });
 });
 
-describe("findContractInvoices", () => {
-  /** Cases below are the real shapes the yearly book was found to hold. */
-  function candidate(fields: {
+describe("classifyInvoice", () => {
+  /** Cases below are the real shapes the book was found to hold. */
+  function invoice(fields: {
     reason: string | null;
-    total: number;
-    /** The stretch the invoice covers, as the mirror resolved it at ingest. */
-    period: [string, string] | null;
-  }): ContractInvoiceCandidate & { total: number } {
-    return {
-      billingReason: fields.reason,
-      total: fields.total,
-      periodStart: fields.period ? fields.period[0] : null,
-      periodEnd: fields.period ? fields.period[1] : null,
-    };
-  }
-
-  it("picks the year-long conversion invoice over its same-day true-up", () => {
-    // A team converted from monthly to yearly mid-stream: the contract is a
-    // `subscription_update` covering a year, raised alongside a last month of
-    // usage — and behind them, months of cycle invoices from before.
-    const trueUp = candidate({
-      reason: "subscription_update",
-      total: 758_724,
-      period: ["2026-04-23", "2026-05-23"],
-    });
-    const contract = candidate({
-      reason: "subscription_update",
-      total: 6_480_000,
-      period: ["2026-05-23", "2027-05-23"],
-    });
-    const oldCycle = candidate({
-      reason: "subscription_cycle",
-      total: 745_028,
-      period: ["2026-03-23", "2026-04-23"],
-    });
-
-    expect(findContractInvoices([trueUp, contract, oldCycle])).toEqual([
-      contract,
-    ]);
-    expect(findContractInvoices([contract, trueUp, oldCycle])).toEqual([
-      contract,
-    ]);
-  });
-
-  it("adds a partial-period upsell on top of the annual bill", () => {
-    // A contract billed by hand, then upsold mid-year: the upsell covers the
-    // stretch from its sale to the contract's renewal date, and both invoices
-    // are the contract's worth.
-    const upsell = candidate({
-      reason: "manual",
-      total: 3_260_000,
-      period: ["2026-06-08", "2026-10-31"],
-    });
-    const annual = candidate({
-      reason: "manual",
-      total: 4_588_994,
-      period: ["2024-10-30", "2025-10-30"],
-    });
-
-    expect(findContractInvoices([upsell, annual])).toEqual([upsell, annual]);
-  });
-
-  it("drops an upsell older than the annual bill", () => {
-    // A renewal bakes the upsells sold before it into its own amount.
-    const annual = candidate({
-      reason: "subscription_cycle",
-      total: 1_500_000,
-      period: ["2026-01-02", "2027-01-02"],
-    });
-    const bakedIn = candidate({
-      reason: "manual",
-      total: 300_000,
-      period: ["2025-06-01", "2026-01-02"],
-    });
-
-    expect(findContractInvoices([annual, bakedIn])).toEqual([annual]);
-  });
-
-  it("keeps only the newest of two year-spanning bills", () => {
-    // A contract replaced mid-stream — a new subscription, or last year's
-    // renewal behind this year's — counts once.
-    const thisYear = candidate({
-      reason: "subscription_create",
-      total: 1_590_000,
-      period: ["2026-01-02", "2027-01-02"],
-    });
-    const lastYear = candidate({
-      reason: "subscription_cycle",
-      total: 1_773_605,
-      period: ["2025-01-03", "2026-01-03"],
-    });
-
-    expect(findContractInvoices([thisYear, lastYear])).toEqual([thisYear]);
-  });
-
-  it("lets a period-less sales invoice replace the annual bill", () => {
-    // A dashboard invoice often stamps a single day rather than the stretch
-    // the money covers; raised after the annual bill, it re-bills the whole
-    // contract rather than adding to it.
-    const reBilled = candidate({
-      reason: "manual",
-      total: 1_050_000,
-      period: ["2026-02-12", "2026-02-12"],
-    });
-    const previous = candidate({
-      reason: "subscription_cycle",
-      total: 1_000_000,
-      period: ["2025-01-24", "2026-01-24"],
-    });
-
-    expect(findContractInvoices([reBilled, previous])).toEqual([reBilled]);
-  });
-
-  it("skips the zero invoice a sales-opened subscription starts on", () => {
-    const opening = candidate({
-      reason: "subscription_create",
-      total: 0,
-      period: ["2026-06-02", "2026-06-17"],
-    });
-
-    expect(findContractInvoices([opening])).toEqual([]);
-  });
-
-  it("falls back to the newest sales invoice when no bill spans a year", () => {
-    const renewal = candidate({
-      reason: "manual",
-      total: 1_050_000,
-      period: null,
-    });
-
-    expect(findContractInvoices([renewal])).toEqual([renewal]);
-  });
-
-  it("reports nothing when no invoice reads as a contract", () => {
-    const monthlyCycle = candidate({
-      reason: "subscription_cycle",
-      total: 96_000,
-      period: ["2026-02-23", "2026-03-23"],
-    });
-
-    expect(findContractInvoices([monthlyCycle])).toEqual([]);
-  });
-});
-
-describe("getAmortizedCoverage", () => {
-  it("uses the stored period when it reads forward", () => {
-    expect(
-      getAmortizedCoverage({
-        invoicedAt: new Date("2026-05-23"),
-        coveredFrom: new Date("2026-05-23"),
-        coveredUntil: new Date("2027-05-23"),
-      }),
-    ).toEqual({
-      start: Date.parse("2026-05-23"),
-      end: Date.parse("2027-05-23"),
-    });
-  });
-
-  it("spreads an arrears-stamped invoice over the year ahead", () => {
-    // An annual bill whose period ends the day it was raised is collecting
-    // for the year to come, whatever its lines claim.
-    expect(
-      getAmortizedCoverage({
-        invoicedAt: new Date("2025-10-30"),
-        coveredFrom: new Date("2024-10-30"),
-        coveredUntil: new Date("2025-10-30"),
-      }),
-    ).toEqual({
-      start: Date.parse("2025-10-30"),
-      end: Date.parse("2026-10-30"),
-    });
-  });
-
-  it("spreads a period-less invoice over the year from issuance", () => {
-    expect(
-      getAmortizedCoverage({
-        invoicedAt: new Date("2026-02-11"),
-        coveredFrom: null,
-        coveredUntil: null,
-      }),
-    ).toEqual({
-      start: Date.parse("2026-02-11"),
-      end: Date.parse("2027-02-11"),
-    });
-  });
-});
-
-describe("getYearlyMonthSplits", () => {
-  // January through March 2026, the bound closing March.
-  const MONTHS = [
-    new Date("2026-01-01"),
-    new Date("2026-02-01"),
-    new Date("2026-03-01"),
-  ];
-  const END = new Date("2026-04-01");
-
-  function contractInvoice(fields: {
-    amount: number;
-    covered: [string, string];
-    currency?: string;
+    issued: string;
+    period?: [string, string];
   }) {
     return {
-      amount: fields.amount,
-      currency: fields.currency ?? "eur",
-      invoicedAt: new Date(fields.covered[0]),
-      coveredFrom: new Date(fields.covered[0]),
-      coveredUntil: new Date(fields.covered[1]),
+      billingReason: fields.reason,
+      stripeCreatedAt: new Date(fields.issued).toISOString(),
+      periodStart: fields.period
+        ? new Date(fields.period[0]).toISOString()
+        : null,
+      periodEnd: fields.period
+        ? new Date(fields.period[1]).toISOString()
+        : null,
     };
   }
 
-  it("amortizes a renewal day by day over the months it covers", () => {
-    // 365 euros over 365 days: a euro a day, so each month weighs its length.
-    const contract = {
-      invoices: [
-        contractInvoice({ amount: 365, covered: ["2026-01-01", "2027-01-01"] }),
-      ],
-    };
-
-    const splits = getYearlyMonthSplits([contract], MONTHS, END);
-
-    expect(splits.map((split) => split.revenue)).toEqual([31, 28, 31]);
-    expect(splits.map((split) => split.teamsCount)).toEqual([1, 1, 1]);
+  const coverage = (from: string, to: string) => ({
+    kind: "contract" as const,
+    coverage: { start: Date.parse(from), end: Date.parse(to) },
   });
 
-  it("files an upsell only on the stretch it was sold for", () => {
-    const contract = {
-      invoices: [
-        contractInvoice({ amount: 28, covered: ["2026-02-15", "2026-03-15"] }),
-      ],
-    };
-
-    const splits = getYearlyMonthSplits([contract], MONTHS, END);
-
-    expect(splits.map((split) => split.revenue)).toEqual([0, 14, 14]);
-    expect(splits.map((split) => split.teamsCount)).toEqual([0, 1, 1]);
+  it("reads a year-long bill as a contract, whatever Stripe filed it under", () => {
+    // A monthly-to-yearly conversion arrives as a `subscription_update`.
+    expect(
+      classifyInvoice(
+        invoice({
+          reason: "subscription_update",
+          issued: "2026-05-23",
+          period: ["2026-05-23", "2027-05-23"],
+        }),
+        { customerHasTerm: true },
+      ),
+    ).toEqual(coverage("2026-05-23", "2027-05-23"));
   });
 
-  it("counts a contract once per month, however many invoices cover it", () => {
-    const contract = {
-      invoices: [
-        contractInvoice({ amount: 365, covered: ["2026-01-01", "2027-01-01"] }),
-        contractInvoice({ amount: 28, covered: ["2026-02-15", "2026-03-15"] }),
-      ],
-    };
+  it("reads a monthly cycle as the month it was raised in", () => {
+    expect(
+      classifyInvoice(
+        invoice({
+          reason: "subscription_cycle",
+          issued: "2026-03-23",
+          period: ["2026-02-23", "2026-03-23"],
+        }),
+        { customerHasTerm: true },
+      ),
+    ).toEqual({ kind: "monthly" });
+  });
 
-    const splits = getYearlyMonthSplits([contract], MONTHS, END);
+  it("spreads an arrears-stamped contract over the year ahead", () => {
+    // An annual bill whose period ends the day it was raised is collecting for
+    // the year to come, not paying for one already over.
+    expect(
+      classifyInvoice(
+        invoice({
+          reason: "manual",
+          issued: "2025-10-30",
+          period: ["2024-10-30", "2025-10-30"],
+        }),
+        { customerHasTerm: true },
+      ),
+    ).toEqual(coverage("2025-10-30", "2026-10-30"));
+  });
 
-    expect(splits.map((split) => split.teamsCount)).toEqual([1, 1, 1]);
-    expect(splits[1]?.revenue).toBe(42);
+  it("spreads a sales invoice stating no period over the year from issuance", () => {
+    expect(
+      classifyInvoice(invoice({ reason: "manual", issued: "2026-02-11" }), {
+        customerHasTerm: true,
+      }),
+    ).toEqual(coverage("2026-02-11", "2027-02-11"));
+  });
+
+  it("treats a few days stamped on a sales invoice as no period at all", () => {
+    // Dashboard invoices routinely carry the day they were raised; read as
+    // coverage, a year's contract would land in a single week.
+    expect(
+      classifyInvoice(
+        invoice({
+          reason: "manual",
+          issued: "2026-02-11",
+          period: ["2026-02-11", "2026-02-13"],
+        }),
+        { customerHasTerm: true },
+      ),
+    ).toEqual(coverage("2026-02-11", "2027-02-11"));
+  });
+
+  it("reads a one-off from a customer with no term as that month's bill", () => {
+    // The same shape from a customer Argos never billed in terms is a bill
+    // raised by hand, not a year's contract stated without its period.
+    expect(
+      classifyInvoice(invoice({ reason: "manual", issued: "2026-02-11" }), {
+        customerHasTerm: false,
+      }),
+    ).toEqual({ kind: "monthly" });
+  });
+
+  it("reads a hand-raised month as the month it covers", () => {
+    // Legacy and partner deals are billed this way, month after month.
+    expect(
+      classifyInvoice(
+        invoice({
+          reason: "manual",
+          issued: "2026-03-10",
+          period: ["2026-02-21", "2026-03-21"],
+        }),
+        { customerHasTerm: false },
+      ),
+    ).toEqual({ kind: "monthly" });
+  });
+
+  it("keeps a sales-led upsell on the stretch it was sold for", () => {
+    // Sold mid-term, covering from the sale to the contract's renewal date.
+    expect(
+      classifyInvoice(
+        invoice({
+          reason: "manual",
+          issued: "2026-06-09",
+          period: ["2026-06-08", "2026-10-31"],
+        }),
+        { customerHasTerm: true },
+      ),
+    ).toEqual(coverage("2026-06-08", "2026-10-31"));
   });
 });
 

--- a/apps/backend/src/stripe/revenue.test.ts
+++ b/apps/backend/src/stripe/revenue.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { getInvoiceRevenue, startOfUTCMonth } from "./revenue";
+
+describe("getInvoiceRevenue", () => {
+  /** Stripe states amounts in the currency's minor unit. */
+  function invoice(fields: {
+    total: number;
+    total_excluding_tax?: number | null;
+    pre?: number;
+    post?: number;
+  }) {
+    return {
+      total: fields.total,
+      total_excluding_tax: fields.total_excluding_tax ?? null,
+      pre_payment_credit_notes_amount: fields.pre ?? 0,
+      post_payment_credit_notes_amount: fields.post ?? 0,
+    };
+  }
+
+  it("reads the amount excluding tax, in the currency's main unit", () => {
+    // VAT collected for a state is not revenue.
+    expect(
+      getInvoiceRevenue(
+        invoice({ total: 12_000, total_excluding_tax: 10_000 }),
+      ),
+    ).toBe(100);
+  });
+
+  it("falls back to the total when no tax is broken out", () => {
+    expect(getInvoiceRevenue(invoice({ total: 10_000 }))).toBe(100);
+  });
+
+  it("nets out credit notes issued before and after payment", () => {
+    // An invoice refunded after the fact keeps its amount intact, so the
+    // credited half has to be taken off or the total counts money given back.
+    expect(
+      getInvoiceRevenue(
+        invoice({
+          total: 10_000,
+          total_excluding_tax: 10_000,
+          pre: 1_500,
+          post: 2_500,
+        }),
+      ),
+    ).toBe(60);
+  });
+
+  it("reports a fully credited invoice as nothing", () => {
+    expect(
+      getInvoiceRevenue(
+        invoice({ total: 10_000, total_excluding_tax: 10_000, post: 10_000 }),
+      ),
+    ).toBe(0);
+  });
+});
+
+describe("startOfUTCMonth", () => {
+  it("cuts the month in UTC, not where the process happens to run", () => {
+    // The instant below is still July in UTC and already August in Paris. Cut
+    // locally, an invoice stamped here would be filed a month off.
+    const lateJuly = new Date("2026-07-31T23:30:00Z");
+
+    expect(startOfUTCMonth(lateJuly, 0).toISOString()).toBe(
+      "2026-07-01T00:00:00.000Z",
+    );
+  });
+
+  it.each([
+    [0, "2026-08-01T00:00:00.000Z"],
+    [-1, "2026-07-01T00:00:00.000Z"],
+    [-2, "2026-06-01T00:00:00.000Z"],
+  ])("walks %i months back", (offset, expected) => {
+    expect(
+      startOfUTCMonth(new Date("2026-08-22T12:00:00Z"), offset).toISOString(),
+    ).toBe(expected);
+  });
+
+  it("walks back across a year boundary", () => {
+    expect(
+      startOfUTCMonth(new Date("2026-01-15T12:00:00Z"), -2).toISOString(),
+    ).toBe("2025-11-01T00:00:00.000Z");
+  });
+});

--- a/apps/backend/src/stripe/revenue.test.ts
+++ b/apps/backend/src/stripe/revenue.test.ts
@@ -6,6 +6,7 @@ import {
   findContractInvoices,
   getInvoiceRevenue,
   startOfUTCMonth,
+  toEuros,
 } from "./revenue";
 
 describe("getInvoiceRevenue", () => {
@@ -77,6 +78,20 @@ describe("getInvoiceRevenue", () => {
         invoice({ total: 10_000, total_excluding_tax: 10_000, post: 10_000 }),
       ).amount,
     ).toBe(0);
+  });
+});
+
+describe("toEuros", () => {
+  it("brings dollars in at the fixed rate", () => {
+    expect(toEuros({ amount: 1000, currency: "usd" })).toBe(855);
+  });
+
+  it("leaves euros as they are", () => {
+    expect(toEuros({ amount: 1000, currency: "eur" })).toBe(1000);
+  });
+
+  it("keeps an unknown currency at parity, for the foreign caveat to own", () => {
+    expect(toEuros({ amount: 1000, currency: "gbp" })).toBe(1000);
   });
 });
 

--- a/apps/backend/src/stripe/revenue.test.ts
+++ b/apps/backend/src/stripe/revenue.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 import type { ContractInvoiceCandidate } from "./revenue";
 import {
   findContractInvoices,
+  getAmortizedCoverage,
   getInvoiceRevenue,
+  getYearlyMonthSplits,
   startOfUTCMonth,
   toEuros,
 } from "./revenue";
@@ -236,6 +238,114 @@ describe("findContractInvoices", () => {
     });
 
     expect(findContractInvoices([monthlyCycle])).toEqual([]);
+  });
+});
+
+describe("getAmortizedCoverage", () => {
+  it("uses the stored period when it reads forward", () => {
+    expect(
+      getAmortizedCoverage({
+        invoicedAt: new Date("2026-05-23"),
+        coveredFrom: new Date("2026-05-23"),
+        coveredUntil: new Date("2027-05-23"),
+      }),
+    ).toEqual({
+      start: Date.parse("2026-05-23"),
+      end: Date.parse("2027-05-23"),
+    });
+  });
+
+  it("spreads an arrears-stamped invoice over the year ahead", () => {
+    // An annual bill whose period ends the day it was raised is collecting
+    // for the year to come, whatever its lines claim.
+    expect(
+      getAmortizedCoverage({
+        invoicedAt: new Date("2025-10-30"),
+        coveredFrom: new Date("2024-10-30"),
+        coveredUntil: new Date("2025-10-30"),
+      }),
+    ).toEqual({
+      start: Date.parse("2025-10-30"),
+      end: Date.parse("2026-10-30"),
+    });
+  });
+
+  it("spreads a period-less invoice over the year from issuance", () => {
+    expect(
+      getAmortizedCoverage({
+        invoicedAt: new Date("2026-02-11"),
+        coveredFrom: null,
+        coveredUntil: null,
+      }),
+    ).toEqual({
+      start: Date.parse("2026-02-11"),
+      end: Date.parse("2027-02-11"),
+    });
+  });
+});
+
+describe("getYearlyMonthSplits", () => {
+  // January through March 2026, the bound closing March.
+  const MONTHS = [
+    new Date("2026-01-01"),
+    new Date("2026-02-01"),
+    new Date("2026-03-01"),
+  ];
+  const END = new Date("2026-04-01");
+
+  function contractInvoice(fields: {
+    amount: number;
+    covered: [string, string];
+    currency?: string;
+  }) {
+    return {
+      amount: fields.amount,
+      currency: fields.currency ?? "eur",
+      invoicedAt: new Date(fields.covered[0]),
+      coveredFrom: new Date(fields.covered[0]),
+      coveredUntil: new Date(fields.covered[1]),
+    };
+  }
+
+  it("amortizes a renewal day by day over the months it covers", () => {
+    // 365 euros over 365 days: a euro a day, so each month weighs its length.
+    const contract = {
+      invoices: [
+        contractInvoice({ amount: 365, covered: ["2026-01-01", "2027-01-01"] }),
+      ],
+    };
+
+    const splits = getYearlyMonthSplits([contract], MONTHS, END);
+
+    expect(splits.map((split) => split.revenue)).toEqual([31, 28, 31]);
+    expect(splits.map((split) => split.teamsCount)).toEqual([1, 1, 1]);
+  });
+
+  it("files an upsell only on the stretch it was sold for", () => {
+    const contract = {
+      invoices: [
+        contractInvoice({ amount: 28, covered: ["2026-02-15", "2026-03-15"] }),
+      ],
+    };
+
+    const splits = getYearlyMonthSplits([contract], MONTHS, END);
+
+    expect(splits.map((split) => split.revenue)).toEqual([0, 14, 14]);
+    expect(splits.map((split) => split.teamsCount)).toEqual([0, 1, 1]);
+  });
+
+  it("counts a contract once per month, however many invoices cover it", () => {
+    const contract = {
+      invoices: [
+        contractInvoice({ amount: 365, covered: ["2026-01-01", "2027-01-01"] }),
+        contractInvoice({ amount: 28, covered: ["2026-02-15", "2026-03-15"] }),
+      ],
+    };
+
+    const splits = getYearlyMonthSplits([contract], MONTHS, END);
+
+    expect(splits.map((split) => split.teamsCount)).toEqual([1, 1, 1]);
+    expect(splits[1]?.revenue).toBe(42);
   });
 });
 

--- a/apps/backend/src/stripe/revenue.test.ts
+++ b/apps/backend/src/stripe/revenue.test.ts
@@ -15,16 +15,14 @@ describe("getInvoiceRevenue", () => {
     totalExcludingTax?: number | null;
     totalTaxesAmount?: number | null;
     currency?: string;
-    pre?: number;
-    post?: number;
+    credited?: number;
   }) {
     return {
       currency: fields.currency ?? "usd",
       total: fields.total,
       totalExcludingTax: fields.totalExcludingTax ?? null,
       totalTaxesAmount: fields.totalTaxesAmount ?? null,
-      prePaymentCreditNotesAmount: fields.pre ?? 0,
-      postPaymentCreditNotesAmount: fields.post ?? 0,
+      creditedAmountExcludingTax: fields.credited ?? 0,
     };
   }
 
@@ -54,7 +52,7 @@ describe("getInvoiceRevenue", () => {
     ).toEqual({ amount: 100, currency: "eur" });
   });
 
-  it("nets out credit notes issued before and after payment", () => {
+  it("nets out what the credit notes gave back", () => {
     // An invoice refunded after the fact keeps its amount intact, so the
     // credited half has to be taken off or the total counts money given back.
     expect(
@@ -62,17 +60,22 @@ describe("getInvoiceRevenue", () => {
         invoice({
           total: 10_000,
           totalExcludingTax: 10_000,
-          pre: 1_500,
-          post: 2_500,
+          credited: 4_000,
         }),
       ).amount,
     ).toBe(60);
   });
 
-  it("reports a fully credited invoice as nothing", () => {
+  it("reports a fully credited taxed invoice as nothing", () => {
+    // Both sides of the subtraction are ex-tax: taking the credit note's
+    // tax-inclusive total off the ex-tax base would report minus the VAT here.
     expect(
       getInvoiceRevenue(
-        invoice({ total: 10_000, totalExcludingTax: 10_000, post: 10_000 }),
+        invoice({
+          total: 12_000,
+          totalExcludingTax: 10_000,
+          credited: 10_000,
+        }),
       ).amount,
     ).toBe(0);
   });

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -72,14 +72,36 @@ const REPORTING_CURRENCY = "eur";
 const EUR_PER_USD = 0.855;
 
 /**
- * What GitHub Marketplace brings in a month, in dollars, gross of the 5%
- * GitHub keeps.
+ * What GitHub Marketplace brings in a month, in euros, gross of the 5% GitHub
+ * keeps.
  *
- * A constant rather than a lookup: the marketplace book is a handful of teams
- * and barely moves, and GitHub exposes no invoice API to read it from — copy
- * the statement's total here when it changes. From the 2026-05 statement.
+ * The active marketplace subscriptions at their plans' list prices — GitHub
+ * exposes no seller invoice API, so the listing's prices, copied onto the
+ * plans by the `github-marketplace-prices` cron, are the closest thing to the
+ * statement. Zero until that cron (or its bin form) has priced the plans.
  */
-const GITHUB_MARKETPLACE_MONTHLY_USD = 1540;
+async function getGithubMarketplaceMonthlyRevenue(): Promise<number> {
+  const rows = (await Subscription.query()
+    .select("subscriptions.accountId", "plan.githubMonthlyPriceCents")
+    .joinRelated("plan")
+    .where("subscriptions.provider", "github")
+    .whereNotNull("plan.githubMonthlyPriceCents")
+    .whereRaw("?? < now()", "subscriptions.startDate")
+    .whereIn("subscriptions.status", ["active", "past_due"])
+    .where((query) =>
+      query
+        .whereNull("subscriptions.endDate")
+        .orWhereRaw("?? >= now()", "subscriptions.endDate"),
+    )
+    .distinctOn("subscriptions.accountId")
+    .orderBy("subscriptions.accountId")
+    .orderBy("plan.githubMonthlyPriceCents", "DESC")) as unknown as {
+    githubMonthlyPriceCents: number;
+  }[];
+
+  const cents = rows.reduce((sum, row) => sum + row.githubMonthlyPriceCents, 0);
+  return toEuros({ amount: cents / 100, currency: "usd" });
+}
 
 /**
  * Why Stripe raised an invoice, for the ones that are a subscription being
@@ -714,8 +736,8 @@ export type StaffRevenue = {
   /** The contracts behind every month's `yearlyPlans`, largest first. */
   yearlyContracts: StaffYearlyContract[];
   /**
-   * What GitHub Marketplace brings in a month, in euros, gross. A stated
-   * constant, not a reading — see `GITHUB_MARKETPLACE_MONTHLY_USD`.
+   * What GitHub Marketplace brings in a month, in euros, gross — the active
+   * marketplace subscriptions at their plans' list prices.
    */
   githubMarketplaceMonthlyRevenue: number;
 };
@@ -810,9 +832,6 @@ export async function getStaffRevenue(
   return {
     months,
     yearlyContracts,
-    githubMarketplaceMonthlyRevenue: toEuros({
-      amount: GITHUB_MARKETPLACE_MONTHLY_USD,
-      currency: "usd",
-    }),
+    githubMarketplaceMonthlyRevenue: await getGithubMarketplaceMonthlyRevenue(),
   };
 }

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -49,21 +49,14 @@ type StaffRevenueMonth = {
   /** The teams behind `monthlyPlans`, largest first — they sum to it. */
   teams: StaffRevenueMonthTeam[];
   /**
-   * What the annual contracts in force are worth per month: their latest
-   * renewal over twelve.
-   *
-   * The same on every month, being a rate. Amortizing each annual invoice over
-   * the twelve months it covers would be exact, but it would mean reading a
-   * year of invoices to report one month.
+   * What the annual contracts contributed to the month: their invoices
+   * amortized, day by day, over the stretch each one pays for.
    */
   yearlyPlans: StaffRevenueSplit;
 };
 
 /** Upper bound on the window one call will read. */
 export const MAX_MONTHS = 24;
-
-/** Months a yearly contract is spread over. */
-const MONTHS_PER_YEAR = 12;
 
 /** The currency every amount on this page is stated in. */
 const REPORTING_CURRENCY = "eur";
@@ -521,28 +514,85 @@ async function getYearlyContracts(
 }
 
 /**
- * What the annual contracts in force are worth per month: each contract's
- * invoices over twelve, added up.
+ * The stretch a contract invoice's money pays for, in epoch milliseconds.
+ *
+ * The stored period when it reads forward; a year from issuance otherwise —
+ * either the invoice states no period at all (dashboard invoices often stamp
+ * nothing usable), or it is stamped in arrears, its period ending by the day
+ * it was raised, and an annual bill that claims to cover only the past is
+ * collecting for the year ahead.
  */
-function getYearlyRate(contracts: StaffYearlyContract[]): StaffRevenueSplit {
-  const split = createSplit();
+export function getAmortizedCoverage(invoice: {
+  invoicedAt: Date;
+  coveredFrom: Date | null;
+  coveredUntil: Date | null;
+}): { start: number; end: number } {
+  const issued = invoice.invoicedAt.getTime();
+  if (invoice.coveredFrom && invoice.coveredUntil) {
+    const start = invoice.coveredFrom.getTime();
+    const end = invoice.coveredUntil.getTime();
+    if (end > issued && end > start) {
+      return { start, end };
+    }
+  }
+  const yearAhead = new Date(invoice.invoicedAt);
+  yearAhead.setUTCFullYear(yearAhead.getUTCFullYear() + 1);
+  return { start: issued, end: yearAhead.getTime() };
+}
+
+/**
+ * What the annual contracts contributed to each reported month: every
+ * contract invoice amortized, day by day, over the stretch it pays for.
+ *
+ * The monthly equivalent of the annual book: a renewal weighs on the twelve
+ * months it covers, an upsell on the stretch it was sold for, and a month's
+ * figure never moves once written — where a flat rate repainted history on
+ * every renewal.
+ */
+export function getYearlyMonthSplits(
+  contracts: readonly Pick<StaffYearlyContract, "invoices">[],
+  /** The reported months' first instants, oldest first. */
+  monthStarts: readonly Date[],
+  /** One bound past the last month, closing its window. */
+  end: Date,
+): StaffRevenueSplit[] {
+  const splits = monthStarts.map(() => createSplit());
+  const bounds = monthStarts.map((start, index) => {
+    const next = monthStarts[index + 1] ?? end;
+    return { start: start.getTime(), end: next.getTime() };
+  });
 
   for (const contract of contracts) {
-    if (contract.invoices.length === 0) {
-      continue;
-    }
-    // Invoice by invoice rather than off the summed amount, so a contract
-    // partly billed in another currency keeps that part in the parity caveat.
+    const contributed = bounds.map(() => false);
     for (const invoice of contract.invoices) {
-      addToSplit(split, {
-        amount: invoice.amount / MONTHS_PER_YEAR,
-        currency: invoice.currency,
-      });
+      const coverage = getAmortizedCoverage(invoice);
+      const coveredDays = (coverage.end - coverage.start) / DAY_MS;
+      for (const [index, bound] of bounds.entries()) {
+        const overlap =
+          Math.min(coverage.end, bound.end) -
+          Math.max(coverage.start, bound.start);
+        if (overlap <= 0) {
+          continue;
+        }
+        const split = splits[index];
+        invariant(split, "bounds and splits are built together");
+        addToSplit(split, {
+          amount: (invoice.amount * (overlap / DAY_MS)) / coveredDays,
+          currency: invoice.currency,
+        });
+        contributed[index] = true;
+      }
     }
-    split.teamsCount += 1;
+    for (const [index, wasContributed] of contributed.entries()) {
+      if (wasContributed) {
+        const split = splits[index];
+        invariant(split, "bounds and splits are built together");
+        split.teamsCount += 1;
+      }
+    }
   }
 
-  return split;
+  return splits;
 }
 
 /**
@@ -728,8 +778,8 @@ export async function getStaffRevenue(
     const covered =
       contract && contract.invoices.length > 0
         ? Math.min(
-            ...contract.invoices.map((invoice) =>
-              (invoice.coveredFrom ?? invoice.invoicedAt).getTime(),
+            ...contract.invoices.map(
+              (invoice) => getAmortizedCoverage(invoice).start,
             ),
           )
         : Number.NEGATIVE_INFINITY;
@@ -742,19 +792,18 @@ export async function getStaffRevenue(
     teamCustomers,
     yearlyContractStarts,
   });
-  const yearlyRate = getYearlyRate(yearlyContracts);
+  const yearlySplits = getYearlyMonthSplits(yearlyContracts, reported, end);
 
   const months = reported.map((start, index) => {
     const total = totals[index];
-    invariant(total, "every month reported has totals");
+    const yearly = yearlySplits[index];
+    invariant(total && yearly, "every month reported has totals");
     return {
       month: start,
-      revenue: total.split.revenue + yearlyRate.revenue,
+      revenue: total.split.revenue + yearly.revenue,
       monthlyPlans: total.split,
       teams: total.teams,
-      // Copied rather than shared: one object held by every month is one
-      // object a later change can mutate for all of them at once.
-      yearlyPlans: { ...yearlyRate },
+      yearlyPlans: yearly,
     };
   });
 

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -1,8 +1,8 @@
+import { invariant } from "@argos/util/invariant";
 import type Stripe from "stripe";
 
 import config from "@/config";
-import { Subscription } from "@/database/models";
-import { redisCache } from "@/util/redis";
+import { Account, Subscription } from "@/database/models";
 
 import { stripe } from "./index";
 
@@ -10,6 +10,17 @@ import { stripe } from "./index";
 type StaffRevenueSplit = {
   revenue: number;
   teamsCount: number;
+  /**
+   * The part of `revenue` invoiced in a currency other than US dollars, added
+   * in at parity.
+   *
+   * Stripe states each invoice in the currency it was raised in, and converting
+   * one into another needs a rate on the day, which nothing here has. So a euro
+   * invoice is counted as though it were dollars — the rule the staff pages
+   * already print amounts under — and this says how much of the figure rests on
+   * that, which is the only honest thing to do short of an exchange rate.
+   */
+  foreignRevenue: number;
 };
 
 /** What Argos billed over one calendar month. */
@@ -18,20 +29,15 @@ export type StaffRevenueMonth = {
   month: Date;
   /** The two splits below, added up. */
   revenue: number;
-  /**
-   * What teams billed by the month were invoiced that month — the invoices
-   * themselves, so discounts, credit notes and negotiated amounts are already
-   * in it.
-   */
+  /** What teams billed by the month were invoiced that month. */
   monthlyPlans: StaffRevenueSplit;
   /**
    * What the annual contracts in force are worth per month: their latest
-   * invoice over twelve.
+   * renewal over twelve.
    *
    * The same on every month, being a rate. Amortizing each annual invoice over
    * the twelve months it covers would be exact, but it would mean reading a
-   * year of invoices to report one month — the one thing this cannot afford,
-   * being asked at page load.
+   * year of invoices to report one month.
    */
   yearlyPlans: StaffRevenueSplit;
 };
@@ -39,9 +45,7 @@ export type StaffRevenueMonth = {
 /**
  * Upper bound on the window one call will read.
  *
- * Every month is a walk of its own, so the cost grows with the count asked for
- * — bounded here rather than left to the caller, which is what keeps a request
- * from turning into a hundred round trips.
+ * Every month is a walk of its own, so the cost grows with the count asked for.
  */
 export const MAX_MONTHS = 24;
 
@@ -61,6 +65,48 @@ const PAGE_SIZE = 100;
 /** Months a yearly contract is spread over. */
 const MONTHS_PER_YEAR = 12;
 
+/**
+ * Requests in flight at once.
+ *
+ * The months and the annual contracts are all independent, so nothing here
+ * needs to wait — but Stripe rate-limits per account and the client is built
+ * without retries, so an unbounded fan-out turns a wide account into a 429 that
+ * fails the whole page.
+ */
+const MAX_CONCURRENT_REQUESTS = 8;
+
+/** The currency every amount on the staff pages is printed in. */
+const REPORTING_CURRENCY = "usd";
+
+/**
+ * Why Stripe raised an invoice, for the ones that are a subscription being
+ * billed rather than something invoiced on the side.
+ *
+ * A one-off invoice or an accepted quote is revenue, but it is not what a
+ * column headed by a billing interval reports — and a customer of the Stripe
+ * account that is not an Argos team has no business in this page at all.
+ */
+const SUBSCRIPTION_BILLING_REASONS = new Set<Stripe.Invoice.BillingReason>([
+  "subscription",
+  "subscription_create",
+  "subscription_cycle",
+  "subscription_threshold",
+  "subscription_update",
+]);
+
+/**
+ * The reasons a renewal is raised under, which is the only invoice worth
+ * dividing by twelve.
+ *
+ * Narrower than the set above on purpose: a mid-year proration is real revenue
+ * for the month it lands in, but a twelfth of it is not what the contract is
+ * worth per month.
+ */
+const RENEWAL_BILLING_REASONS = new Set<Stripe.Invoice.BillingReason>([
+  "subscription_create",
+  "subscription_cycle",
+]);
+
 /** The placeholder the config falls back to when no key is configured. */
 const MISSING_API_KEY = "no-api-key";
 
@@ -68,21 +114,27 @@ const MISSING_API_KEY = "no-api-key";
 type BilledTeam = {
   accountId: string;
   stripeCustomerId: string;
+  stripeSubscriptionId: string;
   interval: "month" | "year";
 };
 
 /**
- * Every team with a paying subscription, and the interval it is billed on.
+ * Every team on a paying Stripe subscription, and the interval it is billed on.
  *
- * Reads the subscription the same way `getAccountBillings` does — the highest
- * quota among those active, so an account holding two resolves the same one on
- * both sides. Granted plans are excluded: they bill nothing, so no invoice of
- * theirs exists to find.
+ * Narrower than the subscription `getAccountBillings` resolves, deliberately: a
+ * trial is dropped here where that one keeps it, because a trial is invoiced
+ * nothing and this reads invoices. An account holding both a trial and a paid
+ * subscription can therefore resolve a different plan on the two sides — the
+ * paid one here, which is the one that produced the invoices.
+ *
+ * Granted plans are excluded for the same reason: they bill nothing, so no
+ * invoice of theirs exists to find.
  */
 export async function getBilledTeams(): Promise<BilledTeam[]> {
   const rows = (await Subscription.query()
     .select(
       "subscriptions.accountId",
+      "subscriptions.stripeSubscriptionId",
       "accounts.stripeCustomerId",
       "plan.interval",
     )
@@ -92,10 +144,12 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
     .whereNull("accounts.userId")
     .whereNull("accounts.forcedPlanId")
     .whereNotNull("accounts.stripeCustomerId")
+    // A subscription Argos bills through GitHub raises no Stripe invoice, so
+    // there is nothing to look up for it.
+    .whereNotNull("subscriptions.stripeSubscriptionId")
     .whereRaw("?? < now()", "subscriptions.startDate")
-    // A trial is out: it resolves a plan like a paid subscription and pays
-    // nothing. `past_due` is in — the invoice was raised, whether it clears is
-    // a collection question.
+    // `past_due` is in: the invoice was raised, and whether it clears is a
+    // collection question rather than a revenue one.
     .whereIn("subscriptions.status", ["active", "past_due"])
     .where((query) =>
       query
@@ -106,16 +160,42 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
     .orderBy("subscriptions.accountId")
     .orderBy("plan.includedScreenshots", "DESC")) as unknown as {
     accountId: string | number;
+    stripeSubscriptionId: string;
     stripeCustomerId: string;
     interval: "month" | "year";
   }[];
 
   return rows.map((row) => ({
     accountId: String(row.accountId),
+    stripeSubscriptionId: row.stripeSubscriptionId,
     stripeCustomerId: row.stripeCustomerId,
     interval: row.interval,
   }));
 }
+
+/**
+ * Every Stripe customer that is an Argos team, whether or not it still pays.
+ *
+ * Read over all team accounts rather than over the billed ones: a team that has
+ * since churned keeps the invoices it was already sent, and a month it was
+ * invoiced in would otherwise lose it — which is exactly the revenue a
+ * comparison between two months exists to show. Personal accounts are left out,
+ * so what they may have been invoiced never reaches a page about teams.
+ */
+export async function getTeamCustomerIds(): Promise<Set<string>> {
+  const rows = (await Account.query()
+    .select("stripeCustomerId")
+    .whereNotNull("teamId")
+    .whereNull("userId")
+    .whereNotNull("stripeCustomerId")) as unknown as {
+    stripeCustomerId: string;
+  }[];
+
+  return new Set(rows.map((row) => row.stripeCustomerId));
+}
+
+/** What one invoice contributed, in the currency it was raised in. */
+export type InvoiceRevenue = { amount: number; currency: string };
 
 /**
  * What one invoice contributed to revenue, in the currency's main unit.
@@ -124,32 +204,38 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
  * net of credit notes, because an invoice refunded after the fact keeps its
  * `amount_paid` intact — reading that field alone would count money that was
  * given back.
- *
- * Currencies are added at parity, the rule the staff pages already print
- * amounts under: a euro contract is read as dollars rather than converted.
  */
-export function getInvoiceRevenue(
-  invoice: Pick<
-    Stripe.Invoice,
-    | "total"
-    | "total_excluding_tax"
-    | "pre_payment_credit_notes_amount"
-    | "post_payment_credit_notes_amount"
-  >,
-): number {
-  // Null on invoices Stripe states no tax breakdown for, where the total is
-  // already the whole of it.
-  const excludingTax = invoice.total_excluding_tax ?? invoice.total;
+export function getInvoiceRevenue(invoice: {
+  currency: string;
+  total: number;
+  total_excluding_tax: number | null;
+  /** Only the amounts are read, so the rest of Stripe's shape is not asked for. */
+  total_taxes: { amount: number }[] | null;
+  pre_payment_credit_notes_amount: number;
+  post_payment_credit_notes_amount: number;
+}): InvoiceRevenue {
+  // Null on invoices Stripe states no pre-tax total for. The taxes it lists are
+  // taken off the total instead, rather than letting the tax through as
+  // revenue — falling back to `total` alone would overstate every invoice that
+  // collected VAT, and say nothing about it.
+  const excludingTax =
+    invoice.total_excluding_tax ??
+    invoice.total -
+      (invoice.total_taxes ?? []).reduce((sum, tax) => sum + tax.amount, 0);
+
   const credited =
     invoice.pre_payment_credit_notes_amount +
     invoice.post_payment_credit_notes_amount;
 
-  // Stripe states amounts in the currency's minor unit.
-  return (excludingTax - credited) / 100;
+  return {
+    // Stripe states amounts in the currency's minor unit.
+    amount: (excludingTax - credited) / 100,
+    currency: invoice.currency,
+  };
 }
 
 function createSplit(): StaffRevenueSplit {
-  return { revenue: 0, teamsCount: 0 };
+  return { revenue: 0, teamsCount: 0, foreignRevenue: 0 };
 }
 
 function createMonth(month: Date): StaffRevenueMonth {
@@ -161,14 +247,21 @@ function createMonth(month: Date): StaffRevenueMonth {
   };
 }
 
+/** Add one invoice to a split, tracking what of it was not in dollars. */
+function addToSplit(split: StaffRevenueSplit, revenue: InvoiceRevenue): void {
+  split.revenue += revenue.amount;
+  if (revenue.currency !== REPORTING_CURRENCY) {
+    split.foreignRevenue += revenue.amount;
+  }
+}
+
 /**
  * The first instant of the month `offset` months back, in UTC.
  *
  * Deliberately not the calendar helpers, which work in the process's own
  * timezone: Stripe timestamps every invoice in UTC, so a server running on
  * anything else would cut its months hours away from where Stripe cuts them and
- * file the invoices either side of a boundary in the wrong one. Reading UTC on
- * both sides is what makes the figure independent of where it runs.
+ * file the invoices either side of a boundary in the wrong one.
  */
 export function startOfUTCMonth(date: Date, offset: number): Date {
   return new Date(
@@ -176,65 +269,100 @@ export function startOfUTCMonth(date: Date, offset: number): Date {
   );
 }
 
+/** Run `work` over `items`, never more than `MAX_CONCURRENT_REQUESTS` at once. */
+async function mapWithLimit<Item, Result>(
+  items: Item[],
+  work: (item: Item) => Promise<Result>,
+): Promise<Result[]> {
+  const results: Result[] = Array.from({ length: items.length });
+  let next = 0;
+
+  const runners = Array.from(
+    { length: Math.min(MAX_CONCURRENT_REQUESTS, items.length) },
+    async () => {
+      for (let index = next++; index < items.length; index = next++) {
+        const item = items[index];
+        invariant(item !== undefined, "index is inside the list");
+        results[index] = await work(item);
+      }
+    },
+  );
+
+  await Promise.all(runners);
+  return results;
+}
+
 /**
  * What the annual contracts in force are worth per month.
  *
  * One small request per annual team rather than a year of invoices for
- * everyone: an annual subscription raises one invoice a year, so its latest is
- * what it is worth now, and there are few enough of them to ask in parallel.
+ * everyone: an annual subscription renews once a year, so its latest renewal is
+ * what it is worth now.
  *
- * A contract whose first invoice has not been paid yet counts nothing — it has
+ * Listed by subscription and narrowed to a renewal, not simply the customer's
+ * latest paid invoice: an add-on bought mid-year is the most recent invoice a
+ * customer paid, and a twelfth of it would replace the contract's own amount
+ * with a rounding error.
+ *
+ * A contract whose first renewal has not been paid yet counts nothing — it has
  * been invoiced nothing, which is what this reports.
  */
 async function getYearlyRate(teams: BilledTeam[]): Promise<StaffRevenueSplit> {
   const yearlyTeams = teams.filter((team) => team.interval === "year");
   const split = createSplit();
 
-  const invoices = await Promise.all(
-    yearlyTeams.map(async (team) => {
-      const page = await stripe.invoices.list({
-        customer: team.stripeCustomerId,
-        status: "paid",
-        limit: 1,
-      });
-      return page.data[0] ?? null;
-    }),
-  );
+  const invoices = await mapWithLimit(yearlyTeams, async (team) => {
+    // A handful rather than one: the latest invoice on a subscription can be a
+    // proration, and the renewal is the one behind it.
+    const page = await stripe.invoices.list({
+      subscription: team.stripeSubscriptionId,
+      status: "paid",
+      limit: 10,
+    });
+    return (
+      page.data.find(
+        (invoice) =>
+          invoice.billing_reason !== null &&
+          RENEWAL_BILLING_REASONS.has(invoice.billing_reason),
+      ) ?? null
+    );
+  });
 
   for (const invoice of invoices) {
     if (!invoice) {
       continue;
     }
-    split.revenue += getInvoiceRevenue(invoice) / MONTHS_PER_YEAR;
+    const revenue = getInvoiceRevenue(invoice);
+    addToSplit(split, {
+      amount: revenue.amount / MONTHS_PER_YEAR,
+      currency: revenue.currency,
+    });
     split.teamsCount += 1;
   }
 
   return split;
 }
 
-/** What one month's invoices came to, and how many teams they covered. */
-type MonthTotals = { revenue: number; teamsCount: number };
-
 /**
  * Walk one month's invoices.
  *
  * A chain per month rather than one chain over the whole window, because
  * Stripe's pagination is a cursor: a page cannot be asked for until the one
- * before it has answered, so a single walk over three months is three months of
- * round trips end to end. Split by month they run at once, and the wall clock
- * becomes the longest month rather than their sum — which is also why the split
- * is by month rather than by an arbitrary slice: each chain then knows the
- * bucket its invoices belong to, with nothing left to sort out afterwards.
+ * before it has answered, so a single walk over a year is a year of round trips
+ * end to end. Split by month they run at once, and each chain knows the bucket
+ * its invoices belong to.
  */
 async function readMonth(options: {
   from: Date;
   to: Date;
+  /** Customers that are Argos teams — everything else is not this page's. */
+  teamCustomerIds: Set<string>;
   /** Yearly contracts are reported as a rate, so their invoices are skipped. */
   yearlyCustomerIds: Set<string>;
-}): Promise<MonthTotals> {
-  const { from, to, yearlyCustomerIds } = options;
+}): Promise<StaffRevenueSplit> {
+  const { from, to, teamCustomerIds, yearlyCustomerIds } = options;
+  const split = createSplit();
   const customerIds = new Set<string>();
-  let revenue = 0;
   let count = 0;
 
   for await (const invoice of stripe.invoices.list({
@@ -256,29 +384,44 @@ async function readMonth(options: {
       typeof invoice.customer === "string"
         ? invoice.customer
         : invoice.customer?.id;
-    if (!customerId || yearlyCustomerIds.has(customerId)) {
+    if (!customerId || !teamCustomerIds.has(customerId)) {
+      continue;
+    }
+    if (yearlyCustomerIds.has(customerId)) {
+      continue;
+    }
+    if (
+      invoice.billing_reason === null ||
+      !SUBSCRIPTION_BILLING_REASONS.has(invoice.billing_reason)
+    ) {
       continue;
     }
 
-    revenue += getInvoiceRevenue(invoice);
+    addToSplit(split, getInvoiceRevenue(invoice));
     // A team invoiced twice in one month is one team.
     customerIds.add(customerId);
   }
 
-  return { revenue, teamsCount: customerIds.size };
+  split.teamsCount = customerIds.size;
+  return split;
 }
 
 /**
  * What Argos invoiced over the last `monthCount` calendar months, oldest first
  * and the running one last.
  *
- * Asked of Stripe on every call rather than mirrored into a table: the invoices
- * are the answer, and a copy of them is a second source to keep correct as they
- * are voided, refunded and credited.
+ * Asked of Stripe on every call rather than mirrored into a table or held in a
+ * cache: the invoices are the answer, they change behind us as they are paid,
+ * voided and credited, and a copy of them is a second source to keep correct.
  */
-async function fetchStaffRevenue(
+export async function getStaffRevenue(
   monthCount: number,
 ): Promise<StaffRevenueMonth[]> {
+  invariant(
+    monthCount >= 1 && monthCount <= MAX_MONTHS,
+    `monthCount must be between 1 and ${MAX_MONTHS}`,
+  );
+
   if (config.get("stripe.apiKey") === MISSING_API_KEY) {
     throw new Error(
       "Stripe is not configured, so invoiced revenue cannot be read.",
@@ -292,107 +435,38 @@ async function fetchStaffRevenue(
     startOfUTCMonth(now, index - monthCount + 1),
   );
 
-  const teams = await getBilledTeams();
-  // Only the yearly customers are identified, and the monthly bucket takes
-  // everything else. Matching invoices against the teams billed *today* would
-  // drop the invoices of a team that has since churned — and a month it was
-  // invoiced in would quietly lose it, which is exactly the revenue a
-  // comparison between two months exists to show.
+  const [teams, teamCustomerIds] = await Promise.all([
+    getBilledTeams(),
+    getTeamCustomerIds(),
+  ]);
   const yearlyCustomerIds = new Set(
     teams
       .filter((team) => team.interval === "year")
       .map((team) => team.stripeCustomerId),
   );
 
-  // Every request at once: the months are independent walks, and the yearly
-  // rate is its own set of small ones.
   const reported = starts.slice(0, monthCount);
   const [yearlyRate, totals] = await Promise.all([
     getYearlyRate(teams),
-    Promise.all(
+    mapWithLimit(
       reported.map((from, index) => {
         const to = starts[index + 1];
-        if (!to) {
-          throw new Error("every month reported has a bound");
-        }
-        return readMonth({ from, to, yearlyCustomerIds });
+        invariant(to, "every month reported has a bound");
+        return { from, to };
       }),
+      (window) => readMonth({ ...window, teamCustomerIds, yearlyCustomerIds }),
     ),
   ]);
 
   return reported.map((start, index) => {
     const month = createMonth(start);
     const total = totals[index];
-    if (!total) {
-      throw new Error("every month reported has totals");
-    }
+    invariant(total, "every month reported has totals");
     month.monthlyPlans = total;
-    month.yearlyPlans = yearlyRate;
+    // Copied rather than shared: one object held by every month is one object
+    // a later change can mutate for all of them at once.
+    month.yearlyPlans = { ...yearlyRate };
     month.revenue = total.revenue + yearlyRate.revenue;
     return month;
   });
-}
-
-/**
- * The shape of the cached value, bumped whenever `StaffRevenueMonth` changes.
- *
- * An entry outlives the deploy that changes what this returns, so a field
- * renamed below would otherwise be read back for an hour from a value that no
- * longer has it.
- */
-const CACHE_VERSION = 1;
-
-/** How long a window is served from cache. */
-const CACHE_MAX_AGE = 60 * 60 * 1000;
-
-/**
- * Long enough for the walks to finish while holding the lock.
- *
- * The lock's TTL, not a deadline on the work: expiring early would let a second
- * request start the same walks rather than wait on them, which is the stampede
- * the cache exists to prevent.
- */
-const CACHE_LOCK_TIMEOUT = 60 * 1000;
-
-const staffRevenueStore = redisCache.createStore({
-  fetch: fetchStaffRevenue,
-  /**
-   * Everything the answer is a function of, so no two of them share an entry.
-   *
-   * The deployment above all. Without it the key is global to the Redis
-   * instance and any two apps pointed at one serve each other's totals — which
-   * on a developer's machine is not hypothetical: the end-to-end suite and the
-   * dev server share `redis://localhost:6380/1`.
-   */
-  getCacheKey: (monthCount) => [
-    "staff-revenue",
-    CACHE_VERSION,
-    monthCount,
-    config.get("pg.connection.host"),
-    config.get("pg.connection.database"),
-  ],
-  maxAge: CACHE_MAX_AGE,
-  timeout: CACHE_LOCK_TIMEOUT,
-  // Dates do not survive JSON, and the months carry one each.
-  deserialize: (raw) => {
-    const months = JSON.parse(raw) as (Omit<StaffRevenueMonth, "month"> & {
-      month: string;
-    })[];
-    return months.map((month) => ({ ...month, month: new Date(month.month) }));
-  },
-});
-
-/**
- * What Argos invoiced, from cache.
- *
- * Cached for an hour because the figures move at the pace of an invoice: the
- * complete months behind them cannot change at all, and the running one gains a
- * handful a day. An hour costs no freshness anyone can use, and it is what
- * keeps a page that walks a year of invoices from walking it again on every
- * visit.
- */
-export async function getStaffRevenue(
-  monthCount: number,
-): Promise<StaffRevenueMonth[]> {
-  return staffRevenueStore.get(monthCount);
 }

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -1,6 +1,11 @@
 import { invariant } from "@argos/util/invariant";
 
-import { Account, StripeInvoice, Subscription } from "@/database/models";
+import {
+  Account,
+  StripeInvoice,
+  StripeInvoiceSync,
+  Subscription,
+} from "@/database/models";
 
 /** What the teams on one billing interval contributed to a month. */
 type StaffRevenueSplit = {
@@ -240,7 +245,9 @@ export type InvoiceRevenue = { amount: number; currency: string };
  * Excluding tax, because VAT collected on behalf of a state is not revenue, and
  * net of credit notes, because an invoice refunded after the fact keeps its
  * `amount_paid` intact — reading that field alone would count money that was
- * given back.
+ * given back. Both sides of that subtraction are ex-tax: the credited amount
+ * is resolved at ingest from the credit notes themselves, so a fully refunded
+ * taxed invoice nets to zero rather than to minus its VAT.
  */
 export function getInvoiceRevenue(invoice: {
   currency: string;
@@ -248,8 +255,7 @@ export function getInvoiceRevenue(invoice: {
   totalExcludingTax: number | null;
   /** The listed taxes added up — the fallback when no pre-tax total exists. */
   totalTaxesAmount: number | null;
-  prePaymentCreditNotesAmount: number;
-  postPaymentCreditNotesAmount: number;
+  creditedAmountExcludingTax: number;
 }): InvoiceRevenue {
   // Null on invoices Stripe states no pre-tax total for. The taxes it listed
   // are taken off the total instead, rather than letting the tax through as
@@ -259,12 +265,9 @@ export function getInvoiceRevenue(invoice: {
     invoice.totalExcludingTax ??
     invoice.total - (invoice.totalTaxesAmount ?? 0);
 
-  const credited =
-    invoice.prePaymentCreditNotesAmount + invoice.postPaymentCreditNotesAmount;
-
   return {
     // Stripe states amounts in the currency's minor unit.
-    amount: (excludingTax - credited) / 100,
+    amount: (excludingTax - invoice.creditedAmountExcludingTax) / 100,
     currency: invoice.currency,
   };
 }
@@ -455,17 +458,18 @@ async function getYearlyContracts(
       yearlyTeams.map((team) => team.stripeCustomerId),
     )
     .whereIn("status", ["paid", "open"])
+    // A contract in force renews yearly, so its bills are at most a little
+    // over a year old — two years bounds the scan without ever cutting one
+    // off, where an unbounded read would drag a converted team's whole
+    // monthly history along.
+    .where(
+      "stripeCreatedAt",
+      ">=",
+      startOfUTCMonth(new Date(), -24).toISOString(),
+    )
     .orderBy("stripeCreatedAt", "desc");
 
-  const byCustomer = new Map<string, StripeInvoice[]>();
-  for (const row of rows) {
-    let list = byCustomer.get(row.stripeCustomerId);
-    if (!list) {
-      list = [];
-      byCustomer.set(row.stripeCustomerId, list);
-    }
-    list.push(row);
-  }
+  const byCustomer = Map.groupBy(rows, (row) => row.stripeCustomerId);
 
   const contracts = yearlyTeams.map((team) => {
     const all = byCustomer.get(team.stripeCustomerId) ?? [];
@@ -553,15 +557,26 @@ async function readMonths(options: {
   end: Date;
   /** Customers that are Argos teams — everything else is not this page's. */
   teamCustomers: Map<string, TeamCustomer>;
-  /** Yearly contracts are reported as a rate, so their invoices are skipped. */
-  yearlyCustomerIds: Set<string>;
+  /**
+   * When each current annual contract's coverage began, by customer.
+   *
+   * A contract's invoices are reported as a rate, so from that instant on the
+   * customer's invoices are skipped here — but only from then: a team that
+   * converted mid-window keeps its real monthly history, instead of having it
+   * erased by its present interval.
+   */
+  yearlyContractStarts: Map<string, number>;
 }): Promise<{ split: StaffRevenueSplit; teams: StaffRevenueMonthTeam[] }[]> {
-  const { starts, end, teamCustomers, yearlyCustomerIds } = options;
+  const { starts, end, teamCustomers, yearlyContractStarts } = options;
   const first = starts[0];
   invariant(first, "at least one month is reported");
 
   const rows = await StripeInvoice.query()
     .where("status", "paid")
+    .whereIn("billingReason", [
+      ...SUBSCRIPTION_BILLING_REASONS,
+      ...SALES_LED_BILLING_REASONS,
+    ])
     .where("stripeCreatedAt", ">=", first.toISOString())
     .where("stripeCreatedAt", "<", end.toISOString());
 
@@ -586,14 +601,16 @@ async function readMonths(options: {
     if (!team) {
       continue;
     }
-    if (yearlyCustomerIds.has(row.stripeCustomerId)) {
+    // An annual bill is never a month's revenue, whoever it belongs to now: a
+    // churned yearly team's old renewal must not spike the month it landed in.
+    const period = getCoveredPeriod(row);
+    if (period && period.end - period.start >= ANNUAL_PERIOD_MS) {
       continue;
     }
-    if (
-      row.billingReason === null ||
-      (!SUBSCRIPTION_BILLING_REASONS.has(row.billingReason) &&
-        !SALES_LED_BILLING_REASONS.has(row.billingReason))
-    ) {
+    // From its contract's start, a yearly team's invoices — upsells,
+    // true-ups — are the contract's business, reported through the rate.
+    const contractStart = yearlyContractStarts.get(row.stripeCustomerId);
+    if (contractStart !== undefined && created.getTime() >= contractStart) {
       continue;
     }
 
@@ -670,39 +687,61 @@ export async function getStaffRevenue(
     `monthCount must be between 1 and ${MAX_MONTHS}`,
   );
 
-  // Told apart from a quiet month: an empty mirror reports zeros that read as
-  // real figures, and the fix — running the backfill — is on the operator.
-  const mirrored = await StripeInvoice.query().select("id").first();
-  if (!mirrored) {
+  const now = new Date();
+  // Oldest first, the running month last; `end` closes the last window.
+  const reported = Array.from({ length: monthCount }, (_, index) =>
+    startOfUTCMonth(now, index - monthCount + 1),
+  );
+  const end = startOfUTCMonth(now, 1);
+  const first = reported[0];
+  invariant(first, "at least one month is reported");
+
+  const [teams, teamCustomers, deepestSync] = await Promise.all([
+    getBilledTeams(),
+    getTeamCustomers(),
+    StripeInvoiceSync.query().orderBy("sinceDate", "asc").first(),
+  ]);
+
+  // Told apart from a quiet stretch: months the mirror never swept would
+  // report zeros that read as real figures, and the fix — a deeper
+  // backfill — is on the operator.
+  if (!deepestSync || new Date(deepestSync.sinceDate) > first) {
     throw new Error(
-      "The Stripe invoice mirror is empty — run stripe/bin/sync-stripe-invoices with a deep window to backfill it.",
+      "The Stripe invoice mirror does not cover the requested window — run stripe/bin/sync-stripe-invoices with a deeper window to backfill it.",
     );
   }
 
-  const now = new Date();
-  // Oldest first, the running month last. One bound past the end, which is not
-  // itself a month reported: it closes the last window.
-  const starts = Array.from({ length: monthCount + 1 }, (_, index) =>
-    startOfUTCMonth(now, index - monthCount + 1),
-  );
+  const yearlyContracts = await getYearlyContracts(teams);
 
-  const [teams, teamCustomers] = await Promise.all([
-    getBilledTeams(),
-    getTeamCustomers(),
-  ]);
-  const yearlyCustomerIds = new Set(
-    teams
-      .filter((team) => team.interval === "year")
-      .map((team) => team.stripeCustomerId),
-  );
+  // When each current annual contract began covering, so the months only skip
+  // a yearly customer's invoices from that instant on. A contract found but
+  // undatable skips everything, which is the conservative reading.
+  const yearlyContractStarts = new Map<string, number>();
+  for (const team of teams) {
+    if (team.interval !== "year") {
+      continue;
+    }
+    const contract = yearlyContracts.find(
+      (candidate) =>
+        candidate.stripeSubscriptionId === team.stripeSubscriptionId,
+    );
+    const covered =
+      contract && contract.invoices.length > 0
+        ? Math.min(
+            ...contract.invoices.map((invoice) =>
+              (invoice.coveredFrom ?? invoice.invoicedAt).getTime(),
+            ),
+          )
+        : Number.NEGATIVE_INFINITY;
+    yearlyContractStarts.set(team.stripeCustomerId, covered);
+  }
 
-  const reported = starts.slice(0, monthCount);
-  const end = starts[monthCount];
-  invariant(end, "the extra start closes the last window");
-  const [yearlyContracts, totals] = await Promise.all([
-    getYearlyContracts(teams),
-    readMonths({ starts: reported, end, teamCustomers, yearlyCustomerIds }),
-  ]);
+  const totals = await readMonths({
+    starts: reported,
+    end,
+    teamCustomers,
+    yearlyContractStarts,
+  });
   const yearlyRate = getYearlyRate(yearlyContracts);
 
   const months = reported.map((start, index) => {

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -130,8 +130,31 @@ const SUBSCRIPTION_BILLING_REASONS = new Set<string>([
  */
 const ANNUAL_PERIOD_MS = 300 * 24 * 3600 * 1000;
 
-/** A day, under which a period is a bookkeeping point, not coverage. */
-const DAY_MS = 24 * 3600 * 1000;
+/**
+ * Under this, a stated period is a bookkeeping stamp rather than coverage.
+ *
+ * Sales invoices routinely carry the day they were raised as their period, or
+ * a couple of days around it; read as real, a year's contract would amortize
+ * into a single week.
+ */
+const STAMP_PERIOD_MS = 7 * 24 * 3600 * 1000;
+
+/**
+ * Above this, a stated period is a term rather than a month.
+ *
+ * A hand-raised invoice covering about a month is a monthly bill — legacy and
+ * partner deals are billed that way — where one covering longer is a stretch
+ * sold as a block, and belongs to the months it pays for.
+ */
+const MONTHLY_PERIOD_MS = 45 * 24 * 3600 * 1000;
+
+/**
+ * How long a mirror may go unswept before its figures stop being trusted.
+ *
+ * The cron runs daily, so a week of silence means it is not running — and a
+ * mirror nothing reconciles drifts from Stripe invisibly.
+ */
+const STALE_MIRROR_MS = 7 * 24 * 3600 * 1000;
 
 /**
  * The reasons an invoice is raised by a person rather than by a billing cycle.
@@ -327,413 +350,215 @@ export function startOfUTCMonth(date: Date, offset: number): Date {
 
 /** One invoice a contract's worth is read from. */
 type StaffContractInvoice = {
-  /** Net of tax and credit notes, in the currency's main unit. */
+  /** Net of tax and credit notes, in the currency it was raised in. */
   amount: number;
-  /** The currency it was raised in, counted at parity when not USD. */
   currency: string;
   /** When it was raised. */
   invoicedAt: Date;
-  /** The stretch it covers, when it states a real one. */
-  coveredFrom: Date | null;
-  coveredUntil: Date | null;
+  /** The stretch its money pays for, after the next bill clipped it. */
+  coveredFrom: Date;
+  coveredUntil: Date;
+  /** True while it is raised but not yet cleared. */
+  awaitingPayment: boolean;
 };
 
-/** One annual contract in force, and the invoices its rate is read from. */
+/** One annual contract, and the invoices its figure is read from. */
 type StaffYearlyContract = {
   /** The team's slug, which names its pages. */
   slug: string;
   /** The team's display name, when it has one. */
   name: string | null;
-  /** The subscription the database knows the contract by. */
-  stripeSubscriptionId: string;
+  /** The Stripe customer the contract is billed on. */
+  stripeCustomerId: string;
   /**
-   * The invoices below added up, in euros. Null when none was found, in which
-   * case the contract adds nothing to the rate.
+   * The contract's invoices added up, in euros. Null when the team is billed
+   * yearly but no invoice of its contract could be found — an anomaly worth
+   * seeing rather than hiding.
    */
   amount: number | null;
-  /** The invoices the contract is worth, newest first. */
+  /** What the contract contributes to the running month, in euros. */
+  monthlyRevenue: number;
+  /** The invoices it is worth, newest first. */
   invoices: StaffContractInvoice[];
-  /**
-   * True when the invoices found are still awaiting payment. Counted all the
-   * same — a contract invoice raised is money on its way — and flagged, so
-   * collection can be watched.
-   */
+  /** True when every invoice found is still awaiting payment. */
   awaitingPayment: boolean;
 };
 
+/** The statuses an invoice counts under: raised, and not written off. */
+const COUNTED_STATUSES = ["paid", "open"];
+
 /**
- * The parts of a mirrored invoice the contract picker reads. The period is the
- * longest stretch one of the invoice's lines covered, resolved at ingest.
+ * How far back the contract scan reaches beyond the reported window.
+ *
+ * A renewal raised a year before the window can still be paying for its first
+ * months, so the invoices that cover a month are not only the ones raised in
+ * it.
  */
-export type ContractInvoiceCandidate = {
+const CONTRACT_SCAN_MS = 400 * 24 * 3600 * 1000;
+
+/** The parts of a mirrored invoice the classification reads. */
+export type ClassifiableInvoice = {
   billingReason: string | null;
-  total: number;
+  stripeCreatedAt: string;
   periodStart: string | null;
   periodEnd: string | null;
 };
 
-/** The stretch an invoice covers, in epoch milliseconds, or null. */
-function getCoveredPeriod(
-  invoice: ContractInvoiceCandidate,
+/**
+ * The stretch an invoice states it covers, or null when it states none worth
+ * reading.
+ *
+ * A period of a few days is a bookkeeping stamp rather than coverage — sales
+ * invoices carry those routinely — and reading one as real would amortize a
+ * year's contract into a single week.
+ */
+function getStatedPeriod(
+  invoice: ClassifiableInvoice,
 ): { start: number; end: number } | null {
   if (invoice.periodStart === null || invoice.periodEnd === null) {
     return null;
   }
   const start = new Date(invoice.periodStart).getTime();
   const end = new Date(invoice.periodEnd).getTime();
-  // A period under a day is a bookkeeping point, not coverage.
-  return end - start >= DAY_MS ? { start, end } : null;
+  return end - start >= STAMP_PERIOD_MS ? { start, end } : null;
 }
 
-/** Whether an invoice reads as a contract being billed. */
-function isContractInvoice(invoice: ContractInvoiceCandidate): boolean {
-  if (invoice.total === 0) {
-    // Subscriptions opened by sales to carry a contract start on a zero
-    // invoice; the money is on an invoice of its own.
-    return false;
-  }
-  const period = getCoveredPeriod(invoice);
-  return (
-    (period !== null && period.end - period.start >= ANNUAL_PERIOD_MS) ||
-    (invoice.billingReason !== null &&
-      SALES_LED_BILLING_REASONS.has(invoice.billingReason))
-  );
-}
+/** How an invoice was billed, which is what decides where it is reported. */
+export type InvoiceKind =
+  /** A contract, paying for a stretch: reported over the months it covers. */
+  | { kind: "contract"; coverage: { start: number; end: number } }
+  /** Everything else: reported in the month it was raised. */
+  | { kind: "monthly" };
 
 /**
- * The invoices a contract's worth is read from, among the customer's invoices,
- * newest first.
+ * How an invoice is reported, read from the invoice alone.
  *
- * A contract invoice is one that covers about a year — a renewal, a first
- * year, or a mid-stream conversion, whatever Stripe filed it under — or a
- * sales-led invoice, whose periods cannot be trusted. Anything else — monthly
- * cycles from before a conversion, prorations, true-ups — is real revenue but
- * not what the contract is worth.
- *
- * The newest year-spanning bill anchors the contract, and the sales-led
- * invoices raised on top of it since are read by their period: one covering a
- * real partial stretch is an upsell, added to the anchor; one with no readable
- * coverage re-bills the whole contract and replaces it. Upsells older than the
- * anchor are dropped — a renewal bakes them in. With no year-spanning bill at
- * all, the newest sales-led invoice is the contract.
+ * Never from the customer's subscription today: an invoice is a fact of the
+ * month it was raised in, and a team that converts, churns or is billed by
+ * hand must not rewrite what it was already sent. What makes a contract is
+ * either a stretch of about a year, whatever Stripe filed the invoice under,
+ * or a sales-led invoice — those are how deals negotiated outside the
+ * self-serve flow arrive, and their periods are often a stamp or absent.
  */
-export function findContractInvoices<Invoice extends ContractInvoiceCandidate>(
-  invoices: Invoice[],
-): Invoice[] {
-  const contracts = invoices.filter(isContractInvoice);
+export function classifyInvoice(
+  invoice: ClassifiableInvoice,
+  options: {
+    /**
+     * Whether this customer has a bill covering a term elsewhere in the scan.
+     *
+     * What tells a renewal stated without any period — how sales-led annual
+     * deals routinely arrive — from a one-off raised by hand: the first
+     * belongs to a customer Argos bills in terms, the second does not.
+     */
+    customerHasTerm: boolean;
+  },
+): InvoiceKind {
+  const issued = new Date(invoice.stripeCreatedAt).getTime();
+  const period = getStatedPeriod(invoice);
 
-  const annualIndex = contracts.findIndex((invoice) => {
-    const period = getCoveredPeriod(invoice);
-    return period !== null && period.end - period.start >= ANNUAL_PERIOD_MS;
-  });
-  if (annualIndex === -1) {
-    const newest = contracts[0];
-    return newest ? [newest] : [];
+  if (period && period.end - period.start >= ANNUAL_PERIOD_MS) {
+    // Stamped in arrears — its period ends by the day it was raised — reads as
+    // collecting for the year ahead rather than paying for one already over.
+    return period.end > issued
+      ? { kind: "contract", coverage: period }
+      : { kind: "contract", coverage: yearFrom(issued) };
   }
 
-  const newerThanAnnual = contracts.slice(0, annualIndex);
-  const replacement = newerThanAnnual.find(
-    (invoice) => getCoveredPeriod(invoice) === null,
-  );
-  if (replacement) {
-    return [replacement];
-  }
-
-  const annual = contracts[annualIndex];
-  invariant(annual, "the index was just found");
-  return [...newerThanAnnual, annual];
-}
-
-/**
- * The annual contracts in force, each with the invoices it is worth.
- *
- * Read by customer, not by subscription: an annual deal is not always billed
- * through the subscription the database knows. Sales-led contracts arrive as
- * dashboard or quote invoices carried by no subscription at all, and a team
- * converted to yearly mid-stream holds its contract on a `subscription_update`
- * of the old subscription — a subscription lookup misses both.
- *
- * A contract with no paid invoice may still have been billed — enterprise
- * terms run long — so the open invoices are read before concluding nothing,
- * and reported as awaiting payment. A contract with no invoice at all counts
- * nothing, which is what this reports — but it is still listed, so a contract
- * absent from the figure can be seen rather than guessed at.
- */
-async function getYearlyContracts(
-  teams: BilledTeam[],
-): Promise<StaffYearlyContract[]> {
-  const yearlyTeams = teams.filter((team) => team.interval === "year");
-  if (yearlyTeams.length === 0) {
-    return [];
-  }
-
-  const rows = await StripeInvoice.query()
-    .whereIn(
-      "stripeCustomerId",
-      yearlyTeams.map((team) => team.stripeCustomerId),
-    )
-    .whereIn("status", ["paid", "open"])
-    // A contract in force renews yearly, so its bills are at most a little
-    // over a year old — two years bounds the scan without ever cutting one
-    // off, where an unbounded read would drag a converted team's whole
-    // monthly history along.
-    .where(
-      "stripeCreatedAt",
-      ">=",
-      startOfUTCMonth(new Date(), -24).toISOString(),
-    )
-    .orderBy("stripeCreatedAt", "desc");
-
-  const byCustomer = Map.groupBy(rows, (row) => row.stripeCustomerId);
-
-  const contracts = yearlyTeams.map((team) => {
-    const all = byCustomer.get(team.stripeCustomerId) ?? [];
-    let awaitingPayment = false;
-    let found = findContractInvoices(
-      all.filter((row) => row.status === "paid"),
-    );
-    if (found.length === 0) {
-      found = findContractInvoices(all.filter((row) => row.status === "open"));
-      awaitingPayment = found.length > 0;
+  const isSalesLed =
+    invoice.billingReason !== null &&
+    SALES_LED_BILLING_REASONS.has(invoice.billingReason);
+  if (isSalesLed) {
+    if (!period) {
+      return options.customerHasTerm
+        ? { kind: "contract", coverage: yearFrom(issued) }
+        : { kind: "monthly" };
     }
-
-    const invoices = found.map((row) => {
-      const revenue = getInvoiceRevenue(row);
-      const covered = getCoveredPeriod(row);
+    // Sold as a block rather than billed for a month — an upsell covering the
+    // stretch from its sale to the term's renewal date.
+    if (period.end - period.start > MONTHLY_PERIOD_MS) {
       return {
-        amount: revenue.amount,
-        currency: revenue.currency,
-        invoicedAt: new Date(row.stripeCreatedAt),
-        coveredFrom: covered ? new Date(covered.start) : null,
-        coveredUntil: covered ? new Date(covered.end) : null,
+        kind: "contract",
+        coverage: period.end > issued ? period : yearFrom(issued),
       };
-    });
-
-    return {
-      slug: team.slug,
-      name: team.name,
-      stripeSubscriptionId: team.stripeSubscriptionId,
-      amount:
-        invoices.length > 0
-          ? invoices.reduce((sum, invoice) => sum + toEuros(invoice), 0)
-          : null,
-      invoices,
-      awaitingPayment,
-    };
-  });
-
-  // Largest first, the contracts with no invoice found last: the list reads as
-  // the rate's makeup, and a contract adding nothing is the anomaly to end on.
-  return contracts.sort((a, b) => {
-    if (a.amount === null) {
-      return b.amount === null ? 0 : 1;
-    }
-    if (b.amount === null) {
-      return -1;
-    }
-    return b.amount - a.amount;
-  });
-}
-
-/**
- * The stretch a contract invoice's money pays for, in epoch milliseconds.
- *
- * The stored period when it reads forward; a year from issuance otherwise —
- * either the invoice states no period at all (dashboard invoices often stamp
- * nothing usable), or it is stamped in arrears, its period ending by the day
- * it was raised, and an annual bill that claims to cover only the past is
- * collecting for the year ahead.
- */
-export function getAmortizedCoverage(invoice: {
-  invoicedAt: Date;
-  coveredFrom: Date | null;
-  coveredUntil: Date | null;
-}): { start: number; end: number } {
-  const issued = invoice.invoicedAt.getTime();
-  if (invoice.coveredFrom && invoice.coveredUntil) {
-    const start = invoice.coveredFrom.getTime();
-    const end = invoice.coveredUntil.getTime();
-    if (end > issued && end > start) {
-      return { start, end };
     }
   }
-  const yearAhead = new Date(invoice.invoicedAt);
-  yearAhead.setUTCFullYear(yearAhead.getUTCFullYear() + 1);
-  return { start: issued, end: yearAhead.getTime() };
+  return { kind: "monthly" };
 }
 
 /**
- * What the annual contracts contributed to each reported month: every
- * contract invoice amortized, day by day, over the stretch it pays for.
+ * The customers holding a bill that covers a term.
  *
- * The monthly equivalent of the annual book: a renewal weighs on the twelve
- * months it covers, an upsell on the stretch it was sold for, and a month's
- * figure never moves once written — where a flat rate repainted history on
- * every renewal.
+ * What makes a period-less sales invoice read as a renewal of theirs rather
+ * than as a one-off raised by hand.
  */
-export function getYearlyMonthSplits(
-  contracts: readonly Pick<StaffYearlyContract, "invoices">[],
-  /** The reported months' first instants, oldest first. */
-  monthStarts: readonly Date[],
-  /** One bound past the last month, closing its window. */
-  end: Date,
-): StaffRevenueSplit[] {
-  const splits = monthStarts.map(() => createSplit());
-  const bounds = monthStarts.map((start, index) => {
-    const next = monthStarts[index + 1] ?? end;
-    return { start: start.getTime(), end: next.getTime() };
-  });
-
-  for (const contract of contracts) {
-    const contributed = bounds.map(() => false);
-    for (const invoice of contract.invoices) {
-      const coverage = getAmortizedCoverage(invoice);
-      const coveredDays = (coverage.end - coverage.start) / DAY_MS;
-      for (const [index, bound] of bounds.entries()) {
-        const overlap =
-          Math.min(coverage.end, bound.end) -
-          Math.max(coverage.start, bound.start);
-        if (overlap <= 0) {
-          continue;
-        }
-        const split = splits[index];
-        invariant(split, "bounds and splits are built together");
-        addToSplit(split, {
-          amount: (invoice.amount * (overlap / DAY_MS)) / coveredDays,
-          currency: invoice.currency,
-        });
-        contributed[index] = true;
-      }
-    }
-    for (const [index, wasContributed] of contributed.entries()) {
-      if (wasContributed) {
-        const split = splits[index];
-        invariant(split, "bounds and splits are built together");
-        split.teamsCount += 1;
-      }
-    }
-  }
-
-  return splits;
-}
-
-/**
- * Read the whole window's paid invoices from the mirror and file each into its
- * calendar month — one query where the Stripe-reading version walked one
- * paginated chain per month.
- */
-async function readMonths(options: {
-  /** The reported months' first instants, oldest first. */
-  starts: Date[];
-  /** One bound past the last month, closing its window. */
-  end: Date;
-  /** Customers that are Argos teams — everything else is not this page's. */
-  teamCustomers: Map<string, TeamCustomer>;
-  /**
-   * When each current annual contract's coverage began, by customer.
-   *
-   * A contract's invoices are reported as a rate, so from that instant on the
-   * customer's invoices are skipped here — but only from then: a team that
-   * converted mid-window keeps its real monthly history, instead of having it
-   * erased by its present interval.
-   */
-  yearlyContractStarts: Map<string, number>;
-}): Promise<{ split: StaffRevenueSplit; teams: StaffRevenueMonthTeam[] }[]> {
-  const { starts, end, teamCustomers, yearlyContractStarts } = options;
-  const first = starts[0];
-  invariant(first, "at least one month is reported");
-
-  const rows = await StripeInvoice.query()
-    .where("status", "paid")
-    .whereIn("billingReason", [
-      ...SUBSCRIPTION_BILLING_REASONS,
-      ...SALES_LED_BILLING_REASONS,
-    ])
-    .where("stripeCreatedAt", ">=", first.toISOString())
-    .where("stripeCreatedAt", "<", end.toISOString());
-
-  const months: {
-    split: StaffRevenueSplit;
-    byCustomer: Map<string, StaffRevenueMonthTeam>;
-  }[] = starts.map(() => ({
-    split: createSplit(),
-    byCustomer: new Map<string, StaffRevenueMonthTeam>(),
-  }));
-
-  for (const row of rows) {
-    const created = new Date(row.stripeCreatedAt);
-    // Months are consecutive, so the index is a plain calendar distance.
-    const index: number =
-      (created.getUTCFullYear() - first.getUTCFullYear()) * 12 +
-      (created.getUTCMonth() - first.getUTCMonth());
-    const month: (typeof months)[number] | undefined = months[index];
-    invariant(month, "the query bounds the rows to the window");
-
-    const team = teamCustomers.get(row.stripeCustomerId);
-    if (!team) {
-      continue;
-    }
-    // An annual bill is never a month's revenue, whoever it belongs to now: a
-    // churned yearly team's old renewal must not spike the month it landed in.
-    const period = getCoveredPeriod(row);
+function getCustomersWithTerms(
+  invoices: (ClassifiableInvoice & { stripeCustomerId: string })[],
+): Set<string> {
+  const customers = new Set<string>();
+  for (const invoice of invoices) {
+    const period = getStatedPeriod(invoice);
     if (period && period.end - period.start >= ANNUAL_PERIOD_MS) {
-      continue;
+      customers.add(invoice.stripeCustomerId);
     }
-    // From its contract's start, a yearly team's invoices — upsells,
-    // true-ups — are the contract's business, reported through the rate.
-    const contractStart = yearlyContractStarts.get(row.stripeCustomerId);
-    if (contractStart !== undefined && created.getTime() >= contractStart) {
-      continue;
-    }
-
-    const revenue = getInvoiceRevenue(row);
-    // A zero invoice — a usage month under the quota, the opening of a
-    // sales-created subscription — is not a team being invoiced: it would fill
-    // the breakdown with empty lines and dilute the per-team average.
-    if (revenue.amount === 0) {
-      continue;
-    }
-    addToSplit(month.split, revenue);
-
-    // A team invoiced twice in one month is one team, one line deeper.
-    let teamRow = month.byCustomer.get(row.stripeCustomerId);
-    if (!teamRow) {
-      teamRow = {
-        slug: team.slug,
-        name: team.name,
-        stripeCustomerId: row.stripeCustomerId,
-        amount: 0,
-        currency: revenue.currency,
-        revenue: 0,
-      };
-      month.byCustomer.set(row.stripeCustomerId, teamRow);
-    }
-    teamRow.amount += revenue.amount;
-    if (teamRow.currency !== revenue.currency) {
-      // Mixed currencies make the original sum meaningless; the euro figure
-      // still holds.
-      teamRow.currency = null;
-    }
-    teamRow.revenue += toEuros(revenue);
   }
-
-  return months.map((month) => {
-    month.split.teamsCount = month.byCustomer.size;
-    return {
-      split: month.split,
-      // Largest first: the breakdown is read to see who made the month.
-      teams: [...month.byCustomer.values()].sort(
-        (a, b) => b.revenue - a.revenue,
-      ),
-    };
-  });
+  return customers;
 }
 
-/** What Argos invoiced, and the annual contracts behind the yearly rate. */
+/** A year from `issued`, for a contract invoice that states no usable one. */
+function yearFrom(issued: number): { start: number; end: number } {
+  const end = new Date(issued);
+  end.setUTCFullYear(end.getUTCFullYear() + 1);
+  return { start: issued, end: end.getTime() };
+}
+
+/** A contract invoice, with what reading it resolved. */
+type ContractRead = {
+  row: StripeInvoice;
+  revenue: InvoiceRevenue;
+  coverage: { start: number; end: number };
+  /** A full term supersedes the one before it; a shorter one adds to it. */
+  isFullTerm: boolean;
+};
+
+/**
+ * Clip each customer's full-term contracts at the next one's start.
+ *
+ * A renewal takes over from the term before it, and a contract re-billed
+ * mid-term replaces what it re-bills — so their stretches must not overlap, or
+ * the months they share would count both. Shorter contract invoices are
+ * upsells sold on top of a term and are left alone: they are meant to add.
+ */
+function clipContractTerms(reads: ContractRead[]): ContractRead[] {
+  const byCustomer = Map.groupBy(reads, (read) => read.row.stripeCustomerId);
+  const clipped: ContractRead[] = [];
+
+  for (const customerReads of byCustomer.values()) {
+    const terms = customerReads
+      .filter((read) => read.isFullTerm)
+      .sort((a, b) => a.coverage.start - b.coverage.start);
+    for (const [index, term] of terms.entries()) {
+      const next = terms[index + 1];
+      const end = next
+        ? Math.min(term.coverage.end, next.coverage.start)
+        : term.coverage.end;
+      if (end > term.coverage.start) {
+        clipped.push({
+          ...term,
+          coverage: { start: term.coverage.start, end },
+        });
+      }
+    }
+    clipped.push(...customerReads.filter((read) => !read.isFullTerm));
+  }
+
+  return clipped;
+}
+
+/** What Argos invoiced, and the annual contracts behind the yearly figures. */
 export type StaffRevenue = {
   /** Oldest first, the running month last. */
   months: StaffRevenueMonth[];
-  /** The contracts behind every month's `yearlyPlans`, largest first. */
+  /** The contracts behind the yearly figures, largest first. */
   yearlyContracts: StaffYearlyContract[];
   /**
    * What GitHub Marketplace brings in a month, in euros, gross — the active
@@ -742,14 +567,18 @@ export type StaffRevenue = {
   githubMarketplaceMonthlyRevenue: number;
 };
 
+/** Raised by the reader when the mirror cannot answer for the window asked. */
+export class MirrorCoverageError extends Error {}
+
 /**
  * What Argos invoiced over the last `monthCount` calendar months, along with
- * the annual contracts the yearly rate is made of — one read serving both, so
- * the list always explains the figure it came with.
+ * the annual contracts the yearly figures are made of.
  *
- * Read from the `stripe_invoices` mirror rather than from Stripe: the webhooks
- * keep it current and the reconciliation sweep backs them up, so a view costs
- * a few queries instead of a paginated walk of a third party.
+ * Read from the `stripe_invoices` mirror, and read invoice by invoice: what a
+ * month reports is what was raised in it, and what a contract is worth is
+ * spread over the months it pays for. Nothing consults what plan a team is on
+ * today, so a conversion, a churn or a hand-billed deal cannot rewrite a month
+ * that has already been reported.
  */
 export async function getStaffRevenue(
   monthCount: number,
@@ -760,78 +589,307 @@ export async function getStaffRevenue(
   );
 
   const now = new Date();
-  // Oldest first, the running month last; `end` closes the last window.
   const reported = Array.from({ length: monthCount }, (_, index) =>
     startOfUTCMonth(now, index - monthCount + 1),
   );
   const end = startOfUTCMonth(now, 1);
   const first = reported[0];
   invariant(first, "at least one month is reported");
+  const scanStart = new Date(first.getTime() - CONTRACT_SCAN_MS);
 
-  const [teams, teamCustomers, deepestSync] = await Promise.all([
-    getBilledTeams(),
-    getTeamCustomers(),
-    StripeInvoiceSync.query().orderBy("sinceDate", "asc").first(),
-  ]);
+  const [teamCustomers, billedTeams, deepestSync, freshestSync, marketplace] =
+    await Promise.all([
+      getTeamCustomers(),
+      getBilledTeams(),
+      StripeInvoiceSync.query().orderBy("sinceDate", "asc").first(),
+      StripeInvoiceSync.query().orderBy("completedAt", "desc").first(),
+      getGithubMarketplaceMonthlyRevenue(),
+    ]);
 
-  // Told apart from a quiet stretch: months the mirror never swept would
-  // report zeros that read as real figures, and the fix — a deeper
-  // backfill — is on the operator.
-  if (!deepestSync || new Date(deepestSync.sinceDate) > first) {
-    throw new Error(
-      "The Stripe invoice mirror does not cover the requested window — run stripe/bin/sync-stripe-invoices with a deeper window to backfill it.",
+  // Two things have to hold before a figure can be trusted: the mirror was
+  // swept deep enough to hold the contracts that pay for the window, and it
+  // has been swept recently enough that what it holds is still current. A
+  // mirror failing either reports zeros that read as figures.
+  if (!deepestSync || new Date(deepestSync.sinceDate) > scanStart) {
+    throw new MirrorCoverageError(
+      "The Stripe invoice mirror was never swept deep enough for this window — run stripe/bin/sync-stripe-invoices with a deeper window to backfill it.",
+    );
+  }
+  invariant(freshestSync, "a deepest sync means there is a freshest one");
+  if (
+    now.getTime() - new Date(freshestSync.completedAt).getTime() >
+    STALE_MIRROR_MS
+  ) {
+    throw new MirrorCoverageError(
+      `The Stripe invoice mirror has not been swept since ${freshestSync.completedAt} — the stripe-invoice-sync cron is not running.`,
     );
   }
 
-  const yearlyContracts = await getYearlyContracts(teams);
+  const rows = await StripeInvoice.query()
+    .whereIn("status", COUNTED_STATUSES)
+    .whereIn("billingReason", [
+      ...SUBSCRIPTION_BILLING_REASONS,
+      ...SALES_LED_BILLING_REASONS,
+    ])
+    .where("stripeCreatedAt", ">=", scanStart.toISOString())
+    .where("stripeCreatedAt", "<", end.toISOString());
 
-  // When each current annual contract began covering, so the months only skip
-  // a yearly customer's invoices from that instant on. A contract found but
-  // undatable skips everything, which is the conservative reading.
-  const yearlyContractStarts = new Map<string, number>();
-  for (const team of teams) {
-    if (team.interval !== "year") {
+  const customersWithTerms = getCustomersWithTerms(rows);
+
+  // The months, and the contracts, from the same read.
+  const monthSplits = reported.map(() => createSplit());
+  const monthTeams = reported.map(
+    () => new Map<string, StaffRevenueMonthTeam>(),
+  );
+  const yearlySplits = reported.map(() => createSplit());
+  const yearlyMonthCustomers = reported.map(() => new Set<string>());
+  const contractReads: ContractRead[] = [];
+
+  // A month is a calendar month for the bills raised in it, and only as long
+  // as it has been for the contracts spread over it: a contract's share of a
+  // month still filling has to be as partial as the invoices beside it, while
+  // a bill raised a second ago still belongs to the month it was raised in.
+  const monthBounds = reported.map((start, index) => ({
+    start: start.getTime(),
+    end: (reported[index + 1] ?? end).getTime(),
+  }));
+  const amortizeBounds = monthBounds.map((bound) => ({
+    start: bound.start,
+    end: Math.min(bound.end, now.getTime()),
+  }));
+
+  for (const row of rows) {
+    const team = teamCustomers.get(row.stripeCustomerId);
+    if (!team) {
       continue;
     }
-    const contract = yearlyContracts.find(
-      (candidate) =>
-        candidate.stripeSubscriptionId === team.stripeSubscriptionId,
+    const revenue = getInvoiceRevenue(row);
+    // A zero invoice — a usage month under the quota, the opening of a
+    // sales-created subscription — is not a team being invoiced.
+    if (revenue.amount === 0) {
+      continue;
+    }
+
+    const classified = classifyInvoice(row, {
+      customerHasTerm: customersWithTerms.has(row.stripeCustomerId),
+    });
+    if (classified.kind === "contract") {
+      contractReads.push({
+        row,
+        revenue,
+        coverage: classified.coverage,
+        isFullTerm:
+          classified.coverage.end - classified.coverage.start >=
+          ANNUAL_PERIOD_MS,
+      });
+      continue;
+    }
+
+    // A monthly bill belongs to the month it was raised in, and only the
+    // reported window holds months to raise it in.
+    const created = new Date(row.stripeCreatedAt).getTime();
+    if (created < first.getTime()) {
+      continue;
+    }
+    const index = monthBounds.findIndex(
+      (bound) => created >= bound.start && created < bound.end,
     );
-    const covered =
-      contract && contract.invoices.length > 0
-        ? Math.min(
-            ...contract.invoices.map(
-              (invoice) => getAmortizedCoverage(invoice).start,
-            ),
-          )
-        : Number.NEGATIVE_INFINITY;
-    yearlyContractStarts.set(team.stripeCustomerId, covered);
+    const split = monthSplits[index];
+    const teams = monthTeams[index];
+    if (!split || !teams) {
+      continue;
+    }
+    addToSplit(split, revenue);
+
+    // A team invoiced twice in one month is one team, one line deeper.
+    let teamRow = teams.get(row.stripeCustomerId);
+    if (!teamRow) {
+      teamRow = {
+        slug: team.slug,
+        name: team.name,
+        stripeCustomerId: row.stripeCustomerId,
+        amount: 0,
+        currency: revenue.currency,
+        revenue: 0,
+      };
+      teams.set(row.stripeCustomerId, teamRow);
+    }
+    teamRow.amount += revenue.amount;
+    if (teamRow.currency !== revenue.currency) {
+      // Mixed currencies make the original sum meaningless; the euro figure
+      // still holds.
+      teamRow.currency = null;
+    }
+    teamRow.revenue += toEuros(revenue);
   }
 
-  const totals = await readMonths({
-    starts: reported,
-    end,
-    teamCustomers,
-    yearlyContractStarts,
-  });
-  const yearlySplits = getYearlyMonthSplits(yearlyContracts, reported, end);
+  // Contracts, once their terms no longer overlap: spread each one over the
+  // months its money pays for, and remember what each contributes to the
+  // running month for the table to report.
+  const contracts = clipContractTerms(contractReads);
+  const runningIndex = reported.length - 1;
+  const monthlyByCustomer = new Map<string, number>();
+
+  for (const contract of contracts) {
+    const coveredMs = contract.coverage.end - contract.coverage.start;
+    if (coveredMs <= 0) {
+      continue;
+    }
+    for (const [index, bound] of amortizeBounds.entries()) {
+      const overlap =
+        Math.min(contract.coverage.end, bound.end) -
+        Math.max(contract.coverage.start, bound.start);
+      if (overlap <= 0) {
+        continue;
+      }
+      const split = yearlySplits[index];
+      const customers = yearlyMonthCustomers[index];
+      invariant(split && customers, "bounds and splits are built together");
+      const share = {
+        amount: (contract.revenue.amount * overlap) / coveredMs,
+        currency: contract.revenue.currency,
+      };
+      addToSplit(split, share);
+      customers.add(contract.row.stripeCustomerId);
+    }
+
+    // What the contract is worth over a whole month, which is what the table
+    // reports — the running month's own share is partial by design, and a
+    // contract's monthly worth is not.
+    const runningMonth = monthBounds[runningIndex];
+    invariant(runningMonth, "the running month is one of the reported ones");
+    const monthOverlap =
+      Math.min(contract.coverage.end, runningMonth.end) -
+      Math.max(contract.coverage.start, runningMonth.start);
+    if (monthOverlap > 0) {
+      monthlyByCustomer.set(
+        contract.row.stripeCustomerId,
+        (monthlyByCustomer.get(contract.row.stripeCustomerId) ?? 0) +
+          toEuros({
+            amount: (contract.revenue.amount * monthOverlap) / coveredMs,
+            currency: contract.revenue.currency,
+          }),
+      );
+    }
+  }
+
+  for (const [index, split] of yearlySplits.entries()) {
+    split.teamsCount = yearlyMonthCustomers[index]?.size ?? 0;
+  }
 
   const months = reported.map((start, index) => {
-    const total = totals[index];
+    const monthly = monthSplits[index];
     const yearly = yearlySplits[index];
-    invariant(total && yearly, "every month reported has totals");
+    const teams = monthTeams[index];
+    invariant(monthly && yearly && teams, "every month reported has totals");
+    monthly.teamsCount = teams.size;
     return {
       month: start,
-      revenue: total.split.revenue + yearly.revenue,
-      monthlyPlans: total.split,
-      teams: total.teams,
+      revenue: monthly.revenue + yearly.revenue,
+      monthlyPlans: monthly,
+      // Largest first: the breakdown is read to see who made the month.
+      teams: [...teams.values()].sort((a, b) => b.revenue - a.revenue),
       yearlyPlans: yearly,
     };
   });
 
   return {
     months,
-    yearlyContracts,
-    githubMarketplaceMonthlyRevenue: await getGithubMarketplaceMonthlyRevenue(),
+    yearlyContracts: buildYearlyContracts({
+      contracts,
+      teamCustomers,
+      billedTeams,
+      monthlyByCustomer,
+      now,
+    }),
+    githubMarketplaceMonthlyRevenue: marketplace,
   };
+}
+
+/**
+ * The contracts as the table lists them: the ones paying for today, plus the
+ * teams billed yearly whose contract could not be found at all — an anomaly
+ * the figures would otherwise hide, since a contract nobody can find simply
+ * contributes nothing.
+ */
+function buildYearlyContracts(options: {
+  contracts: ContractRead[];
+  teamCustomers: Map<string, TeamCustomer>;
+  billedTeams: BilledTeam[];
+  monthlyByCustomer: Map<string, number>;
+  now: Date;
+}): StaffYearlyContract[] {
+  const { contracts, teamCustomers, billedTeams, monthlyByCustomer, now } =
+    options;
+  const nowMs = now.getTime();
+  const inForce = contracts.filter(
+    (contract) =>
+      contract.coverage.start <= nowMs && nowMs < contract.coverage.end,
+  );
+
+  const rows: StaffYearlyContract[] = [];
+  for (const [customerId, reads] of Map.groupBy(
+    inForce,
+    (read) => read.row.stripeCustomerId,
+  )) {
+    const team = teamCustomers.get(customerId);
+    if (!team) {
+      continue;
+    }
+    const invoices = reads
+      .sort(
+        (a, b) =>
+          new Date(b.row.stripeCreatedAt).getTime() -
+          new Date(a.row.stripeCreatedAt).getTime(),
+      )
+      .map((read) => ({
+        amount: read.revenue.amount,
+        currency: read.revenue.currency,
+        invoicedAt: new Date(read.row.stripeCreatedAt),
+        coveredFrom: new Date(read.coverage.start),
+        coveredUntil: new Date(read.coverage.end),
+        awaitingPayment: read.row.status === "open",
+      }));
+
+    rows.push({
+      slug: team.slug,
+      name: team.name,
+      stripeCustomerId: customerId,
+      amount: reads.reduce((sum, read) => sum + toEuros(read.revenue), 0),
+      monthlyRevenue: monthlyByCustomer.get(customerId) ?? 0,
+      invoices,
+      awaitingPayment: invoices.every((invoice) => invoice.awaitingPayment),
+    });
+  }
+
+  // A team Argos bills yearly whose contract no invoice accounts for: listed
+  // with nothing, because that is what it contributes, and because the reason
+  // is always in Stripe rather than here.
+  const accounted = new Set(rows.map((row) => row.stripeCustomerId));
+  for (const team of billedTeams) {
+    if (team.interval !== "year" || accounted.has(team.stripeCustomerId)) {
+      continue;
+    }
+    rows.push({
+      slug: team.slug,
+      name: team.name,
+      stripeCustomerId: team.stripeCustomerId,
+      amount: null,
+      monthlyRevenue: 0,
+      invoices: [],
+      awaitingPayment: false,
+    });
+  }
+
+  // Largest first, the contracts nothing accounts for last: the list reads as
+  // the figures' makeup, and an anomaly is what to end on.
+  return rows.sort((a, b) => {
+    if (a.amount === null) {
+      return b.amount === null ? 0 : 1;
+    }
+    if (b.amount === null) {
+      return -1;
+    }
+    return b.amount - a.amount;
+  });
 }

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -84,6 +84,12 @@ async function getGithubMarketplaceMonthlyRevenue(): Promise<number> {
   const rows = (await Subscription.query()
     .select("subscriptions.accountId", "plan.githubMonthlyPriceCents")
     .joinRelated("plan")
+    .join("accounts", "accounts.id", "subscriptions.accountId")
+    // The same book the Stripe figures read: teams, and none Argos granted a
+    // plan to rather than bills.
+    .whereNotNull("accounts.teamId")
+    .whereNull("accounts.userId")
+    .whereNull("accounts.forcedPlanId")
     .where("subscriptions.provider", "github")
     .whereNotNull("plan.githubMonthlyPriceCents")
     .whereRaw("?? < now()", "subscriptions.startDate")
@@ -464,23 +470,23 @@ export function classifyInvoice(
       : { kind: "contract", coverage: yearFrom(issued) };
   }
 
+  // Longer than a month, whatever raised it: an upgrade prorated to the end of
+  // a term arrives as a `subscription_update` covering the months that remain,
+  // and belongs to them rather than to the day it was raised.
+  if (period && period.end - period.start > MONTHLY_PERIOD_MS) {
+    return {
+      kind: "contract",
+      coverage: period.end > issued ? period : yearFrom(issued),
+    };
+  }
+
   const isSalesLed =
     invoice.billingReason !== null &&
     SALES_LED_BILLING_REASONS.has(invoice.billingReason);
-  if (isSalesLed) {
-    if (!period) {
-      return options.customerHasTerm
-        ? { kind: "contract", coverage: yearFrom(issued) }
-        : { kind: "monthly" };
-    }
-    // Sold as a block rather than billed for a month — an upsell covering the
-    // stretch from its sale to the term's renewal date.
-    if (period.end - period.start > MONTHLY_PERIOD_MS) {
-      return {
-        kind: "contract",
-        coverage: period.end > issued ? period : yearFrom(issued),
-      };
-    }
+  if (isSalesLed && !period) {
+    return options.customerHasTerm
+      ? { kind: "contract", coverage: yearFrom(issued) }
+      : { kind: "monthly" };
   }
   return { kind: "monthly" };
 }
@@ -516,6 +522,13 @@ type ContractRead = {
   row: StripeInvoice;
   revenue: InvoiceRevenue;
   coverage: { start: number; end: number };
+  /**
+   * The stretch the invoice was raised for, before the next bill clipped it.
+   *
+   * What the money is spread at: an invoice pays for its own term at its own
+   * rate, so a term cut short delivers less rather than the same amount faster.
+   */
+  termMs: number;
   /** A full term supersedes the one before it; a shorter one adds to it. */
   isFullTerm: boolean;
 };
@@ -674,13 +687,13 @@ export async function getStaffRevenue(
       customerHasTerm: customersWithTerms.has(row.stripeCustomerId),
     });
     if (classified.kind === "contract") {
+      const termMs = classified.coverage.end - classified.coverage.start;
       contractReads.push({
         row,
         revenue,
         coverage: classified.coverage,
-        isFullTerm:
-          classified.coverage.end - classified.coverage.start >=
-          ANNUAL_PERIOD_MS,
+        termMs,
+        isFullTerm: termMs >= ANNUAL_PERIOD_MS,
       });
       continue;
     }
@@ -733,8 +746,8 @@ export async function getStaffRevenue(
   const monthlyByCustomer = new Map<string, number>();
 
   for (const contract of contracts) {
-    const coveredMs = contract.coverage.end - contract.coverage.start;
-    if (coveredMs <= 0) {
+    const coveredMs = contract.termMs;
+    if (coveredMs <= 0 || contract.coverage.end <= contract.coverage.start) {
       continue;
     }
     for (const [index, bound] of amortizeBounds.entries()) {
@@ -867,7 +880,9 @@ function buildYearlyContracts(options: {
       amount: reads.reduce((sum, read) => sum + toEuros(read.revenue), 0),
       monthlyRevenue: monthlyByCustomer.get(customerId) ?? 0,
       invoices,
-      awaitingPayment: invoices.every((invoice) => invoice.awaitingPayment),
+      // Any of them, not all: the unpaid renewal beside a settled upsell is
+      // exactly the one whose collection is worth watching.
+      awaitingPayment: invoices.some((invoice) => invoice.awaitingPayment),
     });
   }
 

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -142,6 +142,7 @@ async function getMarketplaceSubscriptions(): Promise<
 function getMarketplaceMonthRevenue(
   subscriptions: MarketplaceSubscription[],
   month: { start: number; end: number },
+  elapsed: { start: number; end: number },
 ): StaffRevenueSplit {
   const split = createSplit();
   const byAccount = new Map<string, number>();
@@ -173,8 +174,11 @@ function getMarketplaceMonthRevenue(
     );
   }
 
+  // A month bills its subscriptions once, so what a month still running has
+  // earned is the share of it that has gone by.
+  const share = (elapsed.end - elapsed.start) / (month.end - month.start) || 0;
   for (const cents of byAccount.values()) {
-    addToSplit(split, { amount: cents / 100, currency: "usd" });
+    addToSplit(split, { amount: (cents / 100) * share, currency: "usd" });
   }
   split.teamsCount = byAccount.size;
   return split;
@@ -388,9 +392,10 @@ export function getInvoiceRevenue(invoice: {
 }
 
 /**
- * An invoice's contribution in euros: dollars at the fixed rate, euros as
- * they are. A currency this page does not know stays at parity — and lands in
- * the foreign share, so the caveat covers it either way.
+ * An invoice's contribution in euros: dollars at the fixed rate, euros as they
+ * are. Stripe raises them in one or the other and never anything else; a third
+ * currency would land at parity and in the foreign share, where the caveat on
+ * screen would at least point at it.
  */
 export function toEuros(revenue: InvoiceRevenue): number {
   return revenue.currency === "usd"
@@ -457,7 +462,7 @@ type StaffYearlyContract = {
   monthlyRevenue: number;
   /** The invoices it is worth, newest first. */
   invoices: StaffContractInvoice[];
-  /** True when every invoice found is still awaiting payment. */
+  /** True when any invoice found is still awaiting payment. */
   awaitingPayment: boolean;
 };
 
@@ -547,7 +552,12 @@ export function classifyInvoice(
   if (period && period.end - period.start > MONTHLY_PERIOD_MS) {
     return {
       kind: "contract",
-      coverage: period.end > issued ? period : yearFrom(issued),
+      // Stamped in arrears — its period ends by the day it was raised — reads
+      // as collecting for the stretch ahead rather than paying for one over.
+      // The same stretch, not a year: a quarter billed late is a quarter, and
+      // stretching it to a year would let it supersede the contract it sits
+      // inside.
+      coverage: period.end > issued ? period : shiftForward(period, issued),
     };
   }
 
@@ -579,6 +589,14 @@ function getCustomersWithTerms(
     }
   }
   return customers;
+}
+
+/** The same stretch, starting when the invoice was raised. */
+function shiftForward(
+  period: { start: number; end: number },
+  issued: number,
+): { start: number; end: number } {
+  return { start: issued, end: issued + (period.end - period.start) };
 }
 
 /** A year from `issued`, for a contract invoice that states no usable one. */
@@ -748,12 +766,6 @@ export async function getStaffRevenue(
       continue;
     }
     const revenue = getInvoiceRevenue(row);
-    // A zero invoice — a usage month under the quota, the opening of a
-    // sales-created subscription — is not a team being invoiced.
-    if (revenue.amount === 0) {
-      continue;
-    }
-
     const classified = classifyInvoice(row, {
       customerHasTerm: customersWithTerms.has(row.stripeCustomerId),
     });
@@ -769,6 +781,15 @@ export async function getStaffRevenue(
       continue;
     }
 
+    // A zero invoice — a usage month under the quota, the opening of a
+    // sales-created subscription — is not a team being invoiced. Only the
+    // monthly side drops it: a contract fully discounted or fully credited is
+    // worth nothing, which is a figure, where dropping it would report the
+    // team as having no contract anyone could find.
+    if (revenue.amount === 0) {
+      continue;
+    }
+
     // A monthly bill belongs to the month it was raised in, and only the
     // reported window holds months to raise it in.
     const created = new Date(row.stripeCreatedAt).getTime();
@@ -780,9 +801,7 @@ export async function getStaffRevenue(
     );
     const split = monthSplits[index];
     const teams = monthTeams[index];
-    if (!split || !teams) {
-      continue;
-    }
+    invariant(split && teams, "the query bounds every row to a reported month");
     addToSplit(split, revenue);
 
     // A team invoiced twice in one month is one team, one line deeper.
@@ -858,7 +877,9 @@ export async function getStaffRevenue(
   }
 
   for (const [index, split] of yearlySplits.entries()) {
-    split.teamsCount = yearlyMonthCustomers[index]?.size ?? 0;
+    const customers = yearlyMonthCustomers[index];
+    invariant(customers, "splits and customers are built together");
+    split.teamsCount = customers.size;
   }
 
   const months = reported.map((start, index) => {
@@ -876,7 +897,13 @@ export async function getStaffRevenue(
       // Largest first: the breakdown is read to see who made the month.
       teams: [...teams.values()].sort((a, b) => b.revenue - a.revenue),
       yearlyPlans: yearly,
-      githubPlans: getMarketplaceMonthRevenue(marketplaceSubscriptions, bound),
+      githubPlans: getMarketplaceMonthRevenue(
+        marketplaceSubscriptions,
+        bound,
+        // As much of the month as has gone by, so the running month's
+        // marketplace band is as partial as the two beside it.
+        amortizeBounds[index] ?? bound,
+      ),
     };
   });
 

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -24,7 +24,7 @@ type StaffRevenueSplit = {
 };
 
 /** What Argos billed over one calendar month. */
-export type StaffRevenueMonth = {
+type StaffRevenueMonth = {
   /** The first instant of the month, in UTC — what names it on screen. */
   month: Date;
   /** The two splits below, added up. */
@@ -95,16 +95,28 @@ const SUBSCRIPTION_BILLING_REASONS = new Set<Stripe.Invoice.BillingReason>([
 ]);
 
 /**
- * The reasons a renewal is raised under, which is the only invoice worth
- * dividing by twelve.
+ * A line covering at least this long reads as a year's bill.
  *
- * Narrower than the set above on purpose: a mid-year proration is real revenue
- * for the month it lands in, but a twelfth of it is not what the contract is
- * worth per month.
+ * Under a full year on purpose: an annual invoice raised a few weeks into the
+ * period it covers, or prorated at conversion, still has to read as the
+ * contract — where a monthly cycle or a one-month true-up never comes close.
  */
-const RENEWAL_BILLING_REASONS = new Set<Stripe.Invoice.BillingReason>([
-  "subscription_create",
-  "subscription_cycle",
+const ANNUAL_PERIOD_SECONDS = 300 * 24 * 3600;
+
+/** A day, under which a line's period is a bookkeeping point, not coverage. */
+const DAY_SECONDS = 24 * 3600;
+
+/**
+ * The reasons an invoice is raised by a person rather than by a billing cycle.
+ *
+ * Sales-led contracts are billed this way — a dashboard invoice or an accepted
+ * quote, often carried by no subscription at all — and their line periods are
+ * frequently missing or degenerate, so they cannot be recognized by coverage
+ * the way cycle invoices can.
+ */
+const SALES_LED_BILLING_REASONS = new Set<Stripe.Invoice.BillingReason>([
+  "manual",
+  "quote_accept",
 ]);
 
 /** The placeholder the config falls back to when no key is configured. */
@@ -113,6 +125,8 @@ const MISSING_API_KEY = "no-api-key";
 /** A team Argos bills through Stripe, and how it is billed. */
 type BilledTeam = {
   accountId: string;
+  slug: string;
+  name: string | null;
   stripeCustomerId: string;
   stripeSubscriptionId: string;
   interval: "month" | "year";
@@ -135,6 +149,8 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
     .select(
       "subscriptions.accountId",
       "subscriptions.stripeSubscriptionId",
+      "accounts.slug",
+      "accounts.name",
       "accounts.stripeCustomerId",
       "plan.interval",
     )
@@ -160,6 +176,8 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
     .orderBy("subscriptions.accountId")
     .orderBy("plan.includedScreenshots", "DESC")) as unknown as {
     accountId: string | number;
+    slug: string;
+    name: string | null;
     stripeSubscriptionId: string;
     stripeCustomerId: string;
     interval: "month" | "year";
@@ -167,6 +185,8 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
 
   return rows.map((row) => ({
     accountId: String(row.accountId),
+    slug: row.slug,
+    name: row.name,
     stripeSubscriptionId: row.stripeSubscriptionId,
     stripeCustomerId: row.stripeCustomerId,
     interval: row.interval,
@@ -292,51 +312,232 @@ async function mapWithLimit<Item, Result>(
   return results;
 }
 
-/**
- * What the annual contracts in force are worth per month.
- *
- * One small request per annual team rather than a year of invoices for
- * everyone: an annual subscription renews once a year, so its latest renewal is
- * what it is worth now.
- *
- * Listed by subscription and narrowed to a renewal, not simply the customer's
- * latest paid invoice: an add-on bought mid-year is the most recent invoice a
- * customer paid, and a twelfth of it would replace the contract's own amount
- * with a rounding error.
- *
- * A contract whose first renewal has not been paid yet counts nothing — it has
- * been invoiced nothing, which is what this reports.
- */
-async function getYearlyRate(teams: BilledTeam[]): Promise<StaffRevenueSplit> {
-  const yearlyTeams = teams.filter((team) => team.interval === "year");
-  const split = createSplit();
+/** One invoice a contract's worth is read from. */
+type StaffContractInvoice = {
+  /** Net of tax and credit notes, in the currency's main unit. */
+  amount: number;
+  /** The currency it was raised in, counted at parity when not USD. */
+  currency: string;
+  /** When it was raised. */
+  invoicedAt: Date;
+  /** The stretch it covers, when it states a real one. */
+  coveredFrom: Date | null;
+  coveredUntil: Date | null;
+};
 
-  const invoices = await mapWithLimit(yearlyTeams, async (team) => {
-    // A handful rather than one: the latest invoice on a subscription can be a
-    // proration, and the renewal is the one behind it.
-    const page = await stripe.invoices.list({
-      subscription: team.stripeSubscriptionId,
-      status: "paid",
-      limit: 10,
-    });
+/** One annual contract in force, and the invoices its rate is read from. */
+type StaffYearlyContract = {
+  /** The team's slug, which names its pages. */
+  slug: string;
+  /** The team's display name, when it has one. */
+  name: string | null;
+  /** The subscription the database knows the contract by. */
+  stripeSubscriptionId: string;
+  /**
+   * The invoices below, added up. Null when none was found, in which case the
+   * contract adds nothing to the rate.
+   */
+  amount: number | null;
+  /** The invoices the contract is worth, newest first. */
+  invoices: StaffContractInvoice[];
+  /**
+   * True when the invoices found are still awaiting payment. Shown, so a
+   * contract in collection is visible, but counted nothing until they clear.
+   */
+  awaitingPayment: boolean;
+};
+
+/** The parts of an invoice the contract picker reads. */
+export type ContractInvoiceCandidate = {
+  billing_reason: Stripe.Invoice.BillingReason | null;
+  total: number;
+  lines: { data: { period: { start: number; end: number } }[] };
+};
+
+/** The longest stretch one of the invoice's lines covers, or null. */
+function getCoveredPeriod(
+  invoice: ContractInvoiceCandidate,
+): { start: number; end: number } | null {
+  let longest: { start: number; end: number } | null = null;
+  for (const line of invoice.lines.data) {
+    if (
+      !longest ||
+      line.period.end - line.period.start > longest.end - longest.start
+    ) {
+      longest = line.period;
+    }
+  }
+  // A period under a day is a bookkeeping point, not coverage.
+  return longest && longest.end - longest.start >= DAY_SECONDS ? longest : null;
+}
+
+/** Whether an invoice reads as a contract being billed. */
+function isContractInvoice(invoice: ContractInvoiceCandidate): boolean {
+  if (invoice.total === 0) {
+    // Subscriptions opened by sales to carry a contract start on a zero
+    // invoice; the money is on an invoice of its own.
+    return false;
+  }
+  const period = getCoveredPeriod(invoice);
+  return (
+    (period !== null && period.end - period.start >= ANNUAL_PERIOD_SECONDS) ||
+    (invoice.billing_reason !== null &&
+      SALES_LED_BILLING_REASONS.has(invoice.billing_reason))
+  );
+}
+
+/**
+ * The invoices a contract's worth is read from, among the customer's invoices,
+ * newest first.
+ *
+ * A contract invoice is one that covers about a year — a renewal, a first
+ * year, or a mid-stream conversion, whatever Stripe filed it under — or a
+ * sales-led invoice, whose periods cannot be trusted. Anything else — monthly
+ * cycles from before a conversion, prorations, true-ups — is real revenue but
+ * not what the contract is worth.
+ *
+ * The newest year-spanning bill anchors the contract, and the sales-led
+ * invoices raised on top of it since are read by their period: one covering a
+ * real partial stretch is an upsell, added to the anchor; one with no readable
+ * coverage re-bills the whole contract and replaces it. Upsells older than the
+ * anchor are dropped — a renewal bakes them in. With no year-spanning bill at
+ * all, the newest sales-led invoice is the contract.
+ */
+export function findContractInvoices<Invoice extends ContractInvoiceCandidate>(
+  invoices: Invoice[],
+): Invoice[] {
+  const contracts = invoices.filter(isContractInvoice);
+
+  const annualIndex = contracts.findIndex((invoice) => {
+    const period = getCoveredPeriod(invoice);
     return (
-      page.data.find(
-        (invoice) =>
-          invoice.billing_reason !== null &&
-          RENEWAL_BILLING_REASONS.has(invoice.billing_reason),
-      ) ?? null
+      period !== null && period.end - period.start >= ANNUAL_PERIOD_SECONDS
     );
   });
+  if (annualIndex === -1) {
+    const newest = contracts[0];
+    return newest ? [newest] : [];
+  }
 
-  for (const invoice of invoices) {
-    if (!invoice) {
+  const newerThanAnnual = contracts.slice(0, annualIndex);
+  const replacement = newerThanAnnual.find(
+    (invoice) => getCoveredPeriod(invoice) === null,
+  );
+  if (replacement) {
+    return [replacement];
+  }
+
+  const annual = contracts[annualIndex];
+  invariant(annual, "the index was just found");
+  return [...newerThanAnnual, annual];
+}
+
+/**
+ * One page is all a lookup reads — a hundred invoices of history is years for
+ * any real customer.
+ */
+const INVOICES_PER_CONTRACT_LOOKUP = 100;
+
+/**
+ * The annual contracts in force, each with the invoices it is worth.
+ *
+ * One request per annual team rather than a year of invoices for everyone: an
+ * annual contract is billed a handful of times a year at most, so its latest
+ * contract invoices are what it is worth now.
+ *
+ * Listed by customer, not by subscription: an annual deal is not always billed
+ * through the subscription the database knows. Sales-led contracts arrive as
+ * dashboard or quote invoices carried by no subscription at all, and a team
+ * converted to yearly mid-stream holds its contract on a `subscription_update`
+ * of the old subscription — a subscription lookup misses both.
+ *
+ * A contract with no paid invoice may still have been billed — enterprise
+ * terms run long — so the open invoices are read before concluding nothing,
+ * and reported as awaiting payment. A contract with no invoice at all counts
+ * nothing, which is what this reports — but it is still listed, so a contract
+ * absent from the figure can be seen rather than guessed at.
+ */
+async function getYearlyContracts(
+  teams: BilledTeam[],
+): Promise<StaffYearlyContract[]> {
+  const yearlyTeams = teams.filter((team) => team.interval === "year");
+
+  const contracts = await mapWithLimit(yearlyTeams, async (team) => {
+    const paid = await stripe.invoices.list({
+      customer: team.stripeCustomerId,
+      status: "paid",
+      limit: INVOICES_PER_CONTRACT_LOOKUP,
+    });
+    let awaitingPayment = false;
+    let found = findContractInvoices(paid.data);
+    if (found.length === 0) {
+      const open = await stripe.invoices.list({
+        customer: team.stripeCustomerId,
+        status: "open",
+        limit: INVOICES_PER_CONTRACT_LOOKUP,
+      });
+      found = findContractInvoices(open.data);
+      awaitingPayment = found.length > 0;
+    }
+
+    const invoices = found.map((invoice) => {
+      const revenue = getInvoiceRevenue(invoice);
+      const covered = getCoveredPeriod(invoice);
+      return {
+        amount: revenue.amount,
+        currency: revenue.currency,
+        // Stripe timestamps in whole seconds.
+        invoicedAt: new Date(invoice.created * 1000),
+        coveredFrom: covered ? new Date(covered.start * 1000) : null,
+        coveredUntil: covered ? new Date(covered.end * 1000) : null,
+      };
+    });
+
+    return {
+      slug: team.slug,
+      name: team.name,
+      stripeSubscriptionId: team.stripeSubscriptionId,
+      amount:
+        invoices.length > 0
+          ? invoices.reduce((sum, invoice) => sum + invoice.amount, 0)
+          : null,
+      invoices,
+      awaitingPayment,
+    };
+  });
+
+  // Largest first, the contracts with no invoice found last: the list reads as
+  // the rate's makeup, and a contract adding nothing is the anomaly to end on.
+  return contracts.sort((a, b) => {
+    if (a.amount === null) {
+      return b.amount === null ? 0 : 1;
+    }
+    if (b.amount === null) {
+      return -1;
+    }
+    return b.amount - a.amount;
+  });
+}
+
+/**
+ * What the annual contracts in force are worth per month: each contract's
+ * invoices over twelve, added up.
+ */
+function getYearlyRate(contracts: StaffYearlyContract[]): StaffRevenueSplit {
+  const split = createSplit();
+
+  for (const contract of contracts) {
+    if (contract.invoices.length === 0 || contract.awaitingPayment) {
       continue;
     }
-    const revenue = getInvoiceRevenue(invoice);
-    addToSplit(split, {
-      amount: revenue.amount / MONTHS_PER_YEAR,
-      currency: revenue.currency,
-    });
+    // Invoice by invoice rather than off the summed amount, so a contract
+    // partly billed in another currency keeps that part in the parity caveat.
+    for (const invoice of contract.invoices) {
+      addToSplit(split, {
+        amount: invoice.amount / MONTHS_PER_YEAR,
+        currency: invoice.currency,
+      });
+    }
     split.teamsCount += 1;
   }
 
@@ -406,9 +607,18 @@ async function readMonth(options: {
   return split;
 }
 
+/** What Argos invoiced, and the annual contracts behind the yearly rate. */
+export type StaffRevenue = {
+  /** Oldest first, the running month last. */
+  months: StaffRevenueMonth[];
+  /** The contracts behind every month's `yearlyPlans`, largest first. */
+  yearlyContracts: StaffYearlyContract[];
+};
+
 /**
- * What Argos invoiced over the last `monthCount` calendar months, oldest first
- * and the running one last.
+ * What Argos invoiced over the last `monthCount` calendar months, along with
+ * the annual contracts the yearly rate is made of — one read serving both, so
+ * the list always explains the figure it came with.
  *
  * Asked of Stripe on every call rather than mirrored into a table or held in a
  * cache: the invoices are the answer, they change behind us as they are paid,
@@ -416,7 +626,7 @@ async function readMonth(options: {
  */
 export async function getStaffRevenue(
   monthCount: number,
-): Promise<StaffRevenueMonth[]> {
+): Promise<StaffRevenue> {
   invariant(
     monthCount >= 1 && monthCount <= MAX_MONTHS,
     `monthCount must be between 1 and ${MAX_MONTHS}`,
@@ -446,8 +656,8 @@ export async function getStaffRevenue(
   );
 
   const reported = starts.slice(0, monthCount);
-  const [yearlyRate, totals] = await Promise.all([
-    getYearlyRate(teams),
+  const [yearlyContracts, totals] = await Promise.all([
+    getYearlyContracts(teams),
     mapWithLimit(
       reported.map((from, index) => {
         const to = starts[index + 1];
@@ -457,8 +667,9 @@ export async function getStaffRevenue(
       (window) => readMonth({ ...window, teamCustomerIds, yearlyCustomerIds }),
     ),
   ]);
+  const yearlyRate = getYearlyRate(yearlyContracts);
 
-  return reported.map((start, index) => {
+  const months = reported.map((start, index) => {
     const month = createMonth(start);
     const total = totals[index];
     invariant(total, "every month reported has totals");
@@ -469,4 +680,6 @@ export async function getStaffRevenue(
     month.revenue = total.revenue + yearlyRate.revenue;
     return month;
   });
+
+  return { months, yearlyContracts };
 }

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -1,10 +1,6 @@
 import { invariant } from "@argos/util/invariant";
-import type Stripe from "stripe";
 
-import config from "@/config";
-import { Account, Subscription } from "@/database/models";
-
-import { stripe } from "./index";
+import { Account, StripeInvoice, Subscription } from "@/database/models";
 
 /** What the teams on one billing interval contributed to a month. */
 type StaffRevenueSplit = {
@@ -58,38 +54,11 @@ type StaffRevenueMonth = {
   yearlyPlans: StaffRevenueSplit;
 };
 
-/**
- * Upper bound on the window one call will read.
- *
- * Every month is a walk of its own, so the cost grows with the count asked for.
- */
+/** Upper bound on the window one call will read. */
 export const MAX_MONTHS = 24;
-
-/**
- * Upper bound on the invoices one month's walk will read.
- *
- * Reached means a month holds more than this service can read in the time a
- * page will wait, and the answer is to stop reading Stripe on every request —
- * not to report the total of however many invoices happened to fit, which would
- * read as a complete figure while silently missing the rest.
- */
-const MAX_INVOICES_PER_MONTH = 2000;
-
-/** Page size, which is also Stripe's maximum. */
-const PAGE_SIZE = 100;
 
 /** Months a yearly contract is spread over. */
 const MONTHS_PER_YEAR = 12;
-
-/**
- * Requests in flight at once.
- *
- * The months and the annual contracts are all independent, so nothing here
- * needs to wait — but Stripe rate-limits per account and the client is built
- * without retries, so an unbounded fan-out turns a wide account into a 429 that
- * fails the whole page.
- */
-const MAX_CONCURRENT_REQUESTS = 8;
 
 /** The currency every amount on this page is stated in. */
 const REPORTING_CURRENCY = "eur";
@@ -118,13 +87,13 @@ const GITHUB_MARKETPLACE_MONTHLY_USD = 1540;
  * Why Stripe raised an invoice, for the ones that are a subscription being
  * billed.
  *
- * Not the whole story for the monthly walk: the odd legacy or partner deal is
- * billed by hand, month after month, and those invoices carry the sales-led
- * reasons below instead. The walk takes both; what stays out is `upcoming` —
+ * Not the whole story for the monthly figures: the odd legacy or partner deal
+ * is billed by hand, month after month, and those invoices carry the sales-led
+ * reasons below instead. The reader takes both; what stays out is `upcoming` —
  * a preview, not an invoice — and pending-item sweeps, which duplicate what
  * the cycle will bill.
  */
-const SUBSCRIPTION_BILLING_REASONS = new Set<Stripe.Invoice.BillingReason>([
+const SUBSCRIPTION_BILLING_REASONS = new Set<string>([
   "subscription",
   "subscription_create",
   "subscription_cycle",
@@ -133,33 +102,27 @@ const SUBSCRIPTION_BILLING_REASONS = new Set<Stripe.Invoice.BillingReason>([
 ]);
 
 /**
- * A line covering at least this long reads as a year's bill.
+ * A period covering at least this long reads as a year's bill.
  *
  * Under a full year on purpose: an annual invoice raised a few weeks into the
  * period it covers, or prorated at conversion, still has to read as the
  * contract — where a monthly cycle or a one-month true-up never comes close.
  */
-const ANNUAL_PERIOD_SECONDS = 300 * 24 * 3600;
+const ANNUAL_PERIOD_MS = 300 * 24 * 3600 * 1000;
 
-/** A day, under which a line's period is a bookkeeping point, not coverage. */
-const DAY_SECONDS = 24 * 3600;
+/** A day, under which a period is a bookkeeping point, not coverage. */
+const DAY_MS = 24 * 3600 * 1000;
 
 /**
  * The reasons an invoice is raised by a person rather than by a billing cycle.
  *
  * Sales-led deals are billed this way — a dashboard invoice or an accepted
  * quote, often carried by no subscription at all — whether the deal is an
- * annual contract or a legacy team invoiced by hand every month. Their line
+ * annual contract or a legacy team invoiced by hand every month. Their
  * periods are frequently missing or degenerate, so they cannot be recognized
  * by coverage the way cycle invoices can.
  */
-const SALES_LED_BILLING_REASONS = new Set<Stripe.Invoice.BillingReason>([
-  "manual",
-  "quote_accept",
-]);
-
-/** The placeholder the config falls back to when no key is configured. */
-const MISSING_API_KEY = "no-api-key";
+const SALES_LED_BILLING_REASONS = new Set<string>(["manual", "quote_accept"]);
 
 /** A team Argos bills through Stripe, and how it is billed. */
 type BilledTeam = {
@@ -271,7 +234,8 @@ export async function getTeamCustomers(): Promise<Map<string, TeamCustomer>> {
 export type InvoiceRevenue = { amount: number; currency: string };
 
 /**
- * What one invoice contributed to revenue, in the currency's main unit.
+ * What one mirrored invoice contributed to revenue, in the currency's main
+ * unit.
  *
  * Excluding tax, because VAT collected on behalf of a state is not revenue, and
  * net of credit notes, because an invoice refunded after the fact keeps its
@@ -281,24 +245,22 @@ export type InvoiceRevenue = { amount: number; currency: string };
 export function getInvoiceRevenue(invoice: {
   currency: string;
   total: number;
-  total_excluding_tax: number | null;
-  /** Only the amounts are read, so the rest of Stripe's shape is not asked for. */
-  total_taxes: { amount: number }[] | null;
-  pre_payment_credit_notes_amount: number;
-  post_payment_credit_notes_amount: number;
+  totalExcludingTax: number | null;
+  /** The listed taxes added up — the fallback when no pre-tax total exists. */
+  totalTaxesAmount: number | null;
+  prePaymentCreditNotesAmount: number;
+  postPaymentCreditNotesAmount: number;
 }): InvoiceRevenue {
-  // Null on invoices Stripe states no pre-tax total for. The taxes it lists are
-  // taken off the total instead, rather than letting the tax through as
+  // Null on invoices Stripe states no pre-tax total for. The taxes it listed
+  // are taken off the total instead, rather than letting the tax through as
   // revenue — falling back to `total` alone would overstate every invoice that
   // collected VAT, and say nothing about it.
   const excludingTax =
-    invoice.total_excluding_tax ??
-    invoice.total -
-      (invoice.total_taxes ?? []).reduce((sum, tax) => sum + tax.amount, 0);
+    invoice.totalExcludingTax ??
+    invoice.total - (invoice.totalTaxesAmount ?? 0);
 
   const credited =
-    invoice.pre_payment_credit_notes_amount +
-    invoice.post_payment_credit_notes_amount;
+    invoice.prePaymentCreditNotesAmount + invoice.postPaymentCreditNotesAmount;
 
   return {
     // Stripe states amounts in the currency's minor unit.
@@ -322,16 +284,6 @@ function createSplit(): StaffRevenueSplit {
   return { revenue: 0, teamsCount: 0, foreignRevenue: 0 };
 }
 
-function createMonth(month: Date): StaffRevenueMonth {
-  return {
-    month,
-    revenue: 0,
-    monthlyPlans: createSplit(),
-    teams: [],
-    yearlyPlans: createSplit(),
-  };
-}
-
 /** Add one invoice to a split, in euros, tracking what was converted. */
 function addToSplit(split: StaffRevenueSplit, revenue: InvoiceRevenue): void {
   const amount = toEuros(revenue);
@@ -353,29 +305,6 @@ export function startOfUTCMonth(date: Date, offset: number): Date {
   return new Date(
     Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + offset, 1),
   );
-}
-
-/** Run `work` over `items`, never more than `MAX_CONCURRENT_REQUESTS` at once. */
-async function mapWithLimit<Item, Result>(
-  items: Item[],
-  work: (item: Item) => Promise<Result>,
-): Promise<Result[]> {
-  const results: Result[] = Array.from({ length: items.length });
-  let next = 0;
-
-  const runners = Array.from(
-    { length: Math.min(MAX_CONCURRENT_REQUESTS, items.length) },
-    async () => {
-      for (let index = next++; index < items.length; index = next++) {
-        const item = items[index];
-        invariant(item !== undefined, "index is inside the list");
-        results[index] = await work(item);
-      }
-    },
-  );
-
-  await Promise.all(runners);
-  return results;
 }
 
 /** One invoice a contract's worth is read from. */
@@ -414,28 +343,28 @@ type StaffYearlyContract = {
   awaitingPayment: boolean;
 };
 
-/** The parts of an invoice the contract picker reads. */
+/**
+ * The parts of a mirrored invoice the contract picker reads. The period is the
+ * longest stretch one of the invoice's lines covered, resolved at ingest.
+ */
 export type ContractInvoiceCandidate = {
-  billing_reason: Stripe.Invoice.BillingReason | null;
+  billingReason: string | null;
   total: number;
-  lines: { data: { period: { start: number; end: number } }[] };
+  periodStart: string | null;
+  periodEnd: string | null;
 };
 
-/** The longest stretch one of the invoice's lines covers, or null. */
+/** The stretch an invoice covers, in epoch milliseconds, or null. */
 function getCoveredPeriod(
   invoice: ContractInvoiceCandidate,
 ): { start: number; end: number } | null {
-  let longest: { start: number; end: number } | null = null;
-  for (const line of invoice.lines.data) {
-    if (
-      !longest ||
-      line.period.end - line.period.start > longest.end - longest.start
-    ) {
-      longest = line.period;
-    }
+  if (invoice.periodStart === null || invoice.periodEnd === null) {
+    return null;
   }
+  const start = new Date(invoice.periodStart).getTime();
+  const end = new Date(invoice.periodEnd).getTime();
   // A period under a day is a bookkeeping point, not coverage.
-  return longest && longest.end - longest.start >= DAY_SECONDS ? longest : null;
+  return end - start >= DAY_MS ? { start, end } : null;
 }
 
 /** Whether an invoice reads as a contract being billed. */
@@ -447,9 +376,9 @@ function isContractInvoice(invoice: ContractInvoiceCandidate): boolean {
   }
   const period = getCoveredPeriod(invoice);
   return (
-    (period !== null && period.end - period.start >= ANNUAL_PERIOD_SECONDS) ||
-    (invoice.billing_reason !== null &&
-      SALES_LED_BILLING_REASONS.has(invoice.billing_reason))
+    (period !== null && period.end - period.start >= ANNUAL_PERIOD_MS) ||
+    (invoice.billingReason !== null &&
+      SALES_LED_BILLING_REASONS.has(invoice.billingReason))
   );
 }
 
@@ -477,9 +406,7 @@ export function findContractInvoices<Invoice extends ContractInvoiceCandidate>(
 
   const annualIndex = contracts.findIndex((invoice) => {
     const period = getCoveredPeriod(invoice);
-    return (
-      period !== null && period.end - period.start >= ANNUAL_PERIOD_SECONDS
-    );
+    return period !== null && period.end - period.start >= ANNUAL_PERIOD_MS;
   });
   if (annualIndex === -1) {
     const newest = contracts[0];
@@ -500,19 +427,9 @@ export function findContractInvoices<Invoice extends ContractInvoiceCandidate>(
 }
 
 /**
- * One page is all a lookup reads — a hundred invoices of history is years for
- * any real customer.
- */
-const INVOICES_PER_CONTRACT_LOOKUP = 100;
-
-/**
  * The annual contracts in force, each with the invoices it is worth.
  *
- * One request per annual team rather than a year of invoices for everyone: an
- * annual contract is billed a handful of times a year at most, so its latest
- * contract invoices are what it is worth now.
- *
- * Listed by customer, not by subscription: an annual deal is not always billed
+ * Read by customer, not by subscription: an annual deal is not always billed
  * through the subscription the database knows. Sales-led contracts arrive as
  * dashboard or quote invoices carried by no subscription at all, and a team
  * converted to yearly mid-stream holds its contract on a `subscription_update`
@@ -528,35 +445,48 @@ async function getYearlyContracts(
   teams: BilledTeam[],
 ): Promise<StaffYearlyContract[]> {
   const yearlyTeams = teams.filter((team) => team.interval === "year");
+  if (yearlyTeams.length === 0) {
+    return [];
+  }
 
-  const contracts = await mapWithLimit(yearlyTeams, async (team) => {
-    const paid = await stripe.invoices.list({
-      customer: team.stripeCustomerId,
-      status: "paid",
-      limit: INVOICES_PER_CONTRACT_LOOKUP,
-    });
+  const rows = await StripeInvoice.query()
+    .whereIn(
+      "stripeCustomerId",
+      yearlyTeams.map((team) => team.stripeCustomerId),
+    )
+    .whereIn("status", ["paid", "open"])
+    .orderBy("stripeCreatedAt", "desc");
+
+  const byCustomer = new Map<string, StripeInvoice[]>();
+  for (const row of rows) {
+    let list = byCustomer.get(row.stripeCustomerId);
+    if (!list) {
+      list = [];
+      byCustomer.set(row.stripeCustomerId, list);
+    }
+    list.push(row);
+  }
+
+  const contracts = yearlyTeams.map((team) => {
+    const all = byCustomer.get(team.stripeCustomerId) ?? [];
     let awaitingPayment = false;
-    let found = findContractInvoices(paid.data);
+    let found = findContractInvoices(
+      all.filter((row) => row.status === "paid"),
+    );
     if (found.length === 0) {
-      const open = await stripe.invoices.list({
-        customer: team.stripeCustomerId,
-        status: "open",
-        limit: INVOICES_PER_CONTRACT_LOOKUP,
-      });
-      found = findContractInvoices(open.data);
+      found = findContractInvoices(all.filter((row) => row.status === "open"));
       awaitingPayment = found.length > 0;
     }
 
-    const invoices = found.map((invoice) => {
-      const revenue = getInvoiceRevenue(invoice);
-      const covered = getCoveredPeriod(invoice);
+    const invoices = found.map((row) => {
+      const revenue = getInvoiceRevenue(row);
+      const covered = getCoveredPeriod(row);
       return {
         amount: revenue.amount,
         currency: revenue.currency,
-        // Stripe timestamps in whole seconds.
-        invoicedAt: new Date(invoice.created * 1000),
-        coveredFrom: covered ? new Date(covered.start * 1000) : null,
-        coveredUntil: covered ? new Date(covered.end * 1000) : null,
+        invoicedAt: new Date(row.stripeCreatedAt),
+        coveredFrom: covered ? new Date(covered.start) : null,
+        coveredUntil: covered ? new Date(covered.end) : null,
       };
     });
 
@@ -612,96 +542,102 @@ function getYearlyRate(contracts: StaffYearlyContract[]): StaffRevenueSplit {
 }
 
 /**
- * Walk one month's invoices.
- *
- * A chain per month rather than one chain over the whole window, because
- * Stripe's pagination is a cursor: a page cannot be asked for until the one
- * before it has answered, so a single walk over a year is a year of round trips
- * end to end. Split by month they run at once, and each chain knows the bucket
- * its invoices belong to.
+ * Read the whole window's paid invoices from the mirror and file each into its
+ * calendar month — one query where the Stripe-reading version walked one
+ * paginated chain per month.
  */
-async function readMonth(options: {
-  from: Date;
-  to: Date;
+async function readMonths(options: {
+  /** The reported months' first instants, oldest first. */
+  starts: Date[];
+  /** One bound past the last month, closing its window. */
+  end: Date;
   /** Customers that are Argos teams — everything else is not this page's. */
   teamCustomers: Map<string, TeamCustomer>;
   /** Yearly contracts are reported as a rate, so their invoices are skipped. */
   yearlyCustomerIds: Set<string>;
-}): Promise<{ split: StaffRevenueSplit; teams: StaffRevenueMonthTeam[] }> {
-  const { from, to, teamCustomers, yearlyCustomerIds } = options;
-  const split = createSplit();
-  const byCustomer = new Map<string, StaffRevenueMonthTeam>();
-  let count = 0;
+}): Promise<{ split: StaffRevenueSplit; teams: StaffRevenueMonthTeam[] }[]> {
+  const { starts, end, teamCustomers, yearlyCustomerIds } = options;
+  const first = starts[0];
+  invariant(first, "at least one month is reported");
 
-  for await (const invoice of stripe.invoices.list({
-    created: {
-      gte: Math.floor(from.getTime() / 1000),
-      lt: Math.floor(to.getTime() / 1000),
-    },
-    status: "paid",
-    limit: PAGE_SIZE,
-  })) {
-    count += 1;
-    if (count > MAX_INVOICES_PER_MONTH) {
-      throw new Error(
-        `More than ${MAX_INVOICES_PER_MONTH} invoices in one month: reading Stripe per request no longer holds.`,
-      );
-    }
+  const rows = await StripeInvoice.query()
+    .where("status", "paid")
+    .where("stripeCreatedAt", ">=", first.toISOString())
+    .where("stripeCreatedAt", "<", end.toISOString());
 
-    const customerId =
-      typeof invoice.customer === "string"
-        ? invoice.customer
-        : invoice.customer?.id;
-    const team = customerId ? teamCustomers.get(customerId) : undefined;
-    if (!customerId || !team) {
+  const months: {
+    split: StaffRevenueSplit;
+    byCustomer: Map<string, StaffRevenueMonthTeam>;
+  }[] = starts.map(() => ({
+    split: createSplit(),
+    byCustomer: new Map<string, StaffRevenueMonthTeam>(),
+  }));
+
+  for (const row of rows) {
+    const created = new Date(row.stripeCreatedAt);
+    // Months are consecutive, so the index is a plain calendar distance.
+    const index: number =
+      (created.getUTCFullYear() - first.getUTCFullYear()) * 12 +
+      (created.getUTCMonth() - first.getUTCMonth());
+    const month: (typeof months)[number] | undefined = months[index];
+    invariant(month, "the query bounds the rows to the window");
+
+    const team = teamCustomers.get(row.stripeCustomerId);
+    if (!team) {
       continue;
     }
-    if (yearlyCustomerIds.has(customerId)) {
+    if (yearlyCustomerIds.has(row.stripeCustomerId)) {
       continue;
     }
     if (
-      invoice.billing_reason === null ||
-      (!SUBSCRIPTION_BILLING_REASONS.has(invoice.billing_reason) &&
-        !SALES_LED_BILLING_REASONS.has(invoice.billing_reason))
+      row.billingReason === null ||
+      (!SUBSCRIPTION_BILLING_REASONS.has(row.billingReason) &&
+        !SALES_LED_BILLING_REASONS.has(row.billingReason))
     ) {
       continue;
     }
 
-    const revenue = getInvoiceRevenue(invoice);
+    const revenue = getInvoiceRevenue(row);
     // A zero invoice — a usage month under the quota, the opening of a
     // sales-created subscription — is not a team being invoiced: it would fill
     // the breakdown with empty lines and dilute the per-team average.
     if (revenue.amount === 0) {
       continue;
     }
-    addToSplit(split, revenue);
+    addToSplit(month.split, revenue);
 
     // A team invoiced twice in one month is one team, one line deeper.
-    let row = byCustomer.get(customerId);
-    if (!row) {
-      row = {
+    let teamRow = month.byCustomer.get(row.stripeCustomerId);
+    if (!teamRow) {
+      teamRow = {
         slug: team.slug,
         name: team.name,
-        stripeCustomerId: customerId,
+        stripeCustomerId: row.stripeCustomerId,
         amount: 0,
         currency: revenue.currency,
         revenue: 0,
       };
-      byCustomer.set(customerId, row);
+      month.byCustomer.set(row.stripeCustomerId, teamRow);
     }
-    row.amount += revenue.amount;
-    if (row.currency !== revenue.currency) {
+    teamRow.amount += revenue.amount;
+    if (teamRow.currency !== revenue.currency) {
       // Mixed currencies make the original sum meaningless; the euro figure
       // still holds.
-      row.currency = null;
+      teamRow.currency = null;
     }
-    row.revenue += toEuros(revenue);
+    teamRow.revenue += toEuros(revenue);
   }
 
-  split.teamsCount = byCustomer.size;
-  // Largest first: the breakdown is read to see who made the month.
-  const teams = [...byCustomer.values()].sort((a, b) => b.revenue - a.revenue);
-  return { split, teams };
+  return months.map((month) => {
+    month.split.teamsCount = month.byCustomer.size;
+    return {
+      split: month.split,
+      // Largest first: the breakdown is read to see who made the month.
+      teams: [...month.byCustomer.values()].sort(
+        (a, b) => b.revenue - a.revenue,
+      ),
+    };
+  });
 }
 
 /** What Argos invoiced, and the annual contracts behind the yearly rate. */
@@ -722,9 +658,9 @@ export type StaffRevenue = {
  * the annual contracts the yearly rate is made of — one read serving both, so
  * the list always explains the figure it came with.
  *
- * Asked of Stripe on every call rather than mirrored into a table or held in a
- * cache: the invoices are the answer, they change behind us as they are paid,
- * voided and credited, and a copy of them is a second source to keep correct.
+ * Read from the `stripe_invoices` mirror rather than from Stripe: the webhooks
+ * keep it current and the reconciliation sweep backs them up, so a view costs
+ * a few queries instead of a paginated walk of a third party.
  */
 export async function getStaffRevenue(
   monthCount: number,
@@ -734,9 +670,12 @@ export async function getStaffRevenue(
     `monthCount must be between 1 and ${MAX_MONTHS}`,
   );
 
-  if (config.get("stripe.apiKey") === MISSING_API_KEY) {
+  // Told apart from a quiet month: an empty mirror reports zeros that read as
+  // real figures, and the fix — running the backfill — is on the operator.
+  const mirrored = await StripeInvoice.query().select("id").first();
+  if (!mirrored) {
     throw new Error(
-      "Stripe is not configured, so invoiced revenue cannot be read.",
+      "The Stripe invoice mirror is empty — run stripe/bin/sync-stripe-invoices with a deep window to backfill it.",
     );
   }
 
@@ -758,30 +697,26 @@ export async function getStaffRevenue(
   );
 
   const reported = starts.slice(0, monthCount);
+  const end = starts[monthCount];
+  invariant(end, "the extra start closes the last window");
   const [yearlyContracts, totals] = await Promise.all([
     getYearlyContracts(teams),
-    mapWithLimit(
-      reported.map((from, index) => {
-        const to = starts[index + 1];
-        invariant(to, "every month reported has a bound");
-        return { from, to };
-      }),
-      (window) => readMonth({ ...window, teamCustomers, yearlyCustomerIds }),
-    ),
+    readMonths({ starts: reported, end, teamCustomers, yearlyCustomerIds }),
   ]);
   const yearlyRate = getYearlyRate(yearlyContracts);
 
   const months = reported.map((start, index) => {
-    const month = createMonth(start);
     const total = totals[index];
     invariant(total, "every month reported has totals");
-    month.monthlyPlans = total.split;
-    month.teams = total.teams;
-    // Copied rather than shared: one object held by every month is one object
-    // a later change can mutate for all of them at once.
-    month.yearlyPlans = { ...yearlyRate };
-    month.revenue = total.split.revenue + yearlyRate.revenue;
-    return month;
+    return {
+      month: start,
+      revenue: total.split.revenue + yearlyRate.revenue,
+      monthlyPlans: total.split,
+      teams: total.teams,
+      // Copied rather than shared: one object held by every month is one
+      // object a later change can mutate for all of them at once.
+      yearlyPlans: { ...yearlyRate },
+    };
   });
 
   return {

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -53,6 +53,11 @@ type StaffRevenueMonth = {
    * amortized, day by day, over the stretch each one pays for.
    */
   yearlyPlans: StaffRevenueSplit;
+  /**
+   * What GitHub Marketplace brought in over the month — beside the two above
+   * rather than inside them, since GitHub bills it and Argos never sees it.
+   */
+  githubPlans: StaffRevenueSplit;
 };
 
 /** Upper bound on the window one call will read. */
@@ -71,42 +76,108 @@ const REPORTING_CURRENCY = "eur";
  */
 const EUR_PER_USD = 0.855;
 
+/** A Marketplace subscription, and the stretch it was billed over. */
+type MarketplaceSubscription = {
+  accountId: string;
+  priceCents: number;
+  startDate: string;
+  endDate: string | null;
+  trialEndDate: string | null;
+};
+
 /**
- * What GitHub Marketplace brings in a month, in euros, gross of the 5% GitHub
- * keeps.
+ * Every team subscription GitHub bills, with the dates that say which months
+ * it was billed over.
  *
- * The active marketplace subscriptions at their plans' list prices — GitHub
- * exposes no seller invoice API, so the listing's prices, copied onto the
- * plans by the `github-marketplace-prices` cron, are the closest thing to the
- * statement. Zero until that cron (or its bin form) has priced the plans.
+ * Read by dates rather than by today's status: what a past month brought in
+ * is what was subscribed *then*, and a subscription cancelled since still
+ * earned the months it ran for. The same book the Stripe figures read —
+ * teams, none of them granted a plan rather than billed.
  */
-async function getGithubMarketplaceMonthlyRevenue(): Promise<number> {
+async function getMarketplaceSubscriptions(): Promise<
+  MarketplaceSubscription[]
+> {
   const rows = (await Subscription.query()
-    .select("subscriptions.accountId", "plan.githubMonthlyPriceCents")
+    .select(
+      "subscriptions.accountId",
+      "subscriptions.startDate",
+      "subscriptions.endDate",
+      "subscriptions.trialEndDate",
+      "plan.githubMonthlyPriceCents",
+    )
     .joinRelated("plan")
     .join("accounts", "accounts.id", "subscriptions.accountId")
-    // The same book the Stripe figures read: teams, and none Argos granted a
-    // plan to rather than bills.
     .whereNotNull("accounts.teamId")
     .whereNull("accounts.userId")
     .whereNull("accounts.forcedPlanId")
     .where("subscriptions.provider", "github")
-    .whereNotNull("plan.githubMonthlyPriceCents")
-    .whereRaw("?? < now()", "subscriptions.startDate")
-    .whereIn("subscriptions.status", ["active", "past_due"])
-    .where((query) =>
-      query
-        .whereNull("subscriptions.endDate")
-        .orWhereRaw("?? >= now()", "subscriptions.endDate"),
-    )
-    .distinctOn("subscriptions.accountId")
-    .orderBy("subscriptions.accountId")
-    .orderBy("plan.githubMonthlyPriceCents", "DESC")) as unknown as {
+    .whereNotNull("plan.githubMonthlyPriceCents")) as unknown as {
+    accountId: string | number;
+    startDate: string;
+    endDate: string | null;
+    trialEndDate: string | null;
     githubMonthlyPriceCents: number;
   }[];
 
-  const cents = rows.reduce((sum, row) => sum + row.githubMonthlyPriceCents, 0);
-  return toEuros({ amount: cents / 100, currency: "usd" });
+  return rows.map((row) => ({
+    accountId: String(row.accountId),
+    priceCents: row.githubMonthlyPriceCents,
+    startDate: row.startDate,
+    endDate: row.endDate,
+    trialEndDate: row.trialEndDate,
+  }));
+}
+
+/**
+ * What GitHub Marketplace brought in over one month, in euros, gross of the
+ * 5% GitHub keeps.
+ *
+ * The subscriptions running that month at their plans' list prices — GitHub
+ * exposes no seller invoice API, only its listing and its subscribers, so
+ * there are no invoices of its to mirror the way Stripe's are. Priced at
+ * today's list, which is the one thing here that has no history: a plan's
+ * price changing would restate the months before it, where the subscribers
+ * that came and went are read from their own dates.
+ */
+function getMarketplaceMonthRevenue(
+  subscriptions: MarketplaceSubscription[],
+  month: { start: number; end: number },
+): StaffRevenueSplit {
+  const split = createSplit();
+  const byAccount = new Map<string, number>();
+
+  for (const subscription of subscriptions) {
+    const started = new Date(subscription.startDate).getTime();
+    const ended = subscription.endDate
+      ? new Date(subscription.endDate).getTime()
+      : Number.POSITIVE_INFINITY;
+    // A trial bills nothing, so a month it was still running through earned
+    // nothing either.
+    const trialEnded = subscription.trialEndDate
+      ? new Date(subscription.trialEndDate).getTime()
+      : Number.NEGATIVE_INFINITY;
+    if (
+      started >= month.end ||
+      ended <= month.start ||
+      trialEnded > month.start
+    ) {
+      continue;
+    }
+    // One subscription per team, the richest, like every other figure here.
+    byAccount.set(
+      subscription.accountId,
+      Math.max(
+        byAccount.get(subscription.accountId) ?? 0,
+        subscription.priceCents,
+      ),
+    );
+  }
+
+  for (const cents of byAccount.values()) {
+    addToSplit(split, { amount: cents / 100, currency: "usd" });
+  }
+  split.teamsCount = byAccount.size;
+  return split;
 }
 
 /**
@@ -573,11 +644,6 @@ export type StaffRevenue = {
   months: StaffRevenueMonth[];
   /** The contracts behind the yearly figures, largest first. */
   yearlyContracts: StaffYearlyContract[];
-  /**
-   * What GitHub Marketplace brings in a month, in euros, gross — the active
-   * marketplace subscriptions at their plans' list prices.
-   */
-  githubMarketplaceMonthlyRevenue: number;
 };
 
 /** Raised by the reader when the mirror cannot answer for the window asked. */
@@ -610,14 +676,19 @@ export async function getStaffRevenue(
   invariant(first, "at least one month is reported");
   const scanStart = new Date(first.getTime() - CONTRACT_SCAN_MS);
 
-  const [teamCustomers, billedTeams, deepestSync, freshestSync, marketplace] =
-    await Promise.all([
-      getTeamCustomers(),
-      getBilledTeams(),
-      StripeInvoiceSync.query().orderBy("sinceDate", "asc").first(),
-      StripeInvoiceSync.query().orderBy("completedAt", "desc").first(),
-      getGithubMarketplaceMonthlyRevenue(),
-    ]);
+  const [
+    teamCustomers,
+    billedTeams,
+    deepestSync,
+    freshestSync,
+    marketplaceSubscriptions,
+  ] = await Promise.all([
+    getTeamCustomers(),
+    getBilledTeams(),
+    StripeInvoiceSync.query().orderBy("sinceDate", "asc").first(),
+    StripeInvoiceSync.query().orderBy("completedAt", "desc").first(),
+    getMarketplaceSubscriptions(),
+  ]);
 
   // Two things have to hold before a figure can be trusted: the mirror was
   // swept deep enough to hold the contracts that pay for the window, and it
@@ -796,6 +867,8 @@ export async function getStaffRevenue(
     const teams = monthTeams[index];
     invariant(monthly && yearly && teams, "every month reported has totals");
     monthly.teamsCount = teams.size;
+    const bound = monthBounds[index];
+    invariant(bound, "every month reported has bounds");
     return {
       month: start,
       revenue: monthly.revenue + yearly.revenue,
@@ -803,6 +876,7 @@ export async function getStaffRevenue(
       // Largest first: the breakdown is read to see who made the month.
       teams: [...teams.values()].sort((a, b) => b.revenue - a.revenue),
       yearlyPlans: yearly,
+      githubPlans: getMarketplaceMonthRevenue(marketplaceSubscriptions, bound),
     };
   });
 
@@ -815,7 +889,6 @@ export async function getStaffRevenue(
       monthlyByCustomer,
       runningMonth,
     }),
-    githubMarketplaceMonthlyRevenue: marketplace,
   };
 }
 

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -11,16 +11,30 @@ type StaffRevenueSplit = {
   revenue: number;
   teamsCount: number;
   /**
-   * The part of `revenue` invoiced in a currency other than US dollars, added
-   * in at parity.
+   * The part of `revenue` invoiced in a currency other than euros, converted
+   * at the page's fixed rate.
    *
-   * Stripe states each invoice in the currency it was raised in, and converting
-   * one into another needs a rate on the day, which nothing here has. So a euro
-   * invoice is counted as though it were dollars — the rule the staff pages
-   * already print amounts under — and this says how much of the figure rests on
-   * that, which is the only honest thing to do short of an exchange rate.
+   * Stripe states each invoice in the currency it was raised in; dollars are
+   * brought into euros at `EUR_PER_USD`, which is fixed rather than the day's
+   * rate — so this says how much of the figure rests on that conversion.
    */
   foreignRevenue: number;
+};
+
+/** What one team was invoiced over a month, one line of the breakdown. */
+type StaffRevenueMonthTeam = {
+  /** The team's slug, which names its pages. */
+  slug: string;
+  /** The team's display name, when it has one. */
+  name: string | null;
+  /** The Stripe customer the invoices were raised on. */
+  stripeCustomerId: string;
+  /** What the invoices add up to, in `currency`. */
+  amount: number;
+  /** The currency the team is invoiced in — null when a month mixes several. */
+  currency: string | null;
+  /** In euros, like the split it sums into. */
+  revenue: number;
 };
 
 /** What Argos billed over one calendar month. */
@@ -31,6 +45,8 @@ type StaffRevenueMonth = {
   revenue: number;
   /** What teams billed by the month were invoiced that month. */
   monthlyPlans: StaffRevenueSplit;
+  /** The teams behind `monthlyPlans`, largest first — they sum to it. */
+  teams: StaffRevenueMonthTeam[];
   /**
    * What the annual contracts in force are worth per month: their latest
    * renewal over twelve.
@@ -75,16 +91,38 @@ const MONTHS_PER_YEAR = 12;
  */
 const MAX_CONCURRENT_REQUESTS = 8;
 
-/** The currency every amount on the staff pages is printed in. */
-const REPORTING_CURRENCY = "usd";
+/** The currency every amount on this page is stated in. */
+const REPORTING_CURRENCY = "eur";
+
+/**
+ * Euros per dollar.
+ *
+ * Fixed rather than fetched: the business is run in euros and this page steers
+ * it, so the figures should move with the book, not with the market — and an
+ * approximate total in the right currency beats an exact one in the wrong one.
+ * ECB said 0.855 on 2026-08-21; update it when the market drifts too far.
+ */
+const EUR_PER_USD = 0.855;
+
+/**
+ * What GitHub Marketplace brings in a month, in dollars, gross of the 5%
+ * GitHub keeps.
+ *
+ * A constant rather than a lookup: the marketplace book is a handful of teams
+ * and barely moves, and GitHub exposes no invoice API to read it from — copy
+ * the statement's total here when it changes. From the 2026-05 statement.
+ */
+const GITHUB_MARKETPLACE_MONTHLY_USD = 1540;
 
 /**
  * Why Stripe raised an invoice, for the ones that are a subscription being
- * billed rather than something invoiced on the side.
+ * billed.
  *
- * A one-off invoice or an accepted quote is revenue, but it is not what a
- * column headed by a billing interval reports — and a customer of the Stripe
- * account that is not an Argos team has no business in this page at all.
+ * Not the whole story for the monthly walk: the odd legacy or partner deal is
+ * billed by hand, month after month, and those invoices carry the sales-led
+ * reasons below instead. The walk takes both; what stays out is `upcoming` —
+ * a preview, not an invoice — and pending-item sweeps, which duplicate what
+ * the cycle will bill.
  */
 const SUBSCRIPTION_BILLING_REASONS = new Set<Stripe.Invoice.BillingReason>([
   "subscription",
@@ -109,10 +147,11 @@ const DAY_SECONDS = 24 * 3600;
 /**
  * The reasons an invoice is raised by a person rather than by a billing cycle.
  *
- * Sales-led contracts are billed this way — a dashboard invoice or an accepted
- * quote, often carried by no subscription at all — and their line periods are
- * frequently missing or degenerate, so they cannot be recognized by coverage
- * the way cycle invoices can.
+ * Sales-led deals are billed this way — a dashboard invoice or an accepted
+ * quote, often carried by no subscription at all — whether the deal is an
+ * annual contract or a legacy team invoiced by hand every month. Their line
+ * periods are frequently missing or degenerate, so they cannot be recognized
+ * by coverage the way cycle invoices can.
  */
 const SALES_LED_BILLING_REASONS = new Set<Stripe.Invoice.BillingReason>([
   "manual",
@@ -193,8 +232,15 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
   }));
 }
 
+/** How a month's breakdown names a team. */
+type TeamCustomer = {
+  slug: string;
+  name: string | null;
+};
+
 /**
- * Every Stripe customer that is an Argos team, whether or not it still pays.
+ * Every Stripe customer that is an Argos team, whether or not it still pays,
+ * with what to call it on screen.
  *
  * Read over all team accounts rather than over the billed ones: a team that has
  * since churned keeps the invoices it was already sent, and a month it was
@@ -202,16 +248,23 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
  * comparison between two months exists to show. Personal accounts are left out,
  * so what they may have been invoiced never reaches a page about teams.
  */
-export async function getTeamCustomerIds(): Promise<Set<string>> {
+export async function getTeamCustomers(): Promise<Map<string, TeamCustomer>> {
   const rows = (await Account.query()
-    .select("stripeCustomerId")
+    .select("stripeCustomerId", "slug", "name")
     .whereNotNull("teamId")
     .whereNull("userId")
     .whereNotNull("stripeCustomerId")) as unknown as {
     stripeCustomerId: string;
+    slug: string;
+    name: string | null;
   }[];
 
-  return new Set(rows.map((row) => row.stripeCustomerId));
+  return new Map(
+    rows.map((row) => [
+      row.stripeCustomerId,
+      { slug: row.slug, name: row.name },
+    ]),
+  );
 }
 
 /** What one invoice contributed, in the currency it was raised in. */
@@ -254,6 +307,17 @@ export function getInvoiceRevenue(invoice: {
   };
 }
 
+/**
+ * An invoice's contribution in euros: dollars at the fixed rate, euros as
+ * they are. A currency this page does not know stays at parity — and lands in
+ * the foreign share, so the caveat covers it either way.
+ */
+export function toEuros(revenue: InvoiceRevenue): number {
+  return revenue.currency === "usd"
+    ? revenue.amount * EUR_PER_USD
+    : revenue.amount;
+}
+
 function createSplit(): StaffRevenueSplit {
   return { revenue: 0, teamsCount: 0, foreignRevenue: 0 };
 }
@@ -263,15 +327,17 @@ function createMonth(month: Date): StaffRevenueMonth {
     month,
     revenue: 0,
     monthlyPlans: createSplit(),
+    teams: [],
     yearlyPlans: createSplit(),
   };
 }
 
-/** Add one invoice to a split, tracking what of it was not in dollars. */
+/** Add one invoice to a split, in euros, tracking what was converted. */
 function addToSplit(split: StaffRevenueSplit, revenue: InvoiceRevenue): void {
-  split.revenue += revenue.amount;
+  const amount = toEuros(revenue);
+  split.revenue += amount;
   if (revenue.currency !== REPORTING_CURRENCY) {
-    split.foreignRevenue += revenue.amount;
+    split.foreignRevenue += amount;
   }
 }
 
@@ -334,15 +400,16 @@ type StaffYearlyContract = {
   /** The subscription the database knows the contract by. */
   stripeSubscriptionId: string;
   /**
-   * The invoices below, added up. Null when none was found, in which case the
-   * contract adds nothing to the rate.
+   * The invoices below added up, in euros. Null when none was found, in which
+   * case the contract adds nothing to the rate.
    */
   amount: number | null;
   /** The invoices the contract is worth, newest first. */
   invoices: StaffContractInvoice[];
   /**
-   * True when the invoices found are still awaiting payment. Shown, so a
-   * contract in collection is visible, but counted nothing until they clear.
+   * True when the invoices found are still awaiting payment. Counted all the
+   * same — a contract invoice raised is money on its way — and flagged, so
+   * collection can be watched.
    */
   awaitingPayment: boolean;
 };
@@ -499,7 +566,7 @@ async function getYearlyContracts(
       stripeSubscriptionId: team.stripeSubscriptionId,
       amount:
         invoices.length > 0
-          ? invoices.reduce((sum, invoice) => sum + invoice.amount, 0)
+          ? invoices.reduce((sum, invoice) => sum + toEuros(invoice), 0)
           : null,
       invoices,
       awaitingPayment,
@@ -527,7 +594,7 @@ function getYearlyRate(contracts: StaffYearlyContract[]): StaffRevenueSplit {
   const split = createSplit();
 
   for (const contract of contracts) {
-    if (contract.invoices.length === 0 || contract.awaitingPayment) {
+    if (contract.invoices.length === 0) {
       continue;
     }
     // Invoice by invoice rather than off the summed amount, so a contract
@@ -557,13 +624,13 @@ async function readMonth(options: {
   from: Date;
   to: Date;
   /** Customers that are Argos teams — everything else is not this page's. */
-  teamCustomerIds: Set<string>;
+  teamCustomers: Map<string, TeamCustomer>;
   /** Yearly contracts are reported as a rate, so their invoices are skipped. */
   yearlyCustomerIds: Set<string>;
-}): Promise<StaffRevenueSplit> {
-  const { from, to, teamCustomerIds, yearlyCustomerIds } = options;
+}): Promise<{ split: StaffRevenueSplit; teams: StaffRevenueMonthTeam[] }> {
+  const { from, to, teamCustomers, yearlyCustomerIds } = options;
   const split = createSplit();
-  const customerIds = new Set<string>();
+  const byCustomer = new Map<string, StaffRevenueMonthTeam>();
   let count = 0;
 
   for await (const invoice of stripe.invoices.list({
@@ -585,7 +652,8 @@ async function readMonth(options: {
       typeof invoice.customer === "string"
         ? invoice.customer
         : invoice.customer?.id;
-    if (!customerId || !teamCustomerIds.has(customerId)) {
+    const team = customerId ? teamCustomers.get(customerId) : undefined;
+    if (!customerId || !team) {
       continue;
     }
     if (yearlyCustomerIds.has(customerId)) {
@@ -593,18 +661,47 @@ async function readMonth(options: {
     }
     if (
       invoice.billing_reason === null ||
-      !SUBSCRIPTION_BILLING_REASONS.has(invoice.billing_reason)
+      (!SUBSCRIPTION_BILLING_REASONS.has(invoice.billing_reason) &&
+        !SALES_LED_BILLING_REASONS.has(invoice.billing_reason))
     ) {
       continue;
     }
 
-    addToSplit(split, getInvoiceRevenue(invoice));
-    // A team invoiced twice in one month is one team.
-    customerIds.add(customerId);
+    const revenue = getInvoiceRevenue(invoice);
+    // A zero invoice — a usage month under the quota, the opening of a
+    // sales-created subscription — is not a team being invoiced: it would fill
+    // the breakdown with empty lines and dilute the per-team average.
+    if (revenue.amount === 0) {
+      continue;
+    }
+    addToSplit(split, revenue);
+
+    // A team invoiced twice in one month is one team, one line deeper.
+    let row = byCustomer.get(customerId);
+    if (!row) {
+      row = {
+        slug: team.slug,
+        name: team.name,
+        stripeCustomerId: customerId,
+        amount: 0,
+        currency: revenue.currency,
+        revenue: 0,
+      };
+      byCustomer.set(customerId, row);
+    }
+    row.amount += revenue.amount;
+    if (row.currency !== revenue.currency) {
+      // Mixed currencies make the original sum meaningless; the euro figure
+      // still holds.
+      row.currency = null;
+    }
+    row.revenue += toEuros(revenue);
   }
 
-  split.teamsCount = customerIds.size;
-  return split;
+  split.teamsCount = byCustomer.size;
+  // Largest first: the breakdown is read to see who made the month.
+  const teams = [...byCustomer.values()].sort((a, b) => b.revenue - a.revenue);
+  return { split, teams };
 }
 
 /** What Argos invoiced, and the annual contracts behind the yearly rate. */
@@ -613,6 +710,11 @@ export type StaffRevenue = {
   months: StaffRevenueMonth[];
   /** The contracts behind every month's `yearlyPlans`, largest first. */
   yearlyContracts: StaffYearlyContract[];
+  /**
+   * What GitHub Marketplace brings in a month, in euros, gross. A stated
+   * constant, not a reading — see `GITHUB_MARKETPLACE_MONTHLY_USD`.
+   */
+  githubMarketplaceMonthlyRevenue: number;
 };
 
 /**
@@ -645,9 +747,9 @@ export async function getStaffRevenue(
     startOfUTCMonth(now, index - monthCount + 1),
   );
 
-  const [teams, teamCustomerIds] = await Promise.all([
+  const [teams, teamCustomers] = await Promise.all([
     getBilledTeams(),
-    getTeamCustomerIds(),
+    getTeamCustomers(),
   ]);
   const yearlyCustomerIds = new Set(
     teams
@@ -664,7 +766,7 @@ export async function getStaffRevenue(
         invariant(to, "every month reported has a bound");
         return { from, to };
       }),
-      (window) => readMonth({ ...window, teamCustomerIds, yearlyCustomerIds }),
+      (window) => readMonth({ ...window, teamCustomers, yearlyCustomerIds }),
     ),
   ]);
   const yearlyRate = getYearlyRate(yearlyContracts);
@@ -673,13 +775,21 @@ export async function getStaffRevenue(
     const month = createMonth(start);
     const total = totals[index];
     invariant(total, "every month reported has totals");
-    month.monthlyPlans = total;
+    month.monthlyPlans = total.split;
+    month.teams = total.teams;
     // Copied rather than shared: one object held by every month is one object
     // a later change can mutate for all of them at once.
     month.yearlyPlans = { ...yearlyRate };
-    month.revenue = total.revenue + yearlyRate.revenue;
+    month.revenue = total.split.revenue + yearlyRate.revenue;
     return month;
   });
 
-  return { months, yearlyContracts };
+  return {
+    months,
+    yearlyContracts,
+    githubMarketplaceMonthlyRevenue: toEuros({
+      amount: GITHUB_MARKETPLACE_MONTHLY_USD,
+      currency: "usd",
+    }),
+  };
 }

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -728,6 +728,8 @@ export async function getStaffRevenue(
   // running month for the table to report.
   const contracts = clipContractTerms(contractReads);
   const runningIndex = reported.length - 1;
+  const runningMonth = monthBounds[runningIndex];
+  invariant(runningMonth, "the running month is one of the reported ones");
   const monthlyByCustomer = new Map<string, number>();
 
   for (const contract of contracts) {
@@ -756,8 +758,6 @@ export async function getStaffRevenue(
     // What the contract is worth over a whole month, which is what the table
     // reports — the running month's own share is partial by design, and a
     // contract's monthly worth is not.
-    const runningMonth = monthBounds[runningIndex];
-    invariant(runningMonth, "the running month is one of the reported ones");
     const monthOverlap =
       Math.min(contract.coverage.end, runningMonth.end) -
       Math.max(contract.coverage.start, runningMonth.start);
@@ -800,36 +800,45 @@ export async function getStaffRevenue(
       teamCustomers,
       billedTeams,
       monthlyByCustomer,
-      now,
+      runningMonth,
     }),
     githubMarketplaceMonthlyRevenue: marketplace,
   };
 }
 
 /**
- * The contracts as the table lists them: the ones paying for today, plus the
- * teams billed yearly whose contract could not be found at all — an anomaly
- * the figures would otherwise hide, since a contract nobody can find simply
- * contributes nothing.
+ * The contracts as the table lists them: the ones paying for any part of the
+ * running month, plus the teams billed yearly whose contract could not be
+ * found at all — an anomaly the figures would otherwise hide, since a contract
+ * nobody can find simply contributes nothing.
+ *
+ * The month rather than today, so the table adds up to the figure it explains:
+ * a contract that ran out on the tenth paid for those ten days, and a row that
+ * only listed contracts still running would come up short against the card.
  */
 function buildYearlyContracts(options: {
   contracts: ContractRead[];
   teamCustomers: Map<string, TeamCustomer>;
   billedTeams: BilledTeam[];
   monthlyByCustomer: Map<string, number>;
-  now: Date;
+  runningMonth: { start: number; end: number };
 }): StaffYearlyContract[] {
-  const { contracts, teamCustomers, billedTeams, monthlyByCustomer, now } =
-    options;
-  const nowMs = now.getTime();
-  const inForce = contracts.filter(
+  const {
+    contracts,
+    teamCustomers,
+    billedTeams,
+    monthlyByCustomer,
+    runningMonth,
+  } = options;
+  const reported = contracts.filter(
     (contract) =>
-      contract.coverage.start <= nowMs && nowMs < contract.coverage.end,
+      contract.coverage.start < runningMonth.end &&
+      contract.coverage.end > runningMonth.start,
   );
 
   const rows: StaffYearlyContract[] = [];
   for (const [customerId, reads] of Map.groupBy(
-    inForce,
+    reported,
     (read) => read.row.stripeCustomerId,
   )) {
     const team = teamCustomers.get(customerId);

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -1,0 +1,398 @@
+import type Stripe from "stripe";
+
+import config from "@/config";
+import { Subscription } from "@/database/models";
+import { redisCache } from "@/util/redis";
+
+import { stripe } from "./index";
+
+/** What the teams on one billing interval contributed to a month. */
+type StaffRevenueSplit = {
+  revenue: number;
+  teamsCount: number;
+};
+
+/** What Argos billed over one calendar month. */
+export type StaffRevenueMonth = {
+  /** The first instant of the month, in UTC — what names it on screen. */
+  month: Date;
+  /** The two splits below, added up. */
+  revenue: number;
+  /**
+   * What teams billed by the month were invoiced that month — the invoices
+   * themselves, so discounts, credit notes and negotiated amounts are already
+   * in it.
+   */
+  monthlyPlans: StaffRevenueSplit;
+  /**
+   * What the annual contracts in force are worth per month: their latest
+   * invoice over twelve.
+   *
+   * The same on every month, being a rate. Amortizing each annual invoice over
+   * the twelve months it covers would be exact, but it would mean reading a
+   * year of invoices to report one month — the one thing this cannot afford,
+   * being asked at page load.
+   */
+  yearlyPlans: StaffRevenueSplit;
+};
+
+/**
+ * Upper bound on the window one call will read.
+ *
+ * Every month is a walk of its own, so the cost grows with the count asked for
+ * — bounded here rather than left to the caller, which is what keeps a request
+ * from turning into a hundred round trips.
+ */
+export const MAX_MONTHS = 24;
+
+/**
+ * Upper bound on the invoices one month's walk will read.
+ *
+ * Reached means a month holds more than this service can read in the time a
+ * page will wait, and the answer is to stop reading Stripe on every request —
+ * not to report the total of however many invoices happened to fit, which would
+ * read as a complete figure while silently missing the rest.
+ */
+const MAX_INVOICES_PER_MONTH = 2000;
+
+/** Page size, which is also Stripe's maximum. */
+const PAGE_SIZE = 100;
+
+/** Months a yearly contract is spread over. */
+const MONTHS_PER_YEAR = 12;
+
+/** The placeholder the config falls back to when no key is configured. */
+const MISSING_API_KEY = "no-api-key";
+
+/** A team Argos bills through Stripe, and how it is billed. */
+type BilledTeam = {
+  accountId: string;
+  stripeCustomerId: string;
+  interval: "month" | "year";
+};
+
+/**
+ * Every team with a paying subscription, and the interval it is billed on.
+ *
+ * Reads the subscription the same way `getAccountBillings` does — the highest
+ * quota among those active, so an account holding two resolves the same one on
+ * both sides. Granted plans are excluded: they bill nothing, so no invoice of
+ * theirs exists to find.
+ */
+export async function getBilledTeams(): Promise<BilledTeam[]> {
+  const rows = (await Subscription.query()
+    .select(
+      "subscriptions.accountId",
+      "accounts.stripeCustomerId",
+      "plan.interval",
+    )
+    .joinRelated("plan")
+    .join("accounts", "accounts.id", "subscriptions.accountId")
+    .whereNotNull("accounts.teamId")
+    .whereNull("accounts.userId")
+    .whereNull("accounts.forcedPlanId")
+    .whereNotNull("accounts.stripeCustomerId")
+    .whereRaw("?? < now()", "subscriptions.startDate")
+    // A trial is out: it resolves a plan like a paid subscription and pays
+    // nothing. `past_due` is in — the invoice was raised, whether it clears is
+    // a collection question.
+    .whereIn("subscriptions.status", ["active", "past_due"])
+    .where((query) =>
+      query
+        .whereNull("subscriptions.endDate")
+        .orWhereRaw("?? >= now()", "subscriptions.endDate"),
+    )
+    .distinctOn("subscriptions.accountId")
+    .orderBy("subscriptions.accountId")
+    .orderBy("plan.includedScreenshots", "DESC")) as unknown as {
+    accountId: string | number;
+    stripeCustomerId: string;
+    interval: "month" | "year";
+  }[];
+
+  return rows.map((row) => ({
+    accountId: String(row.accountId),
+    stripeCustomerId: row.stripeCustomerId,
+    interval: row.interval,
+  }));
+}
+
+/**
+ * What one invoice contributed to revenue, in the currency's main unit.
+ *
+ * Excluding tax, because VAT collected on behalf of a state is not revenue, and
+ * net of credit notes, because an invoice refunded after the fact keeps its
+ * `amount_paid` intact — reading that field alone would count money that was
+ * given back.
+ *
+ * Currencies are added at parity, the rule the staff pages already print
+ * amounts under: a euro contract is read as dollars rather than converted.
+ */
+export function getInvoiceRevenue(
+  invoice: Pick<
+    Stripe.Invoice,
+    | "total"
+    | "total_excluding_tax"
+    | "pre_payment_credit_notes_amount"
+    | "post_payment_credit_notes_amount"
+  >,
+): number {
+  // Null on invoices Stripe states no tax breakdown for, where the total is
+  // already the whole of it.
+  const excludingTax = invoice.total_excluding_tax ?? invoice.total;
+  const credited =
+    invoice.pre_payment_credit_notes_amount +
+    invoice.post_payment_credit_notes_amount;
+
+  // Stripe states amounts in the currency's minor unit.
+  return (excludingTax - credited) / 100;
+}
+
+function createSplit(): StaffRevenueSplit {
+  return { revenue: 0, teamsCount: 0 };
+}
+
+function createMonth(month: Date): StaffRevenueMonth {
+  return {
+    month,
+    revenue: 0,
+    monthlyPlans: createSplit(),
+    yearlyPlans: createSplit(),
+  };
+}
+
+/**
+ * The first instant of the month `offset` months back, in UTC.
+ *
+ * Deliberately not the calendar helpers, which work in the process's own
+ * timezone: Stripe timestamps every invoice in UTC, so a server running on
+ * anything else would cut its months hours away from where Stripe cuts them and
+ * file the invoices either side of a boundary in the wrong one. Reading UTC on
+ * both sides is what makes the figure independent of where it runs.
+ */
+export function startOfUTCMonth(date: Date, offset: number): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + offset, 1),
+  );
+}
+
+/**
+ * What the annual contracts in force are worth per month.
+ *
+ * One small request per annual team rather than a year of invoices for
+ * everyone: an annual subscription raises one invoice a year, so its latest is
+ * what it is worth now, and there are few enough of them to ask in parallel.
+ *
+ * A contract whose first invoice has not been paid yet counts nothing — it has
+ * been invoiced nothing, which is what this reports.
+ */
+async function getYearlyRate(teams: BilledTeam[]): Promise<StaffRevenueSplit> {
+  const yearlyTeams = teams.filter((team) => team.interval === "year");
+  const split = createSplit();
+
+  const invoices = await Promise.all(
+    yearlyTeams.map(async (team) => {
+      const page = await stripe.invoices.list({
+        customer: team.stripeCustomerId,
+        status: "paid",
+        limit: 1,
+      });
+      return page.data[0] ?? null;
+    }),
+  );
+
+  for (const invoice of invoices) {
+    if (!invoice) {
+      continue;
+    }
+    split.revenue += getInvoiceRevenue(invoice) / MONTHS_PER_YEAR;
+    split.teamsCount += 1;
+  }
+
+  return split;
+}
+
+/** What one month's invoices came to, and how many teams they covered. */
+type MonthTotals = { revenue: number; teamsCount: number };
+
+/**
+ * Walk one month's invoices.
+ *
+ * A chain per month rather than one chain over the whole window, because
+ * Stripe's pagination is a cursor: a page cannot be asked for until the one
+ * before it has answered, so a single walk over three months is three months of
+ * round trips end to end. Split by month they run at once, and the wall clock
+ * becomes the longest month rather than their sum — which is also why the split
+ * is by month rather than by an arbitrary slice: each chain then knows the
+ * bucket its invoices belong to, with nothing left to sort out afterwards.
+ */
+async function readMonth(options: {
+  from: Date;
+  to: Date;
+  /** Yearly contracts are reported as a rate, so their invoices are skipped. */
+  yearlyCustomerIds: Set<string>;
+}): Promise<MonthTotals> {
+  const { from, to, yearlyCustomerIds } = options;
+  const customerIds = new Set<string>();
+  let revenue = 0;
+  let count = 0;
+
+  for await (const invoice of stripe.invoices.list({
+    created: {
+      gte: Math.floor(from.getTime() / 1000),
+      lt: Math.floor(to.getTime() / 1000),
+    },
+    status: "paid",
+    limit: PAGE_SIZE,
+  })) {
+    count += 1;
+    if (count > MAX_INVOICES_PER_MONTH) {
+      throw new Error(
+        `More than ${MAX_INVOICES_PER_MONTH} invoices in one month: reading Stripe per request no longer holds.`,
+      );
+    }
+
+    const customerId =
+      typeof invoice.customer === "string"
+        ? invoice.customer
+        : invoice.customer?.id;
+    if (!customerId || yearlyCustomerIds.has(customerId)) {
+      continue;
+    }
+
+    revenue += getInvoiceRevenue(invoice);
+    // A team invoiced twice in one month is one team.
+    customerIds.add(customerId);
+  }
+
+  return { revenue, teamsCount: customerIds.size };
+}
+
+/**
+ * What Argos invoiced over the last `monthCount` calendar months, oldest first
+ * and the running one last.
+ *
+ * Asked of Stripe on every call rather than mirrored into a table: the invoices
+ * are the answer, and a copy of them is a second source to keep correct as they
+ * are voided, refunded and credited.
+ */
+async function fetchStaffRevenue(
+  monthCount: number,
+): Promise<StaffRevenueMonth[]> {
+  if (config.get("stripe.apiKey") === MISSING_API_KEY) {
+    throw new Error(
+      "Stripe is not configured, so invoiced revenue cannot be read.",
+    );
+  }
+
+  const now = new Date();
+  // Oldest first, the running month last. One bound past the end, which is not
+  // itself a month reported: it closes the last window.
+  const starts = Array.from({ length: monthCount + 1 }, (_, index) =>
+    startOfUTCMonth(now, index - monthCount + 1),
+  );
+
+  const teams = await getBilledTeams();
+  // Only the yearly customers are identified, and the monthly bucket takes
+  // everything else. Matching invoices against the teams billed *today* would
+  // drop the invoices of a team that has since churned — and a month it was
+  // invoiced in would quietly lose it, which is exactly the revenue a
+  // comparison between two months exists to show.
+  const yearlyCustomerIds = new Set(
+    teams
+      .filter((team) => team.interval === "year")
+      .map((team) => team.stripeCustomerId),
+  );
+
+  // Every request at once: the months are independent walks, and the yearly
+  // rate is its own set of small ones.
+  const reported = starts.slice(0, monthCount);
+  const [yearlyRate, totals] = await Promise.all([
+    getYearlyRate(teams),
+    Promise.all(
+      reported.map((from, index) => {
+        const to = starts[index + 1];
+        if (!to) {
+          throw new Error("every month reported has a bound");
+        }
+        return readMonth({ from, to, yearlyCustomerIds });
+      }),
+    ),
+  ]);
+
+  return reported.map((start, index) => {
+    const month = createMonth(start);
+    const total = totals[index];
+    if (!total) {
+      throw new Error("every month reported has totals");
+    }
+    month.monthlyPlans = total;
+    month.yearlyPlans = yearlyRate;
+    month.revenue = total.revenue + yearlyRate.revenue;
+    return month;
+  });
+}
+
+/**
+ * The shape of the cached value, bumped whenever `StaffRevenueMonth` changes.
+ *
+ * An entry outlives the deploy that changes what this returns, so a field
+ * renamed below would otherwise be read back for an hour from a value that no
+ * longer has it.
+ */
+const CACHE_VERSION = 1;
+
+/** How long a window is served from cache. */
+const CACHE_MAX_AGE = 60 * 60 * 1000;
+
+/**
+ * Long enough for the walks to finish while holding the lock.
+ *
+ * The lock's TTL, not a deadline on the work: expiring early would let a second
+ * request start the same walks rather than wait on them, which is the stampede
+ * the cache exists to prevent.
+ */
+const CACHE_LOCK_TIMEOUT = 60 * 1000;
+
+const staffRevenueStore = redisCache.createStore({
+  fetch: fetchStaffRevenue,
+  /**
+   * Everything the answer is a function of, so no two of them share an entry.
+   *
+   * The deployment above all. Without it the key is global to the Redis
+   * instance and any two apps pointed at one serve each other's totals — which
+   * on a developer's machine is not hypothetical: the end-to-end suite and the
+   * dev server share `redis://localhost:6380/1`.
+   */
+  getCacheKey: (monthCount) => [
+    "staff-revenue",
+    CACHE_VERSION,
+    monthCount,
+    config.get("pg.connection.host"),
+    config.get("pg.connection.database"),
+  ],
+  maxAge: CACHE_MAX_AGE,
+  timeout: CACHE_LOCK_TIMEOUT,
+  // Dates do not survive JSON, and the months carry one each.
+  deserialize: (raw) => {
+    const months = JSON.parse(raw) as (Omit<StaffRevenueMonth, "month"> & {
+      month: string;
+    })[];
+    return months.map((month) => ({ ...month, month: new Date(month.month) }));
+  },
+});
+
+/**
+ * What Argos invoiced, from cache.
+ *
+ * Cached for an hour because the figures move at the pace of an invoice: the
+ * complete months behind them cannot change at all, and the running one gains a
+ * handful a day. An hour costs no freshness anyone can use, and it is what
+ * keeps a page that walks a year of invoices from walking it again on every
+ * visit.
+ */
+export async function getStaffRevenue(
+  monthCount: number,
+): Promise<StaffRevenueMonth[]> {
+  return staffRevenueStore.get(monthCount);
+}

--- a/apps/frontend/src/containers/Breadcrumb/AccountBreadcrumbMenu.tsx
+++ b/apps/frontend/src/containers/Breadcrumb/AccountBreadcrumbMenu.tsx
@@ -1,4 +1,9 @@
-import { PlusCircleIcon, ShieldUserIcon } from "lucide-react";
+import {
+  BanknoteIcon,
+  Building2Icon,
+  HourglassIcon,
+  PlusCircleIcon,
+} from "lucide-react";
 import { matchPath, useLocation } from "react-router";
 
 import type { AuthAccount } from "@/containers/Auth";
@@ -62,11 +67,17 @@ export function AccountBreadcrumbMenu(props: { account: AuthAccount }) {
       {account.staff ? (
         <MenuSection>
           <MenuHeading>Staff</MenuHeading>
-          <MenuItem icon={<ShieldUserIcon />} href="/staff/teams">
+          {/* One icon each rather than the same staff badge three times: the
+              heading already says these are staff pages, so the icons are free
+              to say which page. */}
+          <MenuItem icon={<Building2Icon />} href="/staff/teams">
             All teams
           </MenuItem>
-          <MenuItem icon={<ShieldUserIcon />} href="/staff/trials">
+          <MenuItem icon={<HourglassIcon />} href="/staff/trials">
             Trials
+          </MenuItem>
+          <MenuItem icon={<BanknoteIcon />} href="/staff/revenue">
+            Revenue
           </MenuItem>
         </MenuSection>
       ) : null}

--- a/apps/frontend/src/pages/Account/Analytics.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.tsx
@@ -19,7 +19,6 @@ import {
 } from "@argos/util/date";
 import { formatDate } from "@argos/util/date-format";
 import { invariant } from "@argos/util/invariant";
-import clsx from "clsx";
 import {
   FileDownIcon,
   GitCompareArrowsIcon,
@@ -47,7 +46,7 @@ import {
 } from "@/gql/graphql";
 import { Badge } from "@/ui/Badge";
 import { Button } from "@/ui/Button";
-import { Card } from "@/ui/Card";
+import { ChartCard } from "@/ui/ChartCard";
 import {
   ChartConfig,
   ChartContainer,
@@ -904,31 +903,6 @@ function Section(props: {
       </div>
       <div className="grid grid-cols-12 gap-6">{props.children}</div>
     </section>
-  );
-}
-
-function ChartCard(props: {
-  className?: string;
-  title: string;
-  description?: React.ReactNode;
-  action?: React.ReactNode;
-  children: React.ReactNode;
-}) {
-  return (
-    <Card className={clsx("flex flex-col", props.className)}>
-      <div className="flex items-start justify-between gap-4 p-5 pb-0">
-        <div>
-          <h3 className="font-semibold">{props.title}</h3>
-          {props.description ? (
-            <p className="text-low text-sm">{props.description}</p>
-          ) : null}
-        </div>
-        {props.action ? <div className="shrink-0">{props.action}</div> : null}
-      </div>
-      <div className="flex min-h-72 flex-1 items-center justify-center p-5">
-        {props.children}
-      </div>
-    </Card>
   );
 }
 

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -42,13 +42,8 @@ import { Tooltip } from "@/ui/Tooltip";
 import { getStripeCustomerURL, getStripeSubscriptionURL } from "./stripe";
 
 /**
- * Asked on its own rather than alongside the team directory: it walks Stripe's
- * invoices, so the two load beside each other, each with its own skeleton, and
- * a slow answer never holds a row of the table back.
- *
- * Every month costs a walk of its own, which is why the count is asked for
- * rather than fixed: the band above the directory wants three, the page that
- * charts a year wants twelve, and neither should pay for the other.
+ * Read from the backend's Stripe invoice mirror — this page is the query's
+ * only consumer, asking for a year plus the running month.
  */
 const StaffRevenueQuery = graphql(`
   query StaffRevenue_staffRevenue($months: Int!) {
@@ -186,15 +181,25 @@ const CONTRACT_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
   currency: "EUR",
 });
 
-/** An invoice in the currency it was raised in — the audit trail to Stripe. */
+/**
+ * An invoice in the currency it was raised in — the audit trail to Stripe.
+ *
+ * Local formatters rather than util/intl's `formatCurrency`: that one follows
+ * the reader's locale, where every figure on this page is pinned to en-US so
+ * the amounts read the same on every staff screen.
+ */
+const INVOICE_PRICE_FORMATS = new Map<string, Intl.NumberFormat>();
 function formatInvoiceAmount(invoice: {
   amount: number;
   currency: string;
 }): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: invoice.currency.toUpperCase(),
-  }).format(invoice.amount);
+  const currency = invoice.currency.toUpperCase();
+  let format = INVOICE_PRICE_FORMATS.get(currency);
+  if (!format) {
+    format = new Intl.NumberFormat("en-US", { style: "currency", currency });
+    INVOICE_PRICE_FORMATS.set(currency, format);
+  }
+  return format.format(invoice.amount);
 }
 
 /** A renewal's date, read in UTC like every other date on the page. */
@@ -232,6 +237,26 @@ function getGrowth(month: number, before: number): number | null {
   return before === 0 ? null : (month - before) / before;
 }
 
+/** A term with its explanation on hover — the page's one affordance for it. */
+function Hint(props: {
+  content: React.ReactNode;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Tooltip content={props.content}>
+      <span
+        className={clsx(
+          "underline decoration-dotted underline-offset-2",
+          props.className,
+        )}
+      >
+        {props.children}
+      </span>
+    </Tooltip>
+  );
+}
+
 /** One half of the amount, with the tooltip that explains that half alone. */
 function SplitAmount(props: {
   amount: number;
@@ -239,11 +264,9 @@ function SplitAmount(props: {
   tooltip: string;
 }) {
   return (
-    <Tooltip content={props.tooltip}>
-      <span className="underline decoration-dotted underline-offset-2">
-        {formatEuros(props.amount)} {props.label}
-      </span>
-    </Tooltip>
+    <Hint content={props.tooltip}>
+      {formatEuros(props.amount)} {props.label}
+    </Hint>
   );
 }
 
@@ -284,13 +307,7 @@ function MonthSplit(props: {
   );
 }
 
-/**
- * The three headline figures, rendered from whatever window was read.
- *
- * Takes the months rather than fetching them, so the band above the directory
- * and the page that charts a year draw the same cards off one query each rather
- * than asking twice.
- */
+/** The three headline figures, rendered from whatever window was read. */
 function RevenueCards(props: {
   /** Oldest first, the running month last. Null while loading. */
   months: readonly RevenueMonth[] | null;
@@ -310,18 +327,15 @@ function RevenueCards(props: {
 
   // An em dash on all three rather than a band that disappears: the figures
   // failing to load is worth seeing on a page whose whole subject is what they
-  // report, and it must not take the directory down with it.
+  // report.
   //
-  // The reason is carried rather than swallowed. This reads a third party at
-  // request time, so it fails in ways only its message explains — a key missing
-  // a permission, a rate limit, a key in the wrong mode — and this page is
-  // staff-only, so there is nobody here to protect from the detail.
+  // The reason is carried rather than swallowed: the realistic failures — the
+  // invoice mirror not backfilled deep enough for the window, a database
+  // error — are exactly the ones whose message tells the operator what to do,
+  // and this page is staff-only, so there is nobody here to protect from the
+  // detail.
   const unavailable = error ? (
-    <Tooltip content={error.message}>
-      <span className="underline decoration-dotted underline-offset-2">
-        unavailable
-      </span>
-    </Tooltip>
+    <Hint content={error.message}>unavailable</Hint>
   ) : null;
 
   /** `undefined` draws the skeleton, `null` an em dash. */
@@ -387,14 +401,12 @@ function RevenueCards(props: {
         hint={
           unavailable ??
           (currentMonth && lastMonth && growth !== null ? (
-            <Tooltip
+            <Hint
               content={`${formatMonth(currentMonth.month)} (${formatEuros(currentMonth.revenue)}) vs ${formatMonth(lastMonth.month)} (${formatEuros(lastMonth.revenue)}). The running month is still filling.`}
             >
-              <span className="underline decoration-dotted underline-offset-2">
-                {formatMonth(currentMonth.month)} vs{" "}
-                {formatMonth(lastMonth.month)}
-              </span>
-            </Tooltip>
+              {formatMonth(currentMonth.month)} vs{" "}
+              {formatMonth(lastMonth.month)}
+            </Hint>
           ) : months ? (
             "nothing to compare"
           ) : (
@@ -418,11 +430,12 @@ const CHART_SERIES = [
   { key: "github", label: "GitHub Marketplace", color: "var(--grass-9)" },
 ] as const;
 
-const CHART_CONFIG: ChartConfig = {
-  monthly: { label: "Monthly plans", color: "var(--pink-9)" },
-  yearly: { label: "Yearly plans", color: "var(--violet-9)" },
-  github: { label: "GitHub Marketplace", color: "var(--grass-9)" },
-};
+const CHART_CONFIG: ChartConfig = Object.fromEntries(
+  CHART_SERIES.map((series) => [
+    series.key,
+    { label: series.label, color: series.color },
+  ]),
+);
 
 /**
  * The window as stacked areas, one point per month, the running one included.
@@ -691,20 +704,12 @@ function RevenueHistory(props: { months: readonly RevenueMonth[] }) {
             <tr className="text-low border-b text-xs font-semibold">
               <th className="w-[16%] px-4 py-3 text-left">Month</th>
               <th className="w-[18%] px-4 py-3 text-right">
-                <Tooltip content="Ex-tax, net of credit notes.">
-                  <span className="underline decoration-dotted underline-offset-2">
-                    Invoiced
-                  </span>
-                </Tooltip>
+                <Hint content="Ex-tax, net of credit notes.">Invoiced</Hint>
               </th>
               <th className="w-[14%] px-4 py-3 text-right">Change</th>
               <th className="w-[14%] px-4 py-3 text-right">Teams</th>
               <th className="w-[18%] px-4 py-3 text-right">
-                <Tooltip content="Monthly revenue per paying team.">
-                  <span className="underline decoration-dotted underline-offset-2">
-                    ARPU
-                  </span>
-                </Tooltip>
+                <Hint content="Monthly revenue per paying team.">ARPU</Hint>
               </th>
               <th className="w-[20%] px-4 py-3 text-right" />
             </tr>
@@ -738,7 +743,6 @@ function describeInvoice(invoice: YearlyContract["invoices"][number]): string {
   return `${formatInvoiceAmount(invoice)} invoiced ${DATE_FORMAT.format(new Date(invoice.invoicedAt))}${covers}.`;
 }
 
-/** One contract, the invoices it is worth and what it adds per month. */
 /** The contract's invoices in their own currency, when they share one. */
 function getOriginalTotal(
   contract: YearlyContract,
@@ -769,7 +773,7 @@ function ContractRow(props: { contract: YearlyContract; index: number }) {
       <td className="p-4 text-right text-sm tabular-nums">
         {contract.amount !== null ? (
           <>
-            <Tooltip
+            <Hint
               content={
                 <div className="flex flex-col gap-1">
                   {contract.invoices.map((invoice, invoiceIndex) => (
@@ -778,28 +782,25 @@ function ContractRow(props: { contract: YearlyContract; index: number }) {
                 </div>
               }
             >
-              <span className="underline decoration-dotted underline-offset-2">
-                {originalTotal
-                  ? formatInvoiceAmount(originalTotal)
-                  : CONTRACT_PRICE_FORMAT.format(contract.amount)}
-              </span>
-            </Tooltip>
+              {originalTotal
+                ? formatInvoiceAmount(originalTotal)
+                : CONTRACT_PRICE_FORMAT.format(contract.amount)}
+            </Hint>
             {contract.awaitingPayment ? (
               <div>
-                <Tooltip content="Raised, not yet paid. Counted — expected to clear.">
-                  <span className="text-warning-low underline decoration-dotted underline-offset-2">
-                    Awaiting payment
-                  </span>
-                </Tooltip>
+                <Hint
+                  className="text-warning-low"
+                  content="Raised, not yet paid. Counted — expected to clear."
+                >
+                  Awaiting payment
+                </Hint>
               </div>
             ) : null}
           </>
         ) : (
-          <Tooltip content="Counts nothing.">
-            <span className="text-danger-low underline decoration-dotted underline-offset-2">
-              no invoice found
-            </span>
-          </Tooltip>
+          <Hint className="text-danger-low" content="Counts nothing.">
+            no invoice found
+          </Hint>
         )}
       </td>
       <td className="p-4 text-right text-sm tabular-nums">
@@ -858,11 +859,7 @@ function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
                 <th className="w-[30%] px-4 py-3 text-left">Team</th>
                 <th className="w-[20%] px-4 py-3 text-right">Invoiced</th>
                 <th className="w-[16%] px-4 py-3 text-right">
-                  <Tooltip content="÷ 12, in euros.">
-                    <span className="underline decoration-dotted underline-offset-2">
-                      Per month
-                    </span>
-                  </Tooltip>
+                  <Hint content="÷ 12, in euros.">Per month</Hint>
                 </th>
                 <th className="w-[18%] px-4 py-3 text-right">Last invoice</th>
                 <th className="w-[16%] px-4 py-3 text-right" />
@@ -881,11 +878,9 @@ function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
               <tr className="text-sm font-medium">
                 <td className="p-4 text-left">Total</td>
                 <td className="p-4 text-right tabular-nums">
-                  <Tooltip content="In euros.">
-                    <span className="underline decoration-dotted underline-offset-2">
-                      {CONTRACT_PRICE_FORMAT.format(total)}
-                    </span>
-                  </Tooltip>
+                  <Hint content="In euros.">
+                    {CONTRACT_PRICE_FORMAT.format(total)}
+                  </Hint>
                 </td>
                 <td className="p-4 text-right tabular-nums">
                   {CONTRACT_PRICE_FORMAT.format(total / 12)}
@@ -956,17 +951,7 @@ function StaffRevenuePage() {
         </>
       ) : error ? null : (
         <ChartCard className="mb-6" title="Invoiced by month">
-          <div className="flex flex-col items-center gap-3 text-center">
-            <Loader className="size-8" delay={0} />
-            {/* Said rather than left to a spinner: this walks a year of Stripe
-                invoices, which is seconds rather than the moment a spinner
-                usually stands for — and knowing why it is slow is the
-                difference between waiting and reloading. */}
-            <div className="text-low max-w-sm text-sm">
-              Reading {PAGE_MONTHS} months of invoices from Stripe. Nothing is
-              stored, so this takes a few seconds the first time each hour.
-            </div>
-          </div>
+          <Loader className="size-8" delay={0} />
         </ChartCard>
       )}
     </PageContainer>

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -227,7 +227,7 @@ function getSplitNote(split: Split): string {
   // the total went through the fixed rate.
   const foreign =
     split.foreignRevenue > 0
-      ? ` ${formatEuros(split.foreignRevenue)} of it was invoiced in another currency — dollars at a fixed rate, anything else at parity.`
+      ? ` ${formatEuros(split.foreignRevenue)} of it was invoiced in dollars, converted at a fixed rate.`
       : "";
 
   return `${teams}${foreign}`;
@@ -747,11 +747,7 @@ function RevenueHistory(props: { months: readonly RevenueMonth[] }) {
 
 /** One counted invoice, described for the amount's breakdown tooltip. */
 function describeInvoice(invoice: YearlyContract["invoices"][number]): string {
-  const covers =
-    invoice.coveredFrom && invoice.coveredUntil
-      ? `, covers ${DATE_FORMAT.format(new Date(invoice.coveredFrom))} to ${DATE_FORMAT.format(new Date(invoice.coveredUntil))}`
-      : "";
-  return `${formatInvoiceAmount(invoice)} invoiced ${DATE_FORMAT.format(new Date(invoice.invoicedAt))}${covers}.`;
+  return `${formatInvoiceAmount(invoice)} invoiced ${DATE_FORMAT.format(new Date(invoice.invoicedAt))}, covers ${DATE_FORMAT.format(new Date(invoice.coveredFrom))} to ${DATE_FORMAT.format(new Date(invoice.coveredUntil))}.`;
 }
 
 /** The contract's invoices in their own currency, when they share one. */
@@ -793,9 +789,13 @@ function ContractRow(props: { contract: YearlyContract; index: number }) {
                 </div>
               }
             >
-              {originalTotal
-                ? formatInvoiceAmount(originalTotal)
-                : CONTRACT_PRICE_FORMAT.format(contract.amount)}
+              {originalTotal ? (
+                formatInvoiceAmount(originalTotal)
+              ) : (
+                // Invoices in more than one currency have no single original
+                // amount; the euro column beside this one still holds.
+                <span className="text-low">—</span>
+              )}
             </Hint>
             {contract.awaitingPayment ? (
               <div>
@@ -965,7 +965,7 @@ function StaffRevenuePage() {
         </PageHeaderContent>
       </PageHeader>
       <RevenueCards months={months} error={error ?? null} />
-      {data && months && contracts ? (
+      {months && contracts ? (
         <>
           <ChartCard className="mb-6" title="Invoiced by month">
             <RevenueChart months={months} />

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -471,7 +471,12 @@ function HistoryRow(props: {
   isLast: boolean;
 }) {
   const { month, before, index, isLast } = props;
-  const growth = before ? getGrowth(month.revenue, before.revenue) : null;
+  // On the monthly figure, like every column here: the yearly rate lives in
+  // its own table, and a change diluted by a flat rate would understate every
+  // move.
+  const growth = before
+    ? getGrowth(month.monthlyPlans.revenue, before.monthlyPlans.revenue)
+    : null;
 
   return (
     <tr
@@ -487,12 +492,6 @@ function HistoryRow(props: {
         {formatPrice(month.monthlyPlans.revenue)}
       </td>
       <td className="p-4 text-right text-sm tabular-nums">
-        {formatPrice(month.yearlyPlans.revenue)}
-      </td>
-      <td className="p-4 text-right text-sm font-medium tabular-nums">
-        {formatPrice(month.revenue)}
-      </td>
-      <td className="p-4 text-right text-sm tabular-nums">
         {growth === null ? (
           <span className="text-low">—</span>
         ) : (
@@ -504,6 +503,15 @@ function HistoryRow(props: {
       </td>
       <td className="p-4 text-right text-sm tabular-nums">
         {month.monthlyPlans.teamsCount}
+      </td>
+      <td className="p-4 text-right text-sm tabular-nums">
+        {month.monthlyPlans.teamsCount > 0 ? (
+          formatPrice(
+            month.monthlyPlans.revenue / month.monthlyPlans.teamsCount,
+          )
+        ) : (
+          <span className="text-low">—</span>
+        )}
       </td>
     </tr>
   );
@@ -527,43 +535,59 @@ function RevenueHistory(props: { months: readonly RevenueMonth[] }) {
   const rows = [...complete].reverse();
 
   return (
-    <div className="overflow-x-auto rounded-sm border">
-      <table className="w-full min-w-160 table-fixed border-collapse">
-        <thead>
-          <tr className="text-low border-b text-xs font-semibold">
-            <th className="w-[18%] px-4 py-3 text-left">Month</th>
-            <th className="w-[18%] px-4 py-3 text-right">Monthly plans</th>
-            <th className="w-[18%] px-4 py-3 text-right">Yearly plans</th>
-            <th className="w-[16%] px-4 py-3 text-right">Total</th>
-            <th className="w-[15%] px-4 py-3 text-right">
-              <Tooltip content="Against the month before it. The running month is not listed: being partial, it would read as a drop that is only the calendar.">
-                <span className="underline decoration-dotted underline-offset-2">
-                  Change
-                </span>
-              </Tooltip>
-            </th>
-            <th className="w-[15%] px-4 py-3 text-right">
-              <Tooltip content="Teams invoiced on a monthly plan that month. Annual contracts are a rate rather than a month's invoices, so they are not counted here.">
-                <span className="underline decoration-dotted underline-offset-2">
-                  Teams
-                </span>
-              </Tooltip>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((month, index) => (
-            <HistoryRow
-              key={month.month}
-              month={month}
-              // `rows` runs newest first, so the month before is the next one.
-              before={rows[index + 1] ?? null}
-              index={index}
-              isLast={index === rows.length - 1}
-            />
-          ))}
-        </tbody>
-      </table>
+    <div>
+      <div className="mb-3">
+        <h3 className="font-semibold">Monthly plans</h3>
+      </div>
+      <div className="overflow-x-auto rounded-sm border">
+        <table className="w-full min-w-160 table-fixed border-collapse">
+          <thead>
+            <tr className="text-low border-b text-xs font-semibold">
+              <th className="w-[22%] px-4 py-3 text-left">Month</th>
+              <th className="w-[21%] px-4 py-3 text-right">
+                <Tooltip content="Invoices issued that month, excluding tax and net of credit notes — what Stripe charged, discounts included.">
+                  <span className="underline decoration-dotted underline-offset-2">
+                    Invoiced
+                  </span>
+                </Tooltip>
+              </th>
+              <th className="w-[18%] px-4 py-3 text-right">
+                <Tooltip content="Against the month before it.">
+                  <span className="underline decoration-dotted underline-offset-2">
+                    Change
+                  </span>
+                </Tooltip>
+              </th>
+              <th className="w-[18%] px-4 py-3 text-right">
+                <Tooltip content="Teams invoiced that month.">
+                  <span className="underline decoration-dotted underline-offset-2">
+                    Teams
+                  </span>
+                </Tooltip>
+              </th>
+              <th className="w-[21%] px-4 py-3 text-right">
+                <Tooltip content="The month's invoices over its teams — what the average team was billed.">
+                  <span className="underline decoration-dotted underline-offset-2">
+                    Per team
+                  </span>
+                </Tooltip>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((month, index) => (
+              <HistoryRow
+                key={month.month}
+                month={month}
+                // `rows` runs newest first, so the month before is the next one.
+                before={rows[index + 1] ?? null}
+                index={index}
+                isLast={index === rows.length - 1}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -562,7 +562,12 @@ function HistoryRow(props: {
           (!isLast || isOpened) && "border-b",
         )}
       >
-        <td className="p-4 text-left text-sm font-medium">
+        {/* The month names walk forward with the calendar, so a visual
+            baseline of this table would need approving every month. */}
+        <td
+          className="p-4 text-left text-sm font-medium"
+          data-visual-test="transparent"
+        >
           {MONTH_YEAR_FORMAT.format(new Date(month.month))}
           {isCurrent ? <span className="text-low"> (running)</span> : null}
         </td>

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -38,6 +38,7 @@ import { Text } from "@/ui/Text";
 import { Tooltip } from "@/ui/Tooltip";
 
 import { formatPrice } from "./pricing";
+import { getStripeSubscriptionURL } from "./stripe";
 
 /**
  * Asked on its own rather than alongside the team directory: it walks Stripe's
@@ -51,25 +52,41 @@ import { formatPrice } from "./pricing";
 const StaffRevenueQuery = graphql(`
   query StaffRevenue_staffRevenue($months: Int!) {
     staffRevenue(months: $months) {
-      month
-      revenue
-      monthlyPlans {
+      months {
+        month
         revenue
-        teamsCount
-        foreignRevenue
+        monthlyPlans {
+          revenue
+          teamsCount
+          foreignRevenue
+        }
+        yearlyPlans {
+          revenue
+          teamsCount
+          foreignRevenue
+        }
       }
-      yearlyPlans {
-        revenue
-        teamsCount
-        foreignRevenue
+      yearlyContracts {
+        slug
+        name
+        stripeSubscriptionId
+        amount
+        awaitingPayment
+        invoices {
+          amount
+          currency
+          invoicedAt
+          coveredFrom
+          coveredUntil
+        }
       }
     }
   }
 `);
 
-type RevenueMonth = DocumentType<
-  typeof StaffRevenueQuery
->["staffRevenue"][number];
+type RevenueData = DocumentType<typeof StaffRevenueQuery>["staffRevenue"];
+type RevenueMonth = RevenueData["months"][number];
+type YearlyContract = RevenueData["yearlyContracts"][number];
 type Split = RevenueMonth["monthlyPlans"];
 
 /** Months the dedicated page reads — a year, plus the one running. */
@@ -88,7 +105,7 @@ const CURRENT_MONTHLY_HINT =
   "Invoices issued so far this month, excluding tax and net of credit notes. Partial by nature: the month is not over.";
 
 const YEARLY_HINT =
-  "Annual contracts in force: their latest invoice ÷ 12. A rate, so it is the same every month rather than a spike in the renewal month.";
+  "Annual contracts in force: their contract invoices ÷ 12. A rate, so it is the same every month rather than a spike in the renewal month.";
 
 /**
  * Stands in for the hint line while the figures load.
@@ -136,6 +153,24 @@ const AXIS_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
   currency: "USD",
   notation: "compact",
   maximumFractionDigits: 0,
+});
+
+/**
+ * Amounts in the contracts table, with cents.
+ *
+ * The rest of the page rounds to the dollar, but this table exists to be added
+ * up against the yearly figure, and twelfths carry cents — a rounded list
+ * would not sum to its own total.
+ */
+const CONTRACT_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+/** A renewal's date, read in UTC like every other date on the page. */
+const DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+  timeZone: "UTC",
 });
 
 function formatMonth(month: string): string {
@@ -533,11 +568,186 @@ function RevenueHistory(props: { months: readonly RevenueMonth[] }) {
   );
 }
 
+/** One counted invoice, described for the amount's breakdown tooltip. */
+function describeInvoice(invoice: YearlyContract["invoices"][number]): string {
+  const covers =
+    invoice.coveredFrom && invoice.coveredUntil
+      ? `, covers ${DATE_FORMAT.format(new Date(invoice.coveredFrom))} to ${DATE_FORMAT.format(new Date(invoice.coveredUntil))}`
+      : "";
+  return `${CONTRACT_PRICE_FORMAT.format(invoice.amount)} invoiced ${DATE_FORMAT.format(new Date(invoice.invoicedAt))}${covers}.`;
+}
+
+/** One contract, the invoices it is worth and what it adds per month. */
+function ContractRow(props: { contract: YearlyContract; index: number }) {
+  const { contract, index } = props;
+  const newestInvoice = contract.invoices[0] ?? null;
+  const foreignCurrencies = [
+    ...new Set(
+      contract.invoices
+        .filter((invoice) => invoice.currency !== "usd")
+        .map((invoice) => invoice.currency.toUpperCase()),
+    ),
+  ];
+
+  return (
+    <tr className={clsx(index % 2 === 0 ? "bg-app" : "bg-subtle", "border-b")}>
+      <td className="p-4 text-left text-sm font-medium">
+        <Link href={`/${contract.slug}`}>{contract.name ?? contract.slug}</Link>
+      </td>
+      <td className="p-4 text-right text-sm tabular-nums">
+        {contract.amount !== null ? (
+          <>
+            <Tooltip
+              content={
+                <div className="flex flex-col gap-1">
+                  {contract.invoices.map((invoice, invoiceIndex) => (
+                    <div key={invoiceIndex}>{describeInvoice(invoice)}</div>
+                  ))}
+                </div>
+              }
+            >
+              <span className="underline decoration-dotted underline-offset-2">
+                {CONTRACT_PRICE_FORMAT.format(contract.amount)}
+              </span>
+            </Tooltip>
+            {contract.invoices.length > 1 ? (
+              <span className="text-low">
+                {" "}
+                ({contract.invoices.length} invoices)
+              </span>
+            ) : null}
+            {foreignCurrencies.length > 0 ? (
+              <span className="text-low">
+                {" "}
+                ({foreignCurrencies.join(", ")} at parity)
+              </span>
+            ) : null}
+            {contract.awaitingPayment ? (
+              <Tooltip content="The invoice was raised but has not been paid yet, so it counts nothing until it clears.">
+                <span className="text-warning-low underline decoration-dotted underline-offset-2">
+                  {" "}
+                  awaiting payment
+                </span>
+              </Tooltip>
+            ) : null}
+          </>
+        ) : (
+          <Tooltip content="No invoice reading as this contract was found on the customer, so it adds nothing to the yearly figure. Its invoices are worth a look in Stripe.">
+            <span className="text-danger-low underline decoration-dotted underline-offset-2">
+              no invoice found
+            </span>
+          </Tooltip>
+        )}
+      </td>
+      <td className="p-4 text-right text-sm tabular-nums">
+        {contract.amount !== null && !contract.awaitingPayment ? (
+          CONTRACT_PRICE_FORMAT.format(contract.amount / 12)
+        ) : (
+          <span className="text-low">—</span>
+        )}
+      </td>
+      <td className="p-4 text-right text-sm tabular-nums">
+        {newestInvoice ? (
+          DATE_FORMAT.format(new Date(newestInvoice.invoicedAt))
+        ) : (
+          <span className="text-low">—</span>
+        )}
+      </td>
+      <td className="p-4 text-right text-sm">
+        <Link
+          href={getStripeSubscriptionURL(contract.stripeSubscriptionId)}
+          target="_blank"
+        >
+          Stripe
+        </Link>
+      </td>
+    </tr>
+  );
+}
+
+/**
+ * The annual contracts one by one — the makeup of the yearly figure.
+ *
+ * Listed so the figure can be audited: the rate is a sum of twelfths read from
+ * Stripe, and when it looks wrong, the contract at fault can only be found by
+ * seeing each one's renewal — including the contracts that contributed
+ * nothing, which the total alone would hide.
+ */
+function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
+  const { contracts } = props;
+  // Awaiting-payment invoices are listed but not counted, like in the figure.
+  const total = contracts.reduce(
+    (sum, contract) =>
+      sum + (contract.awaitingPayment ? 0 : (contract.amount ?? 0)),
+    0,
+  );
+
+  return (
+    <div className="mt-6">
+      <div className="mb-3">
+        <h3 className="font-semibold">Annual contracts</h3>
+      </div>
+      {contracts.length === 0 ? (
+        <p className="text-low text-sm">No annual contracts in force.</p>
+      ) : (
+        <div className="overflow-x-auto rounded-sm border">
+          <table className="w-full min-w-160 table-fixed border-collapse">
+            <thead>
+              <tr className="text-low border-b text-xs font-semibold">
+                <th className="w-[30%] px-4 py-3 text-left">Team</th>
+                <th className="w-[20%] px-4 py-3 text-right">
+                  <Tooltip content="The contract's invoices added up — its latest annual bill, plus upsells raised on top of it since — excluding tax and net of credit notes.">
+                    <span className="underline decoration-dotted underline-offset-2">
+                      Invoiced
+                    </span>
+                  </Tooltip>
+                </th>
+                <th className="w-[16%] px-4 py-3 text-right">
+                  <Tooltip content="The renewal over twelve — this column adds up to the Yearly plans figure.">
+                    <span className="underline decoration-dotted underline-offset-2">
+                      Per month
+                    </span>
+                  </Tooltip>
+                </th>
+                <th className="w-[18%] px-4 py-3 text-right">Last invoice</th>
+                <th className="w-[16%] px-4 py-3 text-right" />
+              </tr>
+            </thead>
+            <tbody>
+              {contracts.map((contract, index) => (
+                <ContractRow
+                  key={contract.stripeSubscriptionId}
+                  contract={contract}
+                  index={index}
+                />
+              ))}
+            </tbody>
+            <tfoot>
+              <tr className="text-sm font-medium">
+                <td className="p-4 text-left">Total</td>
+                <td className="p-4 text-right tabular-nums">
+                  {CONTRACT_PRICE_FORMAT.format(total)}
+                </td>
+                <td className="p-4 text-right tabular-nums">
+                  {CONTRACT_PRICE_FORMAT.format(total / 12)}
+                </td>
+                <td />
+                <td />
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function StaffRevenuePage() {
   const { data, error } = useQuery(StaffRevenueQuery, {
     variables: { months: PAGE_MONTHS },
   });
-  const months = data?.staffRevenue ?? null;
+  const months = data?.staffRevenue.months ?? null;
+  const contracts = data?.staffRevenue.yearlyContracts ?? null;
 
   // Told rather than reported as a failed figure, as the other staff pages do:
   // a reader without access has no figures to wait for, and three tiles reading
@@ -573,7 +783,7 @@ function StaffRevenuePage() {
         </PageHeaderContent>
       </PageHeader>
       <RevenueCards months={months} error={error ?? null} />
-      {months ? (
+      {months && contracts ? (
         <>
           <ChartCard
             className="mb-6"
@@ -583,6 +793,7 @@ function StaffRevenuePage() {
             <RevenueChart months={months} />
           </ChartCard>
           <RevenueHistory months={months} />
+          <YearlyContracts contracts={contracts} />
         </>
       ) : error ? null : (
         <ChartCard

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -39,7 +39,7 @@ import { Loader } from "@/ui/Loader";
 import { StatTile } from "@/ui/StatTile";
 import { Tooltip } from "@/ui/Tooltip";
 
-import { getStripeCustomerURL, getStripeSubscriptionURL } from "./stripe";
+import { getStripeCustomerURL } from "./stripe";
 
 /**
  * Read from the backend's Stripe invoice mirror — this page is the query's
@@ -73,8 +73,9 @@ const StaffRevenueQuery = graphql(`
       yearlyContracts {
         slug
         name
-        stripeSubscriptionId
+        stripeCustomerId
         amount
+        monthlyRevenue
         awaitingPayment
         invoices {
           amount
@@ -82,6 +83,7 @@ const StaffRevenueQuery = graphql(`
           invoicedAt
           coveredFrom
           coveredUntil
+          awaitingPayment
         }
       }
       githubMarketplaceMonthlyRevenue
@@ -513,6 +515,10 @@ function RevenueChart(props: {
                 return MONTH_YEAR_FORMAT.format(new Date(item.payload.month));
               }}
               valueFormatter={(value) => formatEuros(value)}
+              // No total: the Marketplace band is stacked on top of what
+              // Argos invoiced through Stripe, and adding the three would
+              // contradict the cards, which report the Stripe figures alone.
+              hideTotal
             />
           }
         />
@@ -816,7 +822,7 @@ function ContractRow(props: { contract: YearlyContract; index: number }) {
       </td>
       <td className="p-4 text-right text-sm tabular-nums">
         {contract.amount !== null ? (
-          CONTRACT_PRICE_FORMAT.format(contract.amount / 12)
+          CONTRACT_PRICE_FORMAT.format(contract.monthlyRevenue)
         ) : (
           <span className="text-low">—</span>
         )}
@@ -830,7 +836,7 @@ function ContractRow(props: { contract: YearlyContract; index: number }) {
       </td>
       <td className="p-4 text-right text-sm">
         <Link
-          href={getStripeSubscriptionURL(contract.stripeSubscriptionId)}
+          href={getStripeCustomerURL(contract.stripeCustomerId)}
           target="_blank"
         >
           Stripe
@@ -854,6 +860,13 @@ function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
     (sum, contract) => sum + (contract.amount ?? 0),
     0,
   );
+  // Summed from what each contract contributes rather than divided by twelve:
+  // the months are amortized over the stretch each invoice pays for, and an
+  // upsell sold for five months is not a twelfth of anything.
+  const monthlyTotal = contracts.reduce(
+    (sum, contract) => sum + contract.monthlyRevenue,
+    0,
+  );
 
   return (
     <div className="mt-6">
@@ -870,7 +883,9 @@ function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
                 <th className="w-[30%] px-4 py-3 text-left">Team</th>
                 <th className="w-[20%] px-4 py-3 text-right">Invoiced</th>
                 <th className="w-[16%] px-4 py-3 text-right">
-                  <Hint content="÷ 12, in euros.">Per month</Hint>
+                  <Hint content="What it adds to this month, in euros.">
+                    Per month
+                  </Hint>
                 </th>
                 <th className="w-[18%] px-4 py-3 text-right">Last invoice</th>
                 <th className="w-[16%] px-4 py-3 text-right" />
@@ -879,7 +894,7 @@ function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
             <tbody>
               {contracts.map((contract, index) => (
                 <ContractRow
-                  key={contract.stripeSubscriptionId}
+                  key={contract.stripeCustomerId}
                   contract={contract}
                   index={index}
                 />
@@ -894,7 +909,7 @@ function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
                   </Hint>
                 </td>
                 <td className="p-4 text-right tabular-nums">
-                  {CONTRACT_PRICE_FORMAT.format(total / 12)}
+                  {CONTRACT_PRICE_FORMAT.format(monthlyTotal)}
                 </td>
                 <td />
                 <td />

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -111,7 +111,8 @@ const CURRENT_MONTHLY_HINT =
 const YEARLY_HINT =
   "Annual contracts amortized, day by day, over the months they cover. In €.";
 
-const GITHUB_HINT = "Hard coded amount";
+const GITHUB_HINT =
+  "Active Marketplace subscriptions at list price, billed by GitHub. On top of the figure above, not in it.";
 
 /**
  * Stands in for the hint line while the figures load.

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -69,6 +69,11 @@ const StaffRevenueQuery = graphql(`
           teamsCount
           foreignRevenue
         }
+        githubPlans {
+          revenue
+          teamsCount
+          foreignRevenue
+        }
       }
       yearlyContracts {
         slug
@@ -86,7 +91,6 @@ const StaffRevenueQuery = graphql(`
           awaitingPayment
         }
       }
-      githubMarketplaceMonthlyRevenue
     }
   }
 `);
@@ -114,7 +118,7 @@ const YEARLY_HINT =
   "Annual contracts amortized, day by day, over the months they cover. In €.";
 
 const GITHUB_HINT =
-  "Active Marketplace subscriptions at list price, billed by GitHub. On top of the figure above, not in it.";
+  "The month's Marketplace subscriptions at list price, billed by GitHub. On top of the figure above, not in it.";
 
 /**
  * Stands in for the hint line while the figures load.
@@ -280,12 +284,8 @@ function SplitAmount(props: {
  * computes differently — one reads the month's invoices, the other spreads a
  * year's — so they are what a reader has to be able to take apart.
  */
-function MonthSplit(props: {
-  month: RevenueMonth;
-  monthlyHint: string;
-  github: number | null;
-}) {
-  const { month, monthlyHint, github } = props;
+function MonthSplit(props: { month: RevenueMonth; monthlyHint: string }) {
+  const { month, monthlyHint } = props;
 
   return (
     <>
@@ -300,10 +300,14 @@ function MonthSplit(props: {
         label="Yearly"
         tooltip={`${YEARLY_HINT}${getSplitNote(month.yearlyPlans)}`}
       />
-      {github !== null ? (
+      {month.githubPlans.revenue > 0 ? (
         <>
           {" · "}
-          <SplitAmount amount={github} label="GitHub" tooltip={GITHUB_HINT} />
+          <SplitAmount
+            amount={month.githubPlans.revenue}
+            label="GitHub"
+            tooltip={`${GITHUB_HINT}${getSplitNote(month.githubPlans)}`}
+          />
         </>
       ) : null}
     </>
@@ -314,11 +318,9 @@ function MonthSplit(props: {
 function RevenueCards(props: {
   /** Oldest first, the running month last. Null while loading. */
   months: readonly RevenueMonth[] | null;
-  /** The GitHub Marketplace rate, shown beside each month's split. */
-  github: number | null;
   error: Error | null;
 }) {
-  const { months, github, error } = props;
+  const { months, error } = props;
 
   // The last two are the only ones the cards read, whatever the window.
   const currentMonth = months?.at(-1) ?? null;
@@ -362,11 +364,7 @@ function RevenueCards(props: {
         hint={
           unavailable ??
           (lastMonth ? (
-            <MonthSplit
-              month={lastMonth}
-              monthlyHint={LAST_MONTHLY_HINT}
-              github={github}
-            />
+            <MonthSplit month={lastMonth} monthlyHint={LAST_MONTHLY_HINT} />
           ) : (
             HINT_PLACEHOLDER
           ))
@@ -387,7 +385,6 @@ function RevenueCards(props: {
             <MonthSplit
               month={currentMonth}
               monthlyHint={CURRENT_MONTHLY_HINT}
-              github={github}
             />
           ) : (
             HINT_PLACEHOLDER
@@ -449,15 +446,12 @@ const CHART_CONFIG: ChartConfig = Object.fromEntries(
  * carries a slope where twelve separate bars make the reader measure heights
  * against each other.
  */
-function RevenueChart(props: {
-  months: readonly RevenueMonth[];
-  github: number;
-}) {
+function RevenueChart(props: { months: readonly RevenueMonth[] }) {
   const data = props.months.map((month) => ({
     month: month.month,
     monthly: month.monthlyPlans.revenue,
     yearly: month.yearlyPlans.revenue,
-    github: props.github,
+    github: month.githubPlans.revenue,
   }));
 
   return (
@@ -970,18 +964,11 @@ function StaffRevenuePage() {
           <Heading>Revenue</Heading>
         </PageHeaderContent>
       </PageHeader>
-      <RevenueCards
-        months={months}
-        github={data?.staffRevenue.githubMarketplaceMonthlyRevenue ?? null}
-        error={error ?? null}
-      />
+      <RevenueCards months={months} error={error ?? null} />
       {data && months && contracts ? (
         <>
           <ChartCard className="mb-6" title="Invoiced by month">
-            <RevenueChart
-              months={months}
-              github={data.staffRevenue.githubMarketplaceMonthlyRevenue}
-            />
+            <RevenueChart months={months} />
           </ChartCard>
           <RevenueHistory months={months} />
           <YearlyContracts contracts={contracts} />

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -223,7 +223,7 @@ function getSplitNote(split: Split): string {
   // the total went through the fixed rate.
   const foreign =
     split.foreignRevenue > 0
-      ? ` ${formatEuros(split.foreignRevenue)} converted from dollars at a fixed rate.`
+      ? ` ${formatEuros(split.foreignRevenue)} of it was invoiced in another currency — dollars at a fixed rate, anything else at parity.`
       : "";
 
   return `${teams}${foreign}`;
@@ -298,7 +298,7 @@ function MonthSplit(props: {
       <SplitAmount
         amount={month.yearlyPlans.revenue}
         label="Yearly"
-        tooltip={YEARLY_HINT}
+        tooltip={`${YEARLY_HINT}${getSplitNote(month.yearlyPlans)}`}
       />
       {github !== null ? (
         <>
@@ -821,6 +821,13 @@ function ContractRow(props: { contract: YearlyContract; index: number }) {
         )}
       </td>
       <td className="p-4 text-right text-sm tabular-nums">
+        {contract.amount === null ? (
+          <span className="text-low">—</span>
+        ) : (
+          CONTRACT_PRICE_FORMAT.format(contract.amount)
+        )}
+      </td>
+      <td className="p-4 text-right text-sm tabular-nums">
         {contract.amount !== null ? (
           CONTRACT_PRICE_FORMAT.format(contract.monthlyRevenue)
         ) : (
@@ -880,8 +887,13 @@ function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
           <table className="w-full min-w-160 table-fixed border-collapse">
             <thead>
               <tr className="text-low border-b text-xs font-semibold">
-                <th className="w-[30%] px-4 py-3 text-left">Team</th>
-                <th className="w-[20%] px-4 py-3 text-right">Invoiced</th>
+                <th className="w-[26%] px-4 py-3 text-left">Team</th>
+                <th className="w-[18%] px-4 py-3 text-right">Invoiced</th>
+                <th className="w-[16%] px-4 py-3 text-right">
+                  <Hint content="Dollars converted at a fixed rate.">
+                    In euros
+                  </Hint>
+                </th>
                 <th className="w-[16%] px-4 py-3 text-right">
                   <Hint content="What it adds to this month, in euros.">
                     Per month
@@ -903,10 +915,9 @@ function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
             <tfoot>
               <tr className="text-sm font-medium">
                 <td className="p-4 text-left">Total</td>
+                <td />
                 <td className="p-4 text-right tabular-nums">
-                  <Hint content="In euros.">
-                    {CONTRACT_PRICE_FORMAT.format(total)}
-                  </Hint>
+                  {CONTRACT_PRICE_FORMAT.format(total)}
                 </td>
                 <td className="p-4 text-right tabular-nums">
                   {CONTRACT_PRICE_FORMAT.format(monthlyTotal)}

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -553,6 +553,11 @@ function HistoryRow(props: {
     before && !isCurrent
       ? getGrowth(month.monthlyPlans.revenue, before.monthlyPlans.revenue)
       : null;
+  // Rounded before it is read, so a move too small to print cannot come out
+  // coloured one way and signed another: a fifth of a percent down rounds to
+  // a flat 0%, where the raw figure would have painted that zero red. The
+  // `|| 0` is what turns `Math.round`'s negative zero back into a zero.
+  const percent = growth === null ? null : Math.round(growth * 100) || 0;
 
   return (
     <>
@@ -575,14 +580,14 @@ function HistoryRow(props: {
           {formatEuros(month.monthlyPlans.revenue)}
         </td>
         <td className="p-4 text-right text-sm tabular-nums">
-          {growth === null ? (
+          {percent === null ? (
             <span className="text-low">—</span>
           ) : (
             <span
-              className={growth < 0 ? "text-danger-low" : "text-success-low"}
+              className={percent < 0 ? "text-danger-low" : "text-success-low"}
             >
-              {growth > 0 ? "+" : ""}
-              {Math.round(growth * 100)}%
+              {percent > 0 ? "+" : ""}
+              {percent}%
             </span>
           )}
         </td>

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { CombinedGraphQLErrors } from "@apollo/client";
 import { useQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
@@ -5,6 +6,7 @@ import { clsx } from "clsx";
 import {
   CalendarCheckIcon,
   CalendarClockIcon,
+  ChevronDownIcon,
   TrendingDownIcon,
   TrendingUpIcon,
 } from "lucide-react";
@@ -15,6 +17,7 @@ import { AuthGuard } from "@/containers/AuthGuard";
 import type { DocumentType } from "@/gql";
 import { graphql } from "@/gql";
 import { Alert, AlertText, AlertTitle } from "@/ui/Alert";
+import { Button, ButtonIcon } from "@/ui/Button";
 import { ChartCard } from "@/ui/ChartCard";
 import type { ChartConfig } from "@/ui/Charts";
 import {
@@ -34,11 +37,9 @@ import {
 import { Link } from "@/ui/Link";
 import { Loader } from "@/ui/Loader";
 import { StatTile } from "@/ui/StatTile";
-import { Text } from "@/ui/Text";
 import { Tooltip } from "@/ui/Tooltip";
 
-import { formatPrice } from "./pricing";
-import { getStripeSubscriptionURL } from "./stripe";
+import { getStripeCustomerURL, getStripeSubscriptionURL } from "./stripe";
 
 /**
  * Asked on its own rather than alongside the team directory: it walks Stripe's
@@ -60,6 +61,14 @@ const StaffRevenueQuery = graphql(`
           teamsCount
           foreignRevenue
         }
+        teams {
+          slug
+          name
+          stripeCustomerId
+          amount
+          currency
+          revenue
+        }
         yearlyPlans {
           revenue
           teamsCount
@@ -80,6 +89,7 @@ const StaffRevenueQuery = graphql(`
           coveredUntil
         }
       }
+      githubMarketplaceMonthlyRevenue
     }
   }
 `);
@@ -98,14 +108,15 @@ const PAGE_MONTHS = 13;
  * Two rather than one because the halves do not answer the same question: the
  * monthly one reports the month's invoices, the yearly one a rate.
  */
-const LAST_MONTHLY_HINT =
-  "Invoices issued last month, excluding tax and net of credit notes — what Stripe charged, discounts included.";
+const LAST_MONTHLY_HINT = "Last month's invoices, ex-tax, net of credit notes.";
 
 const CURRENT_MONTHLY_HINT =
-  "Invoices issued so far this month, excluding tax and net of credit notes. Partial by nature: the month is not over.";
+  "This month's invoices so far, ex-tax, net of credit notes.";
 
 const YEARLY_HINT =
-  "Annual contracts in force: their contract invoices ÷ 12. A rate, so it is the same every month rather than a spike in the renewal month.";
+  "Annual contracts ÷ 12. The same rate every month converted in €.";
+
+const GITHUB_HINT = "Hard coded amount";
 
 /**
  * Stands in for the hint line while the figures load.
@@ -141,16 +152,24 @@ const MONTH_SHORT_FORMAT = new Intl.DateTimeFormat("en-US", {
 });
 
 /**
- * Amounts on the axis, shortened.
- *
- * Fixed to the same locale and currency as `formatPrice` rather than the
- * reader's own: every other figure on the page is printed in US dollars, and an
- * axis that followed the browser would label the same money differently from
- * the cards above it.
+ * Every amount on this page is in euros — the currency the business is run
+ * in — where the other staff pages price plans in dollars. Dollar invoices are
+ * converted server-side at a fixed rate, which the foreign-share caveats own.
  */
+const EUR_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "EUR",
+  maximumFractionDigits: 0,
+});
+
+function formatEuros(amount: number): string {
+  return EUR_PRICE_FORMAT.format(amount);
+}
+
+/** Amounts on the axis, shortened, in the page's euros. */
 const AXIS_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
   style: "currency",
-  currency: "USD",
+  currency: "EUR",
   notation: "compact",
   maximumFractionDigits: 0,
 });
@@ -158,14 +177,25 @@ const AXIS_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
 /**
  * Amounts in the contracts table, with cents.
  *
- * The rest of the page rounds to the dollar, but this table exists to be added
+ * The rest of the page rounds to the euro, but this table exists to be added
  * up against the yearly figure, and twelfths carry cents — a rounded list
  * would not sum to its own total.
  */
 const CONTRACT_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
   style: "currency",
-  currency: "USD",
+  currency: "EUR",
 });
+
+/** An invoice in the currency it was raised in — the audit trail to Stripe. */
+function formatInvoiceAmount(invoice: {
+  amount: number;
+  currency: string;
+}): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: invoice.currency.toUpperCase(),
+  }).format(invoice.amount);
+}
 
 /** A renewal's date, read in UTC like every other date on the page. */
 const DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
@@ -180,12 +210,12 @@ function formatMonth(month: string): string {
 /** The figures behind a half, appended to its tooltip. */
 function getSplitNote(split: Split): string {
   const teams = ` ${split.teamsCount} ${split.teamsCount === 1 ? "team" : "teams"}.`;
-  // Named only when there is some: on an all-dollar month the caveat would be
-  // noise, and on a month with euros in it the reader has to know the total
-  // holds two currencies added at parity.
+  // Named only when there is some: on an all-euro month the caveat would be
+  // noise, and on a month with dollars in it the reader has to know part of
+  // the total went through the fixed rate.
   const foreign =
     split.foreignRevenue > 0
-      ? ` ${formatPrice(split.foreignRevenue)} of it was invoiced in another currency and is counted at parity, not converted.`
+      ? ` ${formatEuros(split.foreignRevenue)} converted from dollars at a fixed rate.`
       : "";
 
   return `${teams}${foreign}`;
@@ -211,7 +241,7 @@ function SplitAmount(props: {
   return (
     <Tooltip content={props.tooltip}>
       <span className="underline decoration-dotted underline-offset-2">
-        {formatPrice(props.amount)} {props.label}
+        {formatEuros(props.amount)} {props.label}
       </span>
     </Tooltip>
   );
@@ -224,22 +254,32 @@ function SplitAmount(props: {
  * computes differently — one reads the month's invoices, the other spreads a
  * year's — so they are what a reader has to be able to take apart.
  */
-function MonthSplit(props: { month: RevenueMonth; monthlyHint: string }) {
-  const { month, monthlyHint } = props;
+function MonthSplit(props: {
+  month: RevenueMonth;
+  monthlyHint: string;
+  github: number | null;
+}) {
+  const { month, monthlyHint, github } = props;
 
   return (
     <>
       <SplitAmount
         amount={month.monthlyPlans.revenue}
-        label="monthly"
+        label="Monthly"
         tooltip={`${monthlyHint}${getSplitNote(month.monthlyPlans)}`}
       />
       {" · "}
       <SplitAmount
         amount={month.yearlyPlans.revenue}
-        label="yearly"
-        tooltip={`${YEARLY_HINT}${getSplitNote(month.yearlyPlans)}`}
+        label="Yearly"
+        tooltip={YEARLY_HINT}
       />
+      {github !== null ? (
+        <>
+          {" · "}
+          <SplitAmount amount={github} label="GitHub" tooltip={GITHUB_HINT} />
+        </>
+      ) : null}
     </>
   );
 }
@@ -254,9 +294,11 @@ function MonthSplit(props: { month: RevenueMonth; monthlyHint: string }) {
 function RevenueCards(props: {
   /** Oldest first, the running month last. Null while loading. */
   months: readonly RevenueMonth[] | null;
+  /** The GitHub Marketplace rate, shown beside each month's split. */
+  github: number | null;
   error: Error | null;
 }) {
-  const { months, error } = props;
+  const { months, github, error } = props;
 
   // The last two are the only ones the cards read, whatever the window.
   const currentMonth = months?.at(-1) ?? null;
@@ -295,14 +337,19 @@ function RevenueCards(props: {
       <StatTile
         data-visual-test="transparent"
         icon={CalendarCheckIcon}
-        color="success"
+        color="primary"
         label="Last month"
         value={readValue(lastMonth?.revenue ?? null)}
         format="currency"
+        currency="EUR"
         hint={
           unavailable ??
           (lastMonth ? (
-            <MonthSplit month={lastMonth} monthlyHint={LAST_MONTHLY_HINT} />
+            <MonthSplit
+              month={lastMonth}
+              monthlyHint={LAST_MONTHLY_HINT}
+              github={github}
+            />
           ) : (
             HINT_PLACEHOLDER
           ))
@@ -311,16 +358,19 @@ function RevenueCards(props: {
       <StatTile
         data-visual-test="transparent"
         icon={CalendarClockIcon}
-        color="primary"
+        // The storybook token is the design system's pink.
+        color="storybook"
         label="Current month"
         value={readValue(currentMonth?.revenue ?? null)}
         format="currency"
+        currency="EUR"
         hint={
           unavailable ??
           (currentMonth ? (
             <MonthSplit
               month={currentMonth}
               monthlyHint={CURRENT_MONTHLY_HINT}
+              github={github}
             />
           ) : (
             HINT_PLACEHOLDER
@@ -338,7 +388,7 @@ function RevenueCards(props: {
           unavailable ??
           (currentMonth && lastMonth && growth !== null ? (
             <Tooltip
-              content={`${formatMonth(currentMonth.month)} at ${formatPrice(currentMonth.revenue)} against ${formatMonth(lastMonth.month)} at ${formatPrice(lastMonth.revenue)}. The running month is still filling, so this starts the month deeply negative and climbs as the invoices land — it is only comparable to the month before it on the last day.`}
+              content={`${formatMonth(currentMonth.month)} (${formatEuros(currentMonth.revenue)}) vs ${formatMonth(lastMonth.month)} (${formatEuros(lastMonth.revenue)}). The running month is still filling.`}
             >
               <span className="underline decoration-dotted underline-offset-2">
                 {formatMonth(currentMonth.month)} vs{" "}
@@ -357,47 +407,41 @@ function RevenueCards(props: {
 }
 
 /**
- * The two series, in a fixed order with fixed colours.
- *
- * Order and colour follow the halves themselves, not their size: the monthly
- * book keeps its colour whether it is the larger half or not, so a month where
- * the two cross over does not repaint the chart.
- *
- * Violet is the app's own accent, which the account analytics already draw
- * their primary series in — the dominant half wears it. Grass is the second
- * because it is far enough from violet on the blue-yellow axis to survive
- * colour blindness: the pair separates by ΔE 28 under deuteranopia and 33 to
- * normal vision. Grass sits just under 3:1 against the light surface, which the
- * legend and the table below relieve.
+ * The series, in a fixed order with fixed colours: the monthly book keeps its
+ * colour whether it is the larger half or not, so a month where the halves
+ * cross over does not repaint the chart. Pink for the monthly book, violet —
+ * the app's accent — for the annual one, grass for the Marketplace rate.
  */
 const CHART_SERIES = [
-  { key: "monthly", label: "Monthly plans", color: "var(--violet-9)" },
-  { key: "yearly", label: "Yearly plans", color: "var(--grass-9)" },
+  { key: "monthly", label: "Monthly plans", color: "var(--pink-9)" },
+  { key: "yearly", label: "Yearly plans", color: "var(--violet-9)" },
+  { key: "github", label: "GitHub Marketplace", color: "var(--grass-9)" },
 ] as const;
 
 const CHART_CONFIG: ChartConfig = {
-  monthly: { label: "Monthly plans", color: "var(--violet-9)" },
-  yearly: { label: "Yearly plans", color: "var(--grass-9)" },
+  monthly: { label: "Monthly plans", color: "var(--pink-9)" },
+  yearly: { label: "Yearly plans", color: "var(--violet-9)" },
+  github: { label: "GitHub Marketplace", color: "var(--grass-9)" },
 };
 
 /**
- * The window as stacked areas, one point per complete month.
+ * The window as stacked areas, one point per month, the running one included.
  *
- * Stacked because the two halves compose the total the cards report, so the
- * height of the band is the figure and its split is where it came from. Areas
- * rather than bars because what is being read here is a trend over a year, and
- * a filled band carries a slope where twelve separate bars make the reader
- * measure heights against each other.
- *
- * The running month is left out, as it is from the table: a partial point
- * dragged the line down every month, which reads as a collapse rather than as a
- * month still filling.
+ * Stacked because the bands compose the business's total, so the height is
+ * the figure and its split is where it came from. Areas rather than bars
+ * because what is being read here is a trend over a year, and a filled band
+ * carries a slope where twelve separate bars make the reader measure heights
+ * against each other.
  */
-function RevenueChart(props: { months: readonly RevenueMonth[] }) {
-  const data = props.months.slice(0, -1).map((month) => ({
+function RevenueChart(props: {
+  months: readonly RevenueMonth[];
+  github: number;
+}) {
+  const data = props.months.map((month) => ({
     month: month.month,
     monthly: month.monthlyPlans.revenue,
     yearly: month.yearlyPlans.revenue,
+    github: props.github,
   }));
 
   return (
@@ -407,6 +451,21 @@ function RevenueChart(props: { months: readonly RevenueMonth[] }) {
       data-visual-test="transparent"
     >
       <AreaChart accessibilityLayer data={data} margin={{ left: 0, right: 8 }}>
+        <defs>
+          {CHART_SERIES.map((series) => (
+            <linearGradient
+              key={series.key}
+              id={`fill-${series.key}`}
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="1"
+            >
+              <stop offset="0%" stopColor={series.color} stopOpacity={0.3} />
+              <stop offset="100%" stopColor={series.color} stopOpacity={0} />
+            </linearGradient>
+          ))}
+        </defs>
         {/* Horizontal only, dashed: the grid is there to read a height against,
             not to be looked at. */}
         <CartesianGrid vertical={false} strokeDasharray="5 5" />
@@ -439,7 +498,7 @@ function RevenueChart(props: { months: readonly RevenueMonth[] }) {
                 invariant(item, "a tooltip always has a datum");
                 return MONTH_YEAR_FORMAT.format(new Date(item.payload.month));
               }}
-              formatter={(value) => formatPrice(Number(value))}
+              valueFormatter={(value) => formatEuros(value)}
             />
           }
         />
@@ -452,8 +511,7 @@ function RevenueChart(props: { months: readonly RevenueMonth[] }) {
             dataKey={series.key}
             type="monotone"
             stackId="revenue"
-            fill={series.color}
-            fillOpacity={0.4}
+            fill={`url(#fill-${series.key})`}
             stroke={series.color}
             isAnimationActive={false}
           />
@@ -467,53 +525,144 @@ function RevenueChart(props: { months: readonly RevenueMonth[] }) {
 function HistoryRow(props: {
   month: RevenueMonth;
   before: RevenueMonth | null;
+  /** The month still running — partial, so it makes no comparison. */
+  isCurrent: boolean;
   index: number;
   isLast: boolean;
 }) {
-  const { month, before, index, isLast } = props;
+  const { month, before, isCurrent, index, isLast } = props;
+  const [isOpened, setIsOpened] = useState(false);
   // On the monthly figure, like every column here: the yearly rate lives in
   // its own table, and a change diluted by a flat rate would understate every
   // move.
-  const growth = before
-    ? getGrowth(month.monthlyPlans.revenue, before.monthlyPlans.revenue)
-    : null;
+  const growth =
+    before && !isCurrent
+      ? getGrowth(month.monthlyPlans.revenue, before.monthlyPlans.revenue)
+      : null;
 
   return (
-    <tr
-      className={clsx(
-        index % 2 === 0 ? "bg-app" : "bg-subtle",
-        !isLast && "border-b",
-      )}
-    >
-      <td className="p-4 text-left text-sm font-medium">
-        {MONTH_YEAR_FORMAT.format(new Date(month.month))}
-      </td>
-      <td className="p-4 text-right text-sm tabular-nums">
-        {formatPrice(month.monthlyPlans.revenue)}
-      </td>
-      <td className="p-4 text-right text-sm tabular-nums">
-        {growth === null ? (
-          <span className="text-low">—</span>
-        ) : (
-          <span className={growth < 0 ? "text-danger-low" : "text-success-low"}>
-            {growth > 0 ? "+" : ""}
-            {Math.round(growth * 100)}%
-          </span>
+    <>
+      <tr
+        className={clsx(
+          index % 2 === 0 ? "bg-app" : "bg-subtle",
+          (!isLast || isOpened) && "border-b",
         )}
-      </td>
-      <td className="p-4 text-right text-sm tabular-nums">
-        {month.monthlyPlans.teamsCount}
-      </td>
-      <td className="p-4 text-right text-sm tabular-nums">
-        {month.monthlyPlans.teamsCount > 0 ? (
-          formatPrice(
-            month.monthlyPlans.revenue / month.monthlyPlans.teamsCount,
-          )
-        ) : (
-          <span className="text-low">—</span>
-        )}
-      </td>
-    </tr>
+      >
+        <td className="p-4 text-left text-sm font-medium">
+          {MONTH_YEAR_FORMAT.format(new Date(month.month))}
+          {isCurrent ? <span className="text-low"> (running)</span> : null}
+        </td>
+        <td className="p-4 text-right text-sm tabular-nums">
+          {formatEuros(month.monthlyPlans.revenue)}
+        </td>
+        <td className="p-4 text-right text-sm tabular-nums">
+          {growth === null ? (
+            <span className="text-low">—</span>
+          ) : (
+            <span
+              className={growth < 0 ? "text-danger-low" : "text-success-low"}
+            >
+              {growth > 0 ? "+" : ""}
+              {Math.round(growth * 100)}%
+            </span>
+          )}
+        </td>
+        <td className="p-4 text-right text-sm tabular-nums">
+          {month.monthlyPlans.teamsCount}
+        </td>
+        <td className="p-4 text-right text-sm tabular-nums">
+          {month.monthlyPlans.teamsCount > 0 ? (
+            formatEuros(
+              month.monthlyPlans.revenue / month.monthlyPlans.teamsCount,
+            )
+          ) : (
+            <span className="text-low">—</span>
+          )}
+        </td>
+        <td className="p-4 text-right text-sm">
+          {month.teams.length > 0 ? (
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={() => setIsOpened((opened) => !opened)}
+            >
+              View details
+              <ButtonIcon position="right">
+                <ChevronDownIcon
+                  className={clsx(
+                    "transition-transform",
+                    isOpened && "rotate-180",
+                  )}
+                />
+              </ButtonIcon>
+            </Button>
+          ) : null}
+        </td>
+      </tr>
+      {isOpened ? (
+        <tr
+          className={clsx(
+            // Inverted from the month's row, like the team directory's detail
+            // rows: the breakdown reads as inside the month, not as a sibling.
+            index % 2 === 0 ? "bg-subtle" : "bg-app",
+            !isLast && "border-b",
+          )}
+        >
+          <td colSpan={6} className="p-4">
+            <div className="bg-app overflow-x-auto rounded-sm border">
+              <table className="w-full table-fixed border-collapse">
+                <thead>
+                  <tr className="text-low border-b text-xs font-semibold">
+                    <th className="w-[40%] px-4 py-2.5 text-left">Team</th>
+                    <th className="w-[22%] px-4 py-2.5 text-right">Invoiced</th>
+                    <th className="w-[22%] px-4 py-2.5 text-right">In euros</th>
+                    <th className="w-[16%] px-4 py-2.5 text-right" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {month.teams.map((team, teamIndex) => (
+                    <tr
+                      key={team.stripeCustomerId}
+                      className={clsx(
+                        "text-sm",
+                        teamIndex !== month.teams.length - 1 && "border-b",
+                      )}
+                    >
+                      <td className="px-4 py-2.5 text-left">
+                        <Link href={`/${team.slug}`}>
+                          {team.name ?? team.slug}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2.5 text-right tabular-nums">
+                        {team.currency !== null ? (
+                          formatInvoiceAmount({
+                            amount: team.amount,
+                            currency: team.currency,
+                          })
+                        ) : (
+                          <span className="text-low">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-2.5 text-right tabular-nums">
+                        {formatEuros(team.revenue)}
+                      </td>
+                      <td className="px-4 py-2.5 text-right">
+                        <Link
+                          href={getStripeCustomerURL(team.stripeCustomerId)}
+                          target="_blank"
+                        >
+                          Stripe
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </td>
+        </tr>
+      ) : null}
+    </>
   );
 }
 
@@ -529,10 +678,7 @@ function HistoryRow(props: {
  */
 function RevenueHistory(props: { months: readonly RevenueMonth[] }) {
   const { months } = props;
-  // The running month is left out: it is partial, so a column comparing it to
-  // complete months would report a drop that is only the calendar.
-  const complete = months.slice(0, -1);
-  const rows = [...complete].reverse();
+  const rows = [...months].reverse();
 
   return (
     <div>
@@ -543,35 +689,24 @@ function RevenueHistory(props: { months: readonly RevenueMonth[] }) {
         <table className="w-full min-w-160 table-fixed border-collapse">
           <thead>
             <tr className="text-low border-b text-xs font-semibold">
-              <th className="w-[22%] px-4 py-3 text-left">Month</th>
-              <th className="w-[21%] px-4 py-3 text-right">
-                <Tooltip content="Invoices issued that month, excluding tax and net of credit notes — what Stripe charged, discounts included.">
+              <th className="w-[16%] px-4 py-3 text-left">Month</th>
+              <th className="w-[18%] px-4 py-3 text-right">
+                <Tooltip content="Ex-tax, net of credit notes.">
                   <span className="underline decoration-dotted underline-offset-2">
                     Invoiced
                   </span>
                 </Tooltip>
               </th>
+              <th className="w-[14%] px-4 py-3 text-right">Change</th>
+              <th className="w-[14%] px-4 py-3 text-right">Teams</th>
               <th className="w-[18%] px-4 py-3 text-right">
-                <Tooltip content="Against the month before it.">
+                <Tooltip content="Monthly revenue per paying team.">
                   <span className="underline decoration-dotted underline-offset-2">
-                    Change
+                    ARPU
                   </span>
                 </Tooltip>
               </th>
-              <th className="w-[18%] px-4 py-3 text-right">
-                <Tooltip content="Teams invoiced that month.">
-                  <span className="underline decoration-dotted underline-offset-2">
-                    Teams
-                  </span>
-                </Tooltip>
-              </th>
-              <th className="w-[21%] px-4 py-3 text-right">
-                <Tooltip content="The month's invoices over its teams — what the average team was billed.">
-                  <span className="underline decoration-dotted underline-offset-2">
-                    Per team
-                  </span>
-                </Tooltip>
-              </th>
+              <th className="w-[20%] px-4 py-3 text-right" />
             </tr>
           </thead>
           <tbody>
@@ -581,6 +716,8 @@ function RevenueHistory(props: { months: readonly RevenueMonth[] }) {
                 month={month}
                 // `rows` runs newest first, so the month before is the next one.
                 before={rows[index + 1] ?? null}
+                // The newest row is the month still running.
+                isCurrent={index === 0}
                 index={index}
                 isLast={index === rows.length - 1}
               />
@@ -598,20 +735,31 @@ function describeInvoice(invoice: YearlyContract["invoices"][number]): string {
     invoice.coveredFrom && invoice.coveredUntil
       ? `, covers ${DATE_FORMAT.format(new Date(invoice.coveredFrom))} to ${DATE_FORMAT.format(new Date(invoice.coveredUntil))}`
       : "";
-  return `${CONTRACT_PRICE_FORMAT.format(invoice.amount)} invoiced ${DATE_FORMAT.format(new Date(invoice.invoicedAt))}${covers}.`;
+  return `${formatInvoiceAmount(invoice)} invoiced ${DATE_FORMAT.format(new Date(invoice.invoicedAt))}${covers}.`;
 }
 
 /** One contract, the invoices it is worth and what it adds per month. */
+/** The contract's invoices in their own currency, when they share one. */
+function getOriginalTotal(
+  contract: YearlyContract,
+): { amount: number; currency: string } | null {
+  const first = contract.invoices[0];
+  if (
+    !first ||
+    contract.invoices.some((invoice) => invoice.currency !== first.currency)
+  ) {
+    return null;
+  }
+  return {
+    amount: contract.invoices.reduce((sum, invoice) => sum + invoice.amount, 0),
+    currency: first.currency,
+  };
+}
+
 function ContractRow(props: { contract: YearlyContract; index: number }) {
   const { contract, index } = props;
   const newestInvoice = contract.invoices[0] ?? null;
-  const foreignCurrencies = [
-    ...new Set(
-      contract.invoices
-        .filter((invoice) => invoice.currency !== "usd")
-        .map((invoice) => invoice.currency.toUpperCase()),
-    ),
-  ];
+  const originalTotal = getOriginalTotal(contract);
 
   return (
     <tr className={clsx(index % 2 === 0 ? "bg-app" : "bg-subtle", "border-b")}>
@@ -631,32 +779,23 @@ function ContractRow(props: { contract: YearlyContract; index: number }) {
               }
             >
               <span className="underline decoration-dotted underline-offset-2">
-                {CONTRACT_PRICE_FORMAT.format(contract.amount)}
+                {originalTotal
+                  ? formatInvoiceAmount(originalTotal)
+                  : CONTRACT_PRICE_FORMAT.format(contract.amount)}
               </span>
             </Tooltip>
-            {contract.invoices.length > 1 ? (
-              <span className="text-low">
-                {" "}
-                ({contract.invoices.length} invoices)
-              </span>
-            ) : null}
-            {foreignCurrencies.length > 0 ? (
-              <span className="text-low">
-                {" "}
-                ({foreignCurrencies.join(", ")} at parity)
-              </span>
-            ) : null}
             {contract.awaitingPayment ? (
-              <Tooltip content="The invoice was raised but has not been paid yet, so it counts nothing until it clears.">
-                <span className="text-warning-low underline decoration-dotted underline-offset-2">
-                  {" "}
-                  awaiting payment
-                </span>
-              </Tooltip>
+              <div>
+                <Tooltip content="Raised, not yet paid. Counted — expected to clear.">
+                  <span className="text-warning-low underline decoration-dotted underline-offset-2">
+                    Awaiting payment
+                  </span>
+                </Tooltip>
+              </div>
             ) : null}
           </>
         ) : (
-          <Tooltip content="No invoice reading as this contract was found on the customer, so it adds nothing to the yearly figure. Its invoices are worth a look in Stripe.">
+          <Tooltip content="Counts nothing.">
             <span className="text-danger-low underline decoration-dotted underline-offset-2">
               no invoice found
             </span>
@@ -664,7 +803,7 @@ function ContractRow(props: { contract: YearlyContract; index: number }) {
         )}
       </td>
       <td className="p-4 text-right text-sm tabular-nums">
-        {contract.amount !== null && !contract.awaitingPayment ? (
+        {contract.amount !== null ? (
           CONTRACT_PRICE_FORMAT.format(contract.amount / 12)
         ) : (
           <span className="text-low">—</span>
@@ -699,10 +838,8 @@ function ContractRow(props: { contract: YearlyContract; index: number }) {
  */
 function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
   const { contracts } = props;
-  // Awaiting-payment invoices are listed but not counted, like in the figure.
   const total = contracts.reduce(
-    (sum, contract) =>
-      sum + (contract.awaitingPayment ? 0 : (contract.amount ?? 0)),
+    (sum, contract) => sum + (contract.amount ?? 0),
     0,
   );
 
@@ -719,15 +856,9 @@ function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
             <thead>
               <tr className="text-low border-b text-xs font-semibold">
                 <th className="w-[30%] px-4 py-3 text-left">Team</th>
-                <th className="w-[20%] px-4 py-3 text-right">
-                  <Tooltip content="The contract's invoices added up — its latest annual bill, plus upsells raised on top of it since — excluding tax and net of credit notes.">
-                    <span className="underline decoration-dotted underline-offset-2">
-                      Invoiced
-                    </span>
-                  </Tooltip>
-                </th>
+                <th className="w-[20%] px-4 py-3 text-right">Invoiced</th>
                 <th className="w-[16%] px-4 py-3 text-right">
-                  <Tooltip content="The renewal over twelve — this column adds up to the Yearly plans figure.">
+                  <Tooltip content="÷ 12, in euros.">
                     <span className="underline decoration-dotted underline-offset-2">
                       Per month
                     </span>
@@ -750,7 +881,11 @@ function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
               <tr className="text-sm font-medium">
                 <td className="p-4 text-left">Total</td>
                 <td className="p-4 text-right tabular-nums">
-                  {CONTRACT_PRICE_FORMAT.format(total)}
+                  <Tooltip content="In euros.">
+                    <span className="underline decoration-dotted underline-offset-2">
+                      {CONTRACT_PRICE_FORMAT.format(total)}
+                    </span>
+                  </Tooltip>
                 </td>
                 <td className="p-4 text-right tabular-nums">
                   {CONTRACT_PRICE_FORMAT.format(total / 12)}
@@ -801,30 +936,26 @@ function StaffRevenuePage() {
       <PageHeader>
         <PageHeaderContent>
           <Heading>Revenue</Heading>
-          <Text slot="headline">
-            What Argos invoiced, month by month, read from Stripe.
-          </Text>
         </PageHeaderContent>
       </PageHeader>
-      <RevenueCards months={months} error={error ?? null} />
-      {months && contracts ? (
+      <RevenueCards
+        months={months}
+        github={data?.staffRevenue.githubMarketplaceMonthlyRevenue ?? null}
+        error={error ?? null}
+      />
+      {data && months && contracts ? (
         <>
-          <ChartCard
-            className="mb-6"
-            title="Invoiced by month"
-            description="Complete months only — the one running is still filling."
-          >
-            <RevenueChart months={months} />
+          <ChartCard className="mb-6" title="Invoiced by month">
+            <RevenueChart
+              months={months}
+              github={data.staffRevenue.githubMarketplaceMonthlyRevenue}
+            />
           </ChartCard>
           <RevenueHistory months={months} />
           <YearlyContracts contracts={contracts} />
         </>
       ) : error ? null : (
-        <ChartCard
-          className="mb-6"
-          title="Invoiced by month"
-          description="Complete months only — the one running is still filling."
-        >
+        <ChartCard className="mb-6" title="Invoiced by month">
           <div className="flex flex-col items-center gap-3 text-center">
             <Loader className="size-8" delay={0} />
             {/* Said rather than left to a spinner: this walks a year of Stripe

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -109,7 +109,7 @@ const CURRENT_MONTHLY_HINT =
   "This month's invoices so far, ex-tax, net of credit notes.";
 
 const YEARLY_HINT =
-  "Annual contracts ÷ 12. The same rate every month converted in €.";
+  "Annual contracts amortized, day by day, over the months they cover. In €.";
 
 const GITHUB_HINT = "Hard coded amount";
 

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -1,3 +1,4 @@
+import { CombinedGraphQLErrors } from "@apollo/client";
 import { useQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { clsx } from "clsx";
@@ -13,6 +14,7 @@ import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import { AuthGuard } from "@/containers/AuthGuard";
 import type { DocumentType } from "@/gql";
 import { graphql } from "@/gql";
+import { Alert, AlertText, AlertTitle } from "@/ui/Alert";
 import { ChartCard } from "@/ui/ChartCard";
 import type { ChartConfig } from "@/ui/Charts";
 import {
@@ -29,6 +31,7 @@ import {
   PageHeader,
   PageHeaderContent,
 } from "@/ui/Layout";
+import { Link } from "@/ui/Link";
 import { Loader } from "@/ui/Loader";
 import { StatTile } from "@/ui/StatTile";
 import { Text } from "@/ui/Text";
@@ -53,10 +56,12 @@ const StaffRevenueQuery = graphql(`
       monthlyPlans {
         revenue
         teamsCount
+        foreignRevenue
       }
       yearlyPlans {
         revenue
         teamsCount
+        foreignRevenue
       }
     }
   }
@@ -139,7 +144,16 @@ function formatMonth(month: string): string {
 
 /** The figures behind a half, appended to its tooltip. */
 function getSplitNote(split: Split): string {
-  return ` ${split.teamsCount} ${split.teamsCount === 1 ? "team" : "teams"}.`;
+  const teams = ` ${split.teamsCount} ${split.teamsCount === 1 ? "team" : "teams"}.`;
+  // Named only when there is some: on an all-dollar month the caveat would be
+  // noise, and on a month with euros in it the reader has to know the total
+  // holds two currencies added at parity.
+  const foreign =
+    split.foreignRevenue > 0
+      ? ` ${formatPrice(split.foreignRevenue)} of it was invoiced in another currency and is counted at parity, not converted.`
+      : "";
+
+  return `${teams}${foreign}`;
 }
 
 /**
@@ -524,6 +538,29 @@ function StaffRevenuePage() {
     variables: { months: PAGE_MONTHS },
   });
   const months = data?.staffRevenue ?? null;
+
+  // Told rather than reported as a failed figure, as the other staff pages do:
+  // a reader without access has no figures to wait for, and three tiles reading
+  // "unavailable" would send them looking for an outage. Every other failure
+  // stays on the tiles, where it does not take the page down with it.
+  const isForbidden =
+    error !== undefined &&
+    CombinedGraphQLErrors.is(error) &&
+    error.errors.some((item) => item.extensions?.code === "FORBIDDEN");
+
+  if (isForbidden) {
+    return (
+      <PageContainer>
+        <Alert>
+          <AlertTitle>Access restricted</AlertTitle>
+          <AlertText>This page is only available to staff users.</AlertText>
+          <AlertText>
+            <Link href="/teams">Go to your teams</Link>
+          </AlertText>
+        </Alert>
+      </PageContainer>
+    );
+  }
 
   return (
     <PageContainer>

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -1,0 +1,582 @@
+import { useQuery } from "@apollo/client/react";
+import { invariant } from "@argos/util/invariant";
+import { clsx } from "clsx";
+import {
+  CalendarCheckIcon,
+  CalendarClockIcon,
+  TrendingDownIcon,
+  TrendingUpIcon,
+} from "lucide-react";
+import { Helmet } from "react-helmet";
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+
+import { AuthGuard } from "@/containers/AuthGuard";
+import type { DocumentType } from "@/gql";
+import { graphql } from "@/gql";
+import { ChartCard } from "@/ui/ChartCard";
+import type { ChartConfig } from "@/ui/Charts";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/ui/Charts";
+import { Heading } from "@/ui/Heading";
+import {
+  Page,
+  PageContainer,
+  PageHeader,
+  PageHeaderContent,
+} from "@/ui/Layout";
+import { Loader } from "@/ui/Loader";
+import { StatTile } from "@/ui/StatTile";
+import { Text } from "@/ui/Text";
+import { Tooltip } from "@/ui/Tooltip";
+
+import { formatPrice } from "./pricing";
+
+/**
+ * Asked on its own rather than alongside the team directory: it walks Stripe's
+ * invoices, so the two load beside each other, each with its own skeleton, and
+ * a slow answer never holds a row of the table back.
+ *
+ * Every month costs a walk of its own, which is why the count is asked for
+ * rather than fixed: the band above the directory wants three, the page that
+ * charts a year wants twelve, and neither should pay for the other.
+ */
+const StaffRevenueQuery = graphql(`
+  query StaffRevenue_staffRevenue($months: Int!) {
+    staffRevenue(months: $months) {
+      month
+      revenue
+      monthlyPlans {
+        revenue
+        teamsCount
+      }
+      yearlyPlans {
+        revenue
+        teamsCount
+      }
+    }
+  }
+`);
+
+type RevenueMonth = DocumentType<
+  typeof StaffRevenueQuery
+>["staffRevenue"][number];
+type Split = RevenueMonth["monthlyPlans"];
+
+/** Months the dedicated page reads — a year, plus the one running. */
+const PAGE_MONTHS = 13;
+
+/**
+ * How each half is arrived at, one tooltip each.
+ *
+ * Two rather than one because the halves do not answer the same question: the
+ * monthly one reports the month's invoices, the yearly one a rate.
+ */
+const LAST_MONTHLY_HINT =
+  "Invoices issued last month, excluding tax and net of credit notes — what Stripe charged, discounts included.";
+
+const CURRENT_MONTHLY_HINT =
+  "Invoices issued so far this month, excluding tax and net of credit notes. Partial by nature: the month is not over.";
+
+const YEARLY_HINT =
+  "Annual contracts in force: their latest invoice ÷ 12. A rate, so it is the same every month rather than a spike in the renewal month.";
+
+/**
+ * Stands in for the hint line while the figures load.
+ *
+ * `StatTile` only reserves that line's height when it is given a hint at all,
+ * and blanks its content on its own while loading. Handing it nothing until the
+ * data lands drops the line entirely, so the card grows under the reader the
+ * moment it arrives.
+ */
+const HINT_PLACEHOLDER = " ";
+
+/**
+ * The month an amount covers, named.
+ *
+ * Read in UTC, which is where the server cut the month — formatting in the
+ * reader's own zone would name the month before it for anyone west of
+ * Greenwich.
+ */
+const MONTH_FORMAT = new Intl.DateTimeFormat("en-US", {
+  month: "long",
+  timeZone: "UTC",
+});
+
+const MONTH_YEAR_FORMAT = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  year: "numeric",
+  timeZone: "UTC",
+});
+
+const MONTH_SHORT_FORMAT = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  timeZone: "UTC",
+});
+
+/**
+ * Amounts on the axis, shortened.
+ *
+ * Fixed to the same locale and currency as `formatPrice` rather than the
+ * reader's own: every other figure on the page is printed in US dollars, and an
+ * axis that followed the browser would label the same money differently from
+ * the cards above it.
+ */
+const AXIS_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  notation: "compact",
+  maximumFractionDigits: 0,
+});
+
+function formatMonth(month: string): string {
+  return MONTH_FORMAT.format(new Date(month));
+}
+
+/** The figures behind a half, appended to its tooltip. */
+function getSplitNote(split: Split): string {
+  return ` ${split.teamsCount} ${split.teamsCount === 1 ? "team" : "teams"}.`;
+}
+
+/**
+ * How the figure moved between two months, or null when there is nothing to
+ * divide by.
+ *
+ * A month that invoiced nothing is a real answer, but it makes no ratio, and
+ * reporting the growth as infinite would say less than saying nothing.
+ */
+function getGrowth(month: number, before: number): number | null {
+  return before === 0 ? null : (month - before) / before;
+}
+
+/** One half of the amount, with the tooltip that explains that half alone. */
+function SplitAmount(props: {
+  amount: number;
+  label: string;
+  tooltip: string;
+}) {
+  return (
+    <Tooltip content={props.tooltip}>
+      <span className="underline decoration-dotted underline-offset-2">
+        {formatPrice(props.amount)} {props.label}
+      </span>
+    </Tooltip>
+  );
+}
+
+/**
+ * Where a month's amount comes from, under the amount.
+ *
+ * The two intervals rather than any other cut: they are the two things this
+ * computes differently — one reads the month's invoices, the other spreads a
+ * year's — so they are what a reader has to be able to take apart.
+ */
+function MonthSplit(props: { month: RevenueMonth; monthlyHint: string }) {
+  const { month, monthlyHint } = props;
+
+  return (
+    <>
+      <SplitAmount
+        amount={month.monthlyPlans.revenue}
+        label="monthly"
+        tooltip={`${monthlyHint}${getSplitNote(month.monthlyPlans)}`}
+      />
+      {" · "}
+      <SplitAmount
+        amount={month.yearlyPlans.revenue}
+        label="yearly"
+        tooltip={`${YEARLY_HINT}${getSplitNote(month.yearlyPlans)}`}
+      />
+    </>
+  );
+}
+
+/**
+ * The three headline figures, rendered from whatever window was read.
+ *
+ * Takes the months rather than fetching them, so the band above the directory
+ * and the page that charts a year draw the same cards off one query each rather
+ * than asking twice.
+ */
+function RevenueCards(props: {
+  /** Oldest first, the running month last. Null while loading. */
+  months: readonly RevenueMonth[] | null;
+  error: Error | null;
+}) {
+  const { months, error } = props;
+
+  // The last two are the only ones the cards read, whatever the window.
+  const currentMonth = months?.at(-1) ?? null;
+  const lastMonth = months?.at(-2) ?? null;
+  const growth =
+    currentMonth && lastMonth
+      ? getGrowth(currentMonth.revenue, lastMonth.revenue)
+      : null;
+
+  // An em dash on all three rather than a band that disappears: the figures
+  // failing to load is worth seeing on a page whose whole subject is what they
+  // report, and it must not take the directory down with it.
+  //
+  // The reason is carried rather than swallowed. This reads a third party at
+  // request time, so it fails in ways only its message explains — a key missing
+  // a permission, a rate limit, a key in the wrong mode — and this page is
+  // staff-only, so there is nobody here to protect from the detail.
+  const unavailable = error ? (
+    <Tooltip content={error.message}>
+      <span className="underline decoration-dotted underline-offset-2">
+        unavailable
+      </span>
+    </Tooltip>
+  ) : null;
+
+  /** `undefined` draws the skeleton, `null` an em dash. */
+  const readValue = (value: number | null) => {
+    if (error) {
+      return null;
+    }
+    return months ? value : undefined;
+  };
+
+  return (
+    <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <StatTile
+        data-visual-test="transparent"
+        icon={CalendarCheckIcon}
+        color="success"
+        label="Last month"
+        value={readValue(lastMonth?.revenue ?? null)}
+        format="currency"
+        hint={
+          unavailable ??
+          (lastMonth ? (
+            <MonthSplit month={lastMonth} monthlyHint={LAST_MONTHLY_HINT} />
+          ) : (
+            HINT_PLACEHOLDER
+          ))
+        }
+      />
+      <StatTile
+        data-visual-test="transparent"
+        icon={CalendarClockIcon}
+        color="primary"
+        label="Current month"
+        value={readValue(currentMonth?.revenue ?? null)}
+        format="currency"
+        hint={
+          unavailable ??
+          (currentMonth ? (
+            <MonthSplit
+              month={currentMonth}
+              monthlyHint={CURRENT_MONTHLY_HINT}
+            />
+          ) : (
+            HINT_PLACEHOLDER
+          ))
+        }
+      />
+      <StatTile
+        data-visual-test="transparent"
+        icon={growth !== null && growth < 0 ? TrendingDownIcon : TrendingUpIcon}
+        color={growth !== null && growth < 0 ? "warning" : "success"}
+        label="Month over month"
+        value={readValue(growth)}
+        format="percent"
+        hint={
+          unavailable ??
+          (currentMonth && lastMonth && growth !== null ? (
+            <Tooltip
+              content={`${formatMonth(currentMonth.month)} at ${formatPrice(currentMonth.revenue)} against ${formatMonth(lastMonth.month)} at ${formatPrice(lastMonth.revenue)}. The running month is still filling, so this starts the month deeply negative and climbs as the invoices land — it is only comparable to the month before it on the last day.`}
+            >
+              <span className="underline decoration-dotted underline-offset-2">
+                {formatMonth(currentMonth.month)} vs{" "}
+                {formatMonth(lastMonth.month)}
+              </span>
+            </Tooltip>
+          ) : months ? (
+            "nothing to compare"
+          ) : (
+            HINT_PLACEHOLDER
+          ))
+        }
+      />
+    </div>
+  );
+}
+
+/**
+ * The two series, in a fixed order with fixed colours.
+ *
+ * Order and colour follow the halves themselves, not their size: the monthly
+ * book keeps its colour whether it is the larger half or not, so a month where
+ * the two cross over does not repaint the chart.
+ *
+ * Violet is the app's own accent, which the account analytics already draw
+ * their primary series in — the dominant half wears it. Grass is the second
+ * because it is far enough from violet on the blue-yellow axis to survive
+ * colour blindness: the pair separates by ΔE 28 under deuteranopia and 33 to
+ * normal vision. Grass sits just under 3:1 against the light surface, which the
+ * legend and the table below relieve.
+ */
+const CHART_SERIES = [
+  { key: "monthly", label: "Monthly plans", color: "var(--violet-9)" },
+  { key: "yearly", label: "Yearly plans", color: "var(--grass-9)" },
+] as const;
+
+const CHART_CONFIG: ChartConfig = {
+  monthly: { label: "Monthly plans", color: "var(--violet-9)" },
+  yearly: { label: "Yearly plans", color: "var(--grass-9)" },
+};
+
+/**
+ * The window as stacked areas, one point per complete month.
+ *
+ * Stacked because the two halves compose the total the cards report, so the
+ * height of the band is the figure and its split is where it came from. Areas
+ * rather than bars because what is being read here is a trend over a year, and
+ * a filled band carries a slope where twelve separate bars make the reader
+ * measure heights against each other.
+ *
+ * The running month is left out, as it is from the table: a partial point
+ * dragged the line down every month, which reads as a collapse rather than as a
+ * month still filling.
+ */
+function RevenueChart(props: { months: readonly RevenueMonth[] }) {
+  const data = props.months.slice(0, -1).map((month) => ({
+    month: month.month,
+    monthly: month.monthlyPlans.revenue,
+    yearly: month.yearlyPlans.revenue,
+  }));
+
+  return (
+    <ChartContainer
+      config={CHART_CONFIG}
+      className="h-full w-full"
+      data-visual-test="transparent"
+    >
+      <AreaChart accessibilityLayer data={data} margin={{ left: 0, right: 8 }}>
+        {/* Horizontal only, dashed: the grid is there to read a height against,
+            not to be looked at. */}
+        <CartesianGrid vertical={false} strokeDasharray="5 5" />
+        <XAxis
+          dataKey="month"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={12}
+          tickFormatter={(value: string) =>
+            MONTH_SHORT_FORMAT.format(new Date(value))
+          }
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          // Wide enough for the longest compact amount. Left to itself under a
+          // negative margin, the axis cropped its own labels and printed
+          // "8 k $US" where it meant "$38K".
+          width={56}
+          tickFormatter={(value: number) => AXIS_PRICE_FORMAT.format(value)}
+        />
+        <ChartTooltip
+          isAnimationActive={false}
+          content={
+            <ChartTooltipContent
+              // The month is read off the datum rather than off the label:
+              // Recharts hands the label over as a node, not as the value.
+              labelFormatter={(_label, payload) => {
+                const item = payload[0];
+                invariant(item, "a tooltip always has a datum");
+                return MONTH_YEAR_FORMAT.format(new Date(item.payload.month));
+              }}
+              formatter={(value) => formatPrice(Number(value))}
+            />
+          }
+        />
+        {/* Two series, so a legend is not optional: identity must not rest on
+            colour alone. */}
+        <ChartLegend content={<ChartLegendContent />} />
+        {CHART_SERIES.map((series) => (
+          <Area
+            key={series.key}
+            dataKey={series.key}
+            type="monotone"
+            stackId="revenue"
+            fill={series.color}
+            fillOpacity={0.4}
+            stroke={series.color}
+            isAnimationActive={false}
+          />
+        ))}
+      </AreaChart>
+    </ChartContainer>
+  );
+}
+
+/** Month over month down the history, so a trend can be read off the column. */
+function HistoryRow(props: {
+  month: RevenueMonth;
+  before: RevenueMonth | null;
+  index: number;
+  isLast: boolean;
+}) {
+  const { month, before, index, isLast } = props;
+  const growth = before ? getGrowth(month.revenue, before.revenue) : null;
+
+  return (
+    <tr
+      className={clsx(
+        index % 2 === 0 ? "bg-app" : "bg-subtle",
+        !isLast && "border-b",
+      )}
+    >
+      <td className="p-4 text-left text-sm font-medium">
+        {MONTH_YEAR_FORMAT.format(new Date(month.month))}
+      </td>
+      <td className="p-4 text-right text-sm tabular-nums">
+        {formatPrice(month.monthlyPlans.revenue)}
+      </td>
+      <td className="p-4 text-right text-sm tabular-nums">
+        {formatPrice(month.yearlyPlans.revenue)}
+      </td>
+      <td className="p-4 text-right text-sm font-medium tabular-nums">
+        {formatPrice(month.revenue)}
+      </td>
+      <td className="p-4 text-right text-sm tabular-nums">
+        {growth === null ? (
+          <span className="text-low">—</span>
+        ) : (
+          <span className={growth < 0 ? "text-danger-low" : "text-success-low"}>
+            {growth > 0 ? "+" : ""}
+            {Math.round(growth * 100)}%
+          </span>
+        )}
+      </td>
+      <td className="p-4 text-right text-sm tabular-nums">
+        {month.monthlyPlans.teamsCount}
+      </td>
+    </tr>
+  );
+}
+
+/**
+ * The window, month by month.
+ *
+ * The reason this page exists rather than the band alone: three cards say where
+ * revenue stands, a column says which way it has been going — and the months
+ * are already read to draw the cards, so the table costs nothing more.
+ *
+ * Newest first, like every other staff table: the rows people read are the
+ * recent ones.
+ */
+function RevenueHistory(props: { months: readonly RevenueMonth[] }) {
+  const { months } = props;
+  // The running month is left out: it is partial, so a column comparing it to
+  // complete months would report a drop that is only the calendar.
+  const complete = months.slice(0, -1);
+  const rows = [...complete].reverse();
+
+  return (
+    <div className="overflow-x-auto rounded-sm border">
+      <table className="w-full min-w-160 table-fixed border-collapse">
+        <thead>
+          <tr className="text-low border-b text-xs font-semibold">
+            <th className="w-[18%] px-4 py-3 text-left">Month</th>
+            <th className="w-[18%] px-4 py-3 text-right">Monthly plans</th>
+            <th className="w-[18%] px-4 py-3 text-right">Yearly plans</th>
+            <th className="w-[16%] px-4 py-3 text-right">Total</th>
+            <th className="w-[15%] px-4 py-3 text-right">
+              <Tooltip content="Against the month before it. The running month is not listed: being partial, it would read as a drop that is only the calendar.">
+                <span className="underline decoration-dotted underline-offset-2">
+                  Change
+                </span>
+              </Tooltip>
+            </th>
+            <th className="w-[15%] px-4 py-3 text-right">
+              <Tooltip content="Teams invoiced on a monthly plan that month. Annual contracts are a rate rather than a month's invoices, so they are not counted here.">
+                <span className="underline decoration-dotted underline-offset-2">
+                  Teams
+                </span>
+              </Tooltip>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((month, index) => (
+            <HistoryRow
+              key={month.month}
+              month={month}
+              // `rows` runs newest first, so the month before is the next one.
+              before={rows[index + 1] ?? null}
+              index={index}
+              isLast={index === rows.length - 1}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function StaffRevenuePage() {
+  const { data, error } = useQuery(StaffRevenueQuery, {
+    variables: { months: PAGE_MONTHS },
+  });
+  const months = data?.staffRevenue ?? null;
+
+  return (
+    <PageContainer>
+      <PageHeader>
+        <PageHeaderContent>
+          <Heading>Revenue</Heading>
+          <Text slot="headline">
+            What Argos invoiced, month by month, read from Stripe.
+          </Text>
+        </PageHeaderContent>
+      </PageHeader>
+      <RevenueCards months={months} error={error ?? null} />
+      {months ? (
+        <>
+          <ChartCard
+            className="mb-6"
+            title="Invoiced by month"
+            description="Complete months only — the one running is still filling."
+          >
+            <RevenueChart months={months} />
+          </ChartCard>
+          <RevenueHistory months={months} />
+        </>
+      ) : error ? null : (
+        <ChartCard
+          className="mb-6"
+          title="Invoiced by month"
+          description="Complete months only — the one running is still filling."
+        >
+          <div className="flex flex-col items-center gap-3 text-center">
+            <Loader className="size-8" delay={0} />
+            {/* Said rather than left to a spinner: this walks a year of Stripe
+                invoices, which is seconds rather than the moment a spinner
+                usually stands for — and knowing why it is slow is the
+                difference between waiting and reloading. */}
+            <div className="text-low max-w-sm text-sm">
+              Reading {PAGE_MONTHS} months of invoices from Stripe. Nothing is
+              stored, so this takes a few seconds the first time each hour.
+            </div>
+          </div>
+        </ChartCard>
+      )}
+    </PageContainer>
+  );
+}
+
+export function Component() {
+  return (
+    <Page>
+      <Helmet>
+        <title>Staff Revenue</title>
+      </Helmet>
+      <AuthGuard>{() => <StaffRevenuePage />}</AuthGuard>
+    </Page>
+  );
+}

--- a/apps/frontend/src/pages/Staff/index.tsx
+++ b/apps/frontend/src/pages/Staff/index.tsx
@@ -19,6 +19,7 @@ export function Component() {
       <TabLinkList className="px-4" aria-label="Staff navigation">
         <TabLink href="teams">All teams</TabLink>
         <TabLink href="trials">Trials</TabLink>
+        <TabLink href="revenue">Revenue</TabLink>
       </TabLinkList>
       <hr className="border-t" />
       <TabLinkPanel className="flex flex-1 flex-col">

--- a/apps/frontend/src/pages/Staff/stripe.ts
+++ b/apps/frontend/src/pages/Staff/stripe.ts
@@ -6,3 +6,8 @@
 export function getStripeCustomerURL(stripeCustomerId: string) {
   return `https://dashboard.stripe.com/customers/${stripeCustomerId}`;
 }
+
+/** The subscription page in the dashboard, where its invoices are listed. */
+export function getStripeSubscriptionURL(stripeSubscriptionId: string) {
+  return `https://dashboard.stripe.com/subscriptions/${stripeSubscriptionId}`;
+}

--- a/apps/frontend/src/pages/Staff/stripe.ts
+++ b/apps/frontend/src/pages/Staff/stripe.ts
@@ -6,8 +6,3 @@
 export function getStripeCustomerURL(stripeCustomerId: string) {
   return `https://dashboard.stripe.com/customers/${stripeCustomerId}`;
 }
-
-/** The subscription page in the dashboard, where its invoices are listed. */
-export function getStripeSubscriptionURL(stripeSubscriptionId: string) {
-  return `https://dashboard.stripe.com/subscriptions/${stripeSubscriptionId}`;
-}

--- a/apps/frontend/src/router.tsx
+++ b/apps/frontend/src/router.tsx
@@ -281,6 +281,11 @@ export const router: ReturnType<typeof createBrowserRouter> =
                   HydrateFallback,
                   lazy: () => import("./pages/Staff/Trials"),
                 },
+                {
+                  path: "revenue",
+                  HydrateFallback,
+                  lazy: () => import("./pages/Staff/Revenue"),
+                },
               ],
             },
             {

--- a/apps/frontend/src/ui/ChartCard.tsx
+++ b/apps/frontend/src/ui/ChartCard.tsx
@@ -1,0 +1,37 @@
+import { clsx } from "clsx";
+
+import { Card } from "./Card";
+
+/**
+ * A chart on its own surface, with a title above it.
+ *
+ * The white card is what separates a plot from the page around it: an axis
+ * drawn straight onto the app background reads as part of the layout rather
+ * than as a figure. The minimum height keeps a card that is still loading the
+ * same size as one that has drawn, so a dashboard does not reflow under the
+ * reader as its charts arrive.
+ */
+export function ChartCard(props: {
+  className?: string;
+  title: string;
+  description?: React.ReactNode;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card className={clsx("flex flex-col", props.className)}>
+      <div className="flex items-start justify-between gap-4 p-5 pb-0">
+        <div>
+          <h3 className="font-semibold">{props.title}</h3>
+          {props.description ? (
+            <p className="text-low text-sm">{props.description}</p>
+          ) : null}
+        </div>
+        {props.action ? <div className="shrink-0">{props.action}</div> : null}
+      </div>
+      <div className="flex min-h-72 flex-1 items-center justify-center p-5">
+        {props.children}
+      </div>
+    </Card>
+  );
+}

--- a/apps/frontend/src/ui/Charts.tsx
+++ b/apps/frontend/src/ui/Charts.tsx
@@ -126,6 +126,7 @@ export function ChartTooltipContent({
   labelClassName,
   formatter,
   valueFormatter,
+  hideTotal = false,
   color,
   nameKey,
   labelKey,
@@ -143,6 +144,11 @@ export function ChartTooltipContent({
      * series label — where `formatter` replaces the whole row.
      */
     valueFormatter?: (value: number) => React.ReactNode;
+    /**
+     * Drops the Total row, for a chart whose series do not add up to one
+     * figure the page reports.
+     */
+    hideTotal?: boolean;
   }) {
   const { config } = useChart();
 
@@ -271,7 +277,7 @@ export function ChartTooltipContent({
             </div>
           );
         })}
-        {payload.length > 1 && (
+        {payload.length > 1 && !hideTotal && (
           <div className="mt-1 flex w-full justify-between border-t pt-1 font-bold">
             <span>Total</span>
             <span>

--- a/apps/frontend/src/ui/Charts.tsx
+++ b/apps/frontend/src/ui/Charts.tsx
@@ -256,7 +256,9 @@ export function ChartTooltipContent({
                         {itemConfig?.label || item.name}
                       </span>
                     </div>
-                    {item.value && (
+                    {/* Present-or-not rather than truthy: a series worth zero
+                        still has to print its figure. */}
+                    {item.value != null && (
                       <span className="text-default font-medium tabular-nums">
                         {valueFormatter && typeof item.value === "number"
                           ? valueFormatter(item.value)

--- a/apps/frontend/src/ui/Charts.tsx
+++ b/apps/frontend/src/ui/Charts.tsx
@@ -125,6 +125,7 @@ export function ChartTooltipContent({
   labelFormatter,
   labelClassName,
   formatter,
+  valueFormatter,
   color,
   nameKey,
   labelKey,
@@ -137,6 +138,11 @@ export function ChartTooltipContent({
     payload?: any[] | undefined;
     nameKey?: string;
     labelKey?: string;
+    /**
+     * Formats each row's value (and the Total), keeping the indicator and
+     * series label — where `formatter` replaces the whole row.
+     */
+    valueFormatter?: (value: number) => React.ReactNode;
   }) {
   const { config } = useChart();
 
@@ -252,7 +258,9 @@ export function ChartTooltipContent({
                     </div>
                     {item.value && (
                       <span className="text-default font-medium tabular-nums">
-                        {item.value.toLocaleString()}
+                        {valueFormatter && typeof item.value === "number"
+                          ? valueFormatter(item.value)
+                          : item.value.toLocaleString()}
                       </span>
                     )}
                   </div>
@@ -264,7 +272,9 @@ export function ChartTooltipContent({
         {payload.length > 1 && (
           <div className="mt-1 flex w-full justify-between border-t pt-1 font-bold">
             <span>Total</span>
-            <span>{sum.toLocaleString()}</span>
+            <span>
+              {valueFormatter ? valueFormatter(sum) : sum.toLocaleString()}
+            </span>
           </div>
         )}
       </div>

--- a/apps/frontend/src/ui/StatTile.tsx
+++ b/apps/frontend/src/ui/StatTile.tsx
@@ -18,8 +18,10 @@ type StatTileProps = ComponentPropsWithRef<"div"> & {
   color: StatTileColor;
   label: string;
   value: number | null | undefined;
-  /** `currency` renders US dollars — the currency Argos reports revenue in. */
+  /** `currency` renders money, US dollars unless `currency` says otherwise. */
   format?: "number" | "percent" | "currency";
+  /** ISO code for `format="currency"` — the staff pages price in USD, the revenue page in EUR. */
+  currency?: string;
   hint?: React.ReactNode;
   visual?: React.ReactNode;
 };
@@ -37,6 +39,7 @@ export function StatTile({
   label,
   value,
   format = "number",
+  currency = "USD",
   hint,
   visual,
   ...rest
@@ -71,7 +74,7 @@ export function StatTile({
               value={value}
               format={{
                 style: "currency",
-                currency: "USD",
+                currency,
                 maximumFractionDigits: 0,
               }}
             />

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -635,6 +635,8 @@ type RevenueBook = {
   monthlyTeam: string;
   dollarTeam: string;
   contractTeam: string;
+  /** What a month of the contract comes to, as the page prints it. */
+  contractPerMonth: string;
 };
 
 /**
@@ -822,11 +824,22 @@ const revenueTest = staffTest.extend<{ revenueBook: RevenueBook }>({
     // The page refuses a window the mirror was never swept for, so the sweep
     // has to be on record before it will report anything.
     await StripeInvoiceSync.query().insert({
-      sinceDate: startOfUTCMonth(-24).toISOString(),
+      // Deep enough for the window the page asks for, plus the year of
+      // contracts that can still be paying for its first months.
+      sinceDate: startOfUTCMonth(-36).toISOString(),
       completedAt: new Date().toISOString(),
     });
 
-    await use({ monthlyTeam, dollarTeam, contractTeam });
+    // The contract covers twelve months from this month's start, so a month
+    // of it is its amount over that stretch, weighted by this month's length.
+    const termMs = startOfUTCMonth(12).getTime() - startOfUTCMonth(0).getTime();
+    const monthMs = startOfUTCMonth(1).getTime() - startOfUTCMonth(0).getTime();
+    const contractPerMonth = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "EUR",
+    }).format((12_000 * monthMs) / termMs);
+
+    await use({ monthlyTeam, dollarTeam, contractTeam, contractPerMonth });
   },
 });
 
@@ -861,12 +874,15 @@ revenueTest("staff revenue", async ({ page, revenueBook }) => {
   await expect(breakdown.getByText("€855")).toBeVisible();
 
   // The contract is listed on its own, with the invoice its figure is read
-  // from and what that comes to per month.
+  // from and what a month of it comes to — its twelve months are not all the
+  // same length, so the share of this one is what the row reports.
   const contractRow = page
     .getByRole("row")
     .filter({ hasText: revenueBook.contractTeam });
   await expect(contractRow.getByText("€12,000.00")).toBeVisible();
-  await expect(contractRow.getByText("€1,000.00")).toBeVisible();
+  await expect(
+    contractRow.getByText(revenueBook.contractPerMonth),
+  ).toBeVisible();
 
   // Scoped to the monthly table: the contracts table below lists every annual
   // team in the database, which the rest of the suite seeds too.

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -7,6 +7,8 @@ import {
   Build,
   Plan as PlanModel,
   ScreenshotBucket,
+  StripeInvoice,
+  StripeInvoiceSync,
   Subscription,
 } from "../apps/backend/src/database/models";
 import {
@@ -619,6 +621,240 @@ staffTest(
     await screenshot(page, "staff-trial-pipeline-90-days");
   },
 );
+
+/** The first instant of the month `offset` months from now, in UTC. */
+function startOfUTCMonth(offset: number) {
+  const now = new Date();
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + offset, 1),
+  );
+}
+
+type RevenueBook = {
+  /** The teams the mirror was seeded for, by the name the page shows. */
+  monthlyTeam: string;
+  dollarTeam: string;
+  contractTeam: string;
+};
+
+/**
+ * A mirror of invoices to read a revenue page from.
+ *
+ * Dated against the running month rather than fixed, because the page reports
+ * the last thirteen calendar months: a fixed date would fall out of the window
+ * a month after it was written.
+ */
+const revenueTest = staffTest.extend<{ revenueBook: RevenueBook }>({
+  revenueBook: async ({ user }, use, testInfo) => {
+    const prefix = `revenue-${getUniqueTestIdentifier(testInfo)}`;
+    const [monthlyPlan, annualPlan] = await Promise.all([
+      PlanModel.query().insertAndFetch({
+        name: "pro",
+        includedScreenshots: 35_000,
+        usageBased: true,
+        githubSsoIncluded: true,
+        fineGrainedAccessControlIncluded: true,
+        samlIncluded: true,
+        interval: "month",
+      }),
+      PlanModel.query().insertAndFetch({
+        name: "enterprise annual",
+        includedScreenshots: 1_000_000,
+        usageBased: true,
+        githubSsoIncluded: true,
+        fineGrainedAccessControlIncluded: true,
+        samlIncluded: true,
+        interval: "year",
+      }),
+    ]);
+
+    async function createTeam(input: {
+      slug: string;
+      name: string;
+      planId: string;
+    }) {
+      const { account } = await createTeamAccount({
+        slug: `${prefix}-${input.slug}`,
+        name: input.name,
+      });
+      await account
+        .$query()
+        .patch({ stripeCustomerId: `cus_${prefix}-${input.slug}` });
+      await Subscription.query().insert({
+        planId: input.planId,
+        accountId: account.id,
+        provider: "stripe",
+        stripeSubscriptionId: `sub_${prefix}-${input.slug}`,
+        subscriberId: user.user.id,
+        startDate: daysFromNow(-400),
+        endDate: null,
+        paymentMethodFilled: true,
+        status: "active",
+      });
+      return account;
+    }
+
+    /** A team that was invoiced, then left: no subscription, invoices kept. */
+    async function createChurnedTeam(input: { slug: string; name: string }) {
+      const { account } = await createTeamAccount({
+        slug: `${prefix}-${input.slug}`,
+        name: input.name,
+      });
+      await account
+        .$query()
+        .patch({ stripeCustomerId: `cus_${prefix}-${input.slug}` });
+      return account;
+    }
+
+    const monthlyTeam = "Kruger Industrial";
+    const dollarTeam = "Wernham Hogg";
+    const contractTeam = "Bluth Company";
+    await Promise.all([
+      createTeam({
+        slug: "kruger",
+        name: monthlyTeam,
+        planId: monthlyPlan.id,
+      }),
+      createTeam({
+        slug: "wernham",
+        name: dollarTeam,
+        planId: monthlyPlan.id,
+      }),
+      createTeam({
+        slug: "bluth",
+        name: contractTeam,
+        planId: annualPlan.id,
+      }),
+      createChurnedTeam({ slug: "sterling", name: "Sterling Cooper" }),
+    ]);
+
+    const lastMonth = new Date(
+      startOfUTCMonth(-1).getTime() + 5 * 24 * 3600 * 1000,
+    );
+    await StripeInvoice.query().insert([
+      // Two teams billed last month, one of them in dollars: the page states
+      // euros, so the row has to show both what Stripe charged and what it
+      // converts to.
+      {
+        stripeInvoiceId: `in_${prefix}-kruger-last`,
+        stripeCustomerId: `cus_${prefix}-kruger`,
+        stripeCreatedAt: lastMonth.toISOString(),
+        status: "paid",
+        billingReason: "subscription_cycle",
+        currency: "eur",
+        total: 50_000,
+        totalExcludingTax: 50_000,
+        creditedAmountExcludingTax: 0,
+      },
+      {
+        stripeInvoiceId: `in_${prefix}-wernham-last`,
+        stripeCustomerId: `cus_${prefix}-wernham`,
+        stripeCreatedAt: lastMonth.toISOString(),
+        status: "paid",
+        billingReason: "subscription_cycle",
+        currency: "usd",
+        total: 100_000,
+        totalExcludingTax: 100_000,
+        creditedAmountExcludingTax: 0,
+      },
+      // The running month, so the second card has something partial to report.
+      {
+        stripeInvoiceId: `in_${prefix}-kruger-running`,
+        stripeCustomerId: `cus_${prefix}-kruger`,
+        stripeCreatedAt: new Date().toISOString(),
+        status: "paid",
+        billingReason: "subscription_cycle",
+        currency: "eur",
+        total: 10_000,
+        totalExcludingTax: 10_000,
+        creditedAmountExcludingTax: 0,
+      },
+      // A team that has since churned off a yearly contract keeps the renewal
+      // it was sent. Nothing about its subscription says "annual" any more —
+      // only the invoice's own period does — so this is what stands between a
+      // year's contract and a twelvefold spike in the month it was raised.
+      {
+        stripeInvoiceId: `in_${prefix}-sterling-renewal`,
+        stripeCustomerId: `cus_${prefix}-sterling`,
+        stripeCreatedAt: lastMonth.toISOString(),
+        status: "paid",
+        billingReason: "subscription_cycle",
+        currency: "eur",
+        total: 4_800_000,
+        totalExcludingTax: 4_800_000,
+        creditedAmountExcludingTax: 0,
+        periodStart: startOfUTCMonth(-13).toISOString(),
+        periodEnd: startOfUTCMonth(-1).toISOString(),
+      },
+      // An annual contract raised last month: it must stay out of that month's
+      // monthly figures and be amortized over the year it covers instead.
+      {
+        stripeInvoiceId: `in_${prefix}-bluth-contract`,
+        stripeCustomerId: `cus_${prefix}-bluth`,
+        stripeCreatedAt: lastMonth.toISOString(),
+        status: "paid",
+        billingReason: "subscription_cycle",
+        currency: "eur",
+        total: 1_200_000,
+        totalExcludingTax: 1_200_000,
+        creditedAmountExcludingTax: 0,
+        periodStart: startOfUTCMonth(-1).toISOString(),
+        periodEnd: startOfUTCMonth(11).toISOString(),
+      },
+    ]);
+
+    // The page refuses a window the mirror was never swept for, so the sweep
+    // has to be on record before it will report anything.
+    await StripeInvoiceSync.query().insert({
+      sinceDate: startOfUTCMonth(-24).toISOString(),
+      completedAt: new Date().toISOString(),
+    });
+
+    await use({ monthlyTeam, dollarTeam, contractTeam });
+  },
+});
+
+revenueTest("staff revenue", async ({ page, revenueBook }) => {
+  test.slow();
+  await page.goto("/staff/revenue");
+  await expect(page.getByRole("heading", { name: "Revenue" })).toBeVisible();
+
+  // €500 from one team and $1,000 from the other, the dollars converted at the
+  // page's fixed rate: €500 + €855.
+  await expect(page.getByText("€1,355 monthly").first()).toBeVisible();
+
+  const monthlyPlans = page
+    .locator("table")
+    .filter({ has: page.getByRole("columnheader", { name: "ARPU" }) });
+  const lastMonthRow = monthlyPlans.locator("tbody tr").nth(1);
+  await expect(lastMonthRow.getByText("€1,355")).toBeVisible();
+  // Two teams invoiced, so the average is half the month. Neither of the two
+  // annual bills raised that same month is in either figure — not the current
+  // contract, and not the churned team's renewal, whose only mark of being a
+  // year's worth is the period on the invoice itself.
+  await expect(lastMonthRow.getByText("€678")).toBeVisible();
+
+  await lastMonthRow.getByRole("button", { name: "View details" }).click();
+  const breakdown = monthlyPlans.locator("tbody tr").nth(2);
+  await expect(breakdown.getByText(revenueBook.monthlyTeam)).toBeVisible();
+  // What Stripe charged, beside what the page counts it as.
+  await expect(breakdown.getByText("$1,000.00")).toBeVisible();
+  await expect(breakdown.getByText("€855")).toBeVisible();
+
+  // The contract is listed on its own, with the invoice its figure is read
+  // from and what that comes to per month.
+  const contractRow = page
+    .getByRole("row")
+    .filter({ hasText: revenueBook.contractTeam });
+  await expect(contractRow.getByText("€12,000.00")).toBeVisible();
+  await expect(contractRow.getByText("€1,000.00")).toBeVisible();
+
+  // Scoped to the monthly table: the contracts table below lists every annual
+  // team in the database, which the rest of the suite seeds too.
+  await screenshot(page, "staff-revenue-monthly-plans", {
+    element: monthlyPlans,
+  });
+});
 
 loggedTest("staff pages are refused to regular users", async ({ page }) => {
   // Every staff page, not just one: each owns its own query, so each has to

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -621,6 +621,11 @@ staffTest(
 );
 
 loggedTest("staff pages are refused to regular users", async ({ page }) => {
-  await page.goto("/staff/trials");
-  await expect(page.getByText("Access restricted")).toBeVisible();
+  // Every staff page, not just one: each owns its own query, so each has to
+  // turn the refusal into something a reader can act on rather than into a
+  // figure that failed to load.
+  for (const path of ["/staff/teams", "/staff/trials", "/staff/revenue"]) {
+    await page.goto(path);
+    await expect(page.getByText("Access restricted")).toBeVisible();
+  }
 });

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -879,7 +879,9 @@ revenueTest("staff revenue", async ({ page, revenueBook }) => {
   const contractRow = page
     .getByRole("row")
     .filter({ hasText: revenueBook.contractTeam });
-  await expect(contractRow.getByText("€12,000.00")).toBeVisible();
+  // Twice over: what Stripe charged, and what the page counts it as — the
+  // contract is in euros, so both cells read the same.
+  await expect(contractRow.getByText("€12,000.00")).toHaveCount(2);
   await expect(
     contractRow.getByText(revenueBook.contractPerMonth),
   ).toBeVisible();

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -757,6 +757,22 @@ const revenueTest = staffTest.extend<{ revenueBook: RevenueBook }>({
         totalExcludingTax: 100_000,
         creditedAmountExcludingTax: 0,
       },
+      // The month before, so the month after it has something to compare
+      // against — without it every row's change is an em dash and the column
+      // is never rendered at all.
+      {
+        stripeInvoiceId: `in_${prefix}-kruger-before`,
+        stripeCustomerId: `cus_${prefix}-kruger`,
+        stripeCreatedAt: new Date(
+          startOfUTCMonth(-2).getTime() + 5 * 24 * 3600 * 1000,
+        ).toISOString(),
+        status: "paid",
+        billingReason: "subscription_cycle",
+        currency: "eur",
+        total: 100_000,
+        totalExcludingTax: 100_000,
+        creditedAmountExcludingTax: 0,
+      },
       // The running month, so the second card has something partial to report.
       {
         stripeInvoiceId: `in_${prefix}-kruger-running`,
@@ -833,6 +849,9 @@ revenueTest("staff revenue", async ({ page, revenueBook }) => {
   // contract, and not the churned team's renewal, whose only mark of being a
   // year's worth is the period on the invoice itself.
   await expect(lastMonthRow.getByText("€678")).toBeVisible();
+  // €1,000 the month before, so the column reports the climb rather than the
+  // em dash it falls back to with nothing to divide by.
+  await expect(lastMonthRow.getByText("+36%")).toBeVisible();
 
   await lastMonthRow.getByRole("button", { name: "View details" }).click();
   const breakdown = monthlyPlans.locator("tbody tr").nth(2);

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -843,53 +843,65 @@ const revenueTest = staffTest.extend<{ revenueBook: RevenueBook }>({
   },
 });
 
-revenueTest("staff revenue", async ({ page, revenueBook }) => {
-  test.slow();
-  await page.goto("/staff/revenue");
-  await expect(page.getByRole("heading", { name: "Revenue" })).toBeVisible();
+revenueTest.describe("staff revenue", () => {
+  // One browser project, not both: the page has no filter, so every figure on
+  // it is a sum over all the teams in the database — and the projects share
+  // one, truncated once. Seeded twice, the totals double and the assertions
+  // below describe neither run. The skip is declared here so the fixture never
+  // seeds for the project that does not run it.
+  revenueTest.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "the page sums every team, so it can only be seeded once",
+  );
 
-  // €500 from one team and $1,000 from the other, the dollars converted at the
-  // page's fixed rate: €500 + €855.
-  await expect(page.getByText("€1,355 monthly").first()).toBeVisible();
+  revenueTest("staff revenue", async ({ page, revenueBook }) => {
+    test.slow();
+    await page.goto("/staff/revenue");
+    await expect(page.getByRole("heading", { name: "Revenue" })).toBeVisible();
 
-  const monthlyPlans = page
-    .locator("table")
-    .filter({ has: page.getByRole("columnheader", { name: "ARPU" }) });
-  const lastMonthRow = monthlyPlans.locator("tbody tr").nth(1);
-  await expect(lastMonthRow.getByText("€1,355")).toBeVisible();
-  // Two teams invoiced, so the average is half the month. Neither of the two
-  // annual bills raised that same month is in either figure — not the current
-  // contract, and not the churned team's renewal, whose only mark of being a
-  // year's worth is the period on the invoice itself.
-  await expect(lastMonthRow.getByText("€678")).toBeVisible();
-  // €1,000 the month before, so the column reports the climb rather than the
-  // em dash it falls back to with nothing to divide by.
-  await expect(lastMonthRow.getByText("+36%")).toBeVisible();
+    // €500 from one team and $1,000 from the other, the dollars converted at the
+    // page's fixed rate: €500 + €855.
+    await expect(page.getByText("€1,355 monthly").first()).toBeVisible();
 
-  await lastMonthRow.getByRole("button", { name: "View details" }).click();
-  const breakdown = monthlyPlans.locator("tbody tr").nth(2);
-  await expect(breakdown.getByText(revenueBook.monthlyTeam)).toBeVisible();
-  // What Stripe charged, beside what the page counts it as.
-  await expect(breakdown.getByText("$1,000.00")).toBeVisible();
-  await expect(breakdown.getByText("€855")).toBeVisible();
+    const monthlyPlans = page
+      .locator("table")
+      .filter({ has: page.getByRole("columnheader", { name: "ARPU" }) });
+    const lastMonthRow = monthlyPlans.locator("tbody tr").nth(1);
+    await expect(lastMonthRow.getByText("€1,355")).toBeVisible();
+    // Two teams invoiced, so the average is half the month. Neither of the two
+    // annual bills raised that same month is in either figure — not the current
+    // contract, and not the churned team's renewal, whose only mark of being a
+    // year's worth is the period on the invoice itself.
+    await expect(lastMonthRow.getByText("€678")).toBeVisible();
+    // €1,000 the month before, so the column reports the climb rather than the
+    // em dash it falls back to with nothing to divide by.
+    await expect(lastMonthRow.getByText("+36%")).toBeVisible();
 
-  // The contract is listed on its own, with the invoice its figure is read
-  // from and what a month of it comes to — its twelve months are not all the
-  // same length, so the share of this one is what the row reports.
-  const contractRow = page
-    .getByRole("row")
-    .filter({ hasText: revenueBook.contractTeam });
-  // Twice over: what Stripe charged, and what the page counts it as — the
-  // contract is in euros, so both cells read the same.
-  await expect(contractRow.getByText("€12,000.00")).toHaveCount(2);
-  await expect(
-    contractRow.getByText(revenueBook.contractPerMonth),
-  ).toBeVisible();
+    await lastMonthRow.getByRole("button", { name: "View details" }).click();
+    const breakdown = monthlyPlans.locator("tbody tr").nth(2);
+    await expect(breakdown.getByText(revenueBook.monthlyTeam)).toBeVisible();
+    // What Stripe charged, beside what the page counts it as.
+    await expect(breakdown.getByText("$1,000.00")).toBeVisible();
+    await expect(breakdown.getByText("€855")).toBeVisible();
 
-  // Scoped to the monthly table: the contracts table below lists every annual
-  // team in the database, which the rest of the suite seeds too.
-  await screenshot(page, "staff-revenue-monthly-plans", {
-    element: monthlyPlans,
+    // The contract is listed on its own, with the invoice its figure is read
+    // from and what a month of it comes to — its twelve months are not all the
+    // same length, so the share of this one is what the row reports.
+    const contractRow = page
+      .getByRole("row")
+      .filter({ hasText: revenueBook.contractTeam });
+    // Twice over: what Stripe charged, and what the page counts it as — the
+    // contract is in euros, so both cells read the same.
+    await expect(contractRow.getByText("€12,000.00")).toHaveCount(2);
+    await expect(
+      contractRow.getByText(revenueBook.contractPerMonth),
+    ).toBeVisible();
+
+    // Scoped to the monthly table: the contracts table below lists every annual
+    // team in the database, which the rest of the suite seeds too.
+    await screenshot(page, "staff-revenue-monthly-plans", {
+      element: monthlyPlans,
+    });
   });
 });
 

--- a/turbo.json
+++ b/turbo.json
@@ -53,6 +53,7 @@
         "AWS_SCREENSHOTS_BUCKET",
         "SQIDS_ALPHABET",
         "LOG_LEVEL",
+<<<<<<< HEAD
         "ARGOS_TARGET",
         "PG_IAM_AUTH",
         "REDIS_URL",
@@ -65,6 +66,10 @@
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",
         "AWS_SESSION_TOKEN"
+=======
+        "STRIPE_API_KEY",
+        "TZ"
+>>>>>>> 860a2c32 (chore: let the Stripe key through, and keep it out of the tests)
       ]
     },
     "//#watch-codegen": {

--- a/turbo.json
+++ b/turbo.json
@@ -53,7 +53,6 @@
         "AWS_SCREENSHOTS_BUCKET",
         "SQIDS_ALPHABET",
         "LOG_LEVEL",
-<<<<<<< HEAD
         "ARGOS_TARGET",
         "PG_IAM_AUTH",
         "REDIS_URL",
@@ -66,10 +65,6 @@
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",
         "AWS_SESSION_TOKEN"
-=======
-        "STRIPE_API_KEY",
-        "TZ"
->>>>>>> 860a2c32 (chore: let the Stripe key through, and keep it out of the tests)
       ]
     },
     "//#watch-codegen": {


### PR DESCRIPTION
A staff-only Revenue page: what Argos invoiced, month by month. Read from the Stripe invoices themselves rather than recomputed from usage, so the amounts carry what Stripe actually charged — negotiated prices, coupons, credit notes — instead of a second pricing engine of ours that would have to agree with the first. Figures are ex-tax, net of credit notes, and stated in euros, dollar invoices converted at a fixed rate.

## What the page shows

Three cards — last month, the running month, and the change between them — each breaking down into its monthly, yearly and GitHub Marketplace parts. Under them a stacked chart of the year, then two tables:

- **Monthly plans**, month by month, with the change, the teams invoiced and the ARPU. Every row expands into the teams behind it, each with what it was invoiced in its own currency and in euros, and a link to its Stripe customer.
- **Annual contracts**, one row per contract, with the invoices its figure is read from — including the contracts that contributed nothing, which a total alone would hide. Invoices raised but unpaid are counted and flagged, so a contract in collection stays visible.

## Where the figures come from

A `stripe_invoices` table mirrors the fields the figures need, so a view costs a few queries instead of a paginated walk of a third party.

Webhooks are treated as signals only: every invoice or credit-note event re-reads the invoice from the API. Stripe guarantees no delivery order, retries for days, and embeds at most ten lines per payload — trusting the payload would let a stale event regress a paid invoice to open, or truncate the period an annual bill is recognized by. A daily cron reconciles what the webhooks may have missed — new invoices, invoices whose credit notes landed since, rows still unsettled from before the window — and records the stretch it covered. The page refuses a window the mirror was never backfilled for, rather than reporting zeros that would read as figures.

Three things the arithmetic does that a simpler reading gets wrong:

- Credit notes are netted **ex-tax**, read from the notes themselves, so a refunded taxed invoice nets to zero instead of minus its VAT.
- Annual contracts are **amortized day by day** over the months they cover, so a renewal weighs on the months it pays for, an upsell on the stretch it was sold for, and a month's figure never moves once written.
- An annual bill **never lands in a month's monthly figures**, whoever it belongs to now, so a churned yearly team cannot spike the month its renewal was raised in.

GitHub Marketplace is reported beside the Stripe figures, never inside them: GitHub exposes no seller invoice API, so it is priced from the listing's plans times the active marketplace subscriptions.

## Known limits

- **The Marketplace figure is today's book, drawn flat across history.** Every past month is charted at the current subscriptions times the current list price, so updating either rewrites the historical band. The tooltip says as much, but pricing each month from the subscriptions active _that_ month would end it.
- **The "Month over month" card compares a partial month to a complete one**, so it reads as a fall for most of the month. Deliberate — the running figure is what staff want to watch as it fills, and the card's hint says as much.
- **`EUR_PER_USD` is a hand-maintained constant** (0.855, ECB on 2026-08-21). Deliberate — the figures should move with the book, not the market — but it drifts and nothing reminds anyone to update it.

## Deploying

Order matters. **Enable the webhook events only after the deploy is live**: the currently-deployed handler throws on any event type it does not know, and the route turns that into a 500, so events enabled early would be retried for days and could get the endpoint disabled — taking the existing subscription webhooks down with it.

1. Deploy (the migration adds `stripe_invoices`, `stripe_invoice_syncs`, and a price column on `plans`).
2. On the Stripe webhook endpoint, enable exactly: `invoice.created`, `invoice.updated`, `invoice.finalized`, `invoice.paid`, `invoice.voided`, `invoice.marked_uncollectible`, `invoice.deleted`, `credit_note.created`, `credit_note.updated`, `credit_note.voided`.
3. Backfill the mirror once: `stripe/bin/sync-stripe-invoices 760`. The recorded sweep is what lets the page report that far back; the run is sequential and idempotent, so a failed one can simply be run again, and a partial one leaves the page refusing the window rather than showing a truncated figure.
4. Price the marketplace plans: `github/bin/sync-github-marketplace-prices`, or wait for the daily cron — that figure reads €0 until it has run.

The page stays empty-handed but honest until step 3 finishes: it reports itself unavailable with the reason, which is also what it does in the e2e suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
