### PR TITLE
chore(tests): stop the build-switcher tooltip racing the capture

### DIFF
--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -320,6 +320,13 @@ loggedTest(
     });
     await expect(docsItem).toBeVisible();
 
+    // The click left the pointer on the trigger, so its tooltip is counting
+    // down 900ms behind the open popover. Whether it lands before the capture
+    // depends on how long the assertions above took — on a slow run it arrives
+    // and covers the popover's "Builds on this commit" header, which is a diff
+    // no baseline can pin. Stepping off the trigger stops the timer.
+    await page.mouse.move(0, 0);
+
     await screenshot(page, "build-switcher", {
       replacements: {
         [team.account.slug]: "acme",


### PR DESCRIPTION
## The flake

`firefox/build-switcher.png` flipped in [build 5751](https://app.argos-ci.com/argos-ci/argos/builds/5751/421853081) (spotted on #2540, which is unrelated — it only touched the team members dialog).

The only difference between the two frames is a dark **"Switch build"** tooltip drawn on top of the open popover, covering its `Builds on this commit` header. The build list itself, and the checkmark on `default #1`, are identical.

## Why

```ts
await page.getByRole("button", { name: "Switch build" }).click();
```

The click leaves the pointer parked on the trigger, so the tooltip's `TOOLTIP_DELAY` (900ms, `ui/Tooltip.tsx`) starts counting behind the popover. Between that click and `screenshot()` there are three `toBeVisible()` assertions on the popover's options. Under 900ms, no tooltip; over it, the tooltip lands in the capture.

That is exactly the kind of diff no baseline can pin — accepting it would just make it flake back the other way on the next fast run.

Argos agrees it is a flake rather than a regression: **Retry 1 / 3**, flakiness score 2, stability 96%, 1 change in 26 builds.

## The fix

Step off the trigger before capturing, which cancels the hover timer. This is the idiom already used in `project-ignored.spec.ts`. The tooltip's 100ms close delay is well inside the capture.

## Verification

Formatting and linting run clean (`oxfmt`, `oxlint`).

I did **not** run the e2e suite locally: another process was holding port 3000 and the `test` database at the time, and a second Playwright run would have truncated the DB underneath it. The reasoning above is from the Argos frames, the 900ms constant and the existing idiom — CI on this PR is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)