### PR TITLE
fix: repair three modals broken by the Base UI migration

### DIFF
--- a/apps/frontend/src/containers/Project/Contributors/ProjectContributorsList.tsx
+++ b/apps/frontend/src/containers/Project/Contributors/ProjectContributorsList.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useQuery } from "@apollo/client/react";
 import { invariant } from "@argos/util/invariant";
 
@@ -6,6 +5,7 @@ import { useAssertAuthAccount } from "@/containers/Auth";
 import { ProjectContributorLevelLabel } from "@/containers/ProjectContributor";
 import { RemoveMenu, UserListRow } from "@/containers/UserList";
 import { graphql } from "@/gql";
+import { useDialogValueState } from "@/ui/Dialog";
 import {
   List,
   ListEmpty,
@@ -51,15 +51,7 @@ export function ProjectContributorsList(props: {
   readOnly: boolean;
 }) {
   const authAccount = useAssertAuthAccount();
-  const [removedUser, setRemovedUser] = useState<RemovedUser | null>(null);
-  const removeModal = {
-    isOpen: removedUser !== null,
-    onOpenChange: (open: boolean) => {
-      if (!open) {
-        setRemovedUser(null);
-      }
-    },
-  };
+  const removing = useDialogValueState<RemovedUser | null>(null);
   const result = useQuery(ProjectContributorsQuery, {
     variables: {
       projectId: props.projectId,
@@ -112,7 +104,7 @@ export function ProjectContributorsList(props: {
                             actionLabel={
                               isMe ? "Leave Project" : "Remove from Project"
                             }
-                            onRemove={() => setRemovedUser(user)}
+                            onRemove={() => removing.open(user)}
                           />
                         )}
                       </UserListRow>
@@ -153,19 +145,19 @@ export function ProjectContributorsList(props: {
           );
         })()}
       </div>
-      <Modal {...removeModal}>
-        {removedUser ? (
-          authAccount.id === removedUser.id ? (
+      <Modal open={removing.isOpen} onOpenChange={removing.onOpenChange}>
+        {removing.value ? (
+          authAccount.id === removing.value.id ? (
             <LeaveProjectDialog
               projectId={props.projectId}
               projectName={props.projectName}
-              userAccountId={removedUser.id}
+              userAccountId={removing.value.id}
             />
           ) : (
             <RemoveFromProjectDialog
               projectId={props.projectId}
               projectName={props.projectName}
-              user={removedUser}
+              user={removing.value}
             />
           )
         ) : null}

--- a/apps/frontend/src/containers/Project/Token.tsx
+++ b/apps/frontend/src/containers/Project/Token.tsx
@@ -98,9 +98,7 @@ function RegenerateTokenButton(
     <DialogTrigger>
       <Button variant="secondary">Regenerate token</Button>
       <Modal>
-        <Dialog size="medium">
-          <RegenerateTokenDialog {...props} />
-        </Dialog>
+        <RegenerateTokenDialog {...props} />
       </Modal>
     </DialogTrigger>
   );

--- a/apps/frontend/src/ui/menu-kit/Menu.tsx
+++ b/apps/frontend/src/ui/menu-kit/Menu.tsx
@@ -135,7 +135,24 @@ function useSearch(): SearchState {
 /* Trigger and surface                                                        */
 /* -------------------------------------------------------------------------- */
 
-type MenuOpenState = { open: boolean; setOpen: (open: boolean) => void };
+type MenuOpenState = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  /**
+   * Takes the popup out of the DOM now, skipping the exit animation.
+   *
+   * Base UI renders a popover's dismiss layer while `open || mounted`, so a
+   * closing popup keeps its Escape handler and its focus for the length of the
+   * animation. When a row opens a dialog, that leaves the two overlaid, and the
+   * Escape meant for the dialog closes the menu instead — the dialog stays up.
+   *
+   * `actionsRef.close()` does not help: it is `setOpen(false)`, which is what
+   * closing the menu already does. Unmounting is the only one of the two that
+   * ends the overlap. Picking a row is also the one dismissal with nothing to
+   * animate away from — the pointer has already left.
+   */
+  unmount: () => void;
+};
 
 const MenuOpenContext = createContext<MenuOpenState | null>(null);
 
@@ -163,10 +180,19 @@ export function MenuRoot(props: {
     },
     [onOpenChange],
   );
-  const value = useMemo(() => ({ open, setOpen }), [open, setOpen]);
+  const actionsRef = useRef<BasePopover.Root.Actions>(null);
+  const unmount = useCallback(() => actionsRef.current?.unmount(), []);
+  const value = useMemo(
+    () => ({ open, setOpen, unmount }),
+    [open, setOpen, unmount],
+  );
   return (
     <MenuOpenContext value={value}>
-      <BasePopover.Root open={open} onOpenChange={setOpen}>
+      <BasePopover.Root
+        open={open}
+        onOpenChange={setOpen}
+        actionsRef={actionsRef}
+      >
         {children}
       </BasePopover.Root>
     </MenuOpenContext>
@@ -369,6 +395,8 @@ type MenuContextValue = {
   activeId: string | null;
   checkedIndicator: "icon" | "highlight";
   close: () => void;
+  /** What a row calls once its action has run — see `MenuOpenState.unmount`. */
+  closeNow: () => void;
   /**
    * Whether the focused row's submenu is open.
    *
@@ -480,6 +508,12 @@ function MenuList(
 
   const close = useCallback(() => {
     openState?.setOpen(false);
+  }, [openState]);
+
+  /** Closes the menu for good — see `MenuOpenState.unmount`. */
+  const closeNow = useCallback(() => {
+    openState?.setOpen(false);
+    openState?.unmount();
   }, [openState]);
 
   const [isSubmenuOpen, setSubmenuOpen] = useState(false);
@@ -595,6 +629,7 @@ function MenuList(
       activeId,
       checkedIndicator,
       close,
+      closeNow,
       isSubmenuOpen,
       requestSubmenu,
       openSubmenu,
@@ -605,6 +640,7 @@ function MenuList(
       activeId,
       checkedIndicator,
       close,
+      closeNow,
       isSubmenuOpen,
       requestSubmenu,
       openSubmenu,
@@ -989,11 +1025,11 @@ function MenuItemRow(
       setPending(true);
       result.finally(() => {
         setPending(false);
-        menu.close();
+        menu.closeNow();
       });
       return;
     }
-    menu.close();
+    menu.closeNow();
   };
 
   const highlighted =

--- a/tests/project.spec.ts
+++ b/tests/project.spec.ts
@@ -1,7 +1,9 @@
 import { expect } from "@playwright/test";
 
+import { ProjectUser } from "../apps/backend/src/database/models";
+import { createUserAccount } from "../apps/backend/src/database/seeds";
 import { loggedTest } from "./logged-test";
-import { ensureTeamOwner, screenshot } from "./util";
+import { ensureTeamOwner, getUniqueTestIdentifier, screenshot } from "./util";
 
 loggedTest("project builds", async ({ page, auth, team, project, builds }) => {
   await ensureTeamOwner({ team: team.team, user: auth.user });
@@ -61,3 +63,54 @@ loggedTest("project settings", async ({ page, team, auth, project }) => {
     });
   }
 });
+
+loggedTest(
+  "project settings - remove a contributor from the project",
+  async ({ page, team, auth, project }, testInfo) => {
+    await ensureTeamOwner({ team: team.team, user: auth.user });
+    const id = getUniqueTestIdentifier(testInfo);
+    const contributor = await createUserAccount({
+      email: `fox-${id}@acme.com`,
+      name: "Fox Mulder",
+      slug: `fox-${id}`,
+    });
+    await ProjectUser.query().insert({
+      projectId: project.id,
+      userId: contributor.user.id,
+      userLevel: "viewer",
+    });
+
+    await page.goto(
+      `/${team.account.slug}/${project.name}/settings/access-management`,
+    );
+    const row = page.getByRole("row").filter({ hasText: "Fox Mulder" });
+    await expect(row).toBeVisible();
+    await row.getByRole("button").last().click();
+    await page.getByRole("option", { name: "Remove from Project" }).click();
+
+    const dialog = page.getByRole("alertdialog");
+    await expect(
+      dialog.getByRole("heading", { name: "Remove Project contributor" }),
+    ).toBeVisible();
+    await dialog.getByRole("button", { name: "Remove from Project" }).click();
+    await expect(row).toBeHidden();
+  },
+);
+
+loggedTest(
+  "project settings - the regenerate token dialog names itself",
+  async ({ page, team, auth, project }) => {
+    await ensureTeamOwner({ team: team.team, user: auth.user });
+    await page.goto(
+      `/${team.account.slug}/${project.name}/settings/authentication`,
+    );
+    await page.getByRole("button", { name: "Regenerate token" }).click();
+
+    // One box, and it is the one the title names. Nesting a `Dialog` inside
+    // another leaves a second `aria-modal` around it with nothing to name it,
+    // which a screen reader reads as a nameless dialog holding a dialog.
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toHaveCount(1);
+    await expect(dialog).toHaveAccessibleName("Regenerate token");
+  },
+);


### PR DESCRIPTION
An audit of all 48 `<Modal>` call sites in the frontend, driven by Playwright against the real app: open every reachable modal, check it appears, check it carries exactly one `role="dialog"`, check Escape closes it. Three regressions came out of it, one per commit.

## 1. "Remove from Project" never opened

The same shape as #2540 on the team members list, in the file next door: `<Modal {...removeModal}>` where the object carried `isOpen` and `Modal` takes `open`. The prop arrived `undefined`, `useOverlayRoot` treated the modal as uncontrolled and fell back to `defaultOpen: false`. The menu row fired and nothing happened. A JSX spread skips excess-property checking, so the stray key type-checked clean.

Driven with `useDialogValueState` now, like every other controlled modal.

## 2. The regenerate-token dialog had no accessible name

`RegenerateTokenButton` wrapped `RegenerateTokenDialog` in a `Dialog`, and the component renders one itself — two nested `role="dialog" aria-modal="true"` boxes, the outer one pointing `aria-labelledby` at an id nothing renders. Free before #2493, where the role sat on the popup and a `Dialog` was just a styled box; it is the dialog now.

## 3. A modal opened from a menu lost the Escape that followed

The widest of the three: it hit every modal opened from a menu row — deleting an email, removing a member or a contributor, removing a Discord/Teams channel, deleting an automation.

A row's action opens the dialog and closes the menu in the same tick, but closing only *starts* the popup's exit animation. Traced in the page:

```
t=0ms    the row is pressed
t=8ms    the dialog is mounted
t=185ms  the menu popup is finally unmounted
```

For those ~177ms the menu popup is still there holding focus and the top of the dismiss stack, so an Escape meant for the dialog closes the menu and the dialog stays up. It reproduced 4 times in 8.

Fixed by unmounting the popup outright through the `actionsRef` Base UI's popover root exposes, and only when a row runs an action — the one dismissal with nothing to animate away from, since the pointer has already left. Escape and outside-press keep the animation.

## Verification

Each fix was confirmed by removing it again and watching the check fail. `pnpm test:e2e` is green (132 passed) and `pnpm run static-checks` passes.

The audit spec that found these is not included — it was written to sweep the app, not to be maintained. Worth saying that leaves all three unguarded, #3 especially: it is a race, so it will come back quietly if the menu ever animates out again.

Also noticed while running the suite, unrelated to this branch: under parallel load `personal-settings`, `project-deployments`, `project-ignored` and `project-automation-pages` fail intermittently. They fail the same way on unmodified `main` and pass in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)