### PR TITLE
perf(frontend): warm the emoji picker instead of waiting for the click

### DIFF
--- a/apps/frontend/src/containers/RoutePreloader.tsx
+++ b/apps/frontend/src/containers/RoutePreloader.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { matchRoutes, type RouteObject } from "react-router";
 
 import { router } from "@/router";
+import { cancelIdle, requestIdle } from "@/util/idle";
 
 /**
  * Every page is behind `lazy: () => import(...)`, so clicking a link starts a
@@ -28,36 +29,6 @@ const started = new WeakSet<RouteObject>();
  * before the click.
  */
 const HOVER_INTENT_DELAY = 65;
-
-/**
- * How long a visible link waits before being preloaded anyway, idle or not.
- */
-const IDLE_TIMEOUT = 2000;
-
-/**
- * Safari still doesn't ship `requestIdleCallback` — it exists only behind a
- * preference in Technology Preview — so it can't be called unguarded. Without
- * it, fall back to waiting out the same deadline the idle version is given:
- * there is no idle signal to time against, and this is the opportunistic half
- * of the preloader anyway — the intent signals below still fire immediately and
- * cover the click that matters.
- */
-const supportsIdleCallback = typeof window.requestIdleCallback === "function";
-
-function requestIdle(callback: () => void): number {
-  return supportsIdleCallback
-    ? window.requestIdleCallback(callback, { timeout: IDLE_TIMEOUT })
-    : window.setTimeout(callback, IDLE_TIMEOUT);
-}
-
-/** Cancels a handle returned by {@link requestIdle}. */
-function cancelIdle(handle: number): void {
-  if (supportsIdleCallback) {
-    window.cancelIdleCallback(handle);
-  } else {
-    window.clearTimeout(handle);
-  }
-}
 
 /**
  * Preloading spends bandwidth on a guess, which is the wrong trade on a metered

--- a/apps/frontend/src/ui/EmojiPicker.tsx
+++ b/apps/frontend/src/ui/EmojiPicker.tsx
@@ -7,6 +7,7 @@ import {
   type Path,
 } from "react-hook-form";
 
+import { requestIdle } from "@/util/idle";
 import { mergeRefs } from "@/util/merge-refs";
 
 import { Button, type ButtonProps } from "./Button";
@@ -18,13 +19,26 @@ import { Popover } from "./Popover";
 
 export { DialogTrigger as EmojiPickerTrigger } from "./Overlay";
 
+const importEmojiPickerGrid = () => import("./EmojiPickerGrid");
+
 /**
  * The picker grid carries the full emojibase dataset — 571 kB of JSON, plus the
- * index it builds at module scope — so it is loaded on demand. Nothing here can
- * be seen before the user opens the picker, and keeping it out of the static
- * graph is what stops it from riding along in the build page's chunk.
+ * index it builds at module scope — so it stays out of the static graph: that
+ * is what stops it from riding along in the build page's chunk, ahead of the
+ * screenshot diffs that are the reason to open the page.
+ *
+ * Out of the static graph, not off the page: waiting for the click to fetch it
+ * put a spinner in front of every first open. So the chunk is warmed as soon as
+ * the main thread is free, and the boundary below is only ever seen by someone
+ * who opens the picker inside that window.
  */
-const EmojiPickerGrid = lazy(() => import("./EmojiPickerGrid"));
+const EmojiPickerGrid = lazy(importEmojiPickerGrid);
+
+requestIdle(() => {
+  // Fire and forget: a rejected warm-up is a preload that didn't help, and
+  // opening the picker retries the import and reports the failure for real.
+  importEmojiPickerGrid().catch(() => {});
+});
 
 /** Placeholder matching the grid's footprint, so the popover does not resize. */
 function EmojiPickerFallback() {

--- a/apps/frontend/src/util/idle.ts
+++ b/apps/frontend/src/util/idle.ts
@@ -1,0 +1,33 @@
+/**
+ * How long a callback waits for an idle moment before running anyway. Work
+ * scheduled here is opportunistic, so this is a deadline rather than a delay:
+ * a page that never goes idle still gets it, just late.
+ */
+const IDLE_TIMEOUT = 2000;
+
+/**
+ * Safari still doesn't ship `requestIdleCallback` — it exists only behind a
+ * preference in Technology Preview — so it can't be called unguarded. Without
+ * it, fall back to waiting out the same deadline the idle version is given:
+ * there is no idle signal to time against.
+ */
+const supportsIdleCallback = typeof window.requestIdleCallback === "function";
+
+/**
+ * Runs `callback` once the main thread is free, or after {@link IDLE_TIMEOUT}.
+ * Returns a handle for {@link cancelIdle}.
+ */
+export function requestIdle(callback: () => void): number {
+  return supportsIdleCallback
+    ? window.requestIdleCallback(callback, { timeout: IDLE_TIMEOUT })
+    : window.setTimeout(callback, IDLE_TIMEOUT);
+}
+
+/** Cancels a handle returned by {@link requestIdle}. */
+export function cancelIdle(handle: number): void {
+  if (supportsIdleCallback) {
+    window.cancelIdleCallback(handle);
+  } else {
+    window.clearTimeout(handle);
+  }
+}


### PR DESCRIPTION
## What

The emoji picker's grid still lives in its own chunk, but the fetch no longer waits for the click: it is warmed as soon as the main thread goes idle.

- `EmojiPicker` names its `lazy()` factory and calls it once from a module-scope `requestIdle`, so the grid's chunk — 571 kB of emojibase JSON plus the index it builds at module scope — is fetched and evaluated while the page sits idle.
- The idle scheduling, and the guard for Safari (which still doesn't ship `requestIdleCallback`), moves out of `RoutePreloader` into a new `util/idle`, so the two preloaders share one implementation rather than each carrying a copy.

## Why

Splitting the dataset out of the build page's chunk (#53d9c79) was the right trade for the page and the wrong one for the picker. Nothing fetched the chunk until someone clicked, so the first open of a session put a spinner where the emojis belong — a click-time network round trip for 86 kB gzip, on whatever connection the reader happens to have.

Warming it on idle keeps the whole reason for the split — the chunk is still out of the static graph, so it doesn't load ahead of the screenshot diffs that are the reason to open a build — while making the picker feel like it was never lazy at all.

## Verification

- Build output: `EmojiPickerGrid` is still dynamically imported only, and the preload sits in the chunk that owns the picker, which the Build page chunk imports statically — so it starts right after the build page loads.
- Storybook, `UI/EmojiPicker` → `Field` story (renders only the trigger button, never the grid): the network log shows `EmojiPickerGrid.tsx` and both `emojibase-data` JSON files fetched ~40 ms after `EmojiPicker.tsx`, with zero interaction. Clicking the trigger then shows a fully populated grid.
- `pnpm run static-checks`: types, format and lint clean. `knip` fails identically on `main` (unused migration files, unused `pg` dep) — untouched by this change.

## For the reviewer

`React.lazy` still commits its fallback once before swapping in the resolved module, even with the chunk already in memory — that is now a scheduler tick rather than a network round trip, so it should not be visible. I could not time it in a visible tab (the preview pane was hidden, and hidden tabs throttle React's scheduler to ~1 s, making any measurement there meaningless), so I left the boundary as it is. If a flash does show up in practice, rendering the resolved module directly instead of through the boundary removes it.

The editor (TipTap, ~450 kB) is on the same on-demand pattern and still waits for a comment surface to render. Left alone here, easy to warm the same way if we want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)