### PR TITLE
fix(staff): count a team's screenshots from the day it was created

### DIFF
--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -722,12 +722,18 @@ function createAccountActivationByAccountIdLoader() {
     // multiplies project rows.
     const rows = await Project.query()
       .leftJoin("builds", "builds.projectId", "projects.id")
+      .join("accounts", "accounts.id", "projects.accountId")
       .select("projects.accountId")
       .select(
         knex.raw(`count(distinct projects.id) as "projectsCount"`),
         knex.raw(`count(builds.id) as "buildsCount"`),
+        // Only what was built once the account owned the project. A transferred
+        // project brings its whole history along, and those screenshots were
+        // consumed by whoever owned it then — the account's own billing periods
+        // never counted them either, so counting them here is what made the two
+        // staff tabs disagree about the same team.
         knex.raw(
-          `sum(coalesce((builds.stats->>'total')::int, 0)) as "screenshotsCount"`,
+          `sum(coalesce((builds.stats->>'total')::int, 0)) filter (where builds."createdAt" >= accounts."createdAt") as "screenshotsCount"`,
         ),
         knex.raw(
           `min(builds."createdAt") filter (where builds.type = 'check') as "firstComparisonAt"`,

--- a/apps/backend/src/graphql/tests/staffTrialPipeline.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/staffTrialPipeline.e2e.test.ts
@@ -276,6 +276,43 @@ describe("GraphQL staffTrialPipeline", () => {
     expect(findEntry(res, team.id).staff.screenshotsCount).toBe(42);
   });
 
+  it("leaves out builds that ran before the team was created", async () => {
+    const viewer = await createViewer({ staff: true });
+    const team = await factory.TeamAccount.create();
+    const project = await factory.Project.create({ accountId: team.id });
+
+    const stats = {
+      failure: 0,
+      added: 0,
+      unchanged: 0,
+      changed: 0,
+      removed: 0,
+      retryFailure: 0,
+      ignored: 0,
+    };
+    // What a transferred project leaves behind: builds older than the team that
+    // owns them today. Their screenshots are somebody else's consumption, and
+    // the team's own billing periods never counted them.
+    await factory.Build.create({
+      projectId: project.id,
+      createdAt: addDays(new Date(), -20).toISOString(),
+      stats: { ...stats, total: 5625 },
+    });
+    await factory.Build.create({
+      projectId: project.id,
+      stats: { ...stats, total: 271 },
+    });
+
+    const res = await queryPipeline(viewer, 30);
+
+    expectNoGraphQLError(res);
+    const { staff } = findEntry(res, team.id);
+    expect(staff.screenshotsCount).toBe(271);
+    // Only the screenshots are cut at that boundary: the build count is what
+    // the team owns today, transferred history included.
+    expect(staff.buildsCount).toBe(2);
+  });
+
   it("counts projects once even when they have many builds", async () => {
     const viewer = await createViewer({ staff: true });
     const team = await factory.TeamAccount.create();


### PR DESCRIPTION
The Trials tab reports what a team uploaded since signup, the directory reports what it consumed this period. A team still inside its trial has only ever lived in one period, so both have to print the same number. They did not: **8,335** on Trials, **2,710** in the directory, same team, same afternoon.

## Why

The pipeline summed the stats of every build of every project the team owns *today*, with no lower bound. A transferred project brings its history along, so this team — created 22 August, owning a project that had been building since the 1st — was credited with **5,625 screenshots consumed three weeks before it existed**, by whoever owned the project then. Its billing periods start at signup, so the directory never counted them.

| | Before | After |
|---|---|---|
| Trials — since signup | 8,335 | 2,710 |
| Directory — this period | 2,710 | 2,710 |

## The change

One `filter (where builds."createdAt" >= accounts."createdAt")` on the sum, in the activation loader. Only the screenshots are cut at that boundary — the build count stays what the team owns today.

The new test fails on `main` with `expected 5896 to be 271`, which is the production shape in miniature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
