### PR TITLE
fix(team): make "Remove from Team" open its confirmation dialog

### DIFF
--- a/apps/frontend/src/containers/Team/members/Members.tsx
+++ b/apps/frontend/src/containers/Team/members/Members.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState } from "react";
+import { Suspense } from "react";
 
 import { useAssertAuthAccount } from "@/containers/Auth";
 import { DocumentType, graphql } from "@/gql";
@@ -11,7 +11,7 @@ import {
   CardParagraph,
   CardTitle,
 } from "@/ui/Card";
-import { DialogTrigger } from "@/ui/Dialog";
+import { DialogTrigger, useDialogValueState } from "@/ui/Dialog";
 import { List, ListRowLoader } from "@/ui/List";
 import { Modal } from "@/ui/Modal";
 import { Tab, TabList, TabPanel, Tabs } from "@/ui/Tab";
@@ -68,15 +68,7 @@ export function TeamMembers(props: {
 }) {
   const { team } = props;
   const authAccount = useAssertAuthAccount();
-  const [removedUser, setRemovedUser] = useState<RemovedUser | null>(null);
-  const removeFromTeamModal = {
-    isOpen: removedUser !== null,
-    onOpenChange: (open: boolean) => {
-      if (!open) {
-        setRemovedUser(null);
-      }
-    },
-  };
+  const removing = useDialogValueState<RemovedUser | null>(null);
   const me = team.me;
   const amOwner =
     team.permissions.includes(AccountPermission.Admin) ||
@@ -107,7 +99,7 @@ export function TeamMembers(props: {
               <TeamMembersList
                 teamId={team.id}
                 amOwner={amOwner}
-                onRemove={setRemovedUser}
+                onRemove={removing.open}
                 hasGithubSSO={hasGithubSSO}
                 hasFineGrainedAccessControl={hasFineGrainedAccessControl}
               />
@@ -121,7 +113,7 @@ export function TeamMembers(props: {
                   teamName={teamName}
                   githubAccount={team.ssoGithubAccount}
                   amOwner={amOwner}
-                  onRemove={setRemovedUser}
+                  onRemove={removing.open}
                   hasFineGrainedAccessControl={hasFineGrainedAccessControl}
                 />
               </Suspense>
@@ -135,15 +127,15 @@ export function TeamMembers(props: {
             </TabPanel>
           ) : null}
         </Tabs>
-        <Modal {...removeFromTeamModal}>
-          {removedUser ? (
-            authAccount.id === removedUser.id ? (
+        <Modal open={removing.isOpen} onOpenChange={removing.onOpenChange}>
+          {removing.value ? (
+            authAccount.id === removing.value.id ? (
               <LeaveTeamDialog teamName={teamName} teamAccountId={team.id} />
             ) : (
               <RemoveFromTeamDialog
                 teamName={teamName}
                 teamAccountId={team.id}
-                user={removedUser}
+                user={removing.value}
               />
             )
           ) : null}

--- a/apps/frontend/src/containers/Team/members/RemoveFromTeamDialog.tsx
+++ b/apps/frontend/src/containers/Team/members/RemoveFromTeamDialog.tsx
@@ -4,9 +4,9 @@ import { useMutation } from "@apollo/client/react";
 
 import { UserListRow } from "@/containers/UserList";
 import { DocumentType, graphql } from "@/gql";
-import { Button } from "@/ui/Button";
 import {
   Dialog,
+  DialogActionButton,
   DialogBody,
   DialogDismiss,
   DialogFooter,
@@ -44,7 +44,7 @@ export type RemovedUser = DocumentType<
 export const RemoveFromTeamDialog = memo(
   (props: { teamName: string; teamAccountId: string; user: RemovedUser }) => {
     const state = useOverlayTriggerState();
-    const [removeFromTeam, { loading, error }] = useMutation(
+    const [removeFromTeam, { error }] = useMutation(
       RemoveUserFromTeamMutation,
       {
         onCompleted() {
@@ -99,15 +99,14 @@ export const RemoveFromTeamDialog = memo(
             <ErrorMessage>Something went wrong. Please try again.</ErrorMessage>
           )}
           <DialogDismiss>Cancel</DialogDismiss>
-          <Button
-            disabled={loading}
+          <DialogActionButton
             variant="destructive"
-            onClick={() => {
-              removeFromTeam().catch(() => {});
+            onAsyncAction={async () => {
+              await removeFromTeam().catch(() => {});
             }}
           >
             Remove from Team
-          </Button>
+          </DialogActionButton>
         </DialogFooter>
       </Dialog>
     );

--- a/tests/team-settings.spec.ts
+++ b/tests/team-settings.spec.ts
@@ -1,7 +1,9 @@
 import { expect } from "@playwright/test";
 
+import { TeamUser } from "../apps/backend/src/database/models";
+import { createUserAccount } from "../apps/backend/src/database/seeds";
 import { loggedTest } from "./logged-test";
-import { ensureTeamOwner, screenshot } from "./util";
+import { ensureTeamOwner, getUniqueTestIdentifier, screenshot } from "./util";
 
 loggedTest.beforeEach(async ({ auth, team }) => {
   await ensureTeamOwner({ team: team.team, user: auth.user });
@@ -68,3 +70,45 @@ loggedTest("team settings - authentication", async ({ page, team }) => {
   ]);
   await screenshot(page, "team-settings-authentication");
 });
+
+loggedTest(
+  "team settings - remove a member from the team",
+  async ({ page, team }, testInfo) => {
+    const id = getUniqueTestIdentifier(testInfo);
+    const member = await createUserAccount({
+      email: `dana-${id}@acme.com`,
+      name: "Dana Scully",
+      slug: `dana-${id}`,
+    });
+    await TeamUser.query().insert({
+      teamId: team.team.id,
+      userId: member.user.id,
+      userLevel: "member",
+    });
+
+    await page.goto(`/${team.account.slug}/settings/members`);
+    const row = page.getByRole("row").filter({ hasText: "Dana Scully" });
+    await expect(row).toBeVisible();
+
+    await row.locator("button:has(.lucide-ellipsis-vertical)").click();
+    await page.getByRole("option", { name: "Remove from Team" }).click();
+
+    // The whole point of the guard: the dialog is driven by a controlled
+    // `Modal`, and a mismatched prop left it permanently closed — the menu
+    // item worked, and nothing happened.
+    const dialog = page.getByRole("alertdialog");
+    await expect(
+      dialog.getByRole("heading", { name: "Remove Team Member" }),
+    ).toBeVisible();
+
+    await dialog.getByRole("button", { name: "Remove from Team" }).click();
+    await expect(dialog).toBeHidden();
+    await expect(row).toBeHidden();
+    expect(
+      await TeamUser.query().findOne({
+        teamId: team.team.id,
+        userId: member.user.id,
+      }),
+    ).toBeUndefined();
+  },
+);


### PR DESCRIPTION
## The bug

Clicking **Remove from Team** (or **Leave Team**) in the team members list did nothing at all — the confirmation dialog could never open.

`Modal` takes an `open` prop, but the modal was driven by a spread object carrying `isOpen`:

```tsx
<Modal {...removeFromTeamModal}>   // { isOpen, onOpenChange }
```

`open` therefore arrived `undefined`, so `useOverlayRoot` treated the modal as *uncontrolled*, fell back to local state with `defaultOpen: false`, and nothing ever opened it.

TypeScript could not catch this: JSX spreads skip excess-property checking, so the stray `isOpen` type-checks clean. Every other controlled modal in the codebase writes `open={x.isOpen} onOpenChange={x.onOpenChange}` — this was the only spread.

## The fix

- **`Members.tsx`** — replaced the hand-rolled state with `useDialogValueState`, the codebase idiom for exactly this. It fixes the wiring and, via `usePersistentValue`, also keeps the dialog's content mounted through the 200ms exit animation instead of blanking the card mid-close.
- **`RemoveFromTeamDialog.tsx`** — the confirm button used the pre-`DialogActionButton` pattern, which `CLAUDE.md` explicitly rules out ("never track that with a local `loading` boolean"). With `disabled={loading}` the in-flight button lost focus and showed no spinner, and Cancel/Escape stayed live during a destructive mutation. `DialogActionButton` + `onAsyncAction` routes it through `ModalActionContext`.

## Test

Added a guard spec covering menu → dialog → removal, asserting the row disappears and the `TeamUser` row is actually gone.

It earns its place: this regression made a whole destructive action unreachable and nothing caught it.

## Verification

- `pnpm run static-checks` passes (types, format, lint, knip).
- The guard passes with the fix. Reverted `Members.tsx`, rebuilt, re-ran → it fails on the right assertion (`waiting for getByRole('alertdialog')…`), then restored.
- All 7 `team-settings` specs pass.
- Manually confirmed working in the running app.

## Follow-ups (not in this PR)

- The dialog collapses every failure into "Something went wrong. Please try again.", discarding real backend messages like `Can't remove the last user of a team.` — siblings use `getErrorMessage(error)`.
- `RemoveMenu` puts `aria-label` on the menu rather than the trigger button, so the control is nameless to a screen reader (which is why the test locates it by icon class).
- `CLAUDE.md` tells you to drive action dialogs with `useModalAction()`; that hook does not exist anywhere in the repo — `DialogActionButton` is the live API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)