### PR TITLE
chore: authenticate the production database with IAM instead of passwords

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,6 +216,7 @@ jobs:
           image: ${{ needs.build.outputs.image }}
           environment-variables: |
             NODE_ENV=production
+            PG_IAM_AUTH=true
           secrets: |
             DATABASE_URL=/production/database_url
             ENCRYPTION_KEY=/production/encryption_key
@@ -329,6 +330,7 @@ jobs:
           image: ${{ needs.build.outputs.image }}
           environment-variables: |
             NODE_ENV=production
+            PG_IAM_AUTH=true
             API_BASE_URL=https://api.argos-ci.com
             MCP_BASE_URL=https://mcp.argos-ci.com
             SERVER_URL=https://app.argos-ci.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,6 +191,9 @@ To debug with real data shapes, the app can run locally against the production
 database through the `argos_dev_ro` Postgres role — read-only except for the
 two tables the login flow writes (`user_sessions`, `team_users.lastAuthMethod`).
 
+For connecting by hand (TablePlus, `psql`) and for how production authenticates
+at all, see [docs/database-access.md](docs/database-access.md).
+
 ```sh
 pnpm run dev:prod-ro
 ```

--- a/docs/database-access.md
+++ b/docs/database-access.md
@@ -1,0 +1,43 @@
+# Database access
+
+Production Postgres accepts no passwords. Every connection authenticates with
+an RDS IAM token: signed locally from your AWS credentials, valid 15 minutes,
+and checked only when the connection opens — an established session is never
+interrupted by expiry.
+
+Engineers connect as `argos_dev_ro`, which is read-only.
+
+## psql
+
+```bash
+scripts/rds-token.sh --psql                       # connect
+scripts/rds-token.sh --psql -c 'select now()'     # or run one statement
+```
+
+## TablePlus
+
+Set the password field's dropdown to **Command Line** and point it at the
+script:
+
+```
+/your-project-directory/argos/scripts/rds-token.sh --user argos_dev_ro
+```
+
+| Field    | Value                                                     |
+| -------- | --------------------------------------------------------- |
+| Host     | `argos-postgres.c1o45zoep0du.us-east-1.rds.amazonaws.com` |
+| Port     | `5432`                                                    |
+| User     | `argos_dev_ro`                                            |
+| Database | `argos`                                                   |
+| SSL mode | `REQUIRED`                                                |
+
+TablePlus then mints a fresh token per connection, so nothing expires under
+you. Two things have to line up, and both fail as
+`password authentication failed`, which names neither:
+
+- **User must equal `--user`.** A token is signed for one role and RDS rejects
+  it for any other.
+- **SSL mode must be `REQUIRED`.** RDS refuses IAM tokens in the clear.
+
+If you need a token for something else, `scripts/rds-token.sh --raw` prints it
+and nothing else.

