### PR TITLE
feat(build): offer the flakiness prompt on a flaky snapshot

### DIFF
--- a/apps/frontend/src/containers/AiPromptButton.tsx
+++ b/apps/frontend/src/containers/AiPromptButton.tsx
@@ -53,8 +53,8 @@ export function useAiPromptTarget() {
 /** One thing Argos can ask a coding agent to do. */
 export interface AiPrompt {
   /**
-   * What the prompt asks for, as the menu says it ("Review build"). Only shown
-   * when the button carries more than one.
+   * What the prompt asks for ("Review build"). Names the button that performs
+   * it, and the menu row that reaches it.
    */
   label: string;
   /**
@@ -182,8 +182,10 @@ export function AiPromptButton(props: {
             }
             href={agent.getURL(primary.prompt)}
           >
+            {/* Named by what it does, not by where it goes: the agent's mark
+                already says that, and the tooltip spells it out. */}
             <PrimaryContent iconOnly={iconOnly} icon={<agent.Icon />}>
-              Open in {agent.name}
+              {primary.label}
             </PrimaryContent>
           </LinkButton>
         </Tooltip>

--- a/apps/frontend/src/containers/Test/FixFlakinessPrompt.ts
+++ b/apps/frontend/src/containers/Test/FixFlakinessPrompt.ts
@@ -1,0 +1,62 @@
+import { config } from "@/config";
+import type { MetricsPeriod } from "@/gql/graphql";
+
+/**
+ * What the prompt needs to know about the test. Taken apart rather than typed
+ * on a fragment: the test page and a build's sidebar select their metrics under
+ * different names, over different periods.
+ */
+export interface FlakinessPromptTest {
+  id: string;
+  name: string;
+  buildName: string;
+  metrics: {
+    total: number;
+    changes: number;
+    uniqueChanges: number;
+    flakiness: number;
+  };
+}
+
+/**
+ * A prompt to hand to a coding agent so it fixes this test's flakiness on its
+ * own. It carries the numbers Argos measured, the two API calls that expose the
+ * test and the changes that keep coming back, and what to look for once the
+ * agent has the diff images.
+ */
+export function createFixFlakinessPrompt(input: {
+  test: FlakinessPromptTest;
+  accountSlug: string;
+  projectName: string;
+  period: MetricsPeriod;
+  periodLabel: string;
+  testUrl: string;
+}): string {
+  const { test, accountSlug, projectName, period, periodLabel, testUrl } =
+    input;
+  const metrics = test.metrics;
+  const apiBaseUrl = `${config.api.baseUrl}/v2`;
+  const testApiUrl = `${apiBaseUrl}/projects/${accountSlug}/${projectName}/tests/${test.id}`;
+  const flakinessPercent = Math.round(metrics.flakiness * 100);
+
+  return `Fix the flaky Argos visual test "${test.name}" in the ${accountSlug}/${projectName} project.
+
+A visual test is flaky when it keeps capturing a different screenshot while nothing in the UI actually changed. What Argos measured over the ${periodLabel} — builds that ran it: ${metrics.total}, changes: ${metrics.changes}, changes seen only once: ${metrics.uniqueChanges}, flakiness score: ${flakinessPercent}%.
+
+- Test id: ${test.id}
+- Build name: ${test.buildName}
+- Test page: ${testUrl}
+
+1. Read the test and the changes that keep coming back. Use whichever of these you have, in this order:
+   - The Argos CLI, if it is installed: \`npx @argos-ci/cli test get ${test.id} --json\` and \`npx @argos-ci/cli test changes ${test.id} --json\`, with \`--project ${accountSlug}/${projectName}\` unless \`ARGOS_TOKEN\` is a project token.
+   - The Argos MCP server, if it is connected: the \`getTest\` and \`listTestChanges\` tools.
+   - The REST API otherwise, with \`Authorization: Bearer $ARGOS_TOKEN\` (an Argos personal access token):
+     GET ${testApiUrl}?metricsPeriod=${period}
+     GET ${testApiUrl}/changes?metricsPeriod=${period}
+2. For the changes with the highest \`occurrences\`, open \`diff.url\`, \`diff.base.url\` and \`diff.head.url\` and look at what actually moves between the baseline and the capture.
+3. Find that test in this repository from its name and its build name, then work out what makes the screenshot non-deterministic: animations or transitions still running, dates and times, random or unordered data, fonts or images not loaded yet, network timing, scrollbars, carets, third-party embeds.
+4. Fix the root cause so the capture is stable — wait for the real end state instead of a fixed delay, freeze the clock and the random source, order the data. Prefer making the UI deterministic over masking the region.
+5. If a change turns out to be noise that genuinely cannot be made deterministic, ignore it in Argos instead, with its \`id\` from step 1 — \`npx @argos-ci/cli change ignore <changeId> --project ${accountSlug}/${projectName}\`, or:
+   POST ${apiBaseUrl}/projects/${accountSlug}/${projectName}/changes/<changeId>/ignore
+6. Report what was non-deterministic, what you changed, and why the screenshot is stable now.`;
+}

--- a/apps/frontend/src/pages/Build/RightSidebar.tsx
+++ b/apps/frontend/src/pages/Build/RightSidebar.tsx
@@ -97,7 +97,7 @@ export function RightSidebar(
                   occurrences={activeDiff.last7daysOccurrences}
                 />
               ) : null}
-              <TestInsightsSection test={activeDiff.test} />
+              <TestInsightsSection test={activeDiff.test} diff={activeDiff} />
               <TestActivitySection
                 test={activeDiff.test}
                 change={activeDiff.change ?? null}

--- a/apps/frontend/src/pages/Build/sidebar/TestInsightsSection.tsx
+++ b/apps/frontend/src/pages/Build/sidebar/TestInsightsSection.tsx
@@ -1,8 +1,13 @@
 import { invariant } from "@argos/util/invariant";
 import clsx from "clsx";
 
+import { config } from "@/config";
+import { AiPromptButton } from "@/containers/AiPromptButton";
+import { createFixFlakinessPrompt } from "@/containers/Test/FixFlakinessPrompt";
+import { isFlaky } from "@/containers/Test/Flakiness";
 import { FlakinessCircleIndicator } from "@/containers/Test/FlakinessCircleIndicator";
 import { graphql, type DocumentType } from "@/gql";
+import { MetricsPeriod } from "@/gql/graphql";
 import { HeadlessLink } from "@/ui/Link";
 import { Panel, PanelHeader, PanelTitle } from "@/ui/Panel";
 import { Tooltip } from "@/ui/Tooltip";
@@ -18,17 +23,21 @@ import {
   FlakinessTooltip,
   StabilityTooltip,
 } from "../../Test/Widgets";
