### PR TITLE
chore(tests): settle the page before shooting the delete-passkey dialog

### DIFF
--- a/tests/passkeys.spec.ts
+++ b/tests/passkeys.spec.ts
@@ -33,6 +33,11 @@ loggedTest(
     await screenshot(page, "settings/passkeys-edit", { element: editDialog });
     await editDialog.getByRole("button", { name: "Save" }).click();
     await expect(card.getByText("Work laptop")).toBeVisible();
+    // Opening the next dialog while this one is still leaving scrolls the row
+    // into view over a page that has not settled, and it lands at one of two
+    // offsets. Nothing of that shows except through the delete dialog's rounded
+    // corners — which is exactly what kept its screenshot flaky.
+    await expect(editDialog).toBeHidden();
 
     await card.getByRole("button", { name: "Delete Work laptop" }).click();
     const deleteDialog = page.getByRole("alertdialog");


### PR DESCRIPTION
`firefox/settings/passkeys-delete` ([ARGOS-HE1YI](https://app.argos-ci.com/argos-ci/argos/tests/ARGOS-HE1YI)) was the flakiest test in the project: 15 changes over 38 builds, **70% flakiness**, 0 of them seen only once. Its chromium twin ([ARGOS-ALUMB](https://app.argos-ci.com/argos-ci/argos/tests/ARGOS-ALUMB), 65%) has the identical signature.

## What was moving

Both recurring changes touch the same handful of pixels — the outermost row and column of the capture, and the four rounded-corner arcs. Nothing inside the card ever moves.

Those pixels are the only part of the shot that is not the dialog. The captured element is the popup's box, and the popup is `rounded-2xl` over a `fixed inset-0` backdrop, so its corners — plus the half pixel of edge the clip box straddles, the popup landing on `y = 257.5` — show **the page behind**.

And the page behind moves. This is the one screenshot in the suite taken right after another modal closed:

```
Save → expect("Work laptop").toBeVisible()   ← passes while the edit dialog is still animating out
     → click("Delete Work laptop")           ← Playwright scrolls the row into view here
     → screenshot
```

The scroll-into-view runs over a page that has not settled and lands at one of two offsets — I caught an outlier at `scrollY: 103` against the usual `422`, with a visibly different full-page render. At 422 the black "Connect GitHub" button sits right behind the bottom-left corner; at 103 it does not.

Magnified 6×, bottom-left corner. The first three are the renderings the unfixed test produced in 13 local runs; the fourth is the fixed one:

[![flake-corners.png](https://files.argos-ci.com/media/9/6a8e828b348e2296a94d6e21229e219debff983a1447a1ceced7c6445892e23d.webp)](https://app.argos-ci.com/m/fodbe239j9solcxvnarg)

## The fix

Wait for the previous dialog to actually leave before opening the next one.

## Verification

Reproduced and measured locally under CPU load, to approximate CI:

| | distinct renderings |
|---|---|
| before, firefox, 13 runs | **3** (11 / 1 / 1) |
| after, firefox, 16 runs | 1 |
| after, chromium, 16 runs | 1 |
| after, full spec ×6 (all four screenshots) | 1 each |

38 post-fix captures, byte-identical. `pnpm run static-checks` passes; the spec passes on both browsers.

Ruled out along the way, in case this comes up again: **not** the entrance animation — the backdrop sits anywhere between 0.10 and 0.89 opacity when the capture starts and Playwright's `animations: "disabled"` seek handles it (12 runs at varying opacity, identical bytes) — and **not** `backdrop-filter` compositing; forcing it off through `argosCSS` did not stabilise anything, and that attempt is not in this PR.

## Reviewing

**Expect one change to approve**, on both browsers. The fix pins the capture to a rendering that was in the pre-fix minority, so the corner pixels move once and settle after that.

The two existing changes on the test are already marked `ignored` in Argos, from an earlier pass. They are keyed to diff hashes that will no longer occur, so there is nothing to clean up there.

---

Two caveats on confidence. I can show *that* the scroll offset varies and that waiting removes it, but not precisely *why* it lands differently — the edit dialog is still mounted at click time (`[role=dialog]` count is 1 in every run), and any added delay before the capture also suppresses the flake, which is consistent but not proof. Separately, this is a probabilistic fix on a probabilistic failure: 38 clean runs against a ~15% local rate is strong, not certain. The test page will tell.

Next in the flakiness backlog, untouched here: `firefox/build-next-review-dialog` (0.32), `firefox/settings/passkeys-create` (0.28), `firefox/project-deployments` (0.28) — though their `uniqueChanges` counts suggest mostly real changes rather than this failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

