### PR TITLE
Set the toolbar's groups apart with space, not rules

### DIFF
--- a/apps/frontend/src/containers/Build/BuildDiffDetailToolbar.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetailToolbar.tsx
@@ -4,7 +4,6 @@ import { invariant } from "@argos/util/invariant";
 import { useProjectPermission } from "@/containers/Project/PermissionsContext";
 import { ProjectPermission, ScreenshotDiffStatus } from "@/gql/graphql";
 import { useProjectParams } from "@/pages/Project/ProjectParams";
-import { Separator } from "@/ui/Separator";
 import { checkIsImageContentType } from "@/util/content-type";
 
 import type { BuildDiffDetailDocument } from "./BuildDiffDetail";
@@ -88,32 +87,46 @@ export function BuildDiffDetailToolbar(props: BuildDiffDetailToolbarProps) {
     showCommentTool || (canComment && checkCanCommentOnTextDiff(diff));
 
   return (
-    <div className="flex shrink-0 items-center gap-1.5">
-      <ViewToggle blendEnabled={checkDiffCanBeBlended(diff)} />
-      <FitToggle />
-      {fitControls}
+    // Space tells the groups apart, no rule between them — and the same space
+    // that sets the variant switchers apart from this whole bar, so the row has
+    // one distance meaning "a different kind of thing" at every level of it.
+    // Within a group the controls sit close, which is what makes them a group.
+    <div className="flex shrink-0 items-center gap-4">
+      <ToolGroup>
+        <ViewToggle blendEnabled={checkDiffCanBeBlended(diff)} />
+        <FitToggle />
+        {fitControls}
+      </ToolGroup>
       {showOverlayControls && (
-        <>
-          <Separator orientation="vertical" className="w-thin mx-0.5 h-8" />
+        <ToolGroup>
           {/* Reading the mask happens next to the snapshot; how it is painted
               is a preference, and preferences live up here. */}
           {snapshotControls ? <ChangesOverlayControls /> : <SettingsButton />}
-        </>
+        </ToolGroup>
       )}
       {showComments && (
-        <>
-          <Separator orientation="vertical" className="w-thin mx-0.5 h-8" />
+        <ToolGroup>
           {showCommentTool && snapshotControls && <CommentToolToggle />}
           <CommentsVisibilityToggle />
-        </>
+        </ToolGroup>
       )}
-      <div className="group contents">
-        <Separator
-          orientation="vertical"
-          className="w-thin mx-0.5 h-8 group-empty:hidden"
-        />
-        {children}
-      </div>
+      <ToolGroup>{children}</ToolGroup>
+    </div>
+  );
+}
+
+/**
+ * Controls that answer the same question, kept together — and a group is why
+ * the bar can be read at all, now that nothing is ruled off.
+ *
+ * `empty:hidden` because an empty group would otherwise leave its space
+ * behind: the page decides what `children` is, and on some pages it is
+ * nothing.
+ */
+function ToolGroup(props: { children?: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-1.5 empty:hidden">
+      {props.children}
     </div>
   );
 }


### PR DESCRIPTION
Three vertical rules divided the build toolbar's controls — the view modes from the overlay, the overlay from the comments, those from whatever the page adds at the end. They're gone, replaced by space.

The distance is deliberately **the same 16px that separates the variant switchers from the whole controls bar**, so the row reads with one vocabulary: 16px means "a different kind of thing", 6px means "these belong together", at every level of it.

Measured on the seeded build:

```
variants → tools: 16
between tool groups: [16, 16, 16]
within a group: 6
separators left: 0
```

## Notes for the reviewer

- The groups are **real elements** now rather than runs of siblings between rules. That is what keeps `ChangesOverlayControls` spaced as one thing — it returns a fragment of three (toggle, button group, settings), so dropped straight into a 16px row its own parts would have drifted apart.
- `empty:hidden` on a group replaces the rule's old `group-empty:hidden`: a page that passes no `children` shouldn't leave the space behind either.
- This bar is shared with the **test page**, which gets the same treatment. Its own separator (the one above its counters) is a different boundary and is untouched.
- **Still using rules, deliberately left alone** — say the word if you want them aligned too: the media viewer's toolbar (`MediaViewer.tsx`, between its view toggle and the rest) and the floating snapshot actions bar (`ScreenshotActionsToolbar.tsx`, two of them). The media one is the same kind of boundary as what this PR replaced, so it's the likeliest follow-up.

## Verification

`tests/build.spec.ts`, `tests/media.spec.ts` and `tests/project-tests.spec.ts` pass (45), `static-checks` green. The `build-*` and `test-*` baselines shift by the rules disappearing — that's the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)