### PR TITLE
Keep the other variants when switching one

### DIFF
--- a/apps/frontend/src/pages/Build/metadata/testing.ts
+++ b/apps/frontend/src/pages/Build/metadata/testing.ts
@@ -1,0 +1,51 @@
+import type { Metadata, MetadataBrowser, MetadataViewport } from "./utils";
+
+/**
+ * Metadata fixtures for the tests around the variant switchers. Everything the
+ * SDK may leave out is null here, so a case states only the dimensions it is
+ * about.
+ */
+export function metadata(props: Partial<Metadata>): Metadata {
+  return {
+    __typename: "ScreenshotMetadata",
+    url: null,
+    previewUrl: null,
+    colorScheme: null,
+    mediaType: null,
+    automationLibrary: {
+      __typename: "ScreenshotMetadataAutomationLibrary",
+      name: "playwright",
+      version: "1.49.1",
+    },
+    browser: null,
+    sdk: {
+      __typename: "ScreenshotMetadataSDK",
+      name: "@argos-ci/playwright",
+      version: "2.0.0",
+      latestVersion: null,
+    },
+    story: null,
+    viewport: null,
+    test: null,
+    tags: null,
+    ...props,
+  };
+}
+
+export function browser(name: string, version: string): MetadataBrowser {
+  return { __typename: "ScreenshotMetadataBrowser", name, version };
+}
+
+export function viewport(width: number, height: number): MetadataViewport {
+  return { __typename: "ScreenshotMetadataViewport", width, height };
+}
+
+export function story(mode: string): NonNullable<Metadata["story"]> {
+  return {
+    __typename: "ScreenshotMetadataStory",
+    id: "gallery-hero--default",
+    mode,
+    play: false,
+    tags: null,
+  };
+}

--- a/apps/frontend/src/pages/Build/metadata/utils.test.ts
+++ b/apps/frontend/src/pages/Build/metadata/utils.test.ts
@@ -2,14 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import { ScreenshotMetadataColorScheme } from "@/gql/graphql";
 
+import { browser, metadata, story, viewport } from "./testing";
 import {
   getUniqueBrowsers,
   getUniqueColorSchemes,
   getUniqueStoryModes,
   getUniqueViewports,
-  type Metadata,
-  type MetadataBrowser,
-  type MetadataViewport,
 } from "./utils";
 
 /**
@@ -18,50 +16,6 @@ import {
  * wrong order on purpose: what is asserted is that the output does not depend
  * on it.
  */
-function metadata(props: Partial<Metadata>): Metadata {
-  return {
-    __typename: "ScreenshotMetadata",
-    url: null,
-    previewUrl: null,
-    colorScheme: null,
-    mediaType: null,
-    automationLibrary: {
-      __typename: "ScreenshotMetadataAutomationLibrary",
-      name: "playwright",
-      version: "1.49.1",
-    },
-    browser: null,
-    sdk: {
-      __typename: "ScreenshotMetadataSDK",
-      name: "@argos-ci/playwright",
-      version: "2.0.0",
-      latestVersion: null,
-    },
-    story: null,
-    viewport: null,
-    test: null,
-    tags: null,
-    ...props,
-  };
-}
-
-function browser(name: string, version: string): MetadataBrowser {
-  return { __typename: "ScreenshotMetadataBrowser", name, version };
-}
-
-function viewport(width: number, height: number): MetadataViewport {
-  return { __typename: "ScreenshotMetadataViewport", width, height };
-}
-
-function story(mode: string): NonNullable<Metadata["story"]> {
-  return {
-    __typename: "ScreenshotMetadataStory",
-    id: "gallery-hero--default",
-    mode,
-    play: false,
-    tags: null,
-  };
-}
 
 describe("getUniqueBrowsers", () => {
   it("orders by label, then by version", () => {

--- a/apps/frontend/src/pages/Build/metadata/variants/BrowserSwitcher.tsx
+++ b/apps/frontend/src/pages/Build/metadata/variants/BrowserSwitcher.tsx
@@ -18,6 +18,7 @@ import {
   useGetDiffPath,
   type MetadataBrowser,
 } from "../utils";
+import { findVariantSibling } from "./sibling";
 
 export function BrowserSwitcher(props: { diff: Diff; siblingDiffs: Diff[] }) {
   const { diff, siblingDiffs } = props;
@@ -39,9 +40,11 @@ export function BrowserSwitcher(props: { diff: Diff; siblingDiffs: Diff[] }) {
         const isNextActive = (activeIndex + 1) % browsers.length === index;
         const resolvedDiff = isActive
           ? diff
-          : siblingDiffs.find((d) => {
-              const m = resolveDiffMetadata(d);
-              return m?.browser && hashBrowser(m.browser) === key;
+          : findVariantSibling({
+              diff,
+              siblingDiffs,
+              axis: "browser",
+              value: key,
             });
         invariant(resolvedDiff, "diff cannot be null");
         return (

--- a/apps/frontend/src/pages/Build/metadata/variants/ColorSchemeSwitcher.tsx
+++ b/apps/frontend/src/pages/Build/metadata/variants/ColorSchemeSwitcher.tsx
@@ -15,6 +15,7 @@ import {
   resolveDiffMetadata,
   useGetDiffPath,
 } from "../utils";
+import { findVariantSibling } from "./sibling";
 
 function getColorSchemeName(colorScheme: ScreenshotMetadataColorScheme) {
   switch (colorScheme) {
@@ -51,9 +52,12 @@ export function ColorSchemeSwitcher(props: {
         const isActive = active === colorScheme;
         const resolvedDiff = isActive
           ? diff
-          : siblingDiffs.find(
-              (d) => resolveColorScheme(resolveDiffMetadata(d)) === colorScheme,
-            );
+          : findVariantSibling({
+              diff,
+              siblingDiffs,
+              axis: "colorScheme",
+              value: colorScheme,
+            });
         invariant(resolvedDiff, "diff cannot be null");
         const Icon = colorSchemeIcons[colorScheme];
         const label = getColorSchemeLabel(colorScheme);

--- a/apps/frontend/src/pages/Build/metadata/variants/StoryModeSwitcher.tsx
+++ b/apps/frontend/src/pages/Build/metadata/variants/StoryModeSwitcher.tsx
@@ -14,6 +14,7 @@ import {
   resolveDiffMetadata,
   useGetDiffPath,
 } from "../utils";
+import { findVariantSibling } from "./sibling";
 
 export function StoryModeSwitcher(props: { diff: Diff; siblingDiffs: Diff[] }) {
   const { diff, siblingDiffs } = props;
@@ -34,9 +35,12 @@ export function StoryModeSwitcher(props: { diff: Diff; siblingDiffs: Diff[] }) {
         const isNextActive = (activeIndex + 1) % storyModes.length === index;
         const resolvedDiff = isActive
           ? diff
-          : siblingDiffs.find(
-              (d) => resolveDiffMetadata(d)?.story?.mode === mode,
-            );
+          : findVariantSibling({
+              diff,
+              siblingDiffs,
+              axis: "storyMode",
+              value: mode,
+            });
         invariant(resolvedDiff, "diff cannot be null");
         return (
           <StoryModeLinkButton

--- a/apps/frontend/src/pages/Build/metadata/variants/ViewportSwitcher.tsx
+++ b/apps/frontend/src/pages/Build/metadata/variants/ViewportSwitcher.tsx
@@ -16,6 +16,7 @@ import {
   useGetDiffPath,
   type MetadataViewport,
 } from "../utils";
+import { findVariantSibling } from "./sibling";
 
 export function ViewportSwitcher(props: { diff: Diff; siblingDiffs: Diff[] }) {
   const { diff, siblingDiffs } = props;
@@ -37,9 +38,11 @@ export function ViewportSwitcher(props: { diff: Diff; siblingDiffs: Diff[] }) {
         const isNextActive = (activeIndex + 1) % viewports.length === index;
         const resolvedDiff = isActive
           ? diff
-          : siblingDiffs.find((d) => {
-              const m = resolveDiffMetadata(d);
-              return m?.viewport && hashViewport(m.viewport) === key;
+          : findVariantSibling({
+              diff,
+              siblingDiffs,
+              axis: "viewport",
+              value: key,
             });
         invariant(resolvedDiff, "diff cannot be null");
         return (

--- a/apps/frontend/src/pages/Build/metadata/variants/sibling.test.ts
+++ b/apps/frontend/src/pages/Build/metadata/variants/sibling.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { ScreenshotMetadataColorScheme } from "@/gql/graphql";
+
+import { browser, metadata, story, viewport } from "../testing";
+import { countKeptAxes, getVariantPosition } from "./sibling";
+
+const FIREFOX_1440 = metadata({
+  browser: browser("firefox", "133.0"),
+  viewport: viewport(1440, 900),
+});
+
+describe("countKeptAxes", () => {
+  it("prefers the sibling that keeps the viewport when switching browser", () => {
+    const keepsViewport = metadata({
+      browser: browser("chromium", "131.0"),
+      viewport: viewport(1440, 900),
+    });
+    const dropsViewport = metadata({
+      browser: browser("chromium", "131.0"),
+      viewport: viewport(375, 812),
+    });
+    expect(
+      countKeptAxes(FIREFOX_1440, keepsViewport, "browser"),
+    ).toBeGreaterThan(countKeptAxes(FIREFOX_1440, dropsViewport, "browser"));
+  });
+
+  it("prefers the sibling that keeps the browser when switching viewport", () => {
+    const keepsBrowser = metadata({
+      browser: browser("firefox", "133.0"),
+      viewport: viewport(375, 812),
+    });
+    const dropsBrowser = metadata({
+      browser: browser("chromium", "131.0"),
+      viewport: viewport(375, 812),
+    });
+    expect(
+      countKeptAxes(FIREFOX_1440, keepsBrowser, "viewport"),
+    ).toBeGreaterThan(countKeptAxes(FIREFOX_1440, dropsBrowser, "viewport"));
+  });
+
+  it("ignores the dimension being switched", () => {
+    const otherBrowser = metadata({
+      browser: browser("chromium", "131.0"),
+      viewport: viewport(1440, 900),
+    });
+    // Every other dimension is equal, so switching the browser keeps all of
+    // them — the browser itself does not count against the move.
+    expect(countKeptAxes(FIREFOX_1440, otherBrowser, "browser")).toBe(3);
+  });
+
+  it("counts every dimension, not only browser and viewport", () => {
+    const from = metadata({
+      browser: browser("firefox", "133.0"),
+      colorScheme: ScreenshotMetadataColorScheme.Dark,
+      story: story("compact"),
+    });
+    const keepsMode = metadata({
+      browser: browser("firefox", "133.0"),
+      colorScheme: ScreenshotMetadataColorScheme.Light,
+      story: story("compact"),
+    });
+    const dropsMode = metadata({
+      browser: browser("firefox", "133.0"),
+      colorScheme: ScreenshotMetadataColorScheme.Light,
+      story: story("wide"),
+    });
+    expect(countKeptAxes(from, keepsMode, "colorScheme")).toBeGreaterThan(
+      countKeptAxes(from, dropsMode, "colorScheme"),
+    );
+  });
+
+  it("treats a dimension the SDK left out as a value of its own", () => {
+    const noViewport = metadata({ browser: browser("firefox", "133.0") });
+    const withViewport = metadata({
+      browser: browser("firefox", "133.0"),
+      viewport: viewport(1440, 900),
+    });
+    expect(countKeptAxes(noViewport, noViewport, "browser")).toBe(3);
+    expect(countKeptAxes(noViewport, withViewport, "browser")).toBe(2);
+  });
+});
+
+describe("getVariantPosition", () => {
+  it("reads light as the color scheme when none was reported", () => {
+    expect(getVariantPosition(metadata({})).colorScheme).toBe(
+      ScreenshotMetadataColorScheme.Light,
+    );
+  });
+
+  it("says nothing about a snapshot with no metadata at all", () => {
+    expect(getVariantPosition(null)).toEqual({
+      browser: null,
+      viewport: null,
+      colorScheme: null,
+      storyMode: null,
+    });
+  });
+});

--- a/apps/frontend/src/pages/Build/metadata/variants/sibling.ts
+++ b/apps/frontend/src/pages/Build/metadata/variants/sibling.ts
@@ -1,0 +1,83 @@
+import type { Diff } from "../../BuildDiffState";
+import {
+  hashBrowser,
+  hashViewport,
+  resolveColorScheme,
+  resolveDiffMetadata,
+  type Metadata,
+} from "../utils";
+
+/** A dimension a snapshot's siblings can differ along. */
+export type VariantAxis = "browser" | "viewport" | "colorScheme" | "storyMode";
+
+const AXES: VariantAxis[] = ["browser", "viewport", "colorScheme", "storyMode"];
+
+/**
+ * Where a snapshot sits along every dimension at once, as comparable strings.
+ * `null` where the SDK reported nothing — which is a value like any other here:
+ * two snapshots that both say nothing about their viewport are on the same
+ * footing.
+ */
+export function getVariantPosition(
+  metadata: Metadata | null,
+): Record<VariantAxis, string | null> {
+  return {
+    browser: metadata?.browser ? hashBrowser(metadata.browser) : null,
+    viewport: metadata?.viewport ? hashViewport(metadata.viewport) : null,
+    colorScheme: metadata ? resolveColorScheme(metadata) : null,
+    storyMode: metadata?.story?.mode ?? null,
+  };
+}
+
+/**
+ * How much of `from` a move to `candidate` would keep, counting every dimension
+ * but the one being switched.
+ */
+export function countKeptAxes(
+  from: Metadata | null,
+  candidate: Metadata | null,
+  axis: VariantAxis,
+): number {
+  const a = getVariantPosition(from);
+  const b = getVariantPosition(candidate);
+  return AXES.filter((key) => key !== axis && a[key] === b[key]).length;
+}
+
+/**
+ * The sibling to land on when switching `axis` to `value`.
+ *
+ * Not simply the first sibling carrying that value: with two dimensions in play
+ * that is whichever the diff list happens to hold first, so switching the
+ * browser from Firefox at 1440 could quietly drop the viewport back to 375.
+ * Among the siblings that carry the value, this takes the one that keeps most
+ * of where the reviewer already was, so a move along one dimension is only ever
+ * a move along that one.
+ *
+ * Best effort by design: nothing guarantees the matrix is full — Firefox may
+ * only have been captured at 375 — and a switcher that led nowhere would be
+ * worse than one that lands on the nearest thing. Ties go to the earlier
+ * sibling, which is the order the switchers themselves are built in.
+ */
+export function findVariantSibling(input: {
+  diff: Diff;
+  siblingDiffs: Diff[];
+  axis: VariantAxis;
+  value: string;
+}): Diff | undefined {
+  const { diff, siblingDiffs, axis, value } = input;
+  const from = resolveDiffMetadata(diff);
+  let best: Diff | undefined;
+  let bestKept = -1;
+  for (const sibling of siblingDiffs) {
+    const metadata = resolveDiffMetadata(sibling);
+    if (getVariantPosition(metadata)[axis] !== value) {
+      continue;
+    }
+    const kept = countKeptAxes(from, metadata, axis);
+    if (kept > bestKept) {
+      best = sibling;
+      bestKept = kept;
+    }
+  }
+  return best;
+}

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -459,3 +459,49 @@ loggedTest(
     });
   },
 );
+
+loggedTest(
+  "keeps the other variant when switching one",
+  async ({ page, auth, team, project }) => {
+    await ensureTeamOwner({ team: team.team, user: auth.user });
+    const { build, variantKey } = await createVariantSwitchersScenario({
+      projectId: project.id,
+    });
+
+    await page.goto(
+      `/${team.account.slug}/${project.name}/builds/${build.number}`,
+    );
+    await page
+      .getByRole("button", { name: /^(Start review|Browse snapshots)/ })
+      .click();
+
+    const variants = page.getByRole("group", { name: "Snapshot variants" });
+    const snapshotName = (browser: string, width: number) =>
+      new RegExp(
+        `^${browser}/${variantKey.replaceAll("/", "\\/")} vw-${width}\\.png$`,
+      );
+
+    // The build is a 2×2: two browsers, two viewports. Walking one dimension
+    // has to leave the other where it was — the reviewer asked for a different
+    // browser, not a different viewport.
+    await expect(
+      page.getByRole("heading", { name: snapshotName("chromium", 1280) }),
+    ).toBeVisible();
+
+    await variants.getByRole("link", { name: "Firefox" }).click();
+    await expect(
+      page.getByRole("heading", { name: snapshotName("firefox", 1280) }),
+    ).toBeVisible();
+
+    await variants.getByRole("link", { name: "390" }).click();
+    await expect(
+      page.getByRole("heading", { name: snapshotName("firefox", 390) }),
+    ).toBeVisible();
+
+    // And back the other way, so this cannot pass on the diff list's order.
+    await variants.getByRole("link", { name: "Chromium" }).click();
+    await expect(
+      page.getByRole("heading", { name: snapshotName("chromium", 390) }),
+    ).toBeVisible();
+  },
+);


### PR DESCRIPTION
Follow-up to #2527.

## The bug

With two dimensions in play, every switcher jumped to the **first** sibling carrying the value it was asked for — whichever one the diff list happened to hold first, which is by name. So from Firefox at 1440, clicking 375 landed on **Chromium** at 375: you asked for a different viewport and got a different browser as well.

## The fix

The target is now the sibling that keeps most of where the reviewer already was, counting every dimension but the one being switched (browser, viewport, color scheme, story mode).

Best effort by design: nothing guarantees the matrix is full — Firefox may only have been captured at 375 — and a switcher that led nowhere would be worse than one that lands on the nearest thing. Ties go to the earlier sibling, which is the order the switchers themselves are built in.

## Verification

The e2e guard walks the seeded 2×2 (chromium/firefox × 390/1280) **both ways**, because the diff list's own order makes one direction right by accident — chromium/1280 → Firefox already landed on firefox/1280. It is the second step that used to fold the first one back, and that is what fails on the old code:

```
✘ keeps the other variant when switching one
  Locator: getByRole('heading', { name: /^firefox\/…\/with-pagination-and-sticky-header vw-390\.png$/ })
  Expected: visible
```

Confirmed by reverting the resolver to first-match, rebuilding and re-running before trusting it.

Unit tests cover the scoring rule itself (13 in `apps/frontend/src/pages/Build/metadata`), including that the dimension being switched does not count against a candidate, that a dimension the SDK left out is a value like any other, and that story mode and color scheme count as much as browser and viewport. The metadata fixtures moved to `metadata/testing.ts` so both test files share one set.

`tests/build.spec.ts` passes (24), `static-checks` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)