### PR TITLE
Revert "chore(tests): stop the build-switcher tooltip racing the capture"

### DIFF
--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -320,13 +320,6 @@ loggedTest(
     });
     await expect(docsItem).toBeVisible();
 
-    // The click left the pointer on the trigger, so its tooltip is counting
-    // down 900ms behind the open popover. Whether it lands before the capture
-    // depends on how long the assertions above took — on a slow run it arrives
-    // and covers the popover's "Builds on this commit" header, which is a diff
-    // no baseline can pin. Stepping off the trigger stops the timer.
-    await page.mouse.move(0, 0);
-
     await screenshot(page, "build-switcher", {
       replacements: {
         [team.account.slug]: "acme",


### PR DESCRIPTION
This reverts commit 5e792f36a2deb3fe7ee7868ec0ad9e2c52328f49.
