### PR TITLE
fix(backend): say which session expired when the RDS token cannot be signed

### DIFF
--- a/apps/backend/src/config/database.test.ts
+++ b/apps/backend/src/config/database.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { explainRdsTokenFailure } from "./database";
+
+// The AWS SDK's wording when the login session is gone. On the login screen it
+// reads as if the Argos session had expired, which is the whole reason this
+// message exists.
+const EXPIRED = new Error("Your session has expired. Please reauthenticate.");
+
+describe("explainRdsTokenFailure", () => {
+  it("points a developer at the command that fixes it", () => {
+    const message = explainRdsTokenFailure({
+      error: EXPIRED,
+      target: "prod-ro",
+      user: "argos_dev_ro",
+    });
+    expect(message).toContain("AWS session");
+    expect(message).toContain("aws login");
+    expect(message).toContain("Your session has expired.");
+  });
+
+  it("points production at the missing grant instead", () => {
+    const message = explainRdsTokenFailure({
+      error: EXPIRED,
+      target: "local",
+      user: "argos_iam",
+    });
+    expect(message).toContain("rds-db:connect");
+    expect(message).toContain("argos_iam");
+    expect(message).not.toContain("aws login");
+  });
+
+  it("keeps a non-Error cause readable", () => {
+    expect(
+      explainRdsTokenFailure({
+        error: "socket hang up",
+        target: "prod-ro",
+        user: "argos_dev_ro",
+      }),
+    ).toContain("socket hang up");
+  });
+});

--- a/apps/backend/src/config/database.ts
+++ b/apps/backend/src/config/database.ts
@@ -2,7 +2,47 @@ import { invariant } from "@argos/util/invariant";
 import { Signer } from "@aws-sdk/rds-signer";
 import { Knex } from "knex";
 
+import logger from "@/logger";
+
 import type { Config } from ".";
+
+/**
+ * Say what a failed RDS IAM signature means, because nothing downstream can.
+ *
+ * The signer runs inside the pool's connection factory, so its error surfaces
+ * on whatever request happened to need a new connection — and the app renders
+ * it verbatim on the login screen. The AWS SDK's own wording for an expired
+ * session is "Your session has expired. Please reauthenticate.", which on that
+ * screen reads as if the *Argos* session had expired, with nothing naming AWS,
+ * the database, or the command that fixes it.
+ */
+export function explainRdsTokenFailure(input: {
+  error: unknown;
+  target: string;
+  user: string;
+}): string {
+  const cause =
+    input.error instanceof Error ? input.error.message : String(input.error);
+  const hint =
+    input.target === "prod-ro"
+      ? "your AWS session has most likely expired — sign in again (`aws login`, or `aws sso login` on an SSO profile) and retry, the pool signs a new token on the next connection so there is nothing to restart"
+      : `the process needs AWS credentials allowed to \`rds-db:connect\` as "${input.user}"`;
+  return `Could not sign an RDS IAM token to reach the database: ${hint}. (${cause})`;
+}
+
+/**
+ * The connection factory retries every 200ms until the acquire timeout, so an
+ * expired session would otherwise print hundreds of identical lines.
+ */
+let lastReportedAt = 0;
+function reportThrottled(message: string, error: unknown): void {
+  const now = Date.now();
+  if (now - lastReportedAt < 60_000) {
+    return;
+  }
+  lastReportedAt = now;
+  logger.error({ error }, message);
+}
 
 /**
  * Resolve the connection password. With `pg.connection.iamAuth` there is no
@@ -28,7 +68,19 @@ function getPassword(config: Config): string | (() => Promise<string>) {
     port: config.get("pg.connection.port"),
     username: config.get("pg.connection.user"),
   });
-  return () => signer.getAuthToken();
+  return async () => {
+    try {
+      return await signer.getAuthToken();
+    } catch (error) {
+      const message = explainRdsTokenFailure({
+        error,
+        target: config.get("target"),
+        user: config.get("pg.connection.user"),
+      });
+      reportThrottled(message, error);
+      throw new Error(message, { cause: error });
+    }
+  };
 }
 
 /**


### PR DESCRIPTION
## Why

Running `pnpm run dev:prod-ro` with an expired AWS session costs a quarter of an hour, because nothing says that is what happened.

With `PG_IAM_AUTH`, the signer runs inside the pool's connection factory, so the failure surfaces on whatever request happened to need a new connection — and the client renders the server's message verbatim. What you get, on the Argos login screen, is:

> Error message: Your session has expired. Please reauthenticate.

That is the AWS SDK's wording (`@aws-sdk/credential-provider-login`, `TOKEN_EXPIRED`). On that screen it reads as if the *Argos* session had expired. Nothing names AWS, the database, or the command that fixes it — and since established connections keep working, the app half-works while the cause stays invisible.

## What it does

The signature failure now explains itself, once, at the source:

```
Could not sign an RDS IAM token to reach the database: your AWS session has most
likely expired — sign in again (`aws login`, or `aws sso login` on an SSO
profile) and retry, the pool signs a new token on the next connection so there
is nothing to restart. (Your session has expired. Please reauthenticate.)
```

One place covers both surfaces the question usually splits into: the message travels to the UI through the error the client already renders, so the login screen goes from misleading to actionable **without a frontend change**, and the same line is logged for whoever is watching the terminal.

Outside prod-ro the hint changes to the grant that would be missing (`rds-db:connect` as the connecting role), since a production task has no session to renew.

The original error is kept in the text and as the `cause`, so nothing is hidden — the rewrite only adds what the SDK cannot know.

## Notes

- The log is throttled to one line a minute: the connection factory retries every 200ms until the acquire timeout, so an expired session would otherwise print hundreds of identical lines.
- No classification of the underlying error: *any* failure to sign is worth naming, and matching on AWS error shapes would rot.

## Testing

`config/database.test.ts` covers the message: the developer hint names the command, the production hint names the grant instead, and a non-`Error` cause stays readable. `pnpm run static-checks` passes.

Found while debugging a prod-ro login that looked like a broken OAuth flow and was an expired `aws login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
