### PR TITLE
feat(staff): total the bands in the revenue chart tooltip

### DIFF
--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -445,6 +445,10 @@ const CHART_CONFIG: ChartConfig = Object.fromEntries(
  * because what is being read here is a trend over a year, and a filled band
  * carries a slope where twelve separate bars make the reader measure heights
  * against each other.
+ *
+ * The tooltip totals the three bands, the stack's own height. It therefore
+ * reads above the cards, which report what Stripe invoiced alone — the
+ * Marketplace band is billed by GitHub and sits on top of them.
  */
 function RevenueChart(props: { months: readonly RevenueMonth[] }) {
   const data = props.months.map((month) => ({
@@ -509,10 +513,6 @@ function RevenueChart(props: { months: readonly RevenueMonth[] }) {
                 return MONTH_YEAR_FORMAT.format(new Date(item.payload.month));
               }}
               valueFormatter={(value) => formatEuros(value)}
-              // No total: the Marketplace band is stacked on top of what
-              // Argos invoiced through Stripe, and adding the three would
-              // contradict the cards, which report the Stripe figures alone.
-              hideTotal
             />
           }
         />

--- a/apps/frontend/src/ui/Charts.tsx
+++ b/apps/frontend/src/ui/Charts.tsx
@@ -126,7 +126,6 @@ export function ChartTooltipContent({
   labelClassName,
   formatter,
   valueFormatter,
-  hideTotal = false,
   color,
   nameKey,
   labelKey,
@@ -144,11 +143,6 @@ export function ChartTooltipContent({
      * series label — where `formatter` replaces the whole row.
      */
     valueFormatter?: (value: number) => React.ReactNode;
-    /**
-     * Drops the Total row, for a chart whose series do not add up to one
-     * figure the page reports.
-     */
-    hideTotal?: boolean;
   }) {
   const { config } = useChart();
 
@@ -277,7 +271,7 @@ export function ChartTooltipContent({
             </div>
           );
         })}
-        {payload.length > 1 && !hideTotal && (
+        {payload.length > 1 && (
           <div className="mt-1 flex w-full justify-between border-t pt-1 font-bold">
             <span>Total</span>
             <span>


### PR DESCRIPTION
The revenue chart's tooltip listed its three stacked bands without their sum, so the one figure the chart actually draws — the height of the stack — was the one figure a reader had to add up by hand. The shared tooltip already renders that row for the analytics charts; this chart opted out of it with `hideTotal`.

## What the total is

The stack's own height, Marketplace included. It therefore reads **above** the cards, which report what Stripe invoiced alone — the Marketplace band is billed by GitHub and sits on top of them. On a month invoicing €21,075 monthly and €12,190 yearly with €1,428 of Marketplace, the cards say €33,265 and the tooltip says €34,693.

That discrepancy is why the row was dropped in the first place. The alternative — a total limited to the Stripe figures — would no longer be the sum of the rows printed above it, which is worse in a tooltip. So the reason moves into `RevenueChart`'s docstring, where a suppressed row could only leave the reader guessing.

One artifact worth naming: each row is rounded to the euro while the total sums the raw values before rounding, so it can sit a euro off the rows added by hand.

`hideTotal` goes with the change — the revenue chart was its only caller, and a prop no chart passes is a branch nothing exercises.

## Checks

`tsc --noEmit` on the frontend, `oxlint --deny-warnings` and `oxfmt --check` on both files. No story or test to update: the page's only Argos screenshot is framed on the monthly-plans table, not the chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
