### PR TITLE
chore(build): retire the text-diff guard the viewer key made redundant

### DIFF
--- a/apps/frontend/src/containers/Build/DiffEditor.stories.tsx
+++ b/apps/frontend/src/containers/Build/DiffEditor.stories.tsx
@@ -107,8 +107,6 @@ export const EveryHighlightedContentType: Story = {
   },
 };
 
-// HTML, not plain text: the viewer re-renders unconditionally on the plain-text
-// path, so a `text` sample would pass no matter what the cache keys are.
 const DIFF_SAMPLES = [
   {
     baseCacheKey: "screenshot-base-1",
@@ -124,78 +122,11 @@ const DIFF_SAMPLES = [
   },
 ];
 
-function SnapshotSwitcher() {
-  const [index, setIndex] = useState(0);
-  const sample = DIFF_SAMPLES[index];
-  invariant(sample);
-  return (
-    <div className="flex flex-col items-start gap-4">
-      <Button
-        onClick={() => setIndex((value) => (value + 1) % DIFF_SAMPLES.length)}
-      >
-        Next snapshot
-      </Button>
-      <DiffEditor
-        original={sample.original}
-        modified={sample.modified}
-        originalLanguage="html"
-        modifiedLanguage="html"
-        originalCacheKey={sample.baseCacheKey}
-        modifiedCacheKey={sample.headCacheKey}
-        renderSideBySide
-      />
-    </div>
-  );
-}
-
 /** Text rendered by the viewer, which lives in the custom element's shadow DOM. */
 function getViewerText(canvasElement: HTMLElement) {
   const container = canvasElement.querySelector("diffs-container");
   return container?.shadowRoot?.textContent ?? "";
 }
-
-/**
- * The viewer reuses a rendered diff whenever its cache key comes back, so a key
- * shared by two snapshots pins the first one's hunks on screen. That happened:
- * every file handed to the viewer is named "snapshot", the key falls back to
- * the file name when unset, and selecting another text snapshot on the build
- * page kept showing the previous diff until a full page reload. Switching
- * snapshots in place is what proves the keys are distinct — rendering one never
- * would.
- */
-export const SwitchingSnapshots: Story = {
-  args: { value: "", language: "text", cacheKey: "unused" },
-  render: () => (
-    <ColorModeProvider>
-      <SnapshotSwitcher />
-    </ColorModeProvider>
-  ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    await waitFor(
-      () => {
-        expect(getViewerText(canvasElement)).toContain(
-          "the first changed line",
-        );
-      },
-      { timeout: 15_000 },
-    );
-
-    await userEvent.click(
-      canvas.getByRole("button", { name: "Next snapshot" }),
-    );
-
-    await waitFor(
-      () => {
-        const text = getViewerText(canvasElement);
-        expect(text).toContain("the second changed line");
-        expect(text).toContain("the second baseline line");
-        expect(text).not.toContain("the first changed line");
-      },
-      { timeout: 15_000 },
-    );
-  },
-};
 
 /**
  * The viewer adopts the DOM already sitting in its container and skips its first

--- a/apps/frontend/src/containers/Build/DiffEditor.tsx
+++ b/apps/frontend/src/containers/Build/DiffEditor.tsx
@@ -105,11 +105,15 @@ export function DiffEditor<LAnnotation = undefined>(props: {
   originalLanguage: BundledLanguage;
   modifiedLanguage: BundledLanguage;
   /**
-   * Identity of each side, used as the viewer's render/highlight cache key. It
-   * must be unique per snapshot: when it is omitted the viewer falls back to the
-   * file *name*, which is the constant `"snapshot"` below, so every text diff in
-   * the app would share one key. Selecting another snapshot then hits the cache
-   * and keeps painting the previous diff until a full reload drops it.
+   * Identity of each side of the diff. The `key` below is built from these, so
+   * they are what makes the viewer repaint when another snapshot is selected.
+   *
+   * They also reach the library as `cacheKey`, which falls back to the file
+   * *name* — the constant `"snapshot"` below — when unset. That fallback is
+   * harmless while the render cache is per instance and the `key` hands each
+   * snapshot a fresh one, but the worker pool's caches are global and keyed on
+   * it alone. Nothing provides a pool today; the day something does, one shared
+   * key would serve every text diff in the app the same highlight.
    */
   originalCacheKey: string;
   modifiedCacheKey: string;


### PR DESCRIPTION
Cleanup after #2543 → #2547. Jeremy asked whether #2543 had become dead weight; I measured rather than guessed, and the answer splits it in two.

## What the experiments said

**Reverting #2543 on top of #2547 brings the bug back.** Git refuses on its own, and the conflict is the explanation — `key={props.cacheKey}` sits on the line the revert deletes. Pushed through anyway (production code back to pre-#2543, #2547's tests kept):

```
× Switching Snapshots                    (timeout 15000ms)
× Switching Snapshots Through Suspense   (timeout 15000ms)
```

So the props and the `screenshot.id` threading are load-bearing: they are the identity the viewer key is built from.

**Removing only the three `cacheKey:` lines handed to the library, keeping the React keys: all stories green.** Those lines guard something else — the worker pool's caches, which are global and keyed on the cache key alone, so a fresh instance per snapshot does not protect them. Nothing provides a pool today. Cheap insurance, kept, but now documented as insurance instead of as the fix.

## Changes

- **`originalCacheKey` doc rewritten.** It claimed the cache key is what stops the viewer painting the previous snapshot. Since #2547 that is the `key`'s job, and a comment describing a bug covered elsewhere costs more than the lines it occupies.
- **`SwitchingSnapshots` removed.** It switches content on a *mounted* viewer — a state the app can no longer reach, since content never changes without the key changing. It also stays green when either protection is dropped alone, so it catches nothing by itself; the revert experiment above shows the suspending story fails in the one case where both are gone.
- **Stale sample comment removed.** The samples were HTML because the plain-text path re-renders unconditionally and would have masked the cache-key bug. Verified that reason died with the story: with the key removed and the samples switched to `text`, `SwitchingSnapshotsThroughSuspense` still fails.

Net: −69 lines of test, −1 Argos screenshot, and no comment left that says something untrue.

`static-checks` green, remaining stories green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
