### PR TITLE
fix(auth): stop writing "undefined" as the OAuth client id

### DIFF
--- a/apps/backend/src/config/index.ts
+++ b/apps/backend/src/config/index.ts
@@ -297,10 +297,6 @@ export function createConfig() {
         default: "https://github.com/apps/argos-ci-dev",
         env: "GITHUB_APP_URL",
       },
-      loginUrl: {
-        format: String,
-        default: `https://github.com/login/oauth/authorize?scope=user:email&client_id=${process.env["GITHUB_CLIENT_ID"]}`,
-      },
       webhookSecret: {
         format: String,
         default: "development",
@@ -402,10 +398,6 @@ export function createConfig() {
         format: String,
         default: "",
         env: "GITLAB_APP_SECRET",
-      },
-      loginUrl: {
-        format: String,
-        default: `https://gitlab.com/oauth/authorize?scope=read_user&response_type=code&client_id=${process.env["GITLAB_APP_ID"]}`,
       },
       argosAuthSecret: {
         format: String,

--- a/apps/backend/src/web/app-router.ts
+++ b/apps/backend/src/web/app-router.ts
@@ -57,14 +57,18 @@ export const installAppRouter = async (app: express.Application) => {
     github: {
       appUrl: config.get("github.appUrl"),
       clientId: config.get("github.clientId"),
-      loginUrl: config.get("github.loginUrl"),
+      // Built here rather than defaulted in the config: a convict default is
+      // evaluated at module load, so reading the client id from `process.env`
+      // there wrote the string "undefined" into the URL whenever the variable
+      // was absent — a self-hosted install, `dev:prod-ro`, the E2E server.
+      loginUrl: `https://github.com/login/oauth/authorize?scope=user:email&client_id=${config.get("github.clientId")}`,
       marketplaceUrl: config.get("github.marketplaceUrl"),
     },
     githubLight: {
       appUrl: config.get("githubLight.appUrl"),
     },
     gitlab: {
-      loginUrl: config.get("gitlab.loginUrl"),
+      loginUrl: `https://gitlab.com/oauth/authorize?scope=read_user&response_type=code&client_id=${config.get("gitlab.appId")}`,
     },
     stripe: {
       pricingTableId: config.get("stripe.pricingTableId"),


### PR DESCRIPTION
The `github.loginUrl` and `gitlab.loginUrl` config defaults interpolated `process.env` at module load, behind convict's own env plumbing:

```js
default: `https://github.com/login/oauth/authorize?scope=user:email&client_id=${process.env["GITHUB_CLIENT_ID"]}`,
```

Whenever the variable is absent, the template renders the string `"undefined"` and the login button points at `…/authorize?client_id=undefined`, i.e. GitHub's 404 page. That is the case for a self-hosted install without a GitHub app, for the E2E web server in CI, and for `pnpm run dev:prod-ro`, which deliberately loads no `.env` — where this was found.

The two URLs are now built where they are served, from the client id convict resolved.

## Checks

Built server, `/config.js` and `/auth/google/login`:

| | before | after (no credentials) | after (credentials set) |
|---|---|---|---|
| GitHub | `client_id=undefined` | `client_id=` | `client_id=Iv1.testclientid` |
| GitLab | `client_id=undefined` | `client_id=` | `client_id=gitlab-test-app-id` |
| Google | `client_id=` | unchanged | `client_id=1234-test.apps.googleusercontent.com` |

Google never had the bug — its client id already went through convict properly — and is listed only to show the three paths now agree.

`check-types`, `lint` and `check-format` pass.

## Out of scope

An instance with no OAuth app still renders "Continue with GitHub"; the button now leads to a missing-`client_id` error instead of a 404. Hiding a provider the instance cannot authenticate with is a larger change (client config, login and signup screens, account authentication cards, pinned client ids for the E2E screenshots) and is deliberately left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
