### PR TITLE
fix(build): update the text diff when another snapshot is selected

### DIFF
--- a/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
+++ b/apps/frontend/src/containers/Build/BuildDiffDetail.tsx
@@ -792,6 +792,7 @@ function BaseScreenshot({
       }
       return (
         <Snapshot
+          id={diff.baseScreenshot.id}
           url={diff.baseScreenshot.url}
           contentType={diff.baseScreenshot.contentType}
         />
@@ -956,6 +957,7 @@ function CompareScreenshot(props: {
 
       return (
         <Snapshot
+          id={diff.compareScreenshot.id}
           url={diff.compareScreenshot.url}
           contentType={diff.compareScreenshot.contentType}
         />
@@ -1024,6 +1026,7 @@ function CompareScreenshot(props: {
       }
       return (
         <Snapshot
+          id={diff.compareScreenshot.id}
           url={diff.compareScreenshot.url}
           contentType={diff.compareScreenshot.contentType}
         />
@@ -1390,11 +1393,13 @@ const BuildScreenshots = memo(
           <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2 px-4 pt-2 pb-4">
             <BuildSnapshotsDiff
               base={{
+                id: diff.baseScreenshot.id,
                 url: diff.baseScreenshot.url,
                 contentType: diff.baseScreenshot.contentType,
                 header: <BaselineScreenshotHeader build={build} />,
               }}
               head={{
+                id: diff.compareScreenshot.id,
                 url: diff.compareScreenshot.url,
                 contentType: diff.compareScreenshot.contentType,
                 header: <ChangesScreenshotHeader build={build} />,
@@ -1454,7 +1459,7 @@ function Snapshot(props: SnapshotProps) {
   );
 }
 
-type SnapshotProps = { url: string; contentType: string };
+type SnapshotProps = { id: string; url: string; contentType: string };
 
 function SuspendedSnapshot(props: SnapshotProps) {
   const [text] = useTextContent([props.url]);
@@ -1467,6 +1472,7 @@ function SuspendedSnapshot(props: SnapshotProps) {
       <Editor
         value={text}
         language={getLanguageFromContentType(props.contentType)}
+        cacheKey={props.id}
       />
     </EditorContainer>
   );
@@ -1481,8 +1487,8 @@ function EditorContainer(props: { children: React.ReactNode }) {
 }
 
 function DiffSnapshots(props: {
-  base: { url: string; contentType: string };
-  head: { url: string; contentType: string };
+  base: { id: string; url: string; contentType: string };
+  head: { id: string; url: string; contentType: string };
   renderSideBySide: boolean;
   build: BuildFragmentDocument;
   screenshotDiffId: string;
@@ -1496,8 +1502,10 @@ function DiffSnapshots(props: {
         screenshotDiffId={screenshotDiffId}
         original={baseText}
         originalLanguage={getLanguageFromContentType(base.contentType)}
+        originalCacheKey={base.id}
         modified={headText}
         modifiedLanguage={getLanguageFromContentType(head.contentType)}
+        modifiedCacheKey={head.id}
         renderSideBySide={renderSideBySide}
       />
     </EditorContainer>
@@ -1505,6 +1513,7 @@ function DiffSnapshots(props: {
 }
 
 type DiffSnapshotEntry = {
+  id: string;
   url: string;
   contentType: string;
   header: ReactNode;
@@ -1525,7 +1534,11 @@ function BuildSnapshotsDiff(props: {
       return (
         <>
           <div className="flex shrink-0 justify-center">{base.header}</div>
-          <Snapshot url={base.url} contentType={base.contentType} />
+          <Snapshot
+            id={base.id}
+            url={base.url}
+            contentType={base.contentType}
+          />
         </>
       );
     }
@@ -1538,7 +1551,11 @@ function BuildSnapshotsDiff(props: {
         return (
           <>
             <div className="flex shrink-0 justify-center">{base.header}</div>
-            <Snapshot url={base.url} contentType={base.contentType} />
+            <Snapshot
+              id={base.id}
+              url={base.url}
+              contentType={base.contentType}
+            />
           </>
         );
       }

--- a/apps/frontend/src/containers/Build/DiffEditor.stories.tsx
+++ b/apps/frontend/src/containers/Build/DiffEditor.stories.tsx
@@ -1,10 +1,13 @@
+import { useState } from "react";
+import { invariant } from "@argos/util/invariant";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, waitFor, within } from "storybook/test";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 
+import { Button } from "@/ui/Button";
 import { ColorModeProvider } from "@/ui/ColorMode";
 import { StoryTitle } from "@/ui/StoryTitle";
 
-import { Editor, getLanguageFromContentType } from "./DiffEditor";
+import { DiffEditor, Editor, getLanguageFromContentType } from "./DiffEditor";
 
 /**
  * Guards the curated Shiki bundle in `@/shiki/bundle`, which ships grammars only
@@ -64,7 +67,11 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const EveryHighlightedContentType: Story = {
-  args: { value: SAMPLES[0]?.value ?? "", language: "json" },
+  args: {
+    value: SAMPLES[0]?.value ?? "",
+    language: "json",
+    cacheKey: "application/json",
+  },
   render: () => (
     // `Editor` reads the color mode to pick its light/dark Shiki theme.
     <ColorModeProvider>
@@ -75,6 +82,7 @@ export const EveryHighlightedContentType: Story = {
             <Editor
               value={value}
               language={getLanguageFromContentType(contentType)}
+              cacheKey={contentType}
             />
           </div>
         ))}
@@ -93,6 +101,96 @@ export const EveryHighlightedContentType: Story = {
           SAMPLES.length,
         );
         expect(canvas.queryByText("Loading snapshot…")).not.toBeInTheDocument();
+      },
+      { timeout: 15_000 },
+    );
+  },
+};
+
+// HTML, not plain text: the viewer re-renders unconditionally on the plain-text
+// path, so a `text` sample would pass no matter what the cache keys are.
+const DIFF_SAMPLES = [
+  {
+    baseCacheKey: "screenshot-base-1",
+    headCacheKey: "screenshot-head-1",
+    original: '<meta name="description" content="the first baseline line" />',
+    modified: '<meta name="description" content="the first changed line" />',
+  },
+  {
+    baseCacheKey: "screenshot-base-2",
+    headCacheKey: "screenshot-head-2",
+    original: '<meta name="description" content="the second baseline line" />',
+    modified: '<meta name="description" content="the second changed line" />',
+  },
+];
+
+function SnapshotSwitcher() {
+  const [index, setIndex] = useState(0);
+  const sample = DIFF_SAMPLES[index];
+  invariant(sample);
+  return (
+    <div className="flex flex-col items-start gap-4">
+      <Button
+        onClick={() => setIndex((value) => (value + 1) % DIFF_SAMPLES.length)}
+      >
+        Next snapshot
+      </Button>
+      <DiffEditor
+        original={sample.original}
+        modified={sample.modified}
+        originalLanguage="html"
+        modifiedLanguage="html"
+        originalCacheKey={sample.baseCacheKey}
+        modifiedCacheKey={sample.headCacheKey}
+        renderSideBySide
+      />
+    </div>
+  );
+}
+
+/** Text rendered by the viewer, which lives in the custom element's shadow DOM. */
+function getViewerText(canvasElement: HTMLElement) {
+  const container = canvasElement.querySelector("diffs-container");
+  return container?.shadowRoot?.textContent ?? "";
+}
+
+/**
+ * The viewer reuses a rendered diff whenever its cache key comes back, so a key
+ * shared by two snapshots pins the first one's hunks on screen. That happened:
+ * every file handed to the viewer is named "snapshot", the key falls back to
+ * the file name when unset, and selecting another text snapshot on the build
+ * page kept showing the previous diff until a full page reload. Switching
+ * snapshots in place is what proves the keys are distinct — rendering one never
+ * would.
+ */
+export const SwitchingSnapshots: Story = {
+  args: { value: "", language: "text", cacheKey: "unused" },
+  render: () => (
+    <ColorModeProvider>
+      <SnapshotSwitcher />
+    </ColorModeProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(
+      () => {
+        expect(getViewerText(canvasElement)).toContain(
+          "the first changed line",
+        );
+      },
+      { timeout: 15_000 },
+    );
+
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Next snapshot" }),
+    );
+
+    await waitFor(
+      () => {
+        const text = getViewerText(canvasElement);
+        expect(text).toContain("the second changed line");
+        expect(text).toContain("the second baseline line");
+        expect(text).not.toContain("the first changed line");
       },
       { timeout: 15_000 },
     );

--- a/apps/frontend/src/containers/Build/DiffEditor.tsx
+++ b/apps/frontend/src/containers/Build/DiffEditor.tsx
@@ -104,11 +104,27 @@ export function DiffEditor<LAnnotation = undefined>(props: {
   modified: string;
   originalLanguage: BundledLanguage;
   modifiedLanguage: BundledLanguage;
+  /**
+   * Identity of each side, used as the viewer's render/highlight cache key. It
+   * must be unique per snapshot: when it is omitted the viewer falls back to the
+   * file *name*, which is the constant `"snapshot"` below, so every text diff in
+   * the app would share one key. Selecting another snapshot then hits the cache
+   * and keeps painting the previous diff until a full reload drops it.
+   */
+  originalCacheKey: string;
+  modifiedCacheKey: string;
   renderSideBySide: boolean;
   comments?: DiffEditorComments<LAnnotation>;
 }) {
-  const { original, modified, originalLanguage, modifiedLanguage, comments } =
-    props;
+  const {
+    original,
+    modified,
+    originalLanguage,
+    modifiedLanguage,
+    originalCacheKey,
+    modifiedCacheKey,
+    comments,
+  } = props;
   const themeType = useThemeType();
   const options = {
     ...BASE_OPTIONS,
@@ -139,11 +155,13 @@ export function DiffEditor<LAnnotation = undefined>(props: {
           name: "snapshot",
           contents: original,
           lang: originalLanguage,
+          cacheKey: originalCacheKey,
         }}
         newFile={{
           name: "snapshot",
           contents: modified,
           lang: modifiedLanguage,
+          cacheKey: modifiedCacheKey,
         }}
         options={options}
         lineAnnotations={comments?.lineAnnotations}
@@ -154,12 +172,22 @@ export function DiffEditor<LAnnotation = undefined>(props: {
   );
 }
 
-export function Editor(props: { value: string; language: BundledLanguage }) {
+export function Editor(props: {
+  value: string;
+  language: BundledLanguage;
+  /** See {@link DiffEditor}'s `originalCacheKey`. */
+  cacheKey: string;
+}) {
   const themeType = useThemeType();
   return (
     <Suspense fallback={<SnapshotLoader />}>
       <File
-        file={{ name: "snapshot", contents: props.value, lang: props.language }}
+        file={{
+          name: "snapshot",
+          contents: props.value,
+          lang: props.language,
+          cacheKey: props.cacheKey,
+        }}
         options={{ ...BASE_OPTIONS, themeType }}
       />
     </Suspense>

--- a/apps/frontend/src/pages/Build/diffComments/DiffCommentLayer.tsx
+++ b/apps/frontend/src/pages/Build/diffComments/DiffCommentLayer.tsx
@@ -95,6 +95,8 @@ export function DiffCommentLayer(props: {
   modified: string;
   originalLanguage: BundledLanguage;
   modifiedLanguage: BundledLanguage;
+  originalCacheKey: string;
+  modifiedCacheKey: string;
   renderSideBySide: boolean;
 }) {
   const {
@@ -104,6 +106,8 @@ export function DiffCommentLayer(props: {
     modified,
     originalLanguage,
     modifiedLanguage,
+    originalCacheKey,
+    modifiedCacheKey,
     renderSideBySide,
   } = props;
   const commentsEnabled = use(CommentsEnabledContext);
@@ -362,6 +366,8 @@ export function DiffCommentLayer(props: {
         modified={modified}
         originalLanguage={originalLanguage}
         modifiedLanguage={modifiedLanguage}
+        originalCacheKey={originalCacheKey}
+        modifiedCacheKey={modifiedCacheKey}
         renderSideBySide={renderSideBySide}
         comments={comments}
       />


### PR DESCRIPTION
Reported by Sebastien Lorber on [build 1903](https://app.argos-ci.com/meta-open-source/docusaurus/builds/1903/422242813) of `meta-open-source/docusaurus`: clicking another text snapshot changed the URL and the sidebar selection, but the diff in the middle kept showing the previous snapshot. A full browser reload was needed to see the right one.

## Cause

`@pierre/diffs` caches a rendered diff — hunks *and* highlight — under its `cacheKey`, and falls back to the **file name** when none is given. Every file we hand it is named `"snapshot"`, so every text diff in the app shared the key `"snapshot:snapshot"`.

`DiffHunksRenderer.renderDiff` then computes `newContent = !areDiffTargetsEqual(diff, renderCache.diff)`, and `areDiffTargetsEqual` treats two diffs as equal as soon as their cache keys match. The incoming diff was reported as unchanged, the cached render was re-served, and the stale hunks stayed on screen — including the stale `unmodified lines` counts. Reloading dropped the instance, which is why a refresh always fixed it.

Only snapshots with a grammar were affected: the viewer's plain-text path re-renders unconditionally. HTML, JSON, YAML… hit the cache — exactly the reported case.

## Fix

Pass the screenshot id as the cache key, on both sides of the diff and on the single-snapshot viewer. Side benefit: the worker pool's highlight cache becomes usable, where a single shared key made it both useless and wrong.

## Test

`SwitchingSnapshots` in `DiffEditor.stories.tsx` mounts a `DiffEditor`, switches snapshot in place, and reads the rendered text out of the custom element's shadow DOM.

- with the fix: green
- with the `cacheKey`s removed: red — it times out waiting for the second diff, the first one still showing

Rendering a single snapshot could never have caught this, which is why the story switches in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