+import type { Diff } from "../BuildDiffState";
 import { InsightTitle } from "./InsightTitle";
 
 const _TestFragment = graphql(`
   fragment TestInsightsSection_Test on Test {
     id
+    name
+    buildName
     last7daysMetrics: metrics(period: LAST_7_DAYS) {
       all {
         total
         flakiness
         stability
         changes
+        uniqueChanges
         consistency
       }
     }
@@ -37,8 +46,9 @@ const _TestFragment = graphql(`
 
 export function TestInsightsSection(props: {
   test: DocumentType<typeof _TestFragment>;
+  diff: Diff;
 }) {
-  const { test } = props;
+  const { test, diff } = props;
   const params = useProjectParams();
   invariant(params, "can't be used outside of a project route");
   return (
@@ -111,7 +121,69 @@ export function TestInsightsSection(props: {
           </InsightRow>
         </div>
       </div>
+      <FixFlakinessAction diff={diff} />
     </Panel>
+  );
+}
+
+/**
+ * Whether Argos already considers the snapshot in front of the reviewer flaky:
+ * the same change coming back build after build, or a test whose flakiness
+ * score the gauge does not paint green. Either way the capture is noise, and
+ * what has to change is the test rather than the baseline.
+ */
+function checkIsFlakySnapshot(
+  diff: Diff,
+): diff is Diff & { test: NonNullable<Diff["test"]> } {
+  if (!diff.test) {
+    return false;
+  }
+  return (
+    diff.last7daysOccurrences > 1 ||
+    isFlaky(diff.test.last7daysMetrics.all.flakiness)
+  );
+}
+
+/**
+ * The way out of the numbers above, at the point where they say the capture is
+ * unstable. Only on a snapshot Argos calls flaky: on a stable one there is
+ * nothing to fix, and the panel is there to say so.
+ *
+ * It hands out the test's prompt, not one about this capture: a flake is what
+ * the test does over time, and no single screenshot of it is the right one.
+ */
+function FixFlakinessAction(props: { diff: Diff }) {
+  const { diff } = props;
+  const params = useProjectParams();
+  invariant(params, "can't be used outside of a project route");
+  if (!checkIsFlakySnapshot(diff)) {
+    return null;
+  }
+  const { test } = diff;
+  const prompt = createFixFlakinessPrompt({
+    test: { ...test, metrics: test.last7daysMetrics.all },
+    accountSlug: params.accountSlug,
+    projectName: params.projectName,
+    period: MetricsPeriod.Last_7Days,
+    periodLabel: "last 7 days",
+    testUrl: new URL(
+      getTestURL({ ...params, testId: test.id }),
+      config.server.url,
+    ).href,
+  });
+  return (
+    <div className="mt-4 flex px-4">
+      <AiPromptButton
+        size="small"
+        prompts={[
+          {
+            label: "Fix this flaky snapshot",
+            name: "flaky snapshot prompt",
+            prompt,
+          },
+        ]}
+      />
+    </div>
   );
 }
 

--- a/apps/frontend/src/pages/Test/FixFlakinessSection.tsx
+++ b/apps/frontend/src/pages/Test/FixFlakinessSection.tsx
@@ -4,6 +4,7 @@ import { SparklesIcon } from "lucide-react";
 
 import { config } from "@/config";
 import { AiPromptButton } from "@/containers/AiPromptButton";
+import { createFixFlakinessPrompt } from "@/containers/Test/FixFlakinessPrompt";
 import { isFlaky } from "@/containers/Test/Flakiness";
 import { graphql, type DocumentType } from "@/gql";
 import { MetricsPeriod } from "@/gql/graphql";
@@ -32,49 +33,6 @@ const _TestFragment = graphql(`
 type Test = DocumentType<typeof _TestFragment>;
 
 /**
- * A prompt to hand to a coding agent so it fixes this test's flakiness on its
- * own. It carries the numbers Argos measured, the two API calls that expose the
- * test and the changes that keep coming back, and what to look for once the
- * agent has the diff images.
- */
-function buildPrompt(input: {
-  test: Test;
-  accountSlug: string;
-  projectName: string;
-  period: MetricsPeriod;
-  periodLabel: string;
-  testUrl: string;
-}): string {
-  const { test, accountSlug, projectName, period, periodLabel, testUrl } =
-    input;
-  const metrics = test.metrics.all;
-  const apiBaseUrl = `${config.api.baseUrl}/v2`;
-  const testApiUrl = `${apiBaseUrl}/projects/${accountSlug}/${projectName}/tests/${test.id}`;
-  const flakinessPercent = Math.round(metrics.flakiness * 100);
-
-  return `Fix the flaky Argos visual test "${test.name}" in the ${accountSlug}/${projectName} project.
-
-A visual test is flaky when it keeps capturing a different screenshot while nothing in the UI actually changed. What Argos measured over the ${periodLabel} — builds that ran it: ${metrics.total}, changes: ${metrics.changes}, changes seen only once: ${metrics.uniqueChanges}, flakiness score: ${flakinessPercent}%.
-
-- Test id: ${test.id}
-- Build name: ${test.buildName}
-- Test page: ${testUrl}
-
-1. Read the test and the changes that keep coming back. Use whichever of these you have, in this order:
-   - The Argos CLI, if it is installed: \`npx @argos-ci/cli test get ${test.id} --json\` and \`npx @argos-ci/cli test changes ${test.id} --json\`, with \`--project ${accountSlug}/${projectName}\` unless \`ARGOS_TOKEN\` is a project token.
-   - The Argos MCP server, if it is connected: the \`getTest\` and \`listTestChanges\` tools.
-   - The REST API otherwise, with \`Authorization: Bearer $ARGOS_TOKEN\` (an Argos personal access token):
-     GET ${testApiUrl}?metricsPeriod=${period}
-     GET ${testApiUrl}/changes?metricsPeriod=${period}
-2. For the changes with the highest \`occurrences\`, open \`diff.url\`, \`diff.base.url\` and \`diff.head.url\` and look at what actually moves between the baseline and the capture.
-3. Find that test in this repository from its name and its build name, then work out what makes the screenshot non-deterministic: animations or transitions still running, dates and times, random or unordered data, fonts or images not loaded yet, network timing, scrollbars, carets, third-party embeds.
-4. Fix the root cause so the capture is stable — wait for the real end state instead of a fixed delay, freeze the clock and the random source, order the data. Prefer making the UI deterministic over masking the region.
-5. If a change turns out to be noise that genuinely cannot be made deterministic, ignore it in Argos instead, with its \`id\` from step 1 — \`npx @argos-ci/cli change ignore <changeId> --project ${accountSlug}/${projectName}\`, or:
-   POST ${apiBaseUrl}/projects/${accountSlug}/${projectName}/changes/<changeId>/ignore
-6. Report what was non-deterministic, what you changed, and why the screenshot is stable now.`;
-}
-
-/**
  * A prompt to hand to a coding agent so it investigates and fixes this test's
  * flakiness from the API, without anyone having to describe the test to it.
  * Either the agent opens with the prompt already typed in, or the prompt goes to
@@ -97,8 +55,8 @@ export function FixFlakinessSection(props: {
 
   const prompt = useMemo(
     () =>
-      buildPrompt({
-        test,
+      createFixFlakinessPrompt({
+        test: { ...test, metrics: test.metrics.all },
         accountSlug: params.accountSlug,
         projectName: params.projectName,
         period,

--- a/tests/project-tests.spec.ts
+++ b/tests/project-tests.spec.ts
@@ -227,18 +227,17 @@ loggedTest(
     }
 
     // The test is flaky, so the section opens itself: the actions are reachable
-    // without expanding anything. Claude is the agent offered by default.
+    // without expanding anything. The button is named after what it does, and
+    // Claude is the agent offered by default.
     await expect(
       page.getByRole("heading", { name: "Fix with AI" }),
     ).toBeVisible();
-    const openInClaude = page.getByRole("link", {
-      name: "Open in Claude",
-    });
-    await expect(openInClaude).toBeVisible();
+    const fixButton = page.getByRole("link", { name: "Fix flakiness" });
+    await expect(fixButton).toBeVisible();
 
     // The agent is opened through its own deep link, which carries the prompt:
     // it names the test and the API endpoints the agent has to call.
-    const href = (await openInClaude.getAttribute("href")) ?? "";
+    const href = (await fixButton.getAttribute("href")) ?? "";
     expect(href).toMatch(/^claude:\/\/code\/new\?q=/);
     const prompt = new URLSearchParams(href.split("?")[1]).get("q") ?? "";
     expect(prompt).toContain("Fix the flaky Argos visual test");
@@ -285,15 +284,18 @@ loggedTest(
       page.getByRole("button", { name: "Copy prompt" }),
     ).toBeVisible();
 
-    // Picking an agent moves the button back to it. Only Chromium ignores the
-    // unknown scheme the click navigates to; the others would stop on a dialog.
+    // Picking an agent moves the button back to it — the label stays the action,
+    // so the deep link's scheme is what says where it now goes. Only Chromium
+    // ignores the unknown scheme the click navigates to; the others would stop
+    // on a dialog.
     if (browserName === "chromium") {
       await openMenu();
       await page.getByRole("option", { name: "Open in Cursor" }).click();
       await page.reload();
-      await expect(
-        page.getByRole("link", { name: "Open in Cursor" }),
-      ).toBeVisible();
+      await expect(fixButton).toHaveAttribute(
+        "href",
+        /^cursor:\/\/anysphere\.cursor-deeplink\/prompt\?text=/,
+      );
     }
   },
 );
@@ -310,14 +312,12 @@ loggedTest(
     // there, but not competing with the metrics saying the test is fine.
     const heading = page.getByRole("heading", { name: "Fix with AI" });
     await expect(heading).toBeVisible();
-    const openInClaude = page.getByRole("link", {
-      name: "Open in Claude",
-    });
-    await expect(openInClaude).toBeHidden();
+    const fixButton = page.getByRole("link", { name: "Fix flakiness" });
+    await expect(fixButton).toBeHidden();
 
     // And opening it hands out the same prompt.
     await heading.click();
-    await expect(openInClaude).toBeVisible();
+    await expect(fixButton).toBeVisible();
   },
 );
 


### PR DESCRIPTION
The snapshot sidebar of a build already says a capture keeps moving on its own — how many of the last seven days' builds produced the same change, a flakiness score the gauge paints red — and the only thing it offered to do about it was ignore it. The test page, meanwhile, has had a prompt to hand the fix to a coding agent since it shipped.

**Test Insights now carries that same prompt**, on the snapshots Argos already calls flaky: a change that keeps coming back (`occurrences > 1`), or a test whose flakiness the gauge does not paint green. On a stable snapshot the panel is unchanged.

The prompt is the *test's*, not the capture's, and its text is untouched. A flake is what a test does over time, so no single screenshot of it is the right one — reading the current diff first would frame the whole investigation on one draw from an unstable distribution. It moves to `containers/Test/FixFlakinessPrompt.ts` since two pages hand it out now, next to `Flakiness.ts`, which is shared for the same reason. `TestInsightsSection_Test` gains `name`, `buildName` and `uniqueChanges` — what the prompt needs and the fragment did not already select.

### Prompt buttons name the action, not the destination

`AiPromptButton` labels its primary button with the prompt's own `label` — "Fix flakiness" instead of "Open in Claude". The agent's mark already carries where it goes and the tooltip still spells it out, so the words are free to say what happens. The clipboard case keeps saying "Copy …", since that is a different action.

The test page inherits this, so its baselines will show the new label.

### Testing

`pnpm run static-checks`, plus the two Playwright specs covering the prompt on the test page. Their assertions on the prompt text are unchanged; the ones that located the button by "Open in Claude" now use the action label, and the one checking that the picked agent is remembered asserts the deep link's scheme instead, since the label no longer names the agent.

The build-page surface was checked end to end against a seeded flaky change (5 occurrences over 10 builds, 72%): the button appears, and its deep link carries the same prompt the test page produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
