### PR TITLE
feat(staff): rank and sort a month's revenue breakdown

### DIFF
--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { CombinedGraphQLErrors } from "@apollo/client";
 import { useQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
@@ -36,6 +36,7 @@ import {
 } from "@/ui/Layout";
 import { Link } from "@/ui/Link";
 import { Loader } from "@/ui/Loader";
+import { SortHeader, type SortDirection } from "@/ui/SortHeader";
 import { StatTile } from "@/ui/StatTile";
 import { Tooltip } from "@/ui/Tooltip";
 
@@ -99,6 +100,7 @@ type RevenueData = DocumentType<typeof StaffRevenueQuery>["staffRevenue"];
 type RevenueMonth = RevenueData["months"][number];
 type YearlyContract = RevenueData["yearlyContracts"][number];
 type Split = RevenueMonth["monthlyPlans"];
+type MonthTeam = RevenueMonth["teams"][number];
 
 /** Months the dedicated page reads — a year, plus the one running. */
 const PAGE_MONTHS = 13;
@@ -535,6 +537,155 @@ function RevenueChart(props: { months: readonly RevenueMonth[] }) {
   );
 }
 
+type MonthTeamSortKey = "team" | "amount" | "revenue";
+
+/**
+ * Sortable value per column of a month's breakdown.
+ *
+ * `amount` orders on the figure the column prints rather than on its euro
+ * equivalent: the two only diverge across currencies, and a reader comparing
+ * the numbers in front of them is comparing those. The euro column is what
+ * orders the month by weight. A team invoiced in several currencies has no
+ * printable figure at all, so it sorts below every one that has.
+ */
+function getMonthTeamSortValue(
+  team: MonthTeam,
+  key: MonthTeamSortKey,
+): string | number {
+  switch (key) {
+    case "team":
+      return (team.name ?? team.slug).toLowerCase();
+    case "amount":
+      return team.currency === null ? -1 : team.amount;
+    case "revenue":
+      return team.revenue;
+  }
+}
+
+function sortMonthTeams(
+  teams: readonly MonthTeam[],
+  key: MonthTeamSortKey,
+  direction: SortDirection,
+): MonthTeam[] {
+  const factor = direction === "asc" ? 1 : -1;
+
+  return [...teams].sort((a, b) => {
+    const left = getMonthTeamSortValue(a, key);
+    const right = getMonthTeamSortValue(b, key);
+
+    if (typeof left === "string" && typeof right === "string") {
+      return left.localeCompare(right) * factor;
+    }
+
+    return (Number(left) - Number(right)) * factor;
+  });
+}
+
+/**
+ * The teams behind a month's monthly plans, one line each.
+ *
+ * Sorted heaviest first to open, which is the order the backend already sends
+ * and the question the breakdown is opened to answer. The rank column numbers
+ * the rows as they are displayed, so it re-reads as a line number under any
+ * other sort rather than pinning a position the sort has moved.
+ */
+function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
+  const [sortKey, setSortKey] = useState<MonthTeamSortKey>("revenue");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+
+  const onSort = (key: MonthTeamSortKey) => {
+    if (sortKey === key) {
+      setSortDirection((direction) => (direction === "asc" ? "desc" : "asc"));
+      return;
+    }
+
+    setSortKey(key);
+    // Names read best A→Z; the money columns are read biggest-first.
+    setSortDirection(key === "team" ? "asc" : "desc");
+  };
+
+  const teams = useMemo(
+    () => sortMonthTeams(props.teams, sortKey, sortDirection),
+    [props.teams, sortKey, sortDirection],
+  );
+
+  return (
+    <div className="bg-app overflow-x-auto rounded-sm border">
+      <table className="w-full table-fixed border-collapse">
+        <thead>
+          <tr className="text-low border-b text-xs font-semibold">
+            <th className="w-[7%] px-4 py-3 text-right">#</th>
+            <SortHeader
+              label="Team"
+              sortKey="team"
+              activeSortKey={sortKey}
+              direction={sortDirection}
+              onSort={onSort}
+              className="w-[35%] text-left"
+            />
+            <SortHeader
+              label="Invoiced"
+              sortKey="amount"
+              activeSortKey={sortKey}
+              direction={sortDirection}
+              onSort={onSort}
+              className="w-[21%] text-right"
+            />
+            <SortHeader
+              label="In euros"
+              sortKey="revenue"
+              activeSortKey={sortKey}
+              direction={sortDirection}
+              onSort={onSort}
+              className="w-[21%] text-right"
+            />
+            <th className="w-[16%] px-4 py-3 text-right" />
+          </tr>
+        </thead>
+        <tbody>
+          {teams.map((team, teamIndex) => (
+            <tr
+              key={team.stripeCustomerId}
+              className={clsx(
+                "text-sm",
+                teamIndex !== teams.length - 1 && "border-b",
+              )}
+            >
+              <td className="text-low px-4 py-2.5 text-right tabular-nums">
+                {teamIndex + 1}
+              </td>
+              <td className="px-4 py-2.5 text-left">
+                <Link href={`/${team.slug}`}>{team.name ?? team.slug}</Link>
+              </td>
+              <td className="px-4 py-2.5 text-right tabular-nums">
+                {team.currency !== null ? (
+                  formatInvoiceAmount({
+                    amount: team.amount,
+                    currency: team.currency,
+                  })
+                ) : (
+                  <span className="text-low">—</span>
+                )}
+              </td>
+              <td className="px-4 py-2.5 text-right tabular-nums">
+                {formatEuros(team.revenue)}
+              </td>
+              <td className="px-4 py-2.5 text-right">
+                <Link
+                  href={getStripeCustomerURL(team.stripeCustomerId)}
+                  target="_blank"
+                >
+                  Stripe
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 /** Month over month down the history, so a trend can be read off the column. */
 function HistoryRow(props: {
   month: RevenueMonth;
@@ -633,56 +784,7 @@ function HistoryRow(props: {
           )}
         >
           <td colSpan={6} className="p-4">
-            <div className="bg-app overflow-x-auto rounded-sm border">
-              <table className="w-full table-fixed border-collapse">
-                <thead>
-                  <tr className="text-low border-b text-xs font-semibold">
-                    <th className="w-[40%] px-4 py-2.5 text-left">Team</th>
-                    <th className="w-[22%] px-4 py-2.5 text-right">Invoiced</th>
-                    <th className="w-[22%] px-4 py-2.5 text-right">In euros</th>
-                    <th className="w-[16%] px-4 py-2.5 text-right" />
-                  </tr>
-                </thead>
-                <tbody>
-                  {month.teams.map((team, teamIndex) => (
-                    <tr
-                      key={team.stripeCustomerId}
-                      className={clsx(
-                        "text-sm",
-                        teamIndex !== month.teams.length - 1 && "border-b",
-                      )}
-                    >
-                      <td className="px-4 py-2.5 text-left">
-                        <Link href={`/${team.slug}`}>
-                          {team.name ?? team.slug}
-                        </Link>
-                      </td>
-                      <td className="px-4 py-2.5 text-right tabular-nums">
-                        {team.currency !== null ? (
-                          formatInvoiceAmount({
-                            amount: team.amount,
-                            currency: team.currency,
-                          })
-                        ) : (
-                          <span className="text-low">—</span>
-                        )}
-                      </td>
-                      <td className="px-4 py-2.5 text-right tabular-nums">
-                        {formatEuros(team.revenue)}
-                      </td>
-                      <td className="px-4 py-2.5 text-right">
-                        <Link
-                          href={getStripeCustomerURL(team.stripeCustomerId)}
-                          target="_blank"
-                        >
-                          Stripe
-                        </Link>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            <MonthTeamsTable teams={month.teams} />
           </td>
         </tr>
       ) : null}

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -884,6 +884,14 @@ revenueTest.describe("staff revenue", () => {
     await expect(breakdown.getByText("$1,000.00")).toBeVisible();
     await expect(breakdown.getByText("€855")).toBeVisible();
 
+    // Heaviest first to open, so the dollar team leads and the ranks number
+    // that order.
+    const breakdownRows = breakdown.locator("tbody tr");
+    await expect(breakdownRows.nth(0)).toContainText(revenueBook.dollarTeam);
+    await expect(breakdownRows.nth(0).locator("td").first()).toHaveText("1");
+    await expect(breakdownRows.nth(1)).toContainText(revenueBook.monthlyTeam);
+    await expect(breakdownRows.nth(1).locator("td").first()).toHaveText("2");
+
     // The contract is listed on its own, with the invoice its figure is read
     // from and what a month of it comes to — its twelve months are not all the
     // same length, so the share of this one is what the row reports.
@@ -902,6 +910,14 @@ revenueTest.describe("staff revenue", () => {
     await screenshot(page, "staff-revenue-monthly-plans", {
       element: monthlyPlans,
     });
+
+    // After the screenshot: the baseline is worth having in the order the
+    // breakdown opens in.
+    // Sorting by name reverses the two, and the ranks follow the rows rather
+    // than travelling with them.
+    await breakdown.getByRole("button", { name: "Team" }).click();
+    await expect(breakdownRows.nth(0)).toContainText(revenueBook.monthlyTeam);
+    await expect(breakdownRows.nth(0).locator("td").first()).toHaveText("1");
   });
 });
 


### PR DESCRIPTION
The breakdown opened under a month on the Revenue page listed its teams heaviest-first and left it there. Reading it any other way — who was invoiced most in dollars, whether a given team is in the month at all — meant scanning it by eye.

It now carries a rank column and sorts on **Team**, **Invoiced** and **In euros**, reusing the `SortHeader` the trials table already uses.

[![staff-revenue-monthly-plans.png](https://files.argos-ci.com/media/9/a8617c5f5e855253268cd1bed81583ae4c497e8e7af8a192837562b4c39282d8.webp)](https://app.argos-ci.com/m/r6iyhpqso24f8fmbkaj4)

### Decisions worth a look

- **Each month keeps its own sort.** The breakdowns are opened to be compared, and one shared order would move a month the reader is not looking at.
- **`Invoiced` sorts on the figure it prints**, not on its euro equivalent. The two only diverge across currencies, and a reader comparing the numbers in front of them is comparing those — `In euros` is what orders the month by weight. A team invoiced in several currencies has no printable figure at all, so it sorts below every one that has.
- **The rank numbers the rows as displayed** rather than pinning a position. It reads as a rank under the default sort (euros, heaviest first — the order the backend already sends) and as a plain line number under any other.

### Testing

Extended the existing `staff revenue` spec: the ranks number the default order, and clicking `Team` reverses the two seeded teams. The visual baseline above comes from that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)