### PR TITLE
feat(staff): show invoice dates in the revenue month breakdown

### DIFF
--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -395,6 +395,16 @@ export const typeDefs = gql`
     githubPlans: StaffRevenueSplit!
   }
 
+  "One invoice behind a team's month line."
+  type StaffRevenueMonthTeamInvoice {
+    "Net of tax and credit notes, in the currency it was raised in."
+    amount: Float!
+    "The currency it was raised in."
+    currency: String!
+    "When it was raised."
+    invoicedAt: DateTime!
+  }
+
   "What one team was invoiced over a month, one line of the breakdown."
   type StaffRevenueMonthTeam {
     "The team's slug, which names its pages."
@@ -409,6 +419,8 @@ export const typeDefs = gql`
     currency: String
     "In euros, like the split it sums into."
     revenue: Float!
+    "The invoices the line adds up, newest first."
+    invoices: [StaffRevenueMonthTeamInvoice!]!
   }
 
   "One invoice a contract's worth is read from."

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -22,6 +22,15 @@ type StaffRevenueSplit = {
   foreignRevenue: number;
 };
 
+/** One invoice behind a team's month line. */
+type StaffRevenueMonthTeamInvoice = {
+  /** Net of tax and credit notes, in the currency it was raised in. */
+  amount: number;
+  currency: string;
+  /** When it was raised. */
+  invoicedAt: Date;
+};
+
 /** What one team was invoiced over a month, one line of the breakdown. */
 type StaffRevenueMonthTeam = {
   /** The team's slug, which names its pages. */
@@ -36,6 +45,8 @@ type StaffRevenueMonthTeam = {
   currency: string | null;
   /** In euros, like the split it sums into. */
   revenue: number;
+  /** The invoices the line adds up, newest first. */
+  invoices: StaffRevenueMonthTeamInvoice[];
 };
 
 /** What Argos billed over one calendar month. */
@@ -814,6 +825,7 @@ export async function getStaffRevenue(
         amount: 0,
         currency: revenue.currency,
         revenue: 0,
+        invoices: [],
       };
       teams.set(row.stripeCustomerId, teamRow);
     }
@@ -824,6 +836,11 @@ export async function getStaffRevenue(
       teamRow.currency = null;
     }
     teamRow.revenue += toEuros(revenue);
+    teamRow.invoices.push({
+      amount: revenue.amount,
+      currency: revenue.currency,
+      invoicedAt: new Date(row.stripeCreatedAt),
+    });
   }
 
   // Contracts, once their terms no longer overlap: spread each one over the
@@ -888,6 +905,12 @@ export async function getStaffRevenue(
     const teams = monthTeams[index];
     invariant(monthly && yearly && teams, "every month reported has totals");
     monthly.teamsCount = teams.size;
+    // The query reads the mirror in no particular order.
+    for (const team of teams.values()) {
+      team.invoices.sort(
+        (a, b) => b.invoicedAt.getTime() - a.invoicedAt.getTime(),
+      );
+    }
     const bound = monthBounds[index];
     invariant(bound, "every month reported has bounds");
     return {

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -64,6 +64,11 @@ const StaffRevenueQuery = graphql(`
           amount
           currency
           revenue
+          invoices {
+            amount
+            currency
+            invoicedAt
+          }
         }
         yearlyPlans {
           revenue
@@ -537,7 +542,7 @@ function RevenueChart(props: { months: readonly RevenueMonth[] }) {
   );
 }
 
-type MonthTeamSortKey = "team" | "amount" | "revenue";
+type MonthTeamSortKey = "team" | "amount" | "revenue" | "date";
 
 /**
  * Sortable value per column of a month's breakdown.
@@ -559,6 +564,12 @@ function getMonthTeamSortValue(
       return team.currency === null ? -1 : team.amount;
     case "revenue":
       return team.revenue;
+    case "date": {
+      // On the date the column prints — the newest, invoices being sent
+      // newest first.
+      const newest = team.invoices[0];
+      return newest ? new Date(newest.invoicedAt).getTime() : -1;
+    }
   }
 }
 
@@ -614,14 +625,14 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
       <table className="w-full table-fixed border-collapse">
         <thead>
           <tr className="text-low border-b text-xs font-semibold">
-            <th className="w-[7%] px-4 py-3 text-right">#</th>
+            <th className="w-[6%] px-4 py-3 text-right">#</th>
             <SortHeader
               label="Team"
               sortKey="team"
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[35%] text-left"
+              className="w-[28%] text-left"
             />
             <SortHeader
               label="Invoiced"
@@ -629,7 +640,7 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[21%] text-right"
+              className="w-[18%] text-right"
             />
             <SortHeader
               label="In euros"
@@ -637,49 +648,91 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[21%] text-right"
+              className="w-[18%] text-right"
             />
-            <th className="w-[16%] px-4 py-3 text-right" />
+            <SortHeader
+              label="Date"
+              sortKey="date"
+              activeSortKey={sortKey}
+              direction={sortDirection}
+              onSort={onSort}
+              className="w-[18%] text-right"
+            />
+            <th className="w-[12%] px-4 py-3 text-right" />
           </tr>
         </thead>
         <tbody>
-          {teams.map((team, teamIndex) => (
-            <tr
-              key={team.stripeCustomerId}
-              className={clsx(
-                "text-sm",
-                teamIndex !== teams.length - 1 && "border-b",
-              )}
-            >
-              <td className="text-low px-4 py-2.5 text-right tabular-nums">
-                {teamIndex + 1}
-              </td>
-              <td className="px-4 py-2.5 text-left">
-                <Link href={`/${team.slug}`}>{team.name ?? team.slug}</Link>
-              </td>
-              <td className="px-4 py-2.5 text-right tabular-nums">
-                {team.currency !== null ? (
-                  formatInvoiceAmount({
-                    amount: team.amount,
-                    currency: team.currency,
-                  })
-                ) : (
-                  <span className="text-low">—</span>
+          {teams.map((team, teamIndex) => {
+            const newestInvoice = team.invoices[0] ?? null;
+
+            return (
+              <tr
+                key={team.stripeCustomerId}
+                className={clsx(
+                  "text-sm",
+                  teamIndex !== teams.length - 1 && "border-b",
                 )}
-              </td>
-              <td className="px-4 py-2.5 text-right tabular-nums">
-                {formatEuros(team.revenue)}
-              </td>
-              <td className="px-4 py-2.5 text-right">
-                <Link
-                  href={getStripeCustomerURL(team.stripeCustomerId)}
-                  target="_blank"
+              >
+                <td className="text-low px-4 py-2.5 text-right tabular-nums">
+                  {teamIndex + 1}
+                </td>
+                <td className="px-4 py-2.5 text-left">
+                  <Link href={`/${team.slug}`}>{team.name ?? team.slug}</Link>
+                </td>
+                <td className="px-4 py-2.5 text-right tabular-nums">
+                  {team.currency !== null ? (
+                    formatInvoiceAmount({
+                      amount: team.amount,
+                      currency: team.currency,
+                    })
+                  ) : (
+                    <span className="text-low">—</span>
+                  )}
+                </td>
+                <td className="px-4 py-2.5 text-right tabular-nums">
+                  {formatEuros(team.revenue)}
+                </td>
+                {/* The dates walk forward with the calendar, like the month
+                    names above. */}
+                <td
+                  className="px-4 py-2.5 text-right tabular-nums"
+                  data-visual-test="transparent"
                 >
-                  Stripe
-                </Link>
-              </td>
-            </tr>
-          ))}
+                  {newestInvoice === null ? (
+                    <span className="text-low">—</span>
+                  ) : team.invoices.length === 1 ? (
+                    DATE_FORMAT.format(new Date(newestInvoice.invoicedAt))
+                  ) : (
+                    // A team invoiced twice in one month is one line, so the
+                    // column carries the newest date and the tooltip the rest.
+                    <Hint
+                      content={
+                        <div className="flex flex-col gap-1">
+                          {team.invoices.map((invoice, invoiceIndex) => (
+                            <div key={invoiceIndex}>
+                              {formatInvoiceAmount(invoice)} invoiced{" "}
+                              {DATE_FORMAT.format(new Date(invoice.invoicedAt))}
+                              .
+                            </div>
+                          ))}
+                        </div>
+                      }
+                    >
+                      {DATE_FORMAT.format(new Date(newestInvoice.invoicedAt))}
+                    </Hint>
+                  )}
+                </td>
+                <td className="px-4 py-2.5 text-right">
+                  <Link
+                    href={getStripeCustomerURL(team.stripeCustomerId)}
+                    target="_blank"
+                  >
+                    Stripe
+                  </Link>
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -595,13 +595,14 @@ function sortMonthTeams(
 /**
  * The teams behind a month's monthly plans, one line each.
  *
- * Sorted heaviest first to open, which is the order the backend already sends
- * and the question the breakdown is opened to answer. The rank column numbers
- * the rows as they are displayed, so it re-reads as a line number under any
- * other sort rather than pinning a position the sort has moved.
+ * Sorted newest invoice first to open, so the month reads as a ledger; teams
+ * invoiced the same day keep the heaviest-first order the backend sends, the
+ * sort being stable. The rank column numbers the rows as they are displayed,
+ * so it re-reads as a line number under any other sort rather than pinning a
+ * position the sort has moved.
  */
 function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
-  const [sortKey, setSortKey] = useState<MonthTeamSortKey>("revenue");
+  const [sortKey, setSortKey] = useState<MonthTeamSortKey>("date");
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
 
   const onSort = (key: MonthTeamSortKey) => {

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -637,8 +637,9 @@ type RevenueBook = {
   contractTeam: string;
   /** What a month of the contract comes to, as the page prints it. */
   contractPerMonth: string;
-  /** The day last month's invoices were raised, as the page prints it. */
-  invoiceDate: string;
+  /** The days last month's two invoices were raised, as the page prints them. */
+  monthlyInvoiceDate: string;
+  dollarInvoiceDate: string;
 };
 
 /**
@@ -735,6 +736,12 @@ const revenueTest = staffTest.extend<{ revenueBook: RevenueBook }>({
     const lastMonth = new Date(
       startOfUTCMonth(-1).getTime() + 5 * 24 * 3600 * 1000,
     );
+    // A week after the dollar team's bill, on the lighter team: the breakdown
+    // opens newest invoice first, and only a date order that disagrees with
+    // the heaviest-first order the backend sends can show which one won.
+    const lastMonthLater = new Date(
+      startOfUTCMonth(-1).getTime() + 12 * 24 * 3600 * 1000,
+    );
     await StripeInvoice.query().insert([
       // Two teams billed last month, one of them in dollars: the page states
       // euros, so the row has to show both what Stripe charged and what it
@@ -742,7 +749,7 @@ const revenueTest = staffTest.extend<{ revenueBook: RevenueBook }>({
       {
         stripeInvoiceId: `in_${prefix}-kruger-last`,
         stripeCustomerId: `cus_${prefix}-kruger`,
-        stripeCreatedAt: lastMonth.toISOString(),
+        stripeCreatedAt: lastMonthLater.toISOString(),
         status: "paid",
         billingReason: "subscription_cycle",
         currency: "eur",
@@ -841,17 +848,18 @@ const revenueTest = staffTest.extend<{ revenueBook: RevenueBook }>({
       currency: "EUR",
     }).format((12_000 * monthMs) / termMs);
 
-    const invoiceDate = new Intl.DateTimeFormat("en-US", {
+    const dateFormat = new Intl.DateTimeFormat("en-US", {
       dateStyle: "medium",
       timeZone: "UTC",
-    }).format(lastMonth);
+    });
 
     await use({
       monthlyTeam,
       dollarTeam,
       contractTeam,
       contractPerMonth,
-      invoiceDate,
+      monthlyInvoiceDate: dateFormat.format(lastMonthLater),
+      dollarInvoiceDate: dateFormat.format(lastMonth),
     });
   },
 });
@@ -896,15 +904,21 @@ revenueTest.describe("staff revenue", () => {
     // What Stripe charged, beside what the page counts it as.
     await expect(breakdown.getByText("$1,000.00")).toBeVisible();
     await expect(breakdown.getByText("€855")).toBeVisible();
-    // Both lines carry the day their invoice was raised.
-    await expect(breakdown.getByText(revenueBook.invoiceDate)).toHaveCount(2);
+    // Each line carries the day its invoice was raised.
+    await expect(
+      breakdown.getByText(revenueBook.monthlyInvoiceDate),
+    ).toBeVisible();
+    await expect(
+      breakdown.getByText(revenueBook.dollarInvoiceDate),
+    ).toBeVisible();
 
-    // Heaviest first to open, so the dollar team leads and the ranks number
-    // that order.
+    // Newest invoice first to open: the monthly team was billed a week after
+    // the dollar team, so it leads even though it weighs less — the date
+    // orders the breakdown, not the heaviest-first payload the backend sends.
     const breakdownRows = breakdown.locator("tbody tr");
-    await expect(breakdownRows.nth(0)).toContainText(revenueBook.dollarTeam);
+    await expect(breakdownRows.nth(0)).toContainText(revenueBook.monthlyTeam);
     await expect(breakdownRows.nth(0).locator("td").first()).toHaveText("1");
-    await expect(breakdownRows.nth(1)).toContainText(revenueBook.monthlyTeam);
+    await expect(breakdownRows.nth(1)).toContainText(revenueBook.dollarTeam);
     await expect(breakdownRows.nth(1).locator("td").first()).toHaveText("2");
 
     // The contract is listed on its own, with the invoice its figure is read
@@ -928,10 +942,10 @@ revenueTest.describe("staff revenue", () => {
 
     // After the screenshot: the baseline is worth having in the order the
     // breakdown opens in.
-    // Sorting by name reverses the two, and the ranks follow the rows rather
+    // Sorting by weight reverses the two, and the ranks follow the rows rather
     // than travelling with them.
-    await breakdown.getByRole("button", { name: "Team" }).click();
-    await expect(breakdownRows.nth(0)).toContainText(revenueBook.monthlyTeam);
+    await breakdown.getByRole("button", { name: "In euros" }).click();
+    await expect(breakdownRows.nth(0)).toContainText(revenueBook.dollarTeam);
     await expect(breakdownRows.nth(0).locator("td").first()).toHaveText("1");
   });
 });

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -637,6 +637,8 @@ type RevenueBook = {
   contractTeam: string;
   /** What a month of the contract comes to, as the page prints it. */
   contractPerMonth: string;
+  /** The day last month's invoices were raised, as the page prints it. */
+  invoiceDate: string;
 };
 
 /**
@@ -839,7 +841,18 @@ const revenueTest = staffTest.extend<{ revenueBook: RevenueBook }>({
       currency: "EUR",
     }).format((12_000 * monthMs) / termMs);
 
-    await use({ monthlyTeam, dollarTeam, contractTeam, contractPerMonth });
+    const invoiceDate = new Intl.DateTimeFormat("en-US", {
+      dateStyle: "medium",
+      timeZone: "UTC",
+    }).format(lastMonth);
+
+    await use({
+      monthlyTeam,
+      dollarTeam,
+      contractTeam,
+      contractPerMonth,
+      invoiceDate,
+    });
   },
 });
 
@@ -883,6 +896,8 @@ revenueTest.describe("staff revenue", () => {
     // What Stripe charged, beside what the page counts it as.
     await expect(breakdown.getByText("$1,000.00")).toBeVisible();
     await expect(breakdown.getByText("€855")).toBeVisible();
+    // Both lines carry the day their invoice was raised.
+    await expect(breakdown.getByText(revenueBook.invoiceDate)).toHaveCount(2);
 
     // Heaviest first to open, so the dollar team leads and the ranks number
     // that order.


### PR DESCRIPTION
## What

The monthly plans breakdown on the staff revenue page now shows **when** each team was invoiced, not just how much.

- The GraphQL `StaffRevenueMonthTeam` type carries a new `invoices` list (amount, currency, `invoicedAt`), newest first — mirroring what `StaffYearlyContract` already exposes.
- The breakdown table gains a sortable **Date** column printing the newest invoice's date, in UTC like every other date on the page.
- The breakdown **opens sorted by date**, newest invoice first; teams invoiced the same day keep the heaviest-first order the backend sends.
- A team invoiced twice in one month keeps its single line: the column shows the newest date and a tooltip lists every invoice behind it — the same pattern as the annual contracts' *Invoiced* column.

## Notes

- The date cells are `data-visual-test="transparent"`: the seeded dates walk with the calendar, so the Argos baseline would need approving every month otherwise. The `staff-revenue-monthly-plans` baseline changes once with this PR (new column, new default order).
- The Playwright spec seeds the two invoices a week apart, so the date order disagrees with the weight order and the default sort is actually exercised.

## Test plan

- `pnpm run static-checks` ✅
- `pnpm test:unit` (stripe/revenue) — 21 passed ✅
- `pnpm test:integration` (stripe/revenue.e2e) — 17 passed ✅
- `NODE_ENV=test pnpm test:e2e --project=chromium -g "staff revenue"` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
