### PR TITLE
feat(media): put the comment tool in the bar over the media

### DIFF
--- a/apps/frontend/src/containers/Media/MediaCommentLayer.tsx
+++ b/apps/frontend/src/containers/Media/MediaCommentLayer.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from "react";
 import { useApolloClient } from "@apollo/client/react";
 
 import { useAuth } from "@/containers/Auth";
+import { useCommentTool } from "@/containers/Build/CommentTool";
 import { type NormalizedPoint } from "@/containers/Build/projection";
 import { type PaneSize } from "@/containers/Build/Zoomer";
 import { CommentCard } from "@/containers/Comment/CommentCard";
@@ -13,12 +14,12 @@ import {
 import { useIsThreadAnchorShown } from "@/containers/Comment/useCollapsedThread";
 import { useCommentRoleScope } from "@/containers/Comment/useCommentRoleScope";
 import { DocumentType, graphql } from "@/gql";
-import { MediaPermission } from "@/gql/graphql";
 import { type EditorValue } from "@/ui/Editor/Editor";
 import { toast } from "@/ui/Toaster";
 import { getErrorMessage } from "@/util/error";
 
 import { createHandleMediaCommentsPrompt } from "./MediaCommentsPrompt";
+import { checkCanCommentOnMedia } from "./permissions";
 
 const _MediaFragment = graphql(`
   fragment MediaCommentLayer_Media on Media {
@@ -89,8 +90,6 @@ export function MediaCommentLayer(props: {
   viewedVersionId: string;
   paneSize: PaneSize | null;
   imgSize: { width: number; height: number };
-  placing: boolean;
-  onPlacingChange: (placing: boolean) => void;
   /** A thread the sidebar asks to open on the image (see PointCommentLayer). */
   requestedThreadId?: string | null;
   onRequestedThreadConsumed?: () => void;
@@ -100,18 +99,19 @@ export function MediaCommentLayer(props: {
     viewedVersionId,
     paneSize,
     imgSize,
-    placing,
-    onPlacingChange,
     requestedThreadId,
     onRequestedThreadConsumed,
   } = props;
+  // The build's tool, on the build's atom: a reviewer who picks the crosshair
+  // on a snapshot finds it picked here, the same way the view mode carries over.
+  const { mode, activateHand } = useCommentTool();
   const client = useApolloClient();
   const roleScope = useCommentRoleScope();
   const auth = useAuth();
   const accountId =
     auth.status === "authenticated" ? auth.account?.id : undefined;
 
-  const canComment = media.permissions.includes(MediaPermission.Comment);
+  const canComment = checkCanCommentOnMedia(media);
 
   // A resolved thread's pin drops off the image until the reviewer expands the
   // thread again; the panel keeps the thread either way.
@@ -179,7 +179,7 @@ export function MediaCommentLayer(props: {
         });
         // The pin the button armed has been dropped; the next comment starts
         // from a resting toolbar.
-        onPlacingChange(false);
+        activateHand();
         const created = result.data?.addMediaComment.comments.find(
           (comment) => !priorIds.has(comment.id) && !comment.threadId,
         );
@@ -190,7 +190,7 @@ export function MediaCommentLayer(props: {
         throw error;
       }
     },
-    [media.comments, postComment, onPlacingChange],
+    [media.comments, postComment, activateHand],
   );
 
   return (
@@ -200,14 +200,14 @@ export function MediaCommentLayer(props: {
       // The media image is centered in its pane; the build's snapshots are not.
       verticalAlign="center"
       threads={threads}
-      placing={placing && canComment}
+      placing={mode === "comment" && canComment}
       draftAvatar={currentAvatar}
       canAddToReview={false}
       onCreate={handleCreate}
       requestedThreadId={requestedThreadId}
       onRequestedThreadConsumed={onRequestedThreadConsumed}
       // Escape puts the pin tool away once there is nothing left to close.
-      onPlacingDismiss={() => onPlacingChange(false)}
+      onPlacingDismiss={activateHand}
       renderThreadCard={(thread) => (
         <CommentCard
           comment={thread.root}

--- a/apps/frontend/src/containers/Media/MediaComments.tsx
+++ b/apps/frontend/src/containers/Media/MediaComments.tsx
@@ -1,17 +1,11 @@
 import { useState } from "react";
 import { useApolloClient } from "@apollo/client/react";
 import { clsx } from "clsx";
-import {
-  FileUpIcon,
-  MapPinPenIcon,
-  MapPinPlusInsideIcon,
-  UploadIcon,
-  XIcon,
-} from "lucide-react";
+import { FileUpIcon, MapPinPenIcon, UploadIcon } from "lucide-react";
 import { useLocation } from "react-router";
 
 import { useAuth } from "@/containers/Auth";
-import { useBuildHotkey } from "@/containers/Build/BuildHotkeys";
+import { useCommentTool } from "@/containers/Build/CommentTool";
 import { CommentCard } from "@/containers/Comment/CommentCard";
 import {
   getCommentThreads,
@@ -20,12 +14,9 @@ import {
 import { useCommentRoleScope } from "@/containers/Comment/useCommentRoleScope";
 import { useHighlightedCommentId } from "@/containers/Comment/useHighlightedCommentId";
 import { DocumentType, graphql } from "@/gql";
-import { MediaPermission } from "@/gql/graphql";
 import { Activity, ActivityItem } from "@/ui/Activity";
-import { Button } from "@/ui/Button";
 import type { EditorValue } from "@/ui/Editor/Editor";
 import { StandaloneEditor } from "@/ui/Editor/StandaloneEditor";
-import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 import { Link } from "@/ui/Link";
 import { MediaWell } from "@/ui/MediaFrame";
 import { Panel, PanelHeader, PanelTitle } from "@/ui/Panel";
@@ -34,6 +25,7 @@ import { toast } from "@/ui/Toaster";
 import { getErrorMessage } from "@/util/error";
 
 import { createHandleMediaCommentsPrompt } from "./MediaCommentsPrompt";
+import { checkCanCommentOnMedia } from "./permissions";
 
 const _MediaCommentsFragment = graphql(`
   fragment MediaComments_Media on Media {
@@ -144,21 +136,20 @@ export function MediaComments(props: {
   media: Media;
   /** The version on screen — what a new comment will be recorded against. */
   viewedVersionId: string;
-  placing: boolean;
-  onPlacingChange: (placing: boolean) => void;
   /** Open a pinned thread on the image, switching to its version if needed. */
   onOpenPinned: (comment: {
     id: string;
     mediaVersionId: string | null;
   }) => void;
 }) {
-  const { media, viewedVersionId, placing, onPlacingChange, onOpenPinned } =
-    props;
+  const { media, viewedVersionId, onOpenPinned } = props;
+  // The instruction below is the armed tool's, so it reads the tool itself.
+  const { mode } = useCommentTool();
   const client = useApolloClient();
   const roleScope = useCommentRoleScope();
   const [replyPending, setReplyPending] = useState(false);
 
-  const canComment = media.permissions.includes(MediaPermission.Comment);
+  const canComment = checkCanCommentOnMedia(media);
   const entries = getActivityEntries(media);
   const highlightedCommentId = useHighlightedCommentId(
     media.comments.map((comment) => comment.id),
@@ -191,18 +182,13 @@ export function MediaComments(props: {
     <Panel>
       <PanelHeader>
         <PanelTitle>Activity</PanelTitle>
-        {canComment ? (
-          <PinCommentToggle
-            placing={placing}
-            onPlacingChange={onPlacingChange}
-          />
-        ) : null}
       </PanelHeader>
 
       <div className="px-3">
-        {placing ? (
+        {mode === "comment" && canComment ? (
           <p className="text-low bg-ui mb-3 rounded-md px-3 py-2 text-xs">
-            Click the spot on the image you want to comment on.
+            Click the spot on the image you want to comment on. Press Esc to
+            cancel.
           </p>
         ) : null}
 
@@ -251,48 +237,6 @@ export function MediaComments(props: {
         )}
       </div>
     </Panel>
-  );
-}
-
-/**
- * Arm or put away the pin tool — an icon so the panel header stays one line,
- * with the shortcut on its tooltip. Escape also puts the tool away, which is
- * what the cancel state advertises.
- */
-function PinCommentToggle(props: {
-  placing: boolean;
-  onPlacingChange: (placing: boolean) => void;
-}) {
-  const { placing, onPlacingChange } = props;
-  const hotkey = useBuildHotkey(
-    "toggleCommentTool",
-    () => onPlacingChange(!placing),
-    { preventDefault: true },
-  );
-  return placing ? (
-    <HotkeyTooltip description="Cancel" keys={["Esc"]}>
-      <Button
-        variant="primary"
-        size="small"
-        iconOnly
-        aria-label="Cancel"
-        onClick={() => onPlacingChange(false)}
-      >
-        <XIcon />
-      </Button>
-    </HotkeyTooltip>
-  ) : (
-    <HotkeyTooltip description="Pin a comment" keys={hotkey.displayKeys}>
-      <Button
-        variant="secondary"
-        size="small"
-        iconOnly
-        aria-label="Pin a comment"
-        onClick={() => onPlacingChange(true)}
-      >
-        <MapPinPlusInsideIcon />
-      </Button>
-    </HotkeyTooltip>
   );
 }
 

--- a/apps/frontend/src/containers/Media/MediaViewer.tsx
+++ b/apps/frontend/src/containers/Media/MediaViewer.tsx
@@ -27,6 +27,7 @@ import {
   ChangesMask,
   ChangesOverlayControls,
 } from "@/containers/Build/ChangesOverlay";
+import { useCommentTool } from "@/containers/Build/CommentTool";
 import { overlayVisibleAtom } from "@/containers/Build/OverlayStyle";
 import { getImageScale } from "@/containers/Build/projection";
 import {
@@ -40,6 +41,7 @@ import {
   fetchBlob,
   ImageActionsMenu,
 } from "@/containers/Build/ScreenshotActions";
+import { CommentToolToggle } from "@/containers/Build/toolbar/CommentToolToggle";
 import {
   DetailToolbar,
   DetailToolbarNav,
@@ -57,6 +59,7 @@ import { Separator } from "@/ui/Separator";
 import { useResizeObserver } from "@/ui/useResizeObserver";
 
 import { MediaCommentLayer } from "./MediaCommentLayer";
+import { checkCanCommentOnMedia } from "./permissions";
 
 /** One renderable version of a media. */
 type ViewerVersion = {
@@ -174,6 +177,7 @@ export function MediaViewer(props: {
   const { media, counterpart, comments, diff, nav } = props;
   const version = media.version;
   const storedMode = useAtomValue(buildViewModeAtom);
+  const { mode: commentToolMode } = useCommentTool();
   const [onionOpacity, setOnionOpacity] = useAtom(onionOpacityAtom);
   const [swipePosition, setSwipePosition] = useAtom(swipePositionAtom);
   const [swipeHandleY, setSwipeHandleY] = useAtom(swipeHandleYAtom);
@@ -181,9 +185,20 @@ export function MediaViewer(props: {
   if (version.isVideo) {
     return (
       <div className="flex h-full min-h-0 flex-col">
+        {/* A recording has no pane a pin can land on, so a tool armed on the
+            image beside it comes down here as it does on the "before" half
+            alone — and it has to happen above the early return, because this
+            branch is the one page that offers nothing to put it away. */}
+        <DisarmCommentTool enabled={false} />
         {/* A recording gets the same bar as a screenshot — nothing to compare,
-            but the same name in the same place and the same way out of it. */}
-        <MediaViewToolbar title={media.name} nav={nav} compare={null} />
+            and nothing to pin a comment to, but the same name in the same place
+            and the same way out of it. */}
+        <MediaViewToolbar
+          title={media.name}
+          nav={nav}
+          compare={null}
+          commentTool={false}
+        />
         <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-1.5">
           <MediaWell
             aspectRatio={
@@ -292,6 +307,12 @@ export function MediaViewer(props: {
   // than leave the reviewer clicking at an image that cannot take it.
   const commentable = panes.some((pane) => pane.interactive);
 
+  // What it takes for the comment tool to be worth offering: a half on screen
+  // that can take a pin, and a viewer allowed to add to the discussion.
+  // `DisarmCommentTool` is given the same value, so the tool can never stay
+  // armed once the control that would put it away has gone.
+  const canPlacePin = commentable && checkCanCommentOnMedia(comments.media);
+
   // Where the page stacks (below `lg`), the viewer sizes itself from the
   // media's own shape instead of claiming a fixed slice of the viewport: a
   // wide screenshot on a phone would otherwise sit in a mostly-empty well.
@@ -309,11 +330,7 @@ export function MediaViewer(props: {
           pane registered itself as the highlighter, so both have to be under
           one provider. */}
       <BuildDiffHighlighterProvider>
-        <DisarmCommentTool
-          enabled={commentable}
-          placing={comments.placing}
-          onPlacingChange={comments.onPlacingChange}
-        />
+        <DisarmCommentTool enabled={canPlacePin} />
         <div className="flex h-full min-h-0 flex-col gap-2">
           <MediaViewToolbar
             title={media.name}
@@ -321,6 +338,7 @@ export function MediaViewer(props: {
             compare={
               counterpart ? { blendEnabled, hasChanges: diff !== null } : null
             }
+            commentTool={canPlacePin}
           />
 
           <div
@@ -362,7 +380,9 @@ export function MediaViewer(props: {
                 // A single pane — alone, or with both halves blended into it —
                 // has nowhere else the pin could land.
                 pinState={
-                  panes.length > 1 && comments.placing
+                  panes.length > 1 &&
+                  canPlacePin &&
+                  commentToolMode === "comment"
                     ? pane.interactive
                       ? "target"
                       : "excluded"
@@ -385,17 +405,14 @@ export function MediaViewer(props: {
  * takes, and rendering nothing because there is nothing to say: the tool simply
  * stops being armed, the same as pressing Escape.
  */
-function DisarmCommentTool(props: {
-  enabled: boolean;
-  placing: boolean;
-  onPlacingChange: (placing: boolean) => void;
-}) {
-  const { enabled, placing, onPlacingChange } = props;
+function DisarmCommentTool(props: { enabled: boolean }) {
+  const { enabled } = props;
+  const { mode, activateHand } = useCommentTool();
   useEffect(() => {
-    if (!enabled && placing) {
-      onPlacingChange(false);
+    if (!enabled && mode === "comment") {
+      activateHand();
     }
-  }, [enabled, placing, onPlacingChange]);
+  }, [enabled, mode, activateHand]);
   return null;
 }
 
@@ -404,10 +421,12 @@ function DisarmCommentTool(props: {
  * own components: where to go next on the left, what is on screen in the middle,
  * what can be done to it on the right.
  *
- * The compare controls only exist for a pair — whether to compare at all, and
- * the build's three ways to do it — and the overlay controls only once Argos has
- * found changes to mark. The rest of the bar is there either way, which is what
- * makes a video's page and a screenshot's page the same page.
+ * Three of the slots are conditional, each on what it would act on: the compare
+ * controls on there being a pair, the overlay controls on Argos having found
+ * changes to mark, and the comment tool on a half being on screen that can take
+ * a pin. A recording has none of them. What is left — the name, and the arrows
+ * out of it — sits where a screenshot's page puts it, which is what makes the
+ * two the same page.
  */
 function MediaViewToolbar(props: {
   title: string;
@@ -420,8 +439,14 @@ function MediaViewToolbar(props: {
     /** Whether there is a mask to draw — the overlay controls act on nothing without one. */
     hasChanges: boolean;
   } | null;
+  /**
+   * Whether the comment tool belongs on the bar. Not when there is nothing on
+   * screen to pin to — a recording, the "before" half alone, or a visitor who
+   * may only read.
+   */
+  commentTool: boolean;
 }) {
-  const { title, nav, compare } = props;
+  const { title, nav, compare, commentTool } = props;
   return (
     // `mb-4` + the viewer column's `gap-2` puts 24px between the toolbar and
     // the panes, level with the sidebar's action strip.
@@ -465,6 +490,12 @@ function MediaViewToolbar(props: {
                 </>
               ) : null}
             </div>
+          ) : null}
+          {commentTool ? (
+            // Last, because it is the one control here that acts on the media
+            // rather than on how the media is shown — the order the build's own
+            // bar reads in: see the change, then annotate it.
+            <CommentToolToggle />
           ) : null}
         </div>
       </DetailToolbar>

--- a/apps/frontend/src/containers/Media/permissions.ts
+++ b/apps/frontend/src/containers/Media/permissions.ts
@@ -1,0 +1,14 @@
+import { MediaPermission } from "@/gql/graphql";
+
+/**
+ * Whether the viewer may add to a media's discussion.
+ *
+ * One question behind three controls — the panel's composer, the pin layer and
+ * the toolbar's comment tool — so none of them can be offered over a surface
+ * that would reject what it writes.
+ */
+export function checkCanCommentOnMedia(media: {
+  permissions: MediaPermission[];
+}): boolean {
+  return media.permissions.includes(MediaPermission.Comment);
+}

--- a/apps/frontend/src/pages/MediaShare.tsx
+++ b/apps/frontend/src/pages/MediaShare.tsx
@@ -346,7 +346,6 @@ function useAwaitPendingDiff(props: {
 
 function SharePage(props: { media: Media }) {
   const { media } = props;
-  const [placing, setPlacing] = useState(false);
   const [versionId, setVersionId] = useState(media.latestVersion.id);
   // A thread the sidebar asked to open as a marker popover on the image.
   const [requestedThreadId, setRequestedThreadId] = useState<string | null>(
@@ -471,8 +470,6 @@ function SharePage(props: { media: Media }) {
                     comments={{
                       media,
                       viewedVersionId: version.id,
-                      placing,
-                      onPlacingChange: setPlacing,
                       requestedThreadId,
                       onRequestedThreadConsumed: () =>
                         setRequestedThreadId(null),
@@ -506,8 +503,6 @@ function SharePage(props: { media: Media }) {
                     <MediaComments
                       media={media}
                       viewedVersionId={version.id}
-                      placing={placing}
-                      onPlacingChange={setPlacing}
                       onOpenPinned={(comment) => {
                         // The marker only exists on the version the pin was dropped
                         // on, so showing the thread may mean switching to it first.

--- a/tests/media.spec.ts
+++ b/tests/media.spec.ts
@@ -179,7 +179,7 @@ loggedTest(
 
     await page.goto(`/m/${media.after.shareToken}`);
 
-    await page.getByRole("button", { name: "Pin a comment" }).click();
+    await page.getByRole("button", { name: "Comment tool" }).click();
     await expect(
       page.getByText("Click the spot on the image you want to comment on."),
     ).toBeVisible();
@@ -276,7 +276,7 @@ loggedTest(
 
     await page.goto(`/m/${media.solo.shareToken}`);
 
-    await page.getByRole("button", { name: "Pin a comment" }).click();
+    await page.getByRole("button", { name: "Comment tool" }).click();
     await page
       .getByRole("button", { name: "Pick the spot to comment on" })
       .click({ position: { x: 200, y: 150 } });
@@ -410,7 +410,7 @@ loggedTest(
     // is nowhere for a pin to land — the tool puts itself away rather than
     // leaving the reviewer clicking at an image that cannot take one.
     await after.click();
-    await page.getByRole("button", { name: "Pin a comment" }).click();
+    await page.getByRole("button", { name: "Comment tool" }).click();
     await expect(
       page.getByText("Click the spot on the image you want to comment on."),
     ).toBeVisible();
@@ -443,7 +443,7 @@ loggedTest(
       page.locator("[data-media-pane][data-pin-target]"),
     ).toHaveCount(0);
 
-    await page.getByRole("button", { name: "Pin a comment" }).click();
+    await page.getByRole("button", { name: "Comment tool" }).click();
 
     const target = page.locator("[data-media-pane][data-pin-target]");
     await expect(target).toHaveCount(1);
@@ -454,6 +454,45 @@ loggedTest(
     ).toBeVisible();
 
     await screenshot(page, "media-share-pin-target");
+  },
+);
+
+loggedTest(
+  "puts the comment tool away when a recording comes on screen",
+  async ({ page, auth, project }) => {
+    // A recording has no pane a pin can land on, so it offers no comment tool —
+    // which means an armed tool arriving from the image beside it would have
+    // nothing left on the page able to put it away.
+    const media = await createMediaScenario({
+      projectId: project.id,
+      commentAuthorId: auth.user.id,
+      withPullRequest: true,
+    });
+
+    await page.goto(`/m/${media.after.shareToken}`);
+
+    // Armed with the key rather than the button: the shortcut is registered by
+    // the toolbar control now, so this is what says it is still reachable.
+    // Waiting for the control first — the key goes nowhere until the thing that
+    // listens for it is on the page.
+    const tool = page.getByRole("button", { name: "Comment tool" });
+    await expect(tool).toBeVisible();
+    const instruction = page.getByText(
+      "Click the spot on the image you want to comment on.",
+    );
+    await page.keyboard.press("KeyC");
+    await expect(instruction).toBeVisible();
+
+    // Down to the recording, in the app rather than by URL: the page stays
+    // mounted across the two, which is what carries the armed tool over.
+    await page.keyboard.press("ArrowDown");
+    await expect(page).toHaveURL(`/m/${media.video.shareToken}`);
+    await expect(
+      page.getByRole("heading", { name: "checkout-flow.mp4" }),
+    ).toBeVisible();
+
+    await expect(instruction).toBeHidden();
+    await expect(tool).toBeHidden();
   },
 );
 


### PR DESCRIPTION
## The problem

On a shared media, the button that arms the point-comment tool lived in the **Activity panel header** — bottom-right of the sidebar, below the versions list. Nobody looking at a screenshot goes there to find a tool that acts on the screenshot, so in practice the only way to place a pinned comment was knowing to press <kbd>C</kbd>.

## The change

The toggle moves to the bar over the media, last in the row — where the build keeps the same tool, and the order that bar already reads in: see the change, then annotate it. The panel header loses its copy rather than carrying a second toggle for the same state.

`CommentToolToggle` is rendered as it stands, on the atom it already reads — the way every other control on this bar is shared. `ViewToggle` is handed no view mode, `OverlayToggle` no visibility; the media page just renders them and the state carries over. The comment tool now behaves the same way, and the page stops keeping a second copy of it: the `placing` flag and its two props are gone from `MediaShare`, `MediaViewer` and `MediaCommentLayer`, which read the tool where the build's own `ScreenshotCommentLayer` reads it. **Nothing under `containers/Build` or `pages/Build` is touched.**

Being in the viewer lets the control answer to what is on screen:

- armed from the "before" half alone, the old button was a dead press — there is no half that takes a pin, so the tool was disarmed straight back. Now it simply isn't there;
- same for a recording and for a visitor who may only read;
- a recording also disarms it, above the early return its branch takes. That page offers no control at all, so a tool armed on the image beside it used to leave the panel asking for a click that could never land — the guard test covers exactly that, and fails without the fix.

Two smaller things pulled in along the way: `checkCanCommentOnMedia` replaces the three copies of the same permission test, and the panel's instruction now names Escape, which the control it replaced used to advertise on its tooltip.

The Argos baselines for this page will show the new control — expected.

## Notes

`pnpm run static-checks` is green; `tests/media.spec.ts` and `tests/build.spec.ts` pass (37 specs). The media specs locate the tool by `Comment tool`, the name the build's control has always used.

Three related gaps found while in here, left out of this PR:

- there is no show/hide toggle for the pins on a media (the build has `CommentsVisibilityToggle`; `MediaCommentLayer` doesn't read `commentsVisibleAtom`);
- an anonymous visitor on a public link has no way into the `?` dialog — it hangs off the avatar menu, which is a Login button for them;
- `fitView` (<kbd>0</kbd>) declares `envs: ["test", "build"]` but `FitViewButton` mounts on the media page anyway, so the key works there and is missing from the `?` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