--- a/scripts/rds-token.sh
+++ b/scripts/rds-token.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+#
+# Mint a short-lived RDS IAM authentication token for the production database.
+#
+# The production Postgres roles authenticate with IAM only - no role has a
+# password, so there is nothing to store in a password manager and nothing to
+# leak. A token stands in for the password and is valid for 15 minutes.
+#
+#   scripts/rds-token.sh              # read-only role, token to the clipboard
+#   scripts/rds-token.sh --psql       # open psql directly
+#   scripts/rds-token.sh --user argos # another role (needs its own IAM policy)
+#   scripts/rds-token.sh --raw        # just the token, for another program
+#
+# With --psql, anything this script does not recognise is handed to psql, so
+#   scripts/rds-token.sh --psql -c 'select 1'
+# works. Use -- to force what follows to psql (`-- --help`).
+#
+# TablePlus: set the password field's dropdown to "Command Line" and give it
+# this script with the role you want, e.g.
+#   /path/to/scripts/rds-token.sh --user argos_dev_ro
+# TablePlus then fetches a fresh token on every connection, so nothing expires
+# under you. The User field must name the SAME role as --user: the token is
+# signed for one role and RDS rejects it for any other. SSL mode must be
+# REQUIRED, because RDS refuses IAM tokens on plaintext connections.
+#
+# When stdout is not a terminal the script prints only the raw token, which is
+# what makes the above work. Run it by hand and it copies to the clipboard
+# instead.
+#
+# Everything this script prints is ASCII on purpose. A multibyte character
+# touching a variable - an ellipsis right after "$DB_USER" - leaves bash unable
+# to see where the name ends, so it reads the first byte of that character as
+# part of it. That fails only in some locales, which means it survives testing
+# and breaks on a colleague's machine. Braces around every expansion are the
+# other half of the same guard.
+
+set -euo pipefail
+
+# TablePlus runs this from a GUI process, which inherits none of a login
+# shell's PATH - Homebrew included, so `aws` would simply not be found.
+PATH="/opt/homebrew/bin:/usr/local/bin:${PATH}"
+
+HOST="${RDS_HOST:-argos-postgres.c1o45zoep0du.us-east-1.rds.amazonaws.com}"
+PORT="${RDS_PORT:-5432}"
+REGION="${RDS_REGION:-us-east-1}"
+DATABASE="${RDS_DATABASE:-argos}"
+# Not USER: that is the shell's own variable, and clobbering it makes for
+# confusing failures in anything this script goes on to exec.
+DB_USER="${RDS_USER:-argos_dev_ro}"
+SSLMODE="${PGSSLMODE:-require}"
+RUN_PSQL=false
+RAW_OUTPUT=false
+PSQL_ARGS=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --user) DB_USER="$2"; shift 2 ;;
+    --host) HOST="$2"; shift 2 ;;
+    --database) DATABASE="$2"; shift 2 ;;
+    --psql) RUN_PSQL=true; shift ;;
+    --raw) RAW_OUTPUT=true; shift ;;
+    -h | --help)
+      awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+      exit 0
+      ;;
+    --) shift; PSQL_ARGS+=("$@"); break ;;
+    *) PSQL_ARGS+=("$1"); shift ;;
+  esac
+done
+
+if [ ${#PSQL_ARGS[@]} -gt 0 ] && [ "${RUN_PSQL}" = false ]; then
+  echo "unknown argument: ${PSQL_ARGS[0]}" >&2
+  echo "(arguments are forwarded to psql, which only happens with --psql)" >&2
+  exit 1
+fi
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "aws CLI not found - install it with \`brew install awscli\`." >&2
+  exit 1
+fi
+
+# Fail here with a clear message rather than minting a token signed by nothing
+# and letting Postgres report it as a password failure.
+if ! aws sts get-caller-identity >/dev/null 2>&1; then
+  echo "No usable AWS credentials. Sign in first (\`aws sso login\`), then retry." >&2
+  exit 1
+fi
+
+TOKEN=$(aws rds generate-db-auth-token \
+  --hostname "${HOST}" \
+  --port "${PORT}" \
+  --region "${REGION}" \
+  --username "${DB_USER}")
+
+if [ "${RUN_PSQL}" = true ]; then
+  echo "Connecting to ${DATABASE} as ${DB_USER}..." >&2
+  PGPASSWORD="${TOKEN}" PGSSLMODE="${SSLMODE}" exec psql \
+    --host "${HOST}" --port "${PORT}" \
+    --username "${DB_USER}" --dbname "${DATABASE}" \
+    ${PSQL_ARGS[@]+"${PSQL_ARGS[@]}"}
+fi
+
+# Not a terminal means something is reading the token rather than someone -
+# TablePlus's "Command Line" password mode, a pipe, a redirect. Print the bare
+# token and nothing else, with no trailing newline, since a consumer that does
+# not trim would otherwise send it as part of the password.
+if [ ! -t 1 ] || [ "${RAW_OUTPUT}" = true ]; then
+  printf '%s' "${TOKEN}"
+  exit 0
+fi
+
+if command -v pbcopy >/dev/null 2>&1; then
+  printf '%s' "${TOKEN}" | pbcopy
+  echo "Token for \"${DB_USER}\" copied to the clipboard - valid 15 minutes."
+  echo "Paste it as the password in TablePlus (host ${HOST}, SSL mode: require),"
+  echo "or set the password field to \"Command Line\" and never paste again:"
+  echo "  $(cd "$(dirname "$0")" && pwd)/$(basename "$0") --user ${DB_USER}"
+else
+  printf '%s\n' "${TOKEN}"
+fi


### PR DESCRIPTION
## Why

The database accepted a shared password: one value in SSM for every ECS task, another for the RDS master user pasted into TablePlus. Neither expires, both travel through clipboards and vaults, and a leak of either is indefinite full access with nothing in CloudTrail to show for it.

Every connection now signs a 15-minute IAM token instead. Nothing left to store or rotate, each connection attributable to an AWS principal, and a captured token dies on its own.

## ECS

`PG_IAM_AUTH=true` on the app, worker and migration tasks — that is the whole code change. `getKnexConfig` (merged in #2528) hands `pg` a function rather than a password string, and `pg` calls it once per pooled connection, so tokens refresh as the pool turns over without ever interrupting an open session.

`DATABASE_URL` carries no password, only `postgresql://argos_iam@<host>:5432/argos`.

## Humans

```bash
scripts/rds-token.sh          # token to the clipboard
scripts/rds-token.sh --psql   # or connect straight away
```

For TablePlus, set the password field's dropdown to **Command Line** and point it at the script — it then mints a token per connection and nothing expires mid-session.

Two details cost an afternoon between them, so they are in [docs/database-access.md](docs/database-access.md) and in the script's header:

- The token is signed for **one role**, so TablePlus's User field must name the same role as `--user`. Otherwise: `password authentication failed`.
- A GUI process inherits **no login-shell PATH**, so `aws` is simply not found. The script puts Homebrew back on PATH itself.

SSL mode must be `REQUIRED`; RDS refuses IAM tokens in the clear. All three failures report the same message and name none of them.

## Already done in AWS

Steps that had to happen outside this repo are complete and verified against production:

- IAM database authentication enabled on `argos-postgres` (a separate switch from the `rds_iam` grant — miss it and a perfectly valid token is rejected as a password failure).
- `argos_iam` created: `rds_iam` granted, member of `argos`, and `ALTER ROLE argos_iam IN DATABASE argos SET role TO argos` so migrations keep creating objects owned by `argos`.
- `rds-db:connect` granted for `argos_iam` and `argos_dev_ro`.

`scripts/rds-token.sh --user argos_iam --psql -c 'select current_user, session_user'` returns `argos | argos_iam` against production.

## ⚠️ Still to do after merge

Two steps remain, and **they are not in the repo** — this list is the only record:

1. Point `/production/database_url` at `postgresql://argos_iam@argos-postgres.c1o45zoep0du.us-east-1.rds.amazonaws.com:5432/argos` (no password), then release. Migrations run first and are the canary: they fail the release before any task is replaced. Rollback is restoring the old parameter value — `argos` keeps its password until step 2, which is why a second role exists rather than granting `rds_iam` to `argos` in place. A role granted `rds_iam` can no longer use a password, so switching in place would have broken every running task at the instant of the grant.
2. Once healthy: `ALTER ROLE argos WITH NOLOGIN`, then rotate the RDS master password. **Store it before setting it** — the RDS API never returns a password, so one generated inline is unrecoverable and takes the break-glass account with it. 1Password rather than SSM `/production/`, which the execution role and the release workflow both read.

## Reviewer notes

- The app and worker are handed static `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, which take precedence over the ECS task role — so `rds-db:connect` must sit on IAM user `argos-ci-production` while those keys exist. The migration task has no keys and uses `ecsArgosTaskRole`.
- Retiring those keys is now a small, well-defined change: the user's entire permission set is S3 `Get/PutObject` on two buckets plus DynamoDB on `production_files` / `production_deployment_files`. Copy those onto `ecsArgosTaskRole`, add `rds-db:connect`, drop the env vars. The active key is 16 months old, and an inactive one from 2024 is still present and should be deleted.
- The instance is `PubliclyAccessible: true`. IAM auth removes the standing shared password, so this is smaller than it was, but a token is still usable for 15 minutes from anywhere. Closing it means a tunnel — and note the token embeds the hostname it was signed for, so tunnelling would need the script to separate "sign for" from "connect to".
- `ssl: { rejectUnauthorized: false }` means the token crosses a connection whose certificate is never verified. `global-bundle.pem` sits unreferenced at the repo root.

## Testing

Every command in the docs and in the script header was run against production before committing. The TablePlus path was exercised as TablePlus invokes it — piped stdout under `env -i` with a GUI's minimal PATH — and the resulting token opened a connection. The script is verified under `en_US.UTF-8`, `fr_FR.UTF-8`, `C` and `POSIX`; it is deliberately pure ASCII, because a multibyte character touching a variable makes bash misread the variable name in some locales and not others. `pnpm run static-checks` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)