### PR TITLE
fix(build): make the ignore flag open its confirmation dialog

### DIFF
--- a/apps/frontend/src/containers/Build/toolbar/IgnoreButton.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/IgnoreButton.tsx
@@ -10,7 +10,6 @@ import { graphql } from "@/gql";
 import { useProjectParams } from "@/pages/Project/ProjectParams";
 import { Button, type ButtonProps } from "@/ui/Button";
 import { Checkbox } from "@/ui/Checkbox";
-import { DialogTrigger } from "@/ui/Dialog";
 import {
   Dialog,
   DialogBody,
@@ -157,6 +156,11 @@ function EnabledIgnoreButton(props: {
   const hotkey = useBuildHotkey("ignoreChange", toggle, {
     preventDefault: true,
   });
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      setDialog(null);
+    }
+  };
 
   return (
     <>
@@ -170,82 +174,64 @@ function EnabledIgnoreButton(props: {
           variant={isIgnored ? "danger" : "secondary"}
         />
       </HotkeyTooltip>
-      <DialogTrigger
-        open={dialog === "ignore"}
-        onOpenChange={(open) => {
-          if (!open) {
-            setDialog(null);
-          }
-        }}
-      >
-        <Modal>
-          <Dialog size="medium">
-            <DialogBody>
-              <DialogTitle>Ignore Change</DialogTitle>
-              <DialogText>
-                If you ignore this diff, Argos will skip it in future builds.
-                <br />
-                Only ignore it if it’s{" "}
-                <strong>flaky and you’ve seen it happen multiple times</strong>.
-                <br />
-                Argos will ignore{" "}
-                <strong>future diffs that exactly match this one</strong>.
-              </DialogText>
-            </DialogBody>
-            <DialogFooter>
-              <div className="flex flex-1">
-                <Checkbox
-                  onCheckedChange={(value) => {
-                    if (value) {
-                      sessionStorage.setItem(dontShowAgainKey, "true");
-                    } else {
-                      sessionStorage.removeItem(dontShowAgainKey);
-                    }
-                  }}
-                >
-                  Don’t show this again for this session
-                </Checkbox>
-              </div>
-              <DialogDismiss>Cancel</DialogDismiss>
-              <Button variant="destructive" onClick={ignoreChange}>
-                Ignore Change
-              </Button>
-            </DialogFooter>
-          </Dialog>
-        </Modal>
-      </DialogTrigger>
-      <DialogTrigger
-        open={dialog === "unignore"}
-        onOpenChange={(open) => {
-          if (!open) {
-            setDialog(null);
-          }
-        }}
-      >
-        <Modal>
-          <Dialog size="medium">
-            <DialogBody>
-              <DialogTitle>Unignore Change</DialogTitle>
-              <DialogText>
-                Re-enable this diff so Argos will treat it as a change in future
-                builds.
-                <br />
-                <strong>
-                  Only unignore if you’re sure the flake is resolved.
-                </strong>
-                <br />
-                Argos will now track any exact match of this overlay again.
-              </DialogText>
-            </DialogBody>
-            <DialogFooter>
-              <DialogDismiss>Cancel</DialogDismiss>
-              <Button variant="destructive" onClick={unignoreChange}>
-                Unignore Change
-              </Button>
-            </DialogFooter>
-          </Dialog>
-        </Modal>
-      </DialogTrigger>
+      <Modal open={dialog === "ignore"} onOpenChange={handleOpenChange}>
+        <Dialog size="medium">
+          <DialogBody>
+            <DialogTitle>Ignore Change</DialogTitle>
+            <DialogText>
+              If you ignore this diff, Argos will skip it in future builds.
+              <br />
+              Only ignore it if it’s{" "}
+              <strong>flaky and you’ve seen it happen multiple times</strong>.
+              <br />
+              Argos will ignore{" "}
+              <strong>future diffs that exactly match this one</strong>.
+            </DialogText>
+          </DialogBody>
+          <DialogFooter>
+            <div className="flex flex-1">
+              <Checkbox
+                onCheckedChange={(value) => {
+                  if (value) {
+                    sessionStorage.setItem(dontShowAgainKey, "true");
+                  } else {
+                    sessionStorage.removeItem(dontShowAgainKey);
+                  }
+                }}
+              >
+                Don’t show this again for this session
+              </Checkbox>
+            </div>
+            <DialogDismiss>Cancel</DialogDismiss>
+            <Button variant="destructive" onClick={ignoreChange}>
+              Ignore Change
+            </Button>
+          </DialogFooter>
+        </Dialog>
+      </Modal>
+      <Modal open={dialog === "unignore"} onOpenChange={handleOpenChange}>
+        <Dialog size="medium">
+          <DialogBody>
+            <DialogTitle>Unignore Change</DialogTitle>
+            <DialogText>
+              Re-enable this diff so Argos will treat it as a change in future
+              builds.
+              <br />
+              <strong>
+                Only unignore if you’re sure the flake is resolved.
+              </strong>
+              <br />
+              Argos will now track any exact match of this overlay again.
+            </DialogText>
+          </DialogBody>
+          <DialogFooter>
+            <DialogDismiss>Cancel</DialogDismiss>
+            <Button variant="destructive" onClick={unignoreChange}>
+              Unignore Change
+            </Button>
+          </DialogFooter>
+        </Dialog>
+      </Modal>
     </>
   );
 }

--- a/apps/frontend/src/containers/Build/toolbar/IgnoreButton.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/IgnoreButton.tsx
@@ -1,5 +1,5 @@
 import { memo, useState } from "react";
-import { useApolloClient } from "@apollo/client/react";
+import { useApolloClient, useFragment } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 import { FlagOffIcon } from "lucide-react";
 
@@ -34,6 +34,21 @@ const IgnoreChangeMutation = graphql(`
   }
 `);
 
+/**
+ * What the toolbar reads the flag from. The build page fetches its diffs with
+ * `no-cache` (see `useDataState`), so the snapshot it hands down is not a
+ * normalized entity and never hears about the mutation's cache write — the
+ * change would be ignored on the server while the button stayed as it was
+ * until a reload. Both mutations write the change to the cache, so the flag
+ * follows that entity and falls back to the snapshot until it is there.
+ */
+const TestChangeFragment = graphql(`
+  fragment IgnoreButton_TestChange on TestChange {
+    id
+    ignored
+  }
+`);
+
 const UnignoreChangeMutation = graphql(`
   mutation IgnoreButton_unignoreChange($accountSlug: String!, $changeId: ID!) {
     unignoreChange(input: { accountSlug: $accountSlug, changeId: $changeId }) {
@@ -61,11 +76,18 @@ function EnabledIgnoreButton(props: {
   const params = useProjectParams();
   invariant(params, "IgnoreButton requires project params");
   invariant(diff.change, "IgnoreButton requires a change in the diff");
-  const isIgnored = diff.change.ignored;
   const [dialog, setDialog] = useState<"ignore" | "unignore" | null>(null);
   const auth = useAuth();
   const client = useApolloClient();
   const changeId = diff.change.id;
+  const cachedChange = useFragment({
+    fragment: TestChangeFragment,
+    fragmentName: "IgnoreButton_TestChange",
+    from: { __typename: "TestChange", id: changeId },
+  });
+  const isIgnored = cachedChange.complete
+    ? cachedChange.data.ignored
+    : diff.change.ignored;
 
   const ignoreChange = () => {
     const auditTrailId =
@@ -169,6 +191,7 @@ function EnabledIgnoreButton(props: {
         keys={hotkey.displayKeys}
       >
         <BaseIgnoreButton
+          aria-label={isIgnored ? "Unignore change" : "Ignore change"}
           aria-pressed={isIgnored}
           onClick={toggle}
           variant={isIgnored ? "danger" : "secondary"}

--- a/apps/frontend/src/pages/Automation/AutomationRulesList.tsx
+++ b/apps/frontend/src/pages/Automation/AutomationRulesList.tsx
@@ -198,7 +198,7 @@ export function DeleteAutomation(props: {
   }
 
   return (
-    <DialogTrigger
+    <Modal
       open={Boolean(deletedId)}
       onOpenChange={(isOpen) => {
         if (!isOpen) {
@@ -206,16 +206,14 @@ export function DeleteAutomation(props: {
         }
       }}
     >
-      <Modal>
-        <DeleteAutomationDialog
-          projectId={projectId}
-          automationRuleId={latestDeletedId}
-          onCompleted={() => {
-            setDeletedId(null);
-          }}
-        />
-      </Modal>
-    </DialogTrigger>
+      <DeleteAutomationDialog
+        projectId={projectId}
+        automationRuleId={latestDeletedId}
+        onCompleted={() => {
+          setDeletedId(null);
+        }}
+      />
+    </Modal>
   );
 }
 

--- a/apps/frontend/src/ui/Overlay.tsx
+++ b/apps/frontend/src/ui/Overlay.tsx
@@ -121,6 +121,14 @@ export function DialogTrigger(props: {
     triggerElement,
     "DialogTrigger expects a trigger element as its first child",
   );
+  // react-aria accepted a `DialogTrigger` wrapping nothing but an overlay.
+  // Here the first child is the trigger, so that shape renders an empty tree
+  // and the control silently does nothing. A controlled overlay takes `open`
+  // itself: `<Modal open={…} onOpenChange={…}>`.
+  invariant(
+    overlays.length > 0,
+    "DialogTrigger expects an overlay after its trigger",
+  );
   const value = useMemo<OverlayTriggerContextValue>(
     () => ({ state, renderTrigger: getTriggerRenderer(triggerElement) }),
     [state, triggerElement],

--- a/tests/project-ignored.spec.ts
+++ b/tests/project-ignored.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "@playwright/test";
 
+import { ScreenshotDiff } from "../apps/backend/src/database/models";
 import { createIgnoredChangeScenario } from "../apps/backend/src/database/seeds";
 import { loggedTest } from "./logged-test";
 import { ensureTeamOwner, screenshot } from "./util";
@@ -158,5 +159,51 @@ loggedTest(
     await expect(
       page.getByRole("heading", { name: "Nothing is ignored yet" }),
     ).toBeHidden();
+  },
+);
+
+loggedTest(
+  "unignoring a change from the build toolbar",
+  async ({ page, team, project, auth }) => {
+    const { build } = await createIgnoredChangeScenario({
+      projectId: project.id,
+      userId: auth.user.id,
+    });
+    // The build page shows its snapshots only once the build has concluded,
+    // and the scenario builds one for the test trends page, which does not
+    // care either way.
+    await build.$query().patch({ conclusion: "changes-detected" });
+    const diff = await ScreenshotDiff.query()
+      .findOne({ buildId: build.id })
+      .throwIfNotFound();
+
+    await page.goto(
+      `/${team.account.slug}/${project.name}/builds/${build.number}/${diff.id}`,
+    );
+
+    // The change arrives ignored, so the flag offers to take it back.
+    const flag = page.getByRole("button", {
+      name: "Unignore change",
+      exact: true,
+    });
+    await expect(flag).toBeVisible();
+    await flag.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(
+      dialog.getByRole("heading", { name: "Unignore Change" }),
+    ).toBeVisible();
+    await dialog
+      .getByRole("button", { name: "Unignore Change", exact: true })
+      .click();
+
+    // The flag flips without a reload, and the ledger has nothing left in it.
+    await expect(
+      page.getByRole("button", { name: "Ignore change", exact: true }),
+    ).toBeVisible();
+    await page.goto(`/${team.account.slug}/${project.name}/ignored`);
+    await expect(
+      page.getByRole("heading", { name: "Nothing is ignored yet" }),
+    ).toBeVisible();
   },
 );


### PR DESCRIPTION
Pressing the flag under a build snapshot did nothing, and confirming the dialog left it looking untouched. Two regressions stacked on the same button.

## The dialog never opened

`DialogTrigger` was react-aria's until #2493, where it only provided context to its children — so a controlled one wrapping nothing but a `Modal` was a legitimate shape. The one that replaced it consumes its first element child as the trigger and renders only what follows, so that same shape now renders an empty tree. The modals take `open`/`onOpenChange` directly instead, as every other controlled dialog does since #2540.

Both directions were affected — "Ignore" is only reachable past it because "Don't show this again" skips the dialog.

`DeleteAutomation` was written the same way and went silent with it. `DialogTrigger` now asserts it was given an overlay, so the next one fails loudly instead of rendering nothing — that assertion is what turned up the second call site.

## The flag never flipped

Older, and unrelated to Base UI: #1974 replaced the build page's `useQuery` with `apolloClient.query({ fetchPolicy: "no-cache" })`, so the diff the toolbar holds is not a normalized entity and never hears about the mutation's cache write. The change was ignored on the server while the button stayed as it was until a reload.

`useFragment` reads `ignored` off the cache, falling back to the snapshot until the entity is there — which is also what makes the optimistic response, and its rollback on failure, visible on this page.

The flag is icon-only and had no accessible name; it says which way it goes now.

## Tests

One spec in `tests/project-ignored.spec.ts` walks the whole path on a build page — flag, dialog, confirm, flag flipped, ledger emptied. Each half was reverted in turn to check it fails without it: without the modal fix the dialog heading never appears, without the cache read the flag never flips.

Also driven by hand against a dev server, both directions, no reload.

- `project-ignored`, `project-tests`, `project-automation-pages`, `build`: 40 passed
- `pnpm run static-checks`: 11/11

## Not in here

A diff is only an ignorable change once it carries a fingerprint, which the pipeline computes from the diff image. Seeded rows never go through it, so the flag sits disabled on every snapshot of a freshly seeded dev database and the feature cannot be tried at all. Happy to send that as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
