### PR TITLE
fix(jobs): pool consumer AMQP channels, ten consumers to a channel

### DIFF
--- a/apps/backend/src/job-core/amqp.ts
+++ b/apps/backend/src/job-core/amqp.ts
@@ -15,7 +15,7 @@ export function connect(): Promise<ChannelModel> {
     return connectionPromise;
   }
 
-  connectionPromise = pRetry(connectOnce, {
+  const promise = pRetry(connectOnce, {
     onFailedAttempt: ({ error, attemptNumber, retriesLeft }) => {
       logger.info(
         { error, attemptNumber, retriesLeft },
@@ -24,7 +24,19 @@ export function connect(): Promise<ChannelModel> {
     },
   });
 
-  return connectionPromise;
+  connectionPromise = promise;
+
+  // Only `handleClose` clears the promise otherwise, and it never runs when no
+  // connection was ever established: a broker outage outliving the retries
+  // would leave the rejection cached and every later caller — consumers and
+  // publishers alike — would get it back instantly, forever.
+  promise.catch(() => {
+    if (connectionPromise === promise) {
+      connectionPromise = null;
+    }
+  });
+
+  return promise;
 }
 
 async function connectOnce(): Promise<ChannelModel> {

--- a/apps/backend/src/job-core/createJob.ts
+++ b/apps/backend/src/job-core/createJob.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/node";
-import type { Channel, Options } from "amqplib";
+import { type Channel, IllegalOperationError } from "amqplib";
 import pRetry from "p-retry";
 
 import config from "@/config";
@@ -104,12 +104,7 @@ function getPublisherChannel(): Promise<Channel> {
   const promise = pRetry(
     async () => {
       publisherLogger.info("Creating publisher channel");
-      const connection = await connect();
-      const channel = await connection.createChannel();
-      keepChannelErrorHandled(channel);
-      // push() attaches a "drain" listener whenever a send is blocked, and
-      // every job in the process publishes through this one channel.
-      channel.setMaxListeners(0);
+      const channel = await openChannel();
       channel.once("close", () => {
         publisherLogger.info("Publisher channel closed");
         if (publisherChannel === promise) {
@@ -138,30 +133,160 @@ function getPublisherChannel(): Promise<Channel> {
 }
 
 /**
- * Consumers get a channel each.
+ * Consumer channels are pooled, ten consumers to a channel.
  *
- * A broker caps how many consumers one channel may hold — ours at ten — and
- * answers a breach with a connection-level 530, which takes down every other
- * consumer on the connection with it. Sharing a single consumer channel
- * therefore capped how many job types the worker could register at all, and
- * crossing that cap broke every job rather than the one registered last.
- * Channels are the cheap resource here (`channel_max` is 2047), and one
- * consumer per channel also makes `prefetch` — which applies to the next
- * consumer started on the channel — unambiguous.
+ * Two broker limits box this in. A channel accepts at most ten consumers
+ * (`consumer_max_per_channel` on our broker) and answers the eleventh
+ * `basic.consume` with a connection-level 530 that takes every consumer on
+ * the connection down with it — so one channel shared by all consumers broke
+ * once the worker registered more than ten job types. But the node also caps
+ * open channels across every connection (500 on ours), and a channel per
+ * consumer (#2519) reached that ceiling once enough processes were up. Ten
+ * consumers per channel keeps both limits at a distance.
  */
-async function createConsumerChannel(): Promise<Channel> {
+const MAX_CONSUMERS_PER_CHANNEL = 10;
+
+type PooledConsumerChannel = {
+  channel: Promise<Channel>;
+  /**
+   * Slots handed out, counted synchronously at acquire time — before the
+   * channel even exists — so concurrent acquires can never oversubscribe it.
+   */
+  consumers: number;
+  /** Serializes prefetch + consume pairs, see ConsumerChannelSlot.runSetup. */
+  setupChain: Promise<unknown>;
+};
+
+const consumerChannelPool = new Set<PooledConsumerChannel>();
+
+type ConsumerChannelSlot = {
+  channel: Promise<Channel>;
+  /**
+   * `channel.prefetch` applies to the *next* consumer started on the channel,
+   * so two jobs setting up concurrently on a shared channel could land one
+   * job's prefetch on the other's consumer. Setup runs through a per-channel
+   * chain to keep each prefetch + consume pair whole.
+   */
+  runSetup: <T>(fn: () => Promise<T>) => Promise<T>;
+  /**
+   * Takes the channel out of the pool without waiting for its "close" event.
+   * amqplib decodes a whole burst of frames in one turn, so a channel can be
+   * dead before anyone gets to observe it: the close arrives while
+   * `createChannel` is still resolving through the microtask queue, and the
+   * listener below then attaches to an emitter that has already fired. Nothing
+   * would ever evict such an entry, and first-fit would keep handing it out.
+   */
+  discard: () => void;
+  release: () => void;
+};
+
+function acquireConsumerChannelSlot(): ConsumerChannelSlot {
+  const entry =
+    consumerChannelPool
+      .values()
+      .find((candidate) => candidate.consumers < MAX_CONSUMERS_PER_CHANNEL) ??
+    createPooledConsumerChannel();
+  entry.consumers += 1;
+  return {
+    channel: entry.channel,
+    runSetup: (fn) => {
+      // `fn` runs whether or not the previous setup failed — one job's broken
+      // setup must not wedge the other consumers of the channel.
+      const run = entry.setupChain.then(fn, fn);
+      entry.setupChain = run.then(
+        () => undefined,
+        () => undefined,
+      );
+      return run;
+    },
+    discard: () => {
+      consumerChannelPool.delete(entry);
+    },
+    release: () => {
+      entry.consumers -= 1;
+    },
+  };
+}
+
+function createPooledConsumerChannel(): PooledConsumerChannel {
+  const entry: PooledConsumerChannel = {
+    channel: openChannel(),
+    consumers: 0,
+    setupChain: Promise.resolve(),
+  };
+  consumerChannelPool.add(entry);
+  // Evicted as soon as the channel dies (or fails to open) so it never hands
+  // out another slot; the consume loops holding its slots observe the same
+  // termination and retry into a fresh entry.
+  const evict = () => {
+    consumerChannelPool.delete(entry);
+  };
+  entry.channel.then((channel) => channel.once("close", evict), evict);
+  return entry;
+}
+
+async function openChannel(): Promise<Channel> {
   const connection = await connect();
   const channel = await connection.createChannel();
   keepChannelErrorHandled(channel);
+  // Both channels this opens are shared by every job in the process: the
+  // consumers of a pooled channel each wait on its termination with their own
+  // listener pair, and push() attaches a "drain" listener to the publisher
+  // channel whenever a send is blocked.
+  channel.setMaxListeners(0);
   return channel;
 }
 
-async function closeChannel(channel: Channel): Promise<void> {
+/**
+ * Declares the queues a consumer reads from and retries through, on a channel
+ * of its own.
+ *
+ * A declaration that disagrees with an existing queue is answered with a
+ * channel-level 406, which would take down the nine unrelated consumers
+ * sharing a pooled channel — and take them down again on every retry. Queues
+ * are broker-wide, so declaring them here satisfies both the consumer and the
+ * retries it publishes from its own channel.
+ */
+async function assertConsumerQueues(
+  queue: string,
+  retryLadder: RetryTier[],
+): Promise<void> {
+  const channel = await openChannel();
   try {
-    await channel.close();
+    await Promise.all([
+      channel.assertQueue(queue, { durable: true }),
+      ...retryLadder.map((tier) =>
+        channel.assertQueue(
+          getRetryQueueName(queue, tier),
+          getRetryQueueOptions(queue, tier),
+        ),
+      ),
+    ]);
+  } finally {
+    try {
+      await channel.close();
+    } catch {
+      // Already gone, which is how a failed declaration ends: the broker
+      // closes the channel it faulted on.
+    }
+  }
+}
+
+// The consumer must not outlive its loop iteration: left behind, it would
+// keep consuming next to its replacement and hold a consumer slot the pool no
+// longer counts, eventually pushing the shared channel past the broker's
+// ten-consumer cap. Closing the channel would do it, but the channel now
+// belongs to other consumers too.
+async function cancelConsumer(
+  channel: Channel,
+  consumerTag: string,
+): Promise<void> {
+  try {
+    await channel.cancel(consumerTag);
   } catch {
-    // Already closed, which is the usual way out of the consume loop: the
-    // broker or the connection got there first.
+    // Channel already closed, which is the usual way out of the consume loop:
+    // the broker or the connection got there first, and closing cancelled the
+    // consumer with it.
   }
 }
 
@@ -170,11 +295,7 @@ async function closeChannel(channel: Channel): Promise<void> {
 // new channel naturally re-asserts.
 const assertedQueues = new WeakMap<Channel, Map<string, Promise<void>>>();
 
-function ensureQueueAsserted(
-  channel: Channel,
-  queue: string,
-  options: Options.AssertQueue = { durable: true },
-): Promise<void> {
+function ensureQueueAsserted(channel: Channel, queue: string): Promise<void> {
   let queues = assertedQueues.get(channel);
   if (!queues) {
     queues = new Map();
@@ -184,7 +305,9 @@ function ensureQueueAsserted(
   if (existing) {
     return existing;
   }
-  const promise = channel.assertQueue(queue, options).then(() => undefined);
+  const promise = channel
+    .assertQueue(queue, { durable: true })
+    .then(() => undefined);
   queues.set(queue, promise);
   promise.catch(() => {
     queues!.delete(queue);
@@ -192,9 +315,21 @@ function ensureQueueAsserted(
   return promise;
 }
 
-// Resolves when the channel closes, rejects when it errors.
-function observeChannelTermination(channel: Channel): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
+/**
+ * Observes a channel's terminal state: `observed` resolves when the channel
+ * closes and rejects when it errors.
+ *
+ * `dispose` matters now that channels are shared and outlive an iteration:
+ * a promise reaction cannot be detached once attached, so a `Promise.race`
+ * against a channel-lifetime promise would leave one behind on every fault
+ * cycle. Each iteration observes on its own and takes its listeners back.
+ */
+function observeChannelTermination(channel: Channel): {
+  observed: Promise<void>;
+  dispose: () => void;
+} {
+  let dispose!: () => void;
+  const observed = new Promise<void>((resolve, reject) => {
     const onClose = () => {
       channel.off("error", onError);
       resolve();
@@ -205,7 +340,12 @@ function observeChannelTermination(channel: Channel): Promise<void> {
     };
     channel.once("close", onClose);
     channel.once("error", onError);
+    dispose = () => {
+      channel.off("close", onClose);
+      channel.off("error", onError);
+    };
   });
+  return { observed, dispose };
 }
 
 export const createJob = <TValue extends string | number>(
@@ -282,104 +422,123 @@ export const createJob = <TValue extends string | number>(
         async (): Promise<void> => {
           logger.info("Initialize consuming");
 
-          const channel = await createConsumerChannel();
+          // Declaring the queues before taking a slot surfaces a bad
+          // declaration at startup rather than when a job first fails, and
+          // keeps the fault off the shared channel.
+          await assertConsumerQueues(queue, retryLadder);
+
+          const slot = acquireConsumerChannelSlot();
 
           try {
-            await ensureQueueAsserted(channel, queue);
-            // Retries are published from this channel, so the delay queues have
-            // to exist here. Asserting them during setup surfaces a bad
-            // declaration at startup instead of when a job first fails.
-            await Promise.all(
-              retryLadder.map((tier) =>
-                ensureQueueAsserted(
-                  channel,
-                  getRetryQueueName(queue, tier),
-                  getRetryQueueOptions(queue, tier),
-                ),
-              ),
-            );
+            const channel = await slot.channel;
+            // Observed before the first operation on the channel: a channel
+            // that died on the way here has no "close" left to emit, and the
+            // prefetch below then throws instead of the loop waiting forever
+            // for a termination that already happened.
+            const termination = observeChannelTermination(channel);
 
-            // Lets the consume callback signal a fatal error to the outer loop.
-            // The channel goes down with the loop iteration, so the consumer
-            // stops with it and `runForever` re-enters on a fresh one.
-            let signalConsumerFault!: (error: unknown) => void;
-            const consumerFault = new Promise<never>((_, reject) => {
-              signalConsumerFault = reject;
-            });
-            // Prevent an unhandled rejection if the channel terminates first.
-            consumerFault.catch(() => undefined);
+            try {
+              // Lets the consume callback signal a fatal error to the outer
+              // loop. The consumer is cancelled on the way out, so it stops
+              // with the iteration and `runForever` re-enters on a fresh slot.
+              let signalConsumerFault!: (error: unknown) => void;
+              const consumerFault = new Promise<never>((_, reject) => {
+                signalConsumerFault = reject;
+              });
+              // Prevent an unhandled rejection if the channel terminates first.
+              consumerFault.catch(() => undefined);
 
-            await channel.prefetch(prefetch);
-            logger.info("Consuming queue");
-            await channel.consume(queue, async (msg) => {
-              if (!msg) {
-                return;
-              }
-
-              try {
-                let payload: Payload<TValue>;
-
-                try {
-                  payload = parseMessage<TValue>(msg.content);
-                } catch (error) {
-                  channel.ack(msg);
-                  logger.error({ error }, "Invalid payload");
-                  return;
-                }
-
-                const id = payload.args[0];
-                const consumeLogger = logger.child({ id });
-                const ctx = { logger: consumeLogger };
-                try {
-                  await this.run(id, ctx);
-                  channel.ack(msg);
-                } catch (error) {
-                  const tier = getRetryTier(retryLadder, payload.attempts);
-
-                  if (checkIsRetryable(error) && tier) {
-                    consumeLogger.info(
-                      {
-                        error,
-                        attempts: payload.attempts,
-                        delay: tier.delay,
-                      },
-                      "Retrying job after backoff",
+              const { consumerTag } = await slot.runSetup(async () => {
+                await channel.prefetch(prefetch);
+                logger.info("Consuming queue");
+                return channel.consume(queue, async (msg) => {
+                  if (!msg) {
+                    // The broker cancelled the consumer — its queue was
+                    // deleted or moved. Nothing will be delivered here again,
+                    // so fault out and let the loop re-declare and re-register.
+                    signalConsumerFault(
+                      new Error("Consumer cancelled by the broker"),
                     );
-
-                    // Published to the delay queue rather than back to the
-                    // job queue: it waits there for the tier's TTL, then
-                    // RabbitMQ dead-letters it onto the job queue.
-                    channel.sendToQueue(
-                      getRetryQueueName(queue, tier),
-                      serializeMessage({
-                        args: payload.args,
-                        attempts: payload.attempts + 1,
-                      }),
-                      { persistent: true },
-                    );
-
-                    channel.ack(msg);
                     return;
                   }
 
-                  channel.ack(msg);
-                  consumeLogger.error({ error }, "Error while processing job");
-                  await pRetry(() =>
-                    consumer.error?.(payload.args[0], error, ctx),
-                  );
-                }
-              } catch (error) {
-                logger.info({ error }, "Error when processing message");
-                signalConsumerFault(error);
-              }
-            });
+                  try {
+                    let payload: Payload<TValue>;
 
-            await Promise.race([
-              observeChannelTermination(channel),
-              consumerFault,
-            ]);
+                    try {
+                      payload = parseMessage<TValue>(msg.content);
+                    } catch (error) {
+                      channel.ack(msg);
+                      logger.error({ error }, "Invalid payload");
+                      return;
+                    }
+
+                    const id = payload.args[0];
+                    const consumeLogger = logger.child({ id });
+                    const ctx = { logger: consumeLogger };
+                    try {
+                      await this.run(id, ctx);
+                      channel.ack(msg);
+                    } catch (error) {
+                      const tier = getRetryTier(retryLadder, payload.attempts);
+
+                      if (checkIsRetryable(error) && tier) {
+                        consumeLogger.info(
+                          {
+                            error,
+                            attempts: payload.attempts,
+                            delay: tier.delay,
+                          },
+                          "Retrying job after backoff",
+                        );
+
+                        // Published to the delay queue rather than back to the
+                        // job queue: it waits there for the tier's TTL, then
+                        // RabbitMQ dead-letters it onto the job queue.
+                        channel.sendToQueue(
+                          getRetryQueueName(queue, tier),
+                          serializeMessage({
+                            args: payload.args,
+                            attempts: payload.attempts + 1,
+                          }),
+                          { persistent: true },
+                        );
+
+                        channel.ack(msg);
+                        return;
+                      }
+
+                      channel.ack(msg);
+                      consumeLogger.error(
+                        { error },
+                        "Error while processing job",
+                      );
+                      await pRetry(() =>
+                        consumer.error?.(payload.args[0], error, ctx),
+                      );
+                    }
+                  } catch (error) {
+                    logger.info({ error }, "Error when processing message");
+                    signalConsumerFault(error);
+                  }
+                });
+              });
+
+              try {
+                await Promise.race([termination.observed, consumerFault]);
+              } finally {
+                await cancelConsumer(channel, consumerTag);
+              }
+            } finally {
+              termination.dispose();
+            }
+          } catch (error) {
+            if (error instanceof IllegalOperationError) {
+              slot.discard();
+            }
+            throw error;
           } finally {
-            await closeChannel(channel);
+            slot.release();
           }
         },
         {


### PR DESCRIPTION
## What happened

[#2519](https://github.com/argos-ci/argos/pull/2519) gave every consumer its own channel to escape the broker's ten-consumers-per-channel cap. That traded one limit for another — the node also caps how many channels may be open across every connection, and with a channel per job type per process the workers reached it:

```
Connection closed: 530 (NOT-ALLOWED) with message "NOT_ALLOWED - number of
channels opened on node 'rabbit@localhost' has reached the maximum allowed
limit of 500"
```

Same shape of outage as the one #2519 fixed: a connection-level 530 takes down every consumer and the publisher channel with it, `amqp.ts` reconnects, the loops re-register, and it trips again.

## What changed

Consumers share a channel, **ten at a time**, which sits clear of both limits at once — a worker's twelve job types now occupy two channels instead of twelve. Slots are counted synchronously at acquire time, before the channel exists, so the twelve loops racing at startup pack deterministically (10 + 2) instead of oversubscribing.

Sharing a channel brings back the hazards #2519 had escaped by not sharing, so three of them are handled explicitly:

- **`prefetch` + `consume` pairs run through a per-channel chain.** `basic.qos` applies to the *next* consumer started on the channel, so concurrent setup could otherwise land one job's prefetch on another job's consumer.
- **A faulted consumer cancels itself instead of closing the channel**, which nine other consumers are using. Left behind it would double-consume and hold a slot the pool no longer counts, eventually pushing the channel past the ten-consumer cap.
- **Queues are declared on a throwaway channel.** A declaration that disagrees with an existing queue draws a channel-level 406; on the shared channel that would take down every unrelated consumer with it, on every retry, forever. Queues are broker-wide, so declaring them elsewhere satisfies both the consumer and the retries it publishes.

## Three strandings fixed along the way

Reworking this code surfaced three ways a consumer could stop for the life of the process. All three are worth fixing here because the pool's recovery story depends on them:

- **A channel can die before anything gets to observe it.** amqplib decodes a whole burst of frames in one turn, so a `close` can arrive while `createChannel` is still resolving through the microtask queue — the listener then attaches to an emitter that has already fired. Nothing would ever evict such an entry and first-fit would keep handing it out, so the pool now **discards** an entry whose channel proves dead (`IllegalOperationError`). For the same reason the consume loop now observes termination *before* its first operation on the channel, rather than waiting on an event that cannot come again.
- **A broker-initiated cancel** (queue deleted or moved) delivers a `null` message, which the callback dropped — parking the loop forever with no error and no retry. It now faults, so the loop re-declares the queue and re-registers.
- **`connect()` cached a rejected connection promise** with nothing to clear it (`handleClose` only runs once a connection existed), so a broker outage outliving the ~17 min of retries bricked the process until restart — consumers and publishers alike. It clears itself now, the way the publisher channel already did.

## Verification

Ran `rabbitmq:4.2-alpine` (the production version) with `consumer_max_per_channel = 10` mounted in `conf.d`, and drove the real `createJob` code through it. Dev and CI brokers enforce no limits, so this is the only way to see any of it.

**The reported bug**, reproduced by adding `channel_max_per_node = 30` and running three worker-sized processes:

| | old code (channel per consumer) | this change |
|---|---|---|
| broker log | `not_allowed: "number of channels opened on node ... has reached the maximum allowed limit of 30"` | clean |
| messages processed | one of three processes stuck at **0 of 48** | **144 of 144** |
| channels | 39 wanted, capped out | 9 (2 consumer + 1 publisher each) |

**Broker's own view** under the ten-consumer limit: `rabbitmqctl list_channels` shows 10 / 2 / 0 consumers per channel per process, and `list_consumers` confirms all 36 consumers kept their **own** prefetch value — the setup serialization working. After `close_all_connections` mid-run, everything re-registered in the same shape and kept consuming.

**The two new behaviors**, from one run (counting consumer registrations per queue in the logs):

- a job's queue is deleted → broker cancels its consumer → it re-declares and consumes the next message (2 registrations, message delivered). Before: parked forever at 1.
- a job whose declaration 406s retries five times without ever registering, while **all eleven co-tenants stay registered exactly once** throughout. Before this containment, each of its retries tore them all down.

`pnpm run static-checks` clean (11/11). `pnpm test:integration` 163 files / 1253 tests passing — twice; a third run had one failure while a broker driver of mine was competing for the same local Redis, and it does not reproduce in isolation.

## For the reviewer

**Still no guard test, same reason as #2519**: CI provisions RabbitMQ through GitHub `services:` with no volume mount, so it cannot enforce `consumer_max_per_channel`, and the image ignores the setting from the environment. A test there would pass on the broken code too. Moving RabbitMQ into a container CI runs itself, with the same limits mounted in `docker-compose.yml`, is still worth doing separately — it is what makes this whole class of bug reproducible before production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)