### PR TITLE
fix(build): repaint the text diff when the viewer remounts

### DIFF
--- a/apps/frontend/src/containers/Build/DiffEditor.stories.tsx
+++ b/apps/frontend/src/containers/Build/DiffEditor.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { invariant } from "@argos/util/invariant";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, userEvent, waitFor, within } from "storybook/test";
@@ -190,6 +190,105 @@ export const SwitchingSnapshots: Story = {
         const text = getViewerText(canvasElement);
         expect(text).toContain("the second changed line");
         expect(text).toContain("the second baseline line");
+        expect(text).not.toContain("the first changed line");
+      },
+      { timeout: 15_000 },
+    );
+  },
+};
+
+/**
+ * The viewer adopts the DOM already sitting in its container and skips its first
+ * render when it finds code in there — and `disableFileHeader` leaves no header
+ * to force that render either. React reuses the same element across snapshots
+ * (the subtree suspends on the incoming text and resumes onto the same node), so
+ * the second snapshot used to inherit the first one's markup and never repaint:
+ * the title changed, the diff did not, and only a full reload cleared it.
+ *
+ * Suspending between the two samples is what makes this reproduce — switching
+ * content on a mounted viewer keeps the instance alive and repaints normally.
+ */
+const SUSPENSE_CACHE = new Map<string, string | Promise<void>>();
+
+function useSuspendedText(key: string, value: string): string {
+  const entry = SUSPENSE_CACHE.get(key);
+  if (typeof entry === "string") {
+    return entry;
+  }
+  if (entry) {
+    throw entry;
+  }
+  const promise = new Promise<void>((resolve) => {
+    setTimeout(() => {
+      SUSPENSE_CACHE.set(key, value);
+      resolve();
+    }, 30);
+  });
+  SUSPENSE_CACHE.set(key, promise);
+  throw promise;
+}
+
+function SuspendedDiff(props: { sample: (typeof DIFF_SAMPLES)[number] }) {
+  const { sample } = props;
+  const original = useSuspendedText(sample.baseCacheKey, sample.original);
+  const modified = useSuspendedText(sample.headCacheKey, sample.modified);
+  return (
+    <DiffEditor
+      original={original}
+      modified={modified}
+      originalLanguage="html"
+      modifiedLanguage="html"
+      originalCacheKey={sample.baseCacheKey}
+      modifiedCacheKey={sample.headCacheKey}
+      renderSideBySide
+    />
+  );
+}
+
+function SuspendingSnapshotSwitcher() {
+  const [index, setIndex] = useState(0);
+  const sample = DIFF_SAMPLES[index];
+  invariant(sample);
+  return (
+    <div className="flex flex-col items-start gap-4">
+      <Button
+        onClick={() => setIndex((value) => (value + 1) % DIFF_SAMPLES.length)}
+      >
+        Next snapshot
+      </Button>
+      <Suspense fallback={<div>Loading snapshot…</div>}>
+        <SuspendedDiff sample={sample} />
+      </Suspense>
+    </div>
+  );
+}
+
+export const SwitchingSnapshotsThroughSuspense: Story = {
+  args: { value: "", language: "text", cacheKey: "unused" },
+  render: () => (
+    <ColorModeProvider>
+      <SuspendingSnapshotSwitcher />
+    </ColorModeProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(
+      () => {
+        expect(getViewerText(canvasElement)).toContain(
+          "the first changed line",
+        );
+      },
+      { timeout: 15_000 },
+    );
+
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Next snapshot" }),
+    );
+
+    await waitFor(
+      () => {
+        const text = getViewerText(canvasElement);
+        expect(text).toContain("the second changed line");
         expect(text).not.toContain("the first changed line");
       },
       { timeout: 15_000 },

--- a/apps/frontend/src/containers/Build/DiffEditor.tsx
+++ b/apps/frontend/src/containers/Build/DiffEditor.tsx
@@ -151,6 +151,15 @@ export function DiffEditor<LAnnotation = undefined>(props: {
   return (
     <Suspense fallback={<SnapshotLoader />}>
       <MultiFileDiff<LAnnotation>
+        // A fresh element per snapshot, and not an optimization to drop. The
+        // viewer hydrates onto whatever DOM its container already holds and
+        // skips its first render when it finds a `<pre>` in there, assuming the
+        // markup is its own; `disableFileHeader` removes the header that would
+        // otherwise force that render. React reuses this element across
+        // snapshots — the subtree suspends on the new text and resumes onto the
+        // same node — so without a key the incoming snapshot inherits the
+        // previous one's markup and never repaints.
+        key={`${originalCacheKey}:${modifiedCacheKey}`}
         oldFile={{
           name: "snapshot",
           contents: original,
@@ -182,6 +191,8 @@ export function Editor(props: {
   return (
     <Suspense fallback={<SnapshotLoader />}>
       <File
+        // See {@link DiffEditor}: same hydrate-onto-stale-DOM trap.
+        key={props.cacheKey}
         file={{
           name: "snapshot",
           contents: props.value,


### PR DESCRIPTION
Follow-up to #2543. Sebastien Lorber reported that selecting another text snapshot *still* leaves the previous diff on screen — now intermittently instead of always. Reproduced on production, on [build 1903](https://app.argos-ci.com/meta-open-source/docusaurus/builds/1903/422242800): the header and the sidebar selection move to the new snapshot, the diff never does, and only a full reload clears it.

#2543 was necessary but not sufficient. Distinct cache keys stopped the renderer from *re-serving* a stale render; they don't make it render at all.

## Cause

Switching snapshot suspends the subtree on the incoming text, and React resumes it onto the **same `<diffs-container>` element**: the old `FileDiff` is torn down (`cleanUp` / `recycle`) and a new one hydrates onto a node that still holds the previous snapshot's markup.

`FileDiff.hydrate` renders only if one of these says so:

```js
shouldRenderCode(pre, hasContent, collapsed)  // !collapsed && pre == null && hasContent
shouldRenderHeader(headerElement, hasContent, disableFileHeader)
```

- `pre` is the leftover `<pre>` from the previous snapshot → first is false.
- We pass `disableFileHeader: true` → second is false.

So `render()` is never called. Instrumenting the live instance shows the end state exactly: the hunks renderer holds the **correct** new diff and no result at all —

```
renderCache = { diff.cacheKey: "390513746:390658128", highlighted: true, result: undefined }
pre == null → false      headerElement == null → true, but disableFileHeader → true
```

— and `render({ forceRender: true })` on that stuck instance repaints the correct snapshot immediately. Without `disableFileHeader` the header path would have forced the render and hidden this entirely, which is why it is specific to us.

## Fix

Key each viewer by the snapshot it shows, so React gives it a fresh element and hydrate finds an empty container. Same trap on the single-snapshot `File`, keyed too.

## Test

`SwitchingSnapshotsThroughSuspense` mirrors the app: the sample text arrives through a Suspense boundary, so switching tears the viewer down and remounts it the way the build page does.

- with the fix: green
- with the keys removed: **red**, times out with the first snapshot still displayed

The existing `SwitchingSnapshots` story keeps passing either way — switching content on a *mounted* viewer repaints normally. That's precisely why it didn't catch this, and why the new one suspends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
