### PR TITLE
Read the staff revenue page from the invoice mirror, and seed it

### DIFF
--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -2208,6 +2208,16 @@ async function createRevenueScenario(input: {
     getPlan("standard"),
   ]);
 
+  const scalePlan = await Plan.query().insertAndFetch({
+    name: "scale",
+    includedScreenshots: 250_000,
+    usageBased: true,
+    githubSsoIncluded: true,
+    fineGrainedAccessControlIncluded: true,
+    samlIncluded: true,
+    interval: "month",
+  });
+
   const yearlyPlan = await Plan.query().insertAndFetch({
     name: "enterprise",
     includedScreenshots: 2_000_000,
@@ -2357,6 +2367,8 @@ async function createRevenueScenario(input: {
     slug: string;
     name: string;
     planId: string;
+    /** Negotiated on the subscription, where Stripe states one of its own. */
+    includedScreenshots?: number;
     currency: "eur" | "usd";
     /** The day of the month its cycle bills on, which anchors its periods. */
     dayOfMonth: number;
@@ -2404,6 +2416,9 @@ async function createRevenueScenario(input: {
       currency: team.currency,
       flatPrice: team.flatPrice,
       additionalScreenshotPrice: team.additionalScreenshotPrice,
+      ...(team.includedScreenshots !== undefined && {
+        includedScreenshots: team.includedScreenshots,
+      }),
     });
     await addMembers({
       teamId: teamRow.id,
@@ -2433,6 +2448,21 @@ async function createRevenueScenario(input: {
     from: number;
     growth: number;
     members: string[];
+    /**
+     * The deal it was signed on, where it is not the self-serve one — a
+     * commitment negotiated up from the list plan, with the quota and the unit
+     * price that came with it.
+     *
+     * What decides how far past its quota the team reads: the same bill on the
+     * list plan is a team to call about a contract, and on a commitment three
+     * times the size it is a team well inside the one it already signed.
+     */
+    deal?: {
+      planId: string;
+      flatPrice: number;
+      includedScreenshots: number;
+      screenshotPrice: number;
+    };
     /** Months back the subscription ended, for a team that has churned. */
     endedMonth?: number;
     /**
@@ -2443,16 +2473,23 @@ async function createRevenueScenario(input: {
     /** Cents credited back on the newest bill, as a credit note would. */
     credited?: number;
   }): Promise<void> {
+    const deal = team.deal ?? {
+      planId: monthlyPlan.id,
+      flatPrice: MONTHLY_FLAT_PRICE,
+      includedScreenshots: monthlyPlan.includedScreenshots,
+      screenshotPrice: MONTHLY_SCREENSHOT_PRICE,
+    };
     const accountId = await createBilledTeam({
       slug: team.slug,
       name: team.name,
-      planId: monthlyPlan.id,
+      planId: deal.planId,
+      includedScreenshots: deal.includedScreenshots,
       currency: team.currency,
       dayOfMonth: team.dayOfMonth,
       startedMonth: team.firstMonth - 1,
       ...(team.endedMonth !== undefined && { endedMonth: team.endedMonth }),
-      flatPrice: MONTHLY_FLAT_PRICE,
-      additionalScreenshotPrice: MONTHLY_SCREENSHOT_PRICE,
+      flatPrice: deal.flatPrice,
+      additionalScreenshotPrice: deal.screenshotPrice,
       members: team.members,
     });
 
@@ -2492,10 +2529,8 @@ async function createRevenueScenario(input: {
         from: billedOn(month - 1, team.dayOfMonth),
         to: invoicedAt,
         screenshots:
-          monthlyPlan.includedScreenshots +
-          Math.round(
-            (amount / 100 - MONTHLY_FLAT_PRICE) / MONTHLY_SCREENSHOT_PRICE,
-          ),
+          deal.includedScreenshots +
+          Math.round((amount / 100 - deal.flatPrice) / deal.screenshotPrice),
       });
     }
 
@@ -2574,6 +2609,15 @@ async function createRevenueScenario(input: {
       from: 89_000,
       growth: 1.06,
       members: ["Wile Coyote", "Road Runner", "Marvin Martian"],
+      // A commitment sized to what it was billing when it signed, a year ago:
+      // everything it has grown by since reads as overage, which is what a
+      // team due a renegotiated contract looks like.
+      deal: {
+        planId: scalePlan.id,
+        flatPrice: 890,
+        includedScreenshots: 250_000,
+        screenshotPrice: 0.004,
+      },
     }),
     // In dollars, so the euro figures rest on the page's fixed rate and say so.
     createMonthlyTeam({
@@ -2613,6 +2657,14 @@ async function createRevenueScenario(input: {
       vatRate: 0.2,
       credited: 4_000,
       members: ["Thorn Detective", "Sol Roth"],
+      // A commitment it has only just grown past: a couple of percent, which
+      // is the reading that is neither a problem nor a zero.
+      deal: {
+        planId: scalePlan.id,
+        flatPrice: 399,
+        includedScreenshots: 150_000,
+        screenshotPrice: 0.005,
+      },
     }),
     // Signed six months ago: the month it arrives in is the one that jumps.
     createMonthlyTeam({
@@ -2625,6 +2677,14 @@ async function createRevenueScenario(input: {
       from: 129_000,
       growth: 1.05,
       members: ["Gavin Belson", "Denpok Singh", "Richard Hendricks"],
+      // Well past the quota it signed for, and paying most of its bill in
+      // overage: the row the column exists to surface.
+      deal: {
+        planId: scalePlan.id,
+        flatPrice: 490,
+        includedScreenshots: 250_000,
+        screenshotPrice: 0.005,
+      },
     }),
     createMonthlyTeam({
       slug: "massive-dynamic",

--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -2,6 +2,7 @@ import type { ScreenshotMetadata } from "@argos/schemas/screenshot-metadata";
 import { invariant } from "@argos/util/invariant";
 
 import { concludeBuild } from "@/build/concludeBuild";
+import { startOfUTCMonth } from "@/stripe/revenue";
 import { decodeFingerprint } from "@/util/fingerprint";
 
 import { knex } from "./knex";
@@ -2146,12 +2147,16 @@ export async function seed() {
  */
 const OLDEST_REVENUE_MONTH = -12;
 
-/** The first instant of the month `offset` months from the running one, UTC. */
+/**
+ * The first instant of the month `offset` months from the running one, UTC.
+ *
+ * Cut by the reader's own helper rather than by a copy of it: the revenue page
+ * files an invoice by the month Postgres and Stripe agree it was raised in, so
+ * a seed that cut months anywhere else would land its bills either side of a
+ * boundary the page reads differently.
+ */
 function startOfRelativeMonth(offset: number): Date {
-  const now = new Date();
-  return new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + offset, 1),
-  );
+  return startOfUTCMonth(new Date(), offset);
 }
 
 /**

--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -2614,9 +2614,10 @@ async function createRevenueScenario(input: {
       from: 89_000,
       growth: 1.06,
       members: ["Wile Coyote", "Road Runner", "Marvin Martian"],
-      // A commitment sized to what it was billing when it signed, a year ago:
-      // everything it has grown by since reads as overage, which is what a
-      // team due a renegotiated contract looks like.
+      // The deals differ from one team to the next so the overage column has
+      // a spread to show: this one is a commitment sized to what it was
+      // billing when it signed, so everything it has grown by since reads as
+      // overage — a team due a renegotiated contract.
       deal: {
         planId: scalePlan.id,
         flatPrice: 890,
@@ -2662,8 +2663,6 @@ async function createRevenueScenario(input: {
       vatRate: 0.2,
       credited: 4_000,
       members: ["Thorn Detective", "Sol Roth"],
-      // A commitment it has only just grown past: a couple of percent, which
-      // is the reading that is neither a problem nor a zero.
       deal: {
         planId: scalePlan.id,
         flatPrice: 399,
@@ -2682,8 +2681,6 @@ async function createRevenueScenario(input: {
       from: 129_000,
       growth: 1.05,
       members: ["Gavin Belson", "Denpok Singh", "Richard Hendricks"],
-      // Well past the quota it signed for, and paying most of its bill in
-      // overage: the row the column exists to surface.
       deal: {
         planId: scalePlan.id,
         flatPrice: 490,
@@ -2810,7 +2807,6 @@ async function createRevenueScenario(input: {
       periodStart: billedOn(-13, 15).toISOString(),
       periodEnd: billedOn(-1, 15).toISOString(),
     },
-    // Raised but not yet cleared: the row worth watching in the table.
     {
       stripeInvoiceId: "in_seed_vandelay_renewal",
       stripeCustomerId: customerOf("vandelay"),

--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -2,8 +2,8 @@ import type { ScreenshotMetadata } from "@argos/schemas/screenshot-metadata";
 import { invariant } from "@argos/util/invariant";
 
 import { concludeBuild } from "@/build/concludeBuild";
-import { startOfUTCMonth } from "@/stripe/revenue";
 import { decodeFingerprint } from "@/util/fingerprint";
+import { startOfUTCMonth } from "@/util/utc-month";
 
 import { knex } from "./knex";
 import { UserEmail } from "./models";
@@ -2150,10 +2150,10 @@ const OLDEST_REVENUE_MONTH = -12;
 /**
  * The first instant of the month `offset` months from the running one, UTC.
  *
- * Cut by the reader's own helper rather than by a copy of it: the revenue page
- * files an invoice by the month Postgres and Stripe agree it was raised in, so
- * a seed that cut months anywhere else would land its bills either side of a
- * boundary the page reads differently.
+ * Cut by the same helper the revenue reader uses rather than by a copy of it:
+ * the page files an invoice by the month Postgres and Stripe agree it was
+ * raised in, so a seed that cut months anywhere else would land its bills
+ * either side of a boundary the page reads differently.
  */
 function startOfRelativeMonth(offset: number): Date {
   return startOfUTCMonth(new Date(), offset);

--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -2234,8 +2234,8 @@ async function createRevenueScenario(input: {
   /** The Stripe subscription they are raised against. */
   const subscriptionOf = (slug: string) => `sub_seed_${slug}`;
 
-  /** What the monthly plan charges before any usage, per month. */
-  const MONTHLY_FLAT_PRICE = 99;
+  /** What the monthly plan charges before any usage, per month, at list. */
+  const MONTHLY_FLAT_PRICE = 100;
 
   /** What a screenshot past the quota costs on the monthly plan. */
   const MONTHLY_SCREENSHOT_PRICE = 0.005;

--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -28,6 +28,9 @@ import { ProjectDomain } from "./models/ProjectDomain";
 import { Screenshot } from "./models/Screenshot";
 import { ScreenshotBucket } from "./models/ScreenshotBucket";
 import { ScreenshotDiff } from "./models/ScreenshotDiff";
+import { StripeInvoice } from "./models/StripeInvoice";
+import { StripeInvoiceSync } from "./models/StripeInvoiceSync";
+import { Subscription } from "./models/Subscription";
 import { Team } from "./models/Team";
 import { TeamUser } from "./models/TeamUser";
 import { Test } from "./models/Test";
@@ -1970,6 +1973,7 @@ export async function seed() {
       name: "starter",
       includedScreenshots: 40000,
       githubPlanId: 7786,
+      githubMonthlyPriceCents: 3_000,
       stripeProductId: "prod_MzEZEfBDYFIc53",
       usageBased: false,
       githubSsoIncluded: true,
@@ -1980,6 +1984,7 @@ export async function seed() {
       name: "standard",
       includedScreenshots: 250000,
       githubPlanId: 7787,
+      githubMonthlyPriceCents: 8_000,
       stripeProductId: "prod_MzEavomA8VeCvW",
       usageBased: false,
       githubSsoIncluded: true,
@@ -1990,6 +1995,7 @@ export async function seed() {
       name: "Pro (legacy)",
       includedScreenshots: 1000000,
       githubPlanId: 7788,
+      githubMonthlyPriceCents: 20_000,
       stripeProductId: "prod_MzEawyq1kFcHEn",
       usageBased: false,
       githubSsoIncluded: true,
@@ -2129,6 +2135,694 @@ export async function seed() {
     projectId: bigProject.id,
     authorUserId: greg.user.id,
     replierUserId: jeremy.user.id,
+  });
+
+  await createRevenueScenario({ subscriberId: jeremy.user.id });
+}
+
+/**
+ * The oldest month the staff revenue page reports: it reads a year plus the
+ * running one.
+ */
+const OLDEST_REVENUE_MONTH = -12;
+
+/** The first instant of the month `offset` months from the running one, UTC. */
+function startOfRelativeMonth(offset: number): Date {
+  const now = new Date();
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + offset, 1),
+  );
+}
+
+/**
+ * The `day`th of the month `offset` months from the running one, at 9am UTC.
+ *
+ * Clamped to the month's own length rather than spilling into the next one: a
+ * team billed on the 30th is billed on the 28th of February, the way Stripe
+ * moves a cycle anchor a short month cannot hold — and a bill that spilled
+ * would be reported in a month its team was never billed in.
+ */
+function billedOn(offset: number, day: number): Date {
+  const month = startOfRelativeMonth(offset);
+  const lastDay = new Date(
+    Date.UTC(month.getUTCFullYear(), month.getUTCMonth() + 1, 0),
+  ).getUTCDate();
+  return new Date(
+    Date.UTC(
+      month.getUTCFullYear(),
+      month.getUTCMonth(),
+      Math.min(day, lastDay),
+      9,
+    ),
+  );
+}
+
+/**
+ * The book the staff pages read: the teams Argos bills, the invoices behind
+ * them, the usage those invoices were raised on, and the Marketplace
+ * subscriptions GitHub bills.
+ *
+ * One set of teams for the two pages, and one story: a team's bill in the
+ * revenue breakdown is the one the team directory prices its period at, and
+ * the screenshots it lists are what that amount was computed from. Seeding a
+ * team without them left the directory quoting thousands against a consumption
+ * of zero.
+ *
+ * Dated against the running month rather than fixed, because the revenue page
+ * reports the last thirteen calendar months — fixed dates would fall out of the
+ * window a month after they were written. The Stripe ids are made up; nothing
+ * here talks to Stripe, and the pages only read them back to build their links.
+ */
+async function createRevenueScenario(input: {
+  subscriberId: string;
+}): Promise<void> {
+  /** A plan out of the catalog seeded above. */
+  async function getPlan(name: string): Promise<Plan> {
+    const plan = await Plan.query().findOne({ name });
+    invariant(plan, `the ${name} plan is seeded above`);
+    return plan;
+  }
+
+  const [monthlyPlan, marketplacePlan] = await Promise.all([
+    getPlan("pro"),
+    getPlan("standard"),
+  ]);
+
+  const yearlyPlan = await Plan.query().insertAndFetch({
+    name: "enterprise",
+    includedScreenshots: 2_000_000,
+    usageBased: true,
+    githubSsoIncluded: true,
+    fineGrainedAccessControlIncluded: true,
+    samlIncluded: true,
+    interval: "year",
+  });
+
+  /** The Stripe customer a team's invoices are raised on. */
+  const customerOf = (slug: string) => `cus_seed_${slug}`;
+
+  /** The Stripe subscription they are raised against. */
+  const subscriptionOf = (slug: string) => `sub_seed_${slug}`;
+
+  /** What the monthly plan charges before any usage, per month. */
+  const MONTHLY_FLAT_PRICE = 99;
+
+  /** What a screenshot past the quota costs on the monthly plan. */
+  const MONTHLY_SCREENSHOT_PRICE = 0.005;
+
+  /** The same, negotiated down, on a contract. */
+  const CONTRACT_SCREENSHOT_PRICE = 0.002;
+
+  /** A bucket a fortnight is what the usage below is spread over. */
+  const FORTNIGHT_MS = 14 * 24 * 3600 * 1000;
+
+  /**
+   * People in a team. The directory counts them and lists them in its detail
+   * panel, where a team of nobody reads as broken data rather than as a team
+   * nobody joined. They are members of nothing else: the seeded staff can
+   * already open every team, so making them owners would only crowd the
+   * account switcher.
+   */
+  async function addMembers(member: {
+    teamId: string;
+    slug: string;
+    names: string[];
+  }): Promise<void> {
+    const users = await Promise.all(
+      member.names.map((name) => {
+        const handle = name.toLowerCase().replaceAll(" ", ".");
+        return createUserAccount({
+          email: `${handle}@${member.slug}.example.com`,
+          slug: `${member.slug}-${handle.replaceAll(".", "-")}`,
+          name,
+        });
+      }),
+    );
+    await TeamUser.query().insert(
+      users.map((user, index) => ({
+        teamId: member.teamId,
+        userId: user.user.id,
+        userLevel: index === 0 ? ("owner" as const) : ("member" as const),
+      })),
+    );
+  }
+
+  /**
+   * The screenshots a team consumed over one billing period.
+   *
+   * Carried by buckets, because that is what the billing counts, and spread a
+   * fortnight apart over the period. None is dated ahead of now: the running
+   * period has to read as partial, and it is the buckets it has not reached
+   * that make it so.
+   */
+  function bucketsOver(usage: {
+    projectId: string;
+    from: Date;
+    to: Date;
+    screenshots: number;
+  }) {
+    const span = usage.to.getTime() - usage.from.getTime();
+    const count = Math.max(1, Math.round(span / FORTNIGHT_MS));
+    const share = Math.round(usage.screenshots / count);
+    const rows = [];
+    for (let index = 0; index < count; index++) {
+      const createdAt = new Date(usage.from.getTime() + (span * index) / count);
+      if (createdAt.getTime() > Date.now()) {
+        break;
+      }
+      rows.push({
+        name: "default",
+        commit: "029b662f3ae57bae7a215301067262c1e95bbc95",
+        branch: "main",
+        projectId: usage.projectId,
+        complete: true,
+        valid: true,
+        screenshotCount: share,
+        storybookScreenshotCount: 0,
+        createdAt: createdAt.toISOString(),
+        updatedAt: createdAt.toISOString(),
+      });
+    }
+    return rows;
+  }
+
+  /**
+   * The project a team's usage was produced by, with a build on every bucket.
+   *
+   * The build numbers are handed out here rather than allocated one insert at a
+   * time: the counter moves to whatever a seed sets, so a batch can carry its
+   * own numbering.
+   */
+  async function recordUsage(usage: {
+    accountId: string;
+    periods: { from: Date; to: Date; screenshots: number }[];
+  }): Promise<void> {
+    const project = await createProject({
+      accountId: usage.accountId,
+      name: "web",
+    });
+    const buckets = await ScreenshotBucket.query().insertAndFetch(
+      usage.periods.flatMap((period) =>
+        bucketsOver({ projectId: project.id, ...period }),
+      ),
+    );
+    await Build.query().insert(
+      buckets.map((bucket, index) => ({
+        projectId: project.id,
+        compareScreenshotBucketId: bucket.id,
+        number: index + 1,
+        jobStatus: "complete" as const,
+        conclusion: "no-changes" as const,
+        type: "check" as const,
+        // Back through `Date`: the column comes back off the insert as one,
+        // and the model takes its timestamps as ISO strings.
+        createdAt: new Date(bucket.createdAt).toISOString(),
+        updatedAt: new Date(bucket.createdAt).toISOString(),
+        stats: {
+          total: bucket.screenshotCount ?? 0,
+          failure: 0,
+          added: 0,
+          unchanged: bucket.screenshotCount ?? 0,
+          changed: 0,
+          removed: 0,
+          retryFailure: 0,
+          ignored: 0,
+        },
+      })),
+    );
+  }
+
+  /** A team billed through Stripe, and the customer its invoices are on. */
+  async function createBilledTeam(team: {
+    slug: string;
+    name: string;
+    planId: string;
+    currency: "eur" | "usd";
+    /** The day of the month its cycle bills on, which anchors its periods. */
+    dayOfMonth: number;
+    /** Months back the subscription started, negative. */
+    startedMonth: number;
+    /** Months back it ended. Omitted while it is still running. */
+    endedMonth?: number;
+    /** What the plan charges over one period, ex-usage. */
+    flatPrice: number;
+    additionalScreenshotPrice: number;
+    members: string[];
+  }): Promise<string> {
+    const { account, team: teamRow } = await createTeamAccount({
+      slug: team.slug,
+      name: team.name,
+    });
+    await account.$query().patch({ stripeCustomerId: customerOf(team.slug) });
+    const endedMonth = team.endedMonth ?? null;
+    // On the day it bills rather than on the first of the month: the periods
+    // the directory prices are anchored on this date, and they have to be the
+    // stretches the invoices close.
+    const startDate = billedOn(
+      team.startedMonth,
+      team.dayOfMonth,
+    ).toISOString();
+    await Subscription.query().insert({
+      planId: team.planId,
+      accountId: account.id,
+      provider: "stripe",
+      stripeSubscriptionId: subscriptionOf(team.slug),
+      subscriberId: input.subscriberId,
+      startDate,
+      // As old as the subscription it describes: a closed period opening before
+      // the row existed reads as an invoice that was never sent, and the
+      // directory drops it — which would leave every seeded team with no last
+      // period at all.
+      createdAt: startDate,
+      updatedAt: startDate,
+      endDate:
+        endedMonth === null
+          ? null
+          : billedOn(endedMonth, team.dayOfMonth).toISOString(),
+      paymentMethodFilled: true,
+      status: endedMonth === null ? "active" : "canceled",
+      currency: team.currency,
+      flatPrice: team.flatPrice,
+      additionalScreenshotPrice: team.additionalScreenshotPrice,
+    });
+    await addMembers({
+      teamId: teamRow.id,
+      slug: team.slug,
+      names: team.members,
+    });
+    return account.id;
+  }
+
+  /**
+   * A team on the monthly plan: the bills it was sent, all on the same day of
+   * the month, and the usage each one was raised on.
+   *
+   * The usage is read back from the amount rather than invented beside it — the
+   * plan's own price covers the quota, everything past it is the overage — so
+   * the directory's period and the revenue page's invoice are two readings of
+   * one number.
+   */
+  async function createMonthlyTeam(team: {
+    slug: string;
+    name: string;
+    currency: "eur" | "usd";
+    dayOfMonth: number;
+    firstMonth: number;
+    lastMonth: number;
+    /** What the first month was billed, in cents, ex-tax. */
+    from: number;
+    growth: number;
+    members: string[];
+    /** Months back the subscription ended, for a team that has churned. */
+    endedMonth?: number;
+    /**
+     * Bills the tax with no ex-tax total stated, as Stripe leaves the older
+     * invoices — the figures then have to come off the total themselves.
+     */
+    vatRate?: number;
+    /** Cents credited back on the newest bill, as a credit note would. */
+    credited?: number;
+  }): Promise<void> {
+    const accountId = await createBilledTeam({
+      slug: team.slug,
+      name: team.name,
+      planId: monthlyPlan.id,
+      currency: team.currency,
+      dayOfMonth: team.dayOfMonth,
+      startedMonth: team.firstMonth - 1,
+      ...(team.endedMonth !== undefined && { endedMonth: team.endedMonth }),
+      flatPrice: MONTHLY_FLAT_PRICE,
+      additionalScreenshotPrice: MONTHLY_SCREENSHOT_PRICE,
+      members: team.members,
+    });
+
+    const invoices = [];
+    const periods = [];
+    /** The month of the newest bill raised, which the running period follows. */
+    let billedMonth = null;
+    for (let month = team.firstMonth; month <= team.lastMonth; month++) {
+      const invoicedAt = billedOn(month, team.dayOfMonth);
+      // A cycle whose day has not come round yet has billed nothing: the
+      // running month holds only the invoices Stripe has already raised.
+      if (invoicedAt.getTime() > Date.now()) {
+        continue;
+      }
+      const amount =
+        Math.round(
+          (team.from * team.growth ** (month - team.firstMonth)) / 100,
+        ) * 100;
+      const taxes = Math.round(amount * (team.vatRate ?? 0));
+      invoices.push({
+        stripeInvoiceId: `in_seed_${team.slug}_${month}`,
+        stripeCustomerId: customerOf(team.slug),
+        stripeSubscriptionId: subscriptionOf(team.slug),
+        stripeCreatedAt: invoicedAt.toISOString(),
+        status: "paid",
+        billingReason: "subscription_cycle",
+        currency: team.currency,
+        total: amount + taxes,
+        totalExcludingTax: taxes === 0 ? amount : null,
+        totalTaxesAmount: taxes === 0 ? null : taxes,
+        creditedAmountExcludingTax: 0,
+      });
+      billedMonth = month;
+      // The stretch the bill closes, not the one it opens: usage is invoiced
+      // in arrears, so the screenshots behind an amount are the month before it.
+      periods.push({
+        from: billedOn(month - 1, team.dayOfMonth),
+        to: invoicedAt,
+        screenshots:
+          monthlyPlan.includedScreenshots +
+          Math.round(
+            (amount / 100 - MONTHLY_FLAT_PRICE) / MONTHLY_SCREENSHOT_PRICE,
+          ),
+      });
+    }
+
+    // On the newest bill raised rather than on the last one asked for: a cycle
+    // still to come this month has nothing to credit back.
+    const newestInvoice = invoices.at(-1);
+    if (newestInvoice && team.credited) {
+      newestInvoice.creditedAmountExcludingTax = team.credited;
+    }
+    await StripeInvoice.query().insert(invoices);
+
+    // The period now running, whose bill has not been raised yet: consuming at
+    // the rate the last one closed on, and partial because `bucketsOver` stops
+    // at today.
+    const newestPeriod = periods.at(-1);
+    if (newestPeriod && billedMonth !== null && team.endedMonth === undefined) {
+      periods.push({
+        from: newestPeriod.to,
+        to: billedOn(billedMonth + 1, team.dayOfMonth),
+        screenshots: newestPeriod.screenshots,
+      });
+    }
+    await recordUsage({ accountId, periods });
+  }
+
+  /**
+   * A team on a yearly contract: the amount is the contract's own, and the
+   * usage runs under a quota negotiated to hold it.
+   */
+  async function createYearlyTeam(team: {
+    slug: string;
+    name: string;
+    currency: "eur" | "usd";
+    dayOfMonth: number;
+    startedMonth: number;
+    /** What the contract is worth over its year. */
+    flatPrice: number;
+    /** Screenshots the team gets through in a month.  */
+    monthlyScreenshots: number;
+    members: string[];
+  }): Promise<void> {
+    const accountId = await createBilledTeam({
+      slug: team.slug,
+      name: team.name,
+      planId: yearlyPlan.id,
+      currency: team.currency,
+      dayOfMonth: team.dayOfMonth,
+      startedMonth: team.startedMonth,
+      flatPrice: team.flatPrice,
+      additionalScreenshotPrice: CONTRACT_SCREENSHOT_PRICE,
+      members: team.members,
+    });
+    // A yearly subscription's period is its year, so the usage the directory
+    // reads is everything consumed since the running term opened — and a
+    // contract already renewed once has a term behind it that is not the one
+    // being read.
+    const terms = [];
+    for (let start = team.startedMonth; start < 1; start += 12) {
+      terms.push({
+        from: billedOn(start, team.dayOfMonth),
+        to: billedOn(start + 12, team.dayOfMonth),
+        screenshots: team.monthlyScreenshots * 12,
+      });
+    }
+    await recordUsage({ accountId, periods: terms });
+  }
+
+  await Promise.all([
+    createMonthlyTeam({
+      slug: "acme-corp",
+      name: "Acme Corp",
+      currency: "eur",
+      dayOfMonth: 3,
+      firstMonth: OLDEST_REVENUE_MONTH,
+      lastMonth: 0,
+      from: 89_000,
+      growth: 1.06,
+      members: ["Wile Coyote", "Road Runner", "Marvin Martian"],
+    }),
+    // In dollars, so the euro figures rest on the page's fixed rate and say so.
+    createMonthlyTeam({
+      slug: "globex",
+      name: "Globex",
+      currency: "usd",
+      dayOfMonth: 12,
+      firstMonth: -8,
+      lastMonth: 0,
+      from: 74_900,
+      growth: 1.09,
+      members: ["Hank Scorpio", "Homer Simpson"],
+    }),
+    // Churned five months ago: the subscription is over, the invoices it was
+    // sent are not, and the months it was billed in still count it.
+    createMonthlyTeam({
+      slug: "initech",
+      name: "Initech",
+      currency: "eur",
+      dayOfMonth: 7,
+      firstMonth: OLDEST_REVENUE_MONTH,
+      lastMonth: -5,
+      endedMonth: -4,
+      from: 49_000,
+      growth: 1,
+      members: ["Peter Gibbons", "Milton Waddams"],
+    }),
+    createMonthlyTeam({
+      slug: "soylent",
+      name: "Soylent",
+      currency: "eur",
+      dayOfMonth: 21,
+      firstMonth: OLDEST_REVENUE_MONTH,
+      lastMonth: 0,
+      from: 29_000,
+      growth: 1.04,
+      vatRate: 0.2,
+      credited: 4_000,
+      members: ["Thorn Detective", "Sol Roth"],
+    }),
+    // Signed six months ago: the month it arrives in is the one that jumps.
+    createMonthlyTeam({
+      slug: "hooli",
+      name: "Hooli",
+      currency: "eur",
+      dayOfMonth: 17,
+      firstMonth: -6,
+      lastMonth: 0,
+      from: 129_000,
+      growth: 1.05,
+      members: ["Gavin Belson", "Denpok Singh", "Richard Hendricks"],
+    }),
+    createMonthlyTeam({
+      slug: "massive-dynamic",
+      name: "Massive Dynamic",
+      currency: "usd",
+      dayOfMonth: 9,
+      firstMonth: OLDEST_REVENUE_MONTH,
+      lastMonth: 0,
+      from: 59_900,
+      growth: 1.07,
+      members: ["Nina Sharp", "William Bell"],
+    }),
+    // Billed on the 30th, which February has no room for: its bill lands on
+    // the 28th there rather than spilling into March.
+    createMonthlyTeam({
+      slug: "tyrell-corp",
+      name: "Tyrell Corp",
+      currency: "eur",
+      dayOfMonth: 30,
+      firstMonth: -10,
+      lastMonth: 0,
+      from: 39_000,
+      growth: 1.03,
+      members: ["Eldon Tyrell", "Rachael Rosen"],
+    }),
+  ]);
+
+  // Two bills in one month: a mid-cycle true-up beside the cycle itself, which
+  // the breakdown has to fold into the team's single line.
+  await StripeInvoice.query().insert({
+    stripeInvoiceId: "in_seed_soylent_true_up",
+    stripeCustomerId: customerOf("soylent"),
+    stripeSubscriptionId: subscriptionOf("soylent"),
+    stripeCreatedAt: billedOn(-1, 26).toISOString(),
+    status: "paid",
+    billingReason: "subscription_update",
+    currency: "eur",
+    total: 9_600,
+    totalExcludingTax: 8_000,
+    totalTaxesAmount: 1_600,
+    creditedAmountExcludingTax: 0,
+  });
+
+  await Promise.all([
+    createYearlyTeam({
+      slug: "umbrella",
+      name: "Umbrella Corp",
+      currency: "eur",
+      dayOfMonth: 9,
+      startedMonth: -4,
+      flatPrice: 24_000,
+      monthlyScreenshots: 90_000,
+      members: ["Albert Wesker", "Ada Wong"],
+    }),
+    createYearlyTeam({
+      slug: "vandelay",
+      name: "Vandelay Industries",
+      currency: "eur",
+      dayOfMonth: 15,
+      startedMonth: -13,
+      flatPrice: 16_800,
+      monthlyScreenshots: 70_000,
+      members: ["Art Vandelay", "Elaine Benes"],
+    }),
+    createYearlyTeam({
+      slug: "wayne-enterprises",
+      name: "Wayne Enterprises",
+      currency: "usd",
+      dayOfMonth: 5,
+      startedMonth: -8,
+      flatPrice: 30_000,
+      monthlyScreenshots: 130_000,
+      members: ["Lucius Fox", "Alfred Pennyworth", "Selina Kyle"],
+    }),
+    // Billed yearly with no contract invoice to be found: the anomaly the
+    // contracts table exists to surface, rather than a team quietly worth zero.
+    createYearlyTeam({
+      slug: "pied-piper",
+      name: "Pied Piper",
+      currency: "usd",
+      dayOfMonth: 22,
+      startedMonth: -2,
+      flatPrice: 9_600,
+      monthlyScreenshots: 40_000,
+      members: ["Bertram Gilfoyle", "Dinesh Chugtai"],
+    }),
+  ]);
+
+  await StripeInvoice.query().insert([
+    {
+      stripeInvoiceId: "in_seed_umbrella_term",
+      stripeCustomerId: customerOf("umbrella"),
+      stripeSubscriptionId: subscriptionOf("umbrella"),
+      stripeCreatedAt: billedOn(-4, 9).toISOString(),
+      status: "paid",
+      billingReason: "subscription_create",
+      currency: "eur",
+      total: 2_400_000,
+      totalExcludingTax: 2_400_000,
+      creditedAmountExcludingTax: 0,
+      periodStart: billedOn(-4, 9).toISOString(),
+      periodEnd: billedOn(8, 9).toISOString(),
+    },
+    // The term before the renewal below, so the months it paid for carry a
+    // yearly figure too: a contract is worth something in every month it
+    // covers, not only in the one it was raised in.
+    {
+      stripeInvoiceId: "in_seed_vandelay_term",
+      stripeCustomerId: customerOf("vandelay"),
+      stripeSubscriptionId: subscriptionOf("vandelay"),
+      stripeCreatedAt: billedOn(-13, 15).toISOString(),
+      status: "paid",
+      billingReason: "subscription_cycle",
+      currency: "eur",
+      total: 1_440_000,
+      totalExcludingTax: 1_440_000,
+      creditedAmountExcludingTax: 0,
+      periodStart: billedOn(-13, 15).toISOString(),
+      periodEnd: billedOn(-1, 15).toISOString(),
+    },
+    // Raised but not yet cleared: the row worth watching in the table.
+    {
+      stripeInvoiceId: "in_seed_vandelay_renewal",
+      stripeCustomerId: customerOf("vandelay"),
+      stripeSubscriptionId: subscriptionOf("vandelay"),
+      stripeCreatedAt: billedOn(-1, 15).toISOString(),
+      status: "open",
+      billingReason: "subscription_cycle",
+      currency: "eur",
+      total: 1_680_000,
+      totalExcludingTax: 1_680_000,
+      creditedAmountExcludingTax: 0,
+      periodStart: billedOn(-1, 15).toISOString(),
+      periodEnd: billedOn(11, 15).toISOString(),
+    },
+    // A contract in dollars, so the yearly figures carry a converted share of
+    // their own.
+    {
+      stripeInvoiceId: "in_seed_wayne_term",
+      stripeCustomerId: customerOf("wayne-enterprises"),
+      stripeSubscriptionId: subscriptionOf("wayne-enterprises"),
+      stripeCreatedAt: billedOn(-8, 5).toISOString(),
+      status: "paid",
+      billingReason: "quote_accept",
+      currency: "usd",
+      total: 3_000_000,
+      totalExcludingTax: 3_000_000,
+      creditedAmountExcludingTax: 0,
+      periodStart: billedOn(-8, 5).toISOString(),
+      periodEnd: billedOn(4, 5).toISOString(),
+    },
+  ]);
+
+  // Marketplace teams are billed by GitHub, so they have no Stripe customer
+  // and no invoice to mirror: the band is priced from the subscriptions alone.
+  const [stark, cyberdyne] = await Promise.all([
+    createTeamAccount({ slug: "stark-industries", name: "Stark Industries" }),
+    createTeamAccount({ slug: "cyberdyne", name: "Cyberdyne Systems" }),
+  ]);
+  await Promise.all([
+    addMembers({
+      teamId: stark.team.id,
+      slug: "stark-industries",
+      names: ["Tony Stark", "Pepper Potts"],
+    }),
+    addMembers({
+      teamId: cyberdyne.team.id,
+      slug: "cyberdyne",
+      names: ["Miles Dyson"],
+    }),
+    Subscription.query().insert([
+      {
+        planId: marketplacePlan.id,
+        accountId: stark.account.id,
+        provider: "github",
+        startDate: billedOn(-9, 1).toISOString(),
+        endDate: null,
+        paymentMethodFilled: true,
+        status: "active",
+      },
+      {
+        planId: marketplacePlan.id,
+        accountId: cyberdyne.account.id,
+        provider: "github",
+        startDate: billedOn(-16, 1).toISOString(),
+        endDate: billedOn(-3, 1).toISOString(),
+        paymentMethodFilled: true,
+        status: "canceled",
+      },
+    ]),
+  ]);
+
+  // The page refuses a window the mirror was never swept for, and distrusts a
+  // mirror unswept for a week — so the sweep has to be on record, and deep
+  // enough to hold the contracts still paying for the window's first months.
+  await StripeInvoiceSync.query().insert({
+    sinceDate: startOfRelativeMonth(-36).toISOString(),
+    completedAt: new Date().toISOString(),
   });
 }
 

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -405,6 +405,12 @@ export const typeDefs = gql`
     invoicedAt: DateTime!
   }
 
+  "An amount in the currency it is stated in."
+  type StaffRevenuePrice {
+    amount: Float!
+    currency: String!
+  }
+
   "What one team was invoiced over a month, one line of the breakdown."
   type StaffRevenueMonthTeam {
     "The team's slug, which names its pages."
@@ -425,6 +431,20 @@ export const typeDefs = gql`
     accumulated for one still to come.
     """
     screenshotsCount: Int!
+    """
+    What the plan itself costs over a period, before any usage — null when the
+    subscription carries no amount, or when the team is no longer billed.
+
+    This and the two below describe the subscription as it stands today, not as
+    it stood in the month: they are read to decide what to offer a team next.
+    Every other figure on the line is read off the invoice instead, and a plan
+    change cannot rewrite it.
+    """
+    planPrice: StaffRevenuePrice
+    "What a period includes before overage is billed, on that same plan."
+    includedScreenshots: Int
+    "That plan's name, which says whether its quota is worth printing."
+    planName: String
     "The invoices the line adds up, newest first. Empty on an estimate."
     invoices: [StaffRevenueMonthTeamInvoice!]!
     """

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -9,6 +9,7 @@ import {
 } from "@/database/services/period-usage";
 import {
   getStaffRevenue,
+  getStaffRevenueMonthTeams,
   MAX_MONTHS,
   MirrorCoverageError,
 } from "@/stripe/revenue";
@@ -373,12 +374,13 @@ export const typeDefs = gql`
   type StaffRevenueMonth {
     "The first instant of the month, in UTC — what names it on screen."
     month: DateTime!
-    "The two splits below, added up."
+    "The three splits below, added up."
     revenue: Float!
-    "What teams billed by the month were invoiced that month."
+    """
+    What teams billed by the month were invoiced that month. The teams behind
+    it are read one month at a time, by \`staffRevenueMonthTeams\`.
+    """
     monthlyPlans: StaffRevenueSplit!
-    "The teams behind \`monthlyPlans\`, largest first — they sum to it."
-    teams: [StaffRevenueMonthTeam!]!
     """
     What the annual contracts contributed to the month: their invoices
     amortized, day by day, over the stretch each one pays for — the monthly
@@ -547,6 +549,24 @@ export const typeDefs = gql`
   }
 
   extend type Query {
+    """
+    The teams behind one month of \`staffRevenue\`'s monthly plans, largest
+    first (staff only).
+
+    Read a month at a time rather than beside the figures: a line carries the
+    usage its team got through, and pricing a year of that to draw one month
+    is the difference between reading a handful of rows and walking every
+    screenshot the year produced.
+
+    They sum to that month's \`monthlyPlans\`, except on the running month,
+    which also carries the bills its cycles have not raised yet — marked by
+    \`estimatedAt\`, and in no figure the month reports.
+    """
+    staffRevenueMonthTeams(
+      "Any instant of the month; the month it falls in is what is read."
+      month: DateTime!
+    ): [StaffRevenueMonthTeam!]!
+
     """
     List all teams (staff only).
 
@@ -770,6 +790,20 @@ export const resolvers: IResolvers = {
       ]);
 
       return paginateResult({ result: { total, results }, after, first });
+    },
+    staffRevenueMonthTeams: async (_root, args, ctx) => {
+      assertStaff(ctx);
+
+      try {
+        return await getStaffRevenueMonthTeams(args.month);
+      } catch (error) {
+        // Read by the same page as `staffRevenue`, and answered the same way:
+        // a mirror not backfilled is an operator state, not a fault.
+        if (error instanceof MirrorCoverageError) {
+          throw notFound(error.message);
+        }
+        throw error;
+      }
     },
     staffRevenue: async (_root, args, ctx) => {
       assertStaff(ctx);

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -504,12 +504,39 @@ export const typeDefs = gql`
     awaitingPayment: Boolean!
   }
 
+  """
+  Where the running month is heading, once everything it has not billed yet is
+  counted.
+
+  The month itself reports what was invoiced, which is why it reads low all
+  month and only catches up on its last cycle. These are the same three
+  figures, each carried to the end of the month rather than stopped at today.
+  """
+  type StaffRevenueProjection {
+    "The three below, added up."
+    revenue: Float!
+    "Invoiced so far, plus the bills the cycles have not raised yet."
+    monthlyPlans: Float!
+    "A whole month of the contracts, not the share of it that has gone by."
+    yearlyPlans: Float!
+    "A whole month of Marketplace, on the same basis."
+    githubPlans: Float!
+    """
+    The part of \`monthlyPlans\` no invoice exists for: what the subscriptions
+    still to be billed have run up so far, which is a floor rather than a
+    forecast — their usage keeps accruing until the cycle closes.
+    """
+    estimated: Float!
+  }
+
   "What Argos invoiced, and the annual contracts behind the yearly rate."
   type StaffRevenue {
     "The window, oldest first and the running month last."
     months: [StaffRevenueMonth!]!
     "The contracts behind every month's \`yearlyPlans\`, largest first."
     yearlyContracts: [StaffYearlyContract!]!
+    "Where the running month is heading, beside what it has billed."
+    projection: StaffRevenueProjection!
   }
 
   type StaffTeamConnection implements Connection {

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -389,8 +389,10 @@ export const typeDefs = gql`
     yearlyPlans: StaffRevenueSplit!
     """
     What GitHub Marketplace brought in over the month: the subscriptions
-    running then, at their plans' list prices. Beside the two above rather
-    than inside them — GitHub bills it, and \`revenue\` never counts it.
+    running then, at their plans' list prices, each earning the share of the
+    month it was subscribed for. Billed by GitHub rather than invoiced by
+    Argos, and counted in \`revenue\` like the two above it — the figure states
+    what the month was worth, whoever raised the bill.
     """
     githubPlans: StaffRevenueSplit!
   }

--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -419,8 +419,22 @@ export const typeDefs = gql`
     currency: String
     "In euros, like the split it sums into."
     revenue: Float!
-    "The invoices the line adds up, newest first."
+    """
+    Screenshots the line's amount was raised on: what the team consumed over
+    the month for a bill that exists, and what the running period has
+    accumulated for one still to come.
+    """
+    screenshotsCount: Int!
+    "The invoices the line adds up, newest first. Empty on an estimate."
     invoices: [StaffRevenueMonthTeamInvoice!]!
+    """
+    When the cycle is expected to raise a bill Stripe has not billed yet, and
+    null on every line read from a real invoice.
+
+    Such a line is an estimate read off the usage so far, and it is left out of
+    the month's own figures — they report what was invoiced.
+    """
+    estimatedAt: DateTime
   }
 
   "One invoice a contract's worth is read from."

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -528,32 +528,6 @@ describe("getStaffRevenue", () => {
     }
   });
 
-  it("leaves the team alone once its bill has been raised", async () => {
-    // The invoice is the fact; the estimate beside it would count the month
-    // twice over.
-    const now = new Date();
-    await factory.StripeInvoiceSync.create();
-
-    const account = await createTeam({
-      interval: "month",
-      stripeCustomerId: "cus_staff_billed",
-    });
-    await factory.StripeInvoice.create({
-      stripeCustomerId: "cus_staff_billed",
-      stripeCreatedAt: now.toISOString(),
-      billingReason: "subscription_cycle",
-      currency: "eur",
-      total: 50_000,
-      totalExcludingTax: 50_000,
-    });
-
-    const teams = await getStaffRevenueMonthTeams(now);
-
-    expect(teams.map((team) => [team.slug, team.estimatedAt])).toEqual([
-      [account.slug, null],
-    ]);
-  });
-
   it("lists a contract that ran out mid-month, so the table adds up", async () => {
     // It paid for the days before it ended, so it is in the month's figure —
     // and a table that left it out would come up short against the card it

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -143,7 +143,14 @@ describe("getTeamCustomers", () => {
 
     await expect(getTeamCustomers()).resolves.toEqual(
       new Map([
-        ["cus_churned", { slug: account.slug, name: account.name ?? null }],
+        [
+          "cus_churned",
+          {
+            accountId: account.id,
+            slug: account.slug,
+            name: account.name ?? null,
+          },
+        ],
       ]),
     );
   });
@@ -363,6 +370,94 @@ describe("getStaffRevenue", () => {
       (1200 * runningMonth) / currentTerm,
       3,
     );
+  });
+
+  it("estimates the running month's bills that have not been raised", async () => {
+    // A cycle that falls later in the month has invoiced nothing yet, and the
+    // month would read as if the team had left. This is the line that says
+    // otherwise, priced off the usage the period has accumulated — the same
+    // reading the team directory prices it at.
+    const now = new Date();
+    await factory.StripeInvoiceSync.create();
+
+    const plan = await factory.Plan.create({
+      usageBased: true,
+      interval: "month",
+      includedScreenshots: 1000,
+    });
+    const account = await factory.TeamAccount.create({
+      stripeCustomerId: "cus_staff_pending",
+    });
+    const user = await factory.User.create();
+    await factory.Subscription.create({
+      accountId: account.id,
+      planId: plan.id,
+      currency: "eur",
+      provider: "stripe",
+      stripeSubscriptionId: "sub_staff_pending",
+      subscriberId: user.id,
+      // Opened a fortnight ago, so the period it anchors is still running and
+      // the day it bills on is still to come.
+      startDate: new Date(now.getTime() - 14 * 24 * 3600 * 1000).toISOString(),
+      createdAt: new Date(now.getTime() - 14 * 24 * 3600 * 1000).toISOString(),
+      status: "active",
+      flatPrice: 100,
+      additionalScreenshotPrice: 0.01,
+    });
+    const project = await factory.Project.create({ accountId: account.id });
+    await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      screenshotCount: 3000,
+      createdAt: new Date(now.getTime() - 24 * 3600 * 1000).toISOString(),
+    });
+
+    const result = await getStaffRevenue(1);
+    const current = result.months[0];
+    invariant(current);
+    const line = current.teams[0];
+    invariant(line);
+
+    // The plan's own amount, plus the two thousand screenshots past the quota.
+    expect(line.amount).toBe(120);
+    expect(line.revenue).toBe(120);
+    expect(line.screenshotsCount).toBe(3000);
+    expect(line.invoices).toEqual([]);
+    expect(line.estimatedAt).toBeInstanceOf(Date);
+    // An estimate is not revenue: the month reports what was invoiced, which
+    // here is nothing at all.
+    expect(current.monthlyPlans).toEqual({
+      revenue: 0,
+      teamsCount: 0,
+      foreignRevenue: 0,
+    });
+  });
+
+  it("leaves the team alone once its bill has been raised", async () => {
+    // The invoice is the fact; the estimate beside it would count the month
+    // twice over.
+    const now = new Date();
+    await factory.StripeInvoiceSync.create();
+
+    const account = await createTeam({
+      interval: "month",
+      stripeCustomerId: "cus_staff_billed",
+    });
+    await factory.StripeInvoice.create({
+      stripeCustomerId: "cus_staff_billed",
+      stripeCreatedAt: now.toISOString(),
+      billingReason: "subscription_cycle",
+      currency: "eur",
+      total: 50_000,
+      totalExcludingTax: 50_000,
+    });
+
+    const result = await getStaffRevenue(1);
+    const current = result.months[0];
+    invariant(current);
+
+    expect(current.teams.map((team) => [team.slug, team.estimatedAt])).toEqual([
+      [account.slug, null],
+    ]);
   });
 
   it("lists a contract that ran out mid-month, so the table adds up", async () => {

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -7,6 +7,7 @@ import { startOfUTCMonth } from "@/util/utc-month";
 import {
   getBilledTeams,
   getStaffRevenue,
+  getStaffRevenueMonthTeams,
   getTeamCustomers,
   toEuros,
 } from "./revenue";
@@ -320,7 +321,11 @@ describe("getStaffRevenue", () => {
       teamsCount: 3,
       foreignRevenue: 0,
     });
-    expect(last.teams.map((team) => [team.slug, team.revenue])).toEqual([
+    // The teams behind the month are read on their own, a month at a time.
+    const lastMonthTeams = await getStaffRevenueMonthTeams(
+      startOfUTCMonth(now, -1),
+    );
+    expect(lastMonthTeams.map((team) => [team.slug, team.revenue])).toEqual([
       [monthly.slug, 500],
       [yearly.slug, 300],
       [churned.slug, 200],
@@ -336,7 +341,10 @@ describe("getStaffRevenue", () => {
     // The running month is only as long as it has been, so a contract's share
     // of it is as partial as the invoices beside it.
     expect(current.monthlyPlans.revenue).toBe(100);
-    expect(current.teams).toHaveLength(1);
+    expect(current.monthlyPlans.teamsCount).toBe(1);
+    await expect(
+      getStaffRevenueMonthTeams(startOfUTCMonth(now, 0)),
+    ).resolves.toHaveLength(1);
     const elapsed = now.getTime() - startOfUTCMonth(now, 0).getTime();
     const currentTerm =
       startOfUTCMonth(now, 12).getTime() - startOfUTCMonth(now, 0).getTime();
@@ -489,11 +497,12 @@ describe("getStaffRevenue", () => {
       // The team billed on the 10th is nowhere: its cycle has come round, and
       // the next one belongs to the month after. The pending team is there
       // twice — the proration it was sent, and the bill it is still owed.
-      expect(current.teams.map((team) => team.slug)).toEqual([
+      const teams = await getStaffRevenueMonthTeams(now);
+      expect(teams.map((team) => team.slug)).toEqual([
         pending.account.slug,
         pending.account.slug,
       ]);
-      const line = current.teams.find((team) => team.estimatedAt !== null);
+      const line = teams.find((team) => team.estimatedAt !== null);
       invariant(line);
 
       // The plan's own amount, plus the two thousand screenshots past the quota.
@@ -538,11 +547,9 @@ describe("getStaffRevenue", () => {
       totalExcludingTax: 50_000,
     });
 
-    const result = await getStaffRevenue(1);
-    const current = result.months[0];
-    invariant(current);
+    const teams = await getStaffRevenueMonthTeams(now);
 
-    expect(current.teams.map((team) => [team.slug, team.estimatedAt])).toEqual([
+    expect(teams.map((team) => [team.slug, team.estimatedAt])).toEqual([
       [account.slug, null],
     ]);
   });

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -2,12 +2,12 @@ import { invariant } from "@argos/util/invariant";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { factory, setupDatabase } from "@/database/testing";
+import { startOfUTCMonth } from "@/util/utc-month";
 
 import {
   getBilledTeams,
   getStaffRevenue,
   getTeamCustomers,
-  startOfUTCMonth,
   toEuros,
 } from "./revenue";
 
@@ -450,7 +450,7 @@ describe("getStaffRevenue", () => {
           screenshotCount: team.screenshotCount,
           createdAt: new Date(now.getTime() - 24 * 3600 * 1000).toISOString(),
         });
-        return account;
+        return { account, stripeCustomerId: `cus_${team.slug}` };
       };
 
       const pending = await createPendingTeam({
@@ -470,11 +470,30 @@ describe("getStaffRevenue", () => {
         screenshotCount: 9000,
       });
 
+      // Raised mid-month on the pending team, and not by its cycle: an upgrade
+      // prorated on the spot. Its own bill is still due on the 20th, so the
+      // month has both to report — the proration as invoiced, the cycle as
+      // estimated.
+      await factory.StripeInvoice.create({
+        stripeCustomerId: pending.stripeCustomerId,
+        stripeCreatedAt: now.toISOString(),
+        billingReason: "subscription_update",
+        currency: "eur",
+        total: 1_200,
+        totalExcludingTax: 1_200,
+      });
+
       const result = await getStaffRevenue(1);
       const current = result.months[0];
       invariant(current);
-      expect(current.teams.map((team) => team.slug)).toEqual([pending.slug]);
-      const line = current.teams[0];
+      // The team billed on the 10th is nowhere: its cycle has come round, and
+      // the next one belongs to the month after. The pending team is there
+      // twice — the proration it was sent, and the bill it is still owed.
+      expect(current.teams.map((team) => team.slug)).toEqual([
+        pending.account.slug,
+        pending.account.slug,
+      ]);
+      const line = current.teams.find((team) => team.estimatedAt !== null);
       invariant(line);
 
       // The plan's own amount, plus the two thousand screenshots past the quota.
@@ -484,17 +503,17 @@ describe("getStaffRevenue", () => {
       expect(line.invoices).toEqual([]);
       expect(line.estimatedAt).toBeInstanceOf(Date);
       // An estimate is not revenue: the month reports what was invoiced, which
-      // here is nothing at all.
+      // here is the proration alone.
       expect(current.monthlyPlans).toEqual({
-        revenue: 0,
-        teamsCount: 0,
+        revenue: 12,
+        teamsCount: 1,
         foreignRevenue: 0,
       });
-      // Where the month is heading is the other question, and the estimate is
-      // the whole of the answer here.
-      expect(result.projection.monthlyPlans).toBe(120);
+      // Where the month is heading is the other question: the proration it has
+      // been sent, and the cycle bill it has not.
+      expect(result.projection.monthlyPlans).toBe(132);
       expect(result.projection.estimated).toBe(120);
-      expect(result.projection.revenue).toBe(120);
+      expect(result.projection.revenue).toBe(132);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -370,6 +370,16 @@ describe("getStaffRevenue", () => {
       (1200 * runningMonth) / currentTerm,
       3,
     );
+
+    // The projection carries the same contracts to the end of the month, where
+    // the month itself stops at today — that difference is what it exists for.
+    expect(result.projection.yearlyPlans).toBeCloseTo(
+      (1200 * runningMonth) / currentTerm + (4800 * runningMonth) / churnedTerm,
+      3,
+    );
+    expect(result.projection.yearlyPlans).toBeGreaterThan(
+      current.yearlyPlans.revenue,
+    );
   });
 
   it("estimates the running month's bills that have not been raised", async () => {
@@ -430,6 +440,11 @@ describe("getStaffRevenue", () => {
       teamsCount: 0,
       foreignRevenue: 0,
     });
+    // Where the month is heading is the other question, and the estimate is
+    // the whole of the answer here.
+    expect(result.projection.monthlyPlans).toBe(120);
+    expect(result.projection.estimated).toBe(120);
+    expect(result.projection.revenue).toBe(120);
   });
 
   it("leaves the team alone once its bill has been raised", async () => {

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -1,5 +1,5 @@
 import { invariant } from "@argos/util/invariant";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { factory, setupDatabase } from "@/database/testing";
 
@@ -387,64 +387,117 @@ describe("getStaffRevenue", () => {
     // month would read as if the team had left. This is the line that says
     // otherwise, priced off the usage the period has accumulated — the same
     // reading the team directory prices it at.
-    const now = new Date();
-    await factory.StripeInvoiceSync.create();
+    //
+    // The clock is pinned to the middle of the month because that is the whole
+    // subject: which side of the month's end a cycle falls on decides whether
+    // it is this month's bill, and a suite run on the 31st would have no day
+    // left to place one in. Only `Date` is faked — the pool's timers have to
+    // keep running, and Postgres keeps its own clock either way.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    const realNow = new Date();
+    vi.setSystemTime(
+      new Date(
+        Date.UTC(realNow.getUTCFullYear(), realNow.getUTCMonth(), 15, 12),
+      ),
+    );
 
-    const plan = await factory.Plan.create({
-      usageBased: true,
-      interval: "month",
-      includedScreenshots: 1000,
-    });
-    const account = await factory.TeamAccount.create({
-      stripeCustomerId: "cus_staff_pending",
-    });
-    const user = await factory.User.create();
-    await factory.Subscription.create({
-      accountId: account.id,
-      planId: plan.id,
-      currency: "eur",
-      provider: "stripe",
-      stripeSubscriptionId: "sub_staff_pending",
-      subscriberId: user.id,
-      // Opened a fortnight ago, so the period it anchors is still running and
-      // the day it bills on is still to come.
-      startDate: new Date(now.getTime() - 14 * 24 * 3600 * 1000).toISOString(),
-      createdAt: new Date(now.getTime() - 14 * 24 * 3600 * 1000).toISOString(),
-      status: "active",
-      flatPrice: 100,
-      additionalScreenshotPrice: 0.01,
-    });
-    const project = await factory.Project.create({ accountId: account.id });
-    await factory.ScreenshotBucket.create({
-      projectId: project.id,
-      screenshotCount: 3000,
-      createdAt: new Date(now.getTime() - 24 * 3600 * 1000).toISOString(),
-    });
+    try {
+      const now = new Date();
+      await factory.StripeInvoiceSync.create();
 
-    const result = await getStaffRevenue(1);
-    const current = result.months[0];
-    invariant(current);
-    const line = current.teams[0];
-    invariant(line);
+      const plan = await factory.Plan.create({
+        usageBased: true,
+        interval: "month",
+        includedScreenshots: 1000,
+      });
+      const user = await factory.User.create();
 
-    // The plan's own amount, plus the two thousand screenshots past the quota.
-    expect(line.amount).toBe(120);
-    expect(line.revenue).toBe(120);
-    expect(line.screenshotsCount).toBe(3000);
-    expect(line.invoices).toEqual([]);
-    expect(line.estimatedAt).toBeInstanceOf(Date);
-    // An estimate is not revenue: the month reports what was invoiced, which
-    // here is nothing at all.
-    expect(current.monthlyPlans).toEqual({
-      revenue: 0,
-      teamsCount: 0,
-      foreignRevenue: 0,
-    });
-    // Where the month is heading is the other question, and the estimate is
-    // the whole of the answer here.
-    expect(result.projection.monthlyPlans).toBe(120);
-    expect(result.projection.estimated).toBe(120);
-    expect(result.projection.revenue).toBe(120);
+      /** A team billed on `dayOfMonth`, with the usage its bill will read. */
+      const createPendingTeam = async (team: {
+        slug: string;
+        dayOfMonth: number;
+        screenshotCount: number;
+      }) => {
+        const account = await factory.TeamAccount.create({
+          stripeCustomerId: `cus_${team.slug}`,
+        });
+        // A month back, so the period the anniversary anchors is the one
+        // running now.
+        const startDate = new Date(
+          Date.UTC(
+            now.getUTCFullYear(),
+            now.getUTCMonth() - 1,
+            team.dayOfMonth,
+            9,
+          ),
+        ).toISOString();
+        await factory.Subscription.create({
+          accountId: account.id,
+          planId: plan.id,
+          currency: "eur",
+          provider: "stripe",
+          stripeSubscriptionId: `sub_${team.slug}`,
+          subscriberId: user.id,
+          startDate,
+          createdAt: startDate,
+          status: "active",
+          flatPrice: 100,
+          additionalScreenshotPrice: 0.01,
+        });
+        const project = await factory.Project.create({ accountId: account.id });
+        await factory.ScreenshotBucket.create({
+          projectId: project.id,
+          screenshotCount: team.screenshotCount,
+          createdAt: new Date(now.getTime() - 24 * 3600 * 1000).toISOString(),
+        });
+        return account;
+      };
+
+      const pending = await createPendingTeam({
+        slug: "staff_pending",
+        // The 20th, so its period closes inside this month and after today.
+        dayOfMonth: 20,
+        screenshotCount: 3000,
+      });
+      // The 10th: its cycle already came round this month, and the next one
+      // falls in the month after. Whatever it was billed on the 10th is a fact
+      // of this month that the mirror carries — or does not, when a sweep is
+      // behind or the invoice is still a draft — but the bill this period ends
+      // on belongs to next month either way.
+      await createPendingTeam({
+        slug: "staff_billed_already",
+        dayOfMonth: 10,
+        screenshotCount: 9000,
+      });
+
+      const result = await getStaffRevenue(1);
+      const current = result.months[0];
+      invariant(current);
+      expect(current.teams.map((team) => team.slug)).toEqual([pending.slug]);
+      const line = current.teams[0];
+      invariant(line);
+
+      // The plan's own amount, plus the two thousand screenshots past the quota.
+      expect(line.amount).toBe(120);
+      expect(line.revenue).toBe(120);
+      expect(line.screenshotsCount).toBe(3000);
+      expect(line.invoices).toEqual([]);
+      expect(line.estimatedAt).toBeInstanceOf(Date);
+      // An estimate is not revenue: the month reports what was invoiced, which
+      // here is nothing at all.
+      expect(current.monthlyPlans).toEqual({
+        revenue: 0,
+        teamsCount: 0,
+        foreignRevenue: 0,
+      });
+      // Where the month is heading is the other question, and the estimate is
+      // the whole of the answer here.
+      expect(result.projection.monthlyPlans).toBe(120);
+      expect(result.projection.estimated).toBe(120);
+      expect(result.projection.revenue).toBe(120);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("leaves the team alone once its bill has been raised", async () => {
@@ -623,9 +676,12 @@ describe("getStaffRevenue", () => {
       toEuros({ amount: 100 * (elapsed / monthMs), currency: "usd" }),
       3,
     );
-    // Never inside the figure the cards report.
+    // Inside the figure the cards report, like the two beside it: the card
+    // states one amount and prints the three under it.
     expect(current.revenue).toBe(
-      current.monthlyPlans.revenue + current.yearlyPlans.revenue,
+      current.monthlyPlans.revenue +
+        current.yearlyPlans.revenue +
+        current.githubPlans.revenue,
     );
   });
 

--- a/apps/backend/src/stripe/revenue.test.ts
+++ b/apps/backend/src/stripe/revenue.test.ts
@@ -1,11 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  classifyInvoice,
-  getInvoiceRevenue,
-  startOfUTCMonth,
-  toEuros,
-} from "./revenue";
+import { startOfUTCMonth } from "@/util/utc-month";
+
+import { classifyInvoice, getInvoiceRevenue, toEuros } from "./revenue";
 
 describe("getInvoiceRevenue", () => {
   /** Stripe states amounts in the currency's minor unit. */

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -1,11 +1,13 @@
 import { invariant } from "@argos/util/invariant";
 
+import { knex } from "@/database";
 import {
   Account,
   StripeInvoice,
   StripeInvoiceSync,
   Subscription,
 } from "@/database/models";
+import { getAccountBillings } from "@/database/services/period-usage";
 
 /** What the teams on one billing interval contributed to a month. */
 type StaffRevenueSplit = {
@@ -45,8 +47,24 @@ type StaffRevenueMonthTeam = {
   currency: string | null;
   /** In euros, like the split it sums into. */
   revenue: number;
-  /** The invoices the line adds up, newest first. */
+  /**
+   * Screenshots the line's amount was raised on: what the team consumed over
+   * the month for a bill that exists, and what the running period has
+   * accumulated for one still to come — which is the count its estimate was
+   * computed from.
+   */
+  screenshotsCount: number;
+  /** The invoices the line adds up, newest first. Empty on an estimate. */
   invoices: StaffRevenueMonthTeamInvoice[];
+  /**
+   * When the cycle is expected to raise the bill, on a line Stripe has not
+   * billed yet — and null on every line read from a real invoice.
+   *
+   * Such a line is an estimate, so it stays out of the month's own figures:
+   * they report what was invoiced, and a projection summed into them would be
+   * indistinguishable from money that came in.
+   */
+  estimatedAt: Date | null;
 };
 
 /** What Argos billed over one calendar month. */
@@ -267,6 +285,8 @@ type BilledTeam = {
   stripeCustomerId: string;
   stripeSubscriptionId: string;
   interval: "month" | "year";
+  /** What Stripe bills it in, or null on a subscription never synced for it. */
+  currency: string | null;
 };
 
 /**
@@ -286,6 +306,7 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
     .select(
       "subscriptions.accountId",
       "subscriptions.stripeSubscriptionId",
+      "subscriptions.currency",
       "accounts.slug",
       "accounts.name",
       "accounts.stripeCustomerId",
@@ -318,6 +339,7 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
     stripeSubscriptionId: string;
     stripeCustomerId: string;
     interval: "month" | "year";
+    currency: string | null;
   }[];
 
   return rows.map((row) => ({
@@ -327,11 +349,13 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
     stripeSubscriptionId: row.stripeSubscriptionId,
     stripeCustomerId: row.stripeCustomerId,
     interval: row.interval,
+    currency: row.currency,
   }));
 }
 
-/** How a month's breakdown names a team. */
+/** How a month's breakdown names a team, and what it reads its usage off. */
 type TeamCustomer = {
+  accountId: string;
   slug: string;
   name: string | null;
 };
@@ -348,10 +372,11 @@ type TeamCustomer = {
  */
 export async function getTeamCustomers(): Promise<Map<string, TeamCustomer>> {
   const rows = (await Account.query()
-    .select("stripeCustomerId", "slug", "name")
+    .select("id", "stripeCustomerId", "slug", "name")
     .whereNotNull("teamId")
     .whereNull("userId")
     .whereNotNull("stripeCustomerId")) as unknown as {
+    id: string | number;
     stripeCustomerId: string;
     slug: string;
     name: string | null;
@@ -360,9 +385,53 @@ export async function getTeamCustomers(): Promise<Map<string, TeamCustomer>> {
   return new Map(
     rows.map((row) => [
       row.stripeCustomerId,
-      { slug: row.slug, name: row.name },
+      { accountId: String(row.id), slug: row.slug, name: row.name },
     ]),
   );
+}
+
+/** The key a calendar month is filed under in the usage read below. */
+function getMonthKey(month: Date): string {
+  return month.toISOString().slice(0, 7);
+}
+
+/**
+ * Screenshots consumed per team and per calendar month over the window.
+ *
+ * Cut in UTC like the months themselves, and keyed by the year and month
+ * Postgres prints rather than by a timestamp: a truncated date read back
+ * through the process's own timezone would file a bucket in the month next
+ * door for every server not running on UTC.
+ */
+async function getMonthlyScreenshots(window: {
+  from: Date;
+  to: Date;
+}): Promise<Map<string, Map<string, number>>> {
+  const monthKey = `to_char(sb."createdAt" at time zone 'UTC', 'YYYY-MM')`;
+  const rows = (await knex
+    .select("p.accountId")
+    .select(knex.raw(`${monthKey} as "month"`))
+    // Null until a bucket completes, and summed as-is by the billing figures
+    // this sits beside.
+    .select(knex.raw(`coalesce(sum(sb."screenshotCount"), 0) as "count"`))
+    .from("screenshot_buckets as sb")
+    .join("projects as p", "p.id", "sb.projectId")
+    .where("sb.createdAt", ">=", window.from.toISOString())
+    .where("sb.createdAt", "<", window.to.toISOString())
+    .groupBy("p.accountId", knex.raw(monthKey))) as unknown as {
+    accountId: string | number;
+    month: string;
+    count: string | number;
+  }[];
+
+  const result = new Map<string, Map<string, number>>();
+  for (const row of rows) {
+    const accountId = String(row.accountId);
+    const months = result.get(accountId) ?? new Map<string, number>();
+    months.set(row.month, Number(row.count));
+    result.set(accountId, months);
+  }
+  return result;
 }
 
 /** What one invoice contributed, in the currency it was raised in. */
@@ -675,6 +744,83 @@ export type StaffRevenue = {
   yearlyContracts: StaffYearlyContract[];
 };
 
+/**
+ * The bills the running month is still waiting on, priced off the usage so far.
+ *
+ * A team whose cycle falls on the 30th has been invoiced nothing on the 12th,
+ * and the month reads as if it had left. These are the lines that say
+ * otherwise: one per team billed by the month that Stripe has not billed yet,
+ * carrying what the subscription is on course to be invoiced — the plan's own
+ * amount plus the overage the running period has accumulated, which is the
+ * same reading the team directory prices that period at.
+ *
+ * They are estimates, so they are kept out of every figure the month reports.
+ * What they are worth is what the cycle has not decided yet: usage still to
+ * come, a credit note, a plan changed mid-month.
+ */
+async function getEstimatedBills(options: {
+  billedTeams: BilledTeam[];
+  teamCustomers: Map<string, TeamCustomer>;
+  /** The customers a bill was already raised on this month. */
+  invoicedCustomerIds: Set<string>;
+}): Promise<StaffRevenueMonthTeam[]> {
+  const pending = options.billedTeams.filter(
+    (team) =>
+      // Monthly cycles alone: a yearly contract is not owed a bill every month,
+      // and it has a table of its own that says what it is worth.
+      team.interval === "month" &&
+      !options.invoicedCustomerIds.has(team.stripeCustomerId),
+  );
+
+  if (pending.length === 0) {
+    return [];
+  }
+
+  const accounts = await Account.query().findByIds(
+    pending.map((team) => team.accountId),
+  );
+  const billings = await getAccountBillings(accounts);
+  const bills: StaffRevenueMonthTeam[] = [];
+
+  for (const team of pending) {
+    const billing = billings.get(team.accountId);
+    const period = billing?.periodUsage?.billingPeriods.find(
+      (billingPeriod) => !billingPeriod.closed,
+    );
+    // No amount on file means no estimate worth printing: the plan's own price
+    // is most of a bill, and quoting the overage alone would report a team
+    // about to be invoiced as owing next to nothing. A guess in its place would
+    // read exactly like the figures beside it, which are read off Stripe.
+    if (!billing || !period || billing.flatPrice === null) {
+      continue;
+    }
+
+    const customer = options.teamCustomers.get(team.stripeCustomerId);
+    if (!customer) {
+      continue;
+    }
+
+    const revenue = {
+      amount: billing.flatPrice + period.additionalScreenshotCost,
+      currency: team.currency ?? REPORTING_CURRENCY,
+    };
+    bills.push({
+      slug: customer.slug,
+      name: customer.name,
+      stripeCustomerId: team.stripeCustomerId,
+      amount: revenue.amount,
+      currency: revenue.currency,
+      revenue: toEuros(revenue),
+      screenshotsCount: period.screenshotsCount,
+      invoices: [],
+      // The anniversary the period closes on, which is the day the cycle bills.
+      estimatedAt: period.endsAt,
+    });
+  }
+
+  return bills;
+}
+
 /** Raised by the reader when the mirror cannot answer for the window asked. */
 export class MirrorCoverageError extends Error {}
 
@@ -711,12 +857,17 @@ export async function getStaffRevenue(
     deepestSync,
     freshestSync,
     marketplaceSubscriptions,
+    monthlyScreenshots,
   ] = await Promise.all([
     getTeamCustomers(),
     getBilledTeams(),
     StripeInvoiceSync.query().orderBy("sinceDate", "asc").first(),
     StripeInvoiceSync.query().orderBy("completedAt", "desc").first(),
     getMarketplaceSubscriptions(),
+    // Over the reported months alone, not the contract scan: usage is read
+    // beside the bills of the months on screen, and the year of contracts
+    // behind them has no line to carry a count.
+    getMonthlyScreenshots({ from: first, to: end }),
   ]);
 
   // Two things have to hold before a figure can be trusted: the mirror was
@@ -812,7 +963,11 @@ export async function getStaffRevenue(
     );
     const split = monthSplits[index];
     const teams = monthTeams[index];
-    invariant(split && teams, "the query bounds every row to a reported month");
+    const reportedMonth = reported[index];
+    invariant(
+      split && teams && reportedMonth,
+      "the query bounds every row to a reported month",
+    );
     addToSplit(split, revenue);
 
     // A team invoiced twice in one month is one team, one line deeper.
@@ -825,7 +980,12 @@ export async function getStaffRevenue(
         amount: 0,
         currency: revenue.currency,
         revenue: 0,
+        screenshotsCount:
+          monthlyScreenshots
+            .get(team.accountId)
+            ?.get(getMonthKey(reportedMonth)) ?? 0,
         invoices: [],
+        estimatedAt: null,
       };
       teams.set(row.stripeCustomerId, teamRow);
     }
@@ -899,12 +1059,23 @@ export async function getStaffRevenue(
     split.teamsCount = customers.size;
   }
 
+  const runningTeams = monthTeams[runningIndex];
+  invariant(runningTeams, "the running month is one of the reported ones");
+  const estimatedBills = await getEstimatedBills({
+    billedTeams,
+    teamCustomers,
+    invoicedCustomerIds: new Set(runningTeams.keys()),
+  });
+
   const months = reported.map((start, index) => {
     const monthly = monthSplits[index];
     const yearly = yearlySplits[index];
     const teams = monthTeams[index];
     invariant(monthly && yearly && teams, "every month reported has totals");
     monthly.teamsCount = teams.size;
+    // Beside the month's own lines rather than inside its totals: an estimate
+    // is not revenue, and `monthlyPlans` above is what was invoiced.
+    const estimates = index === runningIndex ? estimatedBills : [];
     // The query reads the mirror in no particular order.
     for (const team of teams.values()) {
       team.invoices.sort(
@@ -918,7 +1089,9 @@ export async function getStaffRevenue(
       revenue: monthly.revenue + yearly.revenue,
       monthlyPlans: monthly,
       // Largest first: the breakdown is read to see who made the month.
-      teams: [...teams.values()].sort((a, b) => b.revenue - a.revenue),
+      teams: [...teams.values(), ...estimates].sort(
+        (a, b) => b.revenue - a.revenue,
+      ),
       yearlyPlans: yearly,
       githubPlans: getMarketplaceMonthRevenue(
         marketplaceSubscriptions,

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -8,6 +8,7 @@ import {
   Subscription,
 } from "@/database/models";
 import { getAccountBillings } from "@/database/services/period-usage";
+import { startOfUTCMonth } from "@/util/utc-month";
 
 /** What the teams on one billing interval contributed to a month. */
 type StaffRevenueSplit = {
@@ -54,10 +55,13 @@ type StaffRevenueMonthTeam = {
   /** In euros, like the split it sums into. */
   revenue: number;
   /**
-   * Screenshots the line's amount was raised on: what the team consumed over
-   * the month for a bill that exists, and what the running period has
-   * accumulated for one still to come — which is the count its estimate was
-   * computed from.
+   * Screenshots the team consumed over the month — and, on a line still to be
+   * billed, over the period its estimate was computed on.
+   *
+   * Beside the bill rather than behind it: a cycle bills the period it just
+   * closed, which straddles two calendar months, so this is what the team got
+   * through in the month the line is filed under, not what that invoice was
+   * raised on.
    */
   screenshotsCount: number;
   /**
@@ -195,6 +199,7 @@ function getMarketplaceMonthRevenue(
 ): StaffRevenueSplit {
   const split = createSplit();
   const byAccount = new Map<string, number>();
+  const monthMs = month.end - month.start;
 
   for (const subscription of subscriptions) {
     const started = new Date(subscription.startDate).getTime();
@@ -213,21 +218,26 @@ function getMarketplaceMonthRevenue(
     ) {
       continue;
     }
+    // A month bills its subscriptions once, so what one has earned is the
+    // share of the month it was subscribed for — as much of it as has gone by,
+    // and no more than the part it was there for. Read per subscription rather
+    // than once for the batch: a projection carries the whole month, and a
+    // team that cancelled on the third has not earned the rest of it.
+    const covered =
+      Math.min(ended, elapsed.end) - Math.max(started, elapsed.start);
+    const share = monthMs > 0 ? Math.max(0, covered) / monthMs : 0;
     // One subscription per team, the richest, like every other figure here.
     byAccount.set(
       subscription.accountId,
       Math.max(
         byAccount.get(subscription.accountId) ?? 0,
-        subscription.priceCents,
+        (subscription.priceCents / 100) * share,
       ),
     );
   }
 
-  // A month bills its subscriptions once, so what a month still running has
-  // earned is the share of it that has gone by.
-  const share = (elapsed.end - elapsed.start) / (month.end - month.start) || 0;
-  for (const cents of byAccount.values()) {
-    addToSplit(split, { amount: (cents / 100) * share, currency: "usd" });
+  for (const amount of byAccount.values()) {
+    addToSplit(split, { amount, currency: "usd" });
   }
   split.teamsCount = byAccount.size;
   return split;
@@ -579,20 +589,6 @@ function addToSplit(split: StaffRevenueSplit, revenue: InvoiceRevenue): void {
   }
 }
 
-/**
- * The first instant of the month `offset` months back, in UTC.
- *
- * Deliberately not the calendar helpers, which work in the process's own
- * timezone: Stripe timestamps every invoice in UTC, so a server running on
- * anything else would cut its months hours away from where Stripe cuts them and
- * file the invoices either side of a boundary in the wrong one.
- */
-export function startOfUTCMonth(date: Date, offset: number): Date {
-  return new Date(
-    Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + offset, 1),
-  );
-}
-
 /** One invoice a contract's worth is read from. */
 type StaffContractInvoice = {
   /** Net of tax and credit notes, in the currency it was raised in. */
@@ -909,17 +905,13 @@ function getPlanColumns(team: BilledTeam | undefined): {
  */
 async function getEstimatedBills(options: {
   billedTeams: BilledTeam[];
-  /** The customers a bill was already raised on this month. */
-  invoicedCustomerIds: Set<string>;
   /** The month the estimates are reported in, which bounds when they fall. */
   runningMonth: { start: number; end: number };
 }): Promise<StaffRevenueMonthTeam[]> {
   const pending = options.billedTeams.filter(
-    (team) =>
-      // Monthly cycles alone: a yearly contract is not owed a bill every month,
-      // and it has a table of its own that says what it is worth.
-      team.interval === "month" &&
-      !options.invoicedCustomerIds.has(team.stripeCustomerId),
+    // Monthly cycles alone: a yearly contract is not owed a bill every month,
+    // and it has a table of its own that says what it is worth.
+    (team) => team.interval === "month",
   );
 
   if (pending.length === 0) {
@@ -938,11 +930,11 @@ async function getEstimatedBills(options: {
       (billingPeriod) => !billingPeriod.closed,
     );
     // A cycle that closes after this month bills in the next one, not in this
-    // one. Reached when a bill was raised but the mirror has not caught it —
-    // a sweep a few hours behind, an invoice still in draft, one that netted
-    // nothing — where the customer looks unbilled while its period has already
-    // rolled over. Estimating it here would put a whole extra bill in the
-    // month's projection.
+    // one — which is the whole test, and the only one worth making. It covers
+    // the team whose cycle already came round, whether or not the mirror has
+    // its invoice yet: the period has rolled over either way. Reading the
+    // month's invoices instead would suppress the cycle bill of a team that
+    // was sent a mid-month proration, whose own bill is still to come.
     if (period && period.endsAt.getTime() >= options.runningMonth.end) {
       continue;
     }
@@ -955,6 +947,16 @@ async function getEstimatedBills(options: {
     // cycle bills, and a flat bill left out of the month beats one dated by
     // guesswork.
     if (!billing || !period || billing.flatPrice === null) {
+      continue;
+    }
+
+    // The amount and the period are read off the subscription the billing
+    // resolved, the currency and the plan off the one the team read resolved,
+    // and the two queries do not pick from the same shortlist — a trial counts
+    // for one and not the other. Where they disagree on the interval they have
+    // disagreed on the subscription, and the price would be a year's stamped
+    // into a month.
+    if (billing.plan?.interval !== "month") {
       continue;
     }
 
@@ -1024,9 +1026,11 @@ export async function getStaffRevenue(
     StripeInvoiceSync.query().orderBy("sinceDate", "asc").first(),
     StripeInvoiceSync.query().orderBy("completedAt", "desc").first(),
     getMarketplaceSubscriptions(),
-    // Chained off the customers rather than read beside them: the usage is
-    // wanted for the teams this page has lines for, and unbounded it would
-    // sweep every bucket every project ever produced over the window.
+    // Chained off the customers rather than read beside them: unbounded, this
+    // sweeps every bucket every project in the database ever produced over the
+    // window. It is still wider than the lines the page draws — which of these
+    // teams has an invoice is not known until the read below returns — but the
+    // accounts that never reached Stripe are the bulk of them.
     teamCustomersPromise.then((customers) =>
       // Over the reported months alone, not the contract scan: usage is read
       // beside the bills of the months on screen, and the year of contracts
@@ -1236,13 +1240,7 @@ export async function getStaffRevenue(
     split.teamsCount = customers.size;
   }
 
-  const runningTeams = monthTeams[runningIndex];
-  invariant(runningTeams, "the running month is one of the reported ones");
-  const estimatedBills = await getEstimatedBills({
-    billedTeams,
-    invoicedCustomerIds: new Set(runningTeams.keys()),
-    runningMonth,
-  });
+  const estimatedBills = await getEstimatedBills({ billedTeams, runningMonth });
 
   // What the running month is heading for, rather than what it has billed: the
   // bills its cycles have not raised yet, and the two rates carried to the end

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -33,6 +33,12 @@ type StaffRevenueMonthTeamInvoice = {
   invoicedAt: Date;
 };
 
+/** An amount in the currency it is stated in. */
+type StaffRevenuePrice = {
+  amount: number;
+  currency: string;
+};
+
 /** What one team was invoiced over a month, one line of the breakdown. */
 type StaffRevenueMonthTeam = {
   /** The team's slug, which names its pages. */
@@ -54,6 +60,20 @@ type StaffRevenueMonthTeam = {
    * computed from.
    */
   screenshotsCount: number;
+  /**
+   * What the plan itself costs over a period, before any usage — null when the
+   * subscription carries no amount, or when the team is no longer billed.
+   *
+   * This and the two below describe the subscription **as it stands today**,
+   * not as it stood in the month: they are read to decide what to offer a team
+   * next, which is a question about the present. Every other figure on the line
+   * is read off the invoice and cannot be rewritten by a plan change.
+   */
+  planPrice: StaffRevenuePrice | null;
+  /** What a period includes before overage is billed, on that same plan. */
+  includedScreenshots: number | null;
+  /** That plan's name, which says whether its quota is worth printing. */
+  planName: string | null;
   /** The invoices the line adds up, newest first. Empty on an estimate. */
   invoices: StaffRevenueMonthTeamInvoice[];
   /**
@@ -287,6 +307,19 @@ type BilledTeam = {
   interval: "month" | "year";
   /** What Stripe bills it in, or null on a subscription never synced for it. */
   currency: string | null;
+  /**
+   * What the plan itself costs over a period, as Stripe holds it — null on a
+   * subscription Argos has not read the amount off yet, or one priced by tiers.
+   */
+  flatPrice: number | null;
+  /**
+   * What a period includes before anything is billed as overage: the
+   * subscription's own quota when Stripe states one, the plan's otherwise —
+   * the same order the usage is metered against.
+   */
+  includedScreenshots: number;
+  /** The plan's name, which is what says whether its quota is worth printing. */
+  planName: string;
 };
 
 /**
@@ -310,7 +343,11 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
       "accounts.slug",
       "accounts.name",
       "accounts.stripeCustomerId",
+      "subscriptions.flatPrice",
+      "subscriptions.includedScreenshots",
       "plan.interval",
+      "plan.name as planName",
+      "plan.includedScreenshots as planIncludedScreenshots",
     )
     .joinRelated("plan")
     .join("accounts", "accounts.id", "subscriptions.accountId")
@@ -340,6 +377,10 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
     stripeCustomerId: string;
     interval: "month" | "year";
     currency: string | null;
+    flatPrice: number | null;
+    includedScreenshots: number | null;
+    planName: string;
+    planIncludedScreenshots: number;
   }[];
 
   return rows.map((row) => ({
@@ -350,6 +391,9 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
     stripeCustomerId: row.stripeCustomerId,
     interval: row.interval,
     currency: row.currency,
+    flatPrice: row.flatPrice,
+    includedScreenshots: row.includedScreenshots ?? row.planIncludedScreenshots,
+    planName: row.planName,
   }));
 }
 
@@ -745,6 +789,35 @@ export type StaffRevenue = {
 };
 
 /**
+ * What the team is on today, for the columns that describe the plan rather
+ * than the bill: its price, its quota, and the name that says whether the
+ * quota is worth printing beside a count.
+ *
+ * Null throughout for a team no longer billed — a churned one keeps its
+ * invoices, but there is no plan of its left to describe.
+ */
+function getPlanColumns(team: BilledTeam | undefined): {
+  planPrice: StaffRevenuePrice | null;
+  includedScreenshots: number | null;
+  planName: string | null;
+} {
+  if (!team) {
+    return { planPrice: null, includedScreenshots: null, planName: null };
+  }
+  return {
+    planPrice:
+      team.flatPrice === null
+        ? null
+        : {
+            amount: team.flatPrice,
+            currency: team.currency ?? REPORTING_CURRENCY,
+          },
+    includedScreenshots: team.includedScreenshots,
+    planName: team.planName,
+  };
+}
+
+/**
  * The bills the running month is still waiting on, priced off the usage so far.
  *
  * A team whose cycle falls on the 30th has been invoiced nothing on the 12th,
@@ -812,6 +885,7 @@ async function getEstimatedBills(options: {
       currency: revenue.currency,
       revenue: toEuros(revenue),
       screenshotsCount: period.screenshotsCount,
+      ...getPlanColumns(team),
       invoices: [],
       // The anniversary the period closes on, which is the day the cycle bills.
       estimatedAt: period.endsAt,
@@ -899,6 +973,9 @@ export async function getStaffRevenue(
     .where("stripeCreatedAt", "<", end.toISOString());
 
   const customersWithTerms = getCustomersWithTerms(rows);
+  const billedTeamsByCustomer = new Map(
+    billedTeams.map((team) => [team.stripeCustomerId, team]),
+  );
 
   // The months, and the contracts, from the same read.
   const monthSplits = reported.map(() => createSplit());
@@ -984,6 +1061,7 @@ export async function getStaffRevenue(
           monthlyScreenshots
             .get(team.accountId)
             ?.get(getMonthKey(reportedMonth)) ?? 0,
+        ...getPlanColumns(billedTeamsByCustomer.get(row.stripeCustomerId)),
         invoices: [],
         estimatedAt: null,
       };

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -780,12 +780,41 @@ function clipContractTerms(reads: ContractRead[]): ContractRead[] {
   return clipped;
 }
 
+/**
+ * What the running month is on course to come to, once everything it has not
+ * billed yet is counted.
+ *
+ * The month itself reports what was invoiced, which is why it reads low all
+ * month and only catches up on the last cycle of it. This is the other
+ * question — what the month will be worth — and the three figures below are
+ * the same three, each carried to the end of the month rather than stopped at
+ * today.
+ */
+type StaffRevenueProjection = {
+  /** The three below, added up. */
+  revenue: number;
+  /** Invoiced so far, plus the bills the cycles have not raised yet. */
+  monthlyPlans: number;
+  /** A whole month of the contracts, not the share of it that has gone by. */
+  yearlyPlans: number;
+  /** A whole month of Marketplace, on the same basis. */
+  githubPlans: number;
+  /**
+   * The part of `monthlyPlans` no invoice exists for: what the subscriptions
+   * still to be billed have run up so far, which is a floor rather than a
+   * forecast — their usage keeps accruing until the cycle closes.
+   */
+  estimated: number;
+};
+
 /** What Argos invoiced, and the annual contracts behind the yearly figures. */
 export type StaffRevenue = {
   /** Oldest first, the running month last. */
   months: StaffRevenueMonth[];
   /** The contracts behind the yearly figures, largest first. */
   yearlyContracts: StaffYearlyContract[];
+  /** Where the running month is heading, beside what it has billed. */
+  projection: StaffRevenueProjection;
 };
 
 /**
@@ -1089,6 +1118,8 @@ export async function getStaffRevenue(
   const runningMonth = monthBounds[runningIndex];
   invariant(runningMonth, "the running month is one of the reported ones");
   const monthlyByCustomer = new Map<string, number>();
+  /** The contracts over the whole running month, for the projection. */
+  const projectedYearly = createSplit();
 
   for (const contract of contracts) {
     const coveredMs = contract.termMs;
@@ -1120,6 +1151,10 @@ export async function getStaffRevenue(
       Math.min(contract.coverage.end, runningMonth.end) -
       Math.max(contract.coverage.start, runningMonth.start);
     if (monthOverlap > 0) {
+      addToSplit(projectedYearly, {
+        amount: (contract.revenue.amount * monthOverlap) / coveredMs,
+        currency: contract.revenue.currency,
+      });
       monthlyByCustomer.set(
         contract.row.stripeCustomerId,
         (monthlyByCustomer.get(contract.row.stripeCustomerId) ?? 0) +
@@ -1144,6 +1179,19 @@ export async function getStaffRevenue(
     teamCustomers,
     invoicedCustomerIds: new Set(runningTeams.keys()),
   });
+
+  // What the running month is heading for, rather than what it has billed: the
+  // bills its cycles have not raised yet, and the two rates carried to the end
+  // of the month instead of stopped at today.
+  const runningSplit = monthSplits[runningIndex];
+  invariant(runningSplit, "the running month has a split of its own");
+  const estimated = estimatedBills.reduce((sum, bill) => sum + bill.revenue, 0);
+  const projectedMonthly = runningSplit.revenue + estimated;
+  const projectedGithub = getMarketplaceMonthRevenue(
+    marketplaceSubscriptions,
+    runningMonth,
+    runningMonth,
+  );
 
   const months = reported.map((start, index) => {
     const monthly = monthSplits[index];
@@ -1190,6 +1238,14 @@ export async function getStaffRevenue(
       monthlyByCustomer,
       runningMonth,
     }),
+    projection: {
+      revenue:
+        projectedMonthly + projectedYearly.revenue + projectedGithub.revenue,
+      monthlyPlans: projectedMonthly,
+      yearlyPlans: projectedYearly.revenue,
+      githubPlans: projectedGithub.revenue,
+      estimated,
+    },
   };
 }
 

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -450,31 +450,70 @@ function getMonthKey(month: Date): string {
 async function getMonthlyScreenshots(window: {
   from: Date;
   to: Date;
+  /** The accounts the page will read, which is all it has lines for. */
+  accountIds: string[];
 }): Promise<Map<string, Map<string, number>>> {
-  const monthKey = `to_char(sb."createdAt" at time zone 'UTC', 'YYYY-MM')`;
-  const rows = (await knex
+  if (window.accountIds.length === 0) {
+    return new Map();
+  }
+
+  const from = window.from.toISOString();
+  const to = window.to.toISOString();
+  const result = new Map<string, Map<string, number>>();
+
+  const add = (accountId: string, month: string, count: number) => {
+    const months = result.get(accountId) ?? new Map<string, number>();
+    months.set(month, (months.get(month) ?? 0) + count);
+    result.set(accountId, months);
+  };
+
+  // Two passes, like the billing aggregate this has to agree with: screenshots
+  // hang off buckets, the units a recording is billed as hang off media
+  // versions, and the two reach an account by different joins.
+  const bucketMonth = `to_char(sb."createdAt" at time zone 'UTC', 'YYYY-MM')`;
+  const bucketRows = (await knex
     .select("p.accountId")
-    .select(knex.raw(`${monthKey} as "month"`))
+    .select(knex.raw(`${bucketMonth} as "month"`))
     // Null until a bucket completes, and summed as-is by the billing figures
     // this sits beside.
     .select(knex.raw(`coalesce(sum(sb."screenshotCount"), 0) as "count"`))
     .from("screenshot_buckets as sb")
     .join("projects as p", "p.id", "sb.projectId")
-    .where("sb.createdAt", ">=", window.from.toISOString())
-    .where("sb.createdAt", "<", window.to.toISOString())
-    .groupBy("p.accountId", knex.raw(monthKey))) as unknown as {
+    .whereIn("p.accountId", window.accountIds)
+    .where("sb.createdAt", ">=", from)
+    .where("sb.createdAt", "<", to)
+    .groupBy("p.accountId", knex.raw(bucketMonth))) as unknown as {
     accountId: string | number;
     month: string;
     count: string | number;
   }[];
-
-  const result = new Map<string, Map<string, number>>();
-  for (const row of rows) {
-    const accountId = String(row.accountId);
-    const months = result.get(accountId) ?? new Map<string, number>();
-    months.set(row.month, Number(row.count));
-    result.set(accountId, months);
+  for (const row of bucketRows) {
+    add(String(row.accountId), row.month, Number(row.count));
   }
+
+  // Billed on the day the upload completed, not the day the media row was
+  // created: replacing a recording uploads a new version long after.
+  const mediaMonth = `to_char(mv."uploadedAt" at time zone 'UTC', 'YYYY-MM')`;
+  const mediaRows = (await knex
+    .select("p.accountId")
+    .select(knex.raw(`${mediaMonth} as "month"`))
+    .select(knex.raw(`coalesce(sum(mv."billedUnits"), 0) as "count"`))
+    .from("media_versions as mv")
+    .join("media as m", "m.id", "mv.mediaId")
+    .join("projects as p", "p.id", "m.projectId")
+    .whereIn("p.accountId", window.accountIds)
+    .whereNotNull("mv.uploadedAt")
+    .where("mv.uploadedAt", ">=", from)
+    .where("mv.uploadedAt", "<", to)
+    .groupBy("p.accountId", knex.raw(mediaMonth))) as unknown as {
+    accountId: string | number;
+    month: string;
+    count: string | number;
+  }[];
+  for (const row of mediaRows) {
+    add(String(row.accountId), row.month, Number(row.count));
+  }
+
   return result;
 }
 
@@ -833,15 +872,23 @@ function getPlanColumns(team: BilledTeam | undefined): {
   if (!team) {
     return { planPrice: null, includedScreenshots: null, planName: null };
   }
+  // Stripe states every amount per billing period, and a yearly subscription's
+  // period is a year. Every figure on this line is a month's, so the price is
+  // brought back to one — the same reading the staff tables hold everywhere.
+  const months = team.interval === "year" ? 12 : 1;
   return {
     planPrice:
       team.flatPrice === null
         ? null
         : {
-            amount: team.flatPrice,
+            amount: team.flatPrice / months,
             currency: team.currency ?? REPORTING_CURRENCY,
           },
-    includedScreenshots: team.includedScreenshots,
+    // Not divided the way the price is, and not reported at all off a monthly
+    // cycle: a quota resets once a period, so a year's has no share that a
+    // month's usage could be read against. Stating a twelfth of it would
+    // invent a limit the team is never metered on.
+    includedScreenshots: months === 1 ? team.includedScreenshots : null,
     planName: team.planName,
   };
 }
@@ -862,9 +909,10 @@ function getPlanColumns(team: BilledTeam | undefined): {
  */
 async function getEstimatedBills(options: {
   billedTeams: BilledTeam[];
-  teamCustomers: Map<string, TeamCustomer>;
   /** The customers a bill was already raised on this month. */
   invoicedCustomerIds: Set<string>;
+  /** The month the estimates are reported in, which bounds when they fall. */
+  runningMonth: { start: number; end: number };
 }): Promise<StaffRevenueMonthTeam[]> {
   const pending = options.billedTeams.filter(
     (team) =>
@@ -889,16 +937,24 @@ async function getEstimatedBills(options: {
     const period = billing?.periodUsage?.billingPeriods.find(
       (billingPeriod) => !billingPeriod.closed,
     );
-    // No amount on file means no estimate worth printing: the plan's own price
-    // is most of a bill, and quoting the overage alone would report a team
-    // about to be invoiced as owing next to nothing. A guess in its place would
-    // read exactly like the figures beside it, which are read off Stripe.
-    if (!billing || !period || billing.flatPrice === null) {
+    // A cycle that closes after this month bills in the next one, not in this
+    // one. Reached when a bill was raised but the mirror has not caught it —
+    // a sweep a few hours behind, an invoice still in draft, one that netted
+    // nothing — where the customer looks unbilled while its period has already
+    // rolled over. Estimating it here would put a whole extra bill in the
+    // month's projection.
+    if (period && period.endsAt.getTime() >= options.runningMonth.end) {
       continue;
     }
-
-    const customer = options.teamCustomers.get(team.stripeCustomerId);
-    if (!customer) {
+    // Two ways a subscription has nothing to estimate from, and neither is
+    // worth a guess. No amount on file: the plan's own price is most of a
+    // bill, so quoting the overage alone would report a team about to be
+    // invoiced as owing next to nothing — and a figure of ours would read
+    // exactly like the ones beside it, which are read off Stripe. No running
+    // period: the plan is not metered by usage, so nothing here knows when its
+    // cycle bills, and a flat bill left out of the month beats one dated by
+    // guesswork.
+    if (!billing || !period || billing.flatPrice === null) {
       continue;
     }
 
@@ -907,8 +963,8 @@ async function getEstimatedBills(options: {
       currency: team.currency ?? REPORTING_CURRENCY,
     };
     bills.push({
-      slug: customer.slug,
-      name: customer.name,
+      slug: team.slug,
+      name: team.name,
       stripeCustomerId: team.stripeCustomerId,
       amount: revenue.amount,
       currency: revenue.currency,
@@ -954,6 +1010,7 @@ export async function getStaffRevenue(
   invariant(first, "at least one month is reported");
   const scanStart = new Date(first.getTime() - CONTRACT_SCAN_MS);
 
+  const teamCustomersPromise = getTeamCustomers();
   const [
     teamCustomers,
     billedTeams,
@@ -962,15 +1019,24 @@ export async function getStaffRevenue(
     marketplaceSubscriptions,
     monthlyScreenshots,
   ] = await Promise.all([
-    getTeamCustomers(),
+    teamCustomersPromise,
     getBilledTeams(),
     StripeInvoiceSync.query().orderBy("sinceDate", "asc").first(),
     StripeInvoiceSync.query().orderBy("completedAt", "desc").first(),
     getMarketplaceSubscriptions(),
-    // Over the reported months alone, not the contract scan: usage is read
-    // beside the bills of the months on screen, and the year of contracts
-    // behind them has no line to carry a count.
-    getMonthlyScreenshots({ from: first, to: end }),
+    // Chained off the customers rather than read beside them: the usage is
+    // wanted for the teams this page has lines for, and unbounded it would
+    // sweep every bucket every project ever produced over the window.
+    teamCustomersPromise.then((customers) =>
+      // Over the reported months alone, not the contract scan: usage is read
+      // beside the bills of the months on screen, and the year of contracts
+      // behind them has no line to carry a count.
+      getMonthlyScreenshots({
+        from: first,
+        to: end,
+        accountIds: [...customers.values()].map((team) => team.accountId),
+      }),
+    ),
   ]);
 
   // Two things have to hold before a figure can be trusted: the mirror was
@@ -1151,17 +1217,15 @@ export async function getStaffRevenue(
       Math.min(contract.coverage.end, runningMonth.end) -
       Math.max(contract.coverage.start, runningMonth.start);
     if (monthOverlap > 0) {
-      addToSplit(projectedYearly, {
+      const monthShare = {
         amount: (contract.revenue.amount * monthOverlap) / coveredMs,
         currency: contract.revenue.currency,
-      });
+      };
+      addToSplit(projectedYearly, monthShare);
       monthlyByCustomer.set(
         contract.row.stripeCustomerId,
         (monthlyByCustomer.get(contract.row.stripeCustomerId) ?? 0) +
-          toEuros({
-            amount: (contract.revenue.amount * monthOverlap) / coveredMs,
-            currency: contract.revenue.currency,
-          }),
+          toEuros(monthShare),
       );
     }
   }
@@ -1176,8 +1240,8 @@ export async function getStaffRevenue(
   invariant(runningTeams, "the running month is one of the reported ones");
   const estimatedBills = await getEstimatedBills({
     billedTeams,
-    teamCustomers,
     invoicedCustomerIds: new Set(runningTeams.keys()),
+    runningMonth,
   });
 
   // What the running month is heading for, rather than what it has billed: the
@@ -1210,22 +1274,25 @@ export async function getStaffRevenue(
     }
     const bound = monthBounds[index];
     invariant(bound, "every month reported has bounds");
+    const githubPlans = getMarketplaceMonthRevenue(
+      marketplaceSubscriptions,
+      bound,
+      // As much of the month as has gone by, so the running month's marketplace
+      // band is as partial as the two beside it.
+      amortizeBounds[index] ?? bound,
+    );
     return {
       month: start,
-      revenue: monthly.revenue + yearly.revenue,
+      // All three bands: the card states one figure, and a reader adding the
+      // three under it has to arrive at it.
+      revenue: monthly.revenue + yearly.revenue + githubPlans.revenue,
       monthlyPlans: monthly,
       // Largest first: the breakdown is read to see who made the month.
       teams: [...teams.values(), ...estimates].sort(
         (a, b) => b.revenue - a.revenue,
       ),
       yearlyPlans: yearly,
-      githubPlans: getMarketplaceMonthRevenue(
-        marketplaceSubscriptions,
-        bound,
-        // As much of the month as has gone by, so the running month's
-        // marketplace band is as partial as the two beside it.
-        amortizeBounds[index] ?? bound,
-      ),
+      githubPlans,
     };
   });
 

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -99,8 +99,6 @@ type StaffRevenueMonth = {
   revenue: number;
   /** What teams billed by the month were invoiced that month. */
   monthlyPlans: StaffRevenueSplit;
-  /** The teams behind `monthlyPlans`, largest first — they sum to it. */
-  teams: StaffRevenueMonthTeam[];
   /**
    * What the annual contracts contributed to the month: their invoices
    * amortized, day by day, over the stretch each one pays for.
@@ -918,13 +916,38 @@ async function getEstimatedBills(options: {
     return [];
   }
 
+  // Which cycles can still bill this month is a question the subscriptions
+  // answer on their own, off an index. The usage aggregate below is the
+  // heaviest read on the page, so it is asked only about the teams that can
+  // produce a line at all — on the last days of a month, a handful of them.
+  const subscriptions = await Subscription.query().whereIn(
+    "stripeSubscriptionId",
+    pending.map((team) => team.stripeSubscriptionId),
+  );
+  const subscriptionByAccountId = new Map(
+    subscriptions.map((subscription) => [subscription.accountId, subscription]),
+  );
+  const now = new Date();
+  const due = pending.filter((team) => {
+    const subscription = subscriptionByAccountId.get(team.accountId);
+    return (
+      subscription !== undefined &&
+      subscription.getPeriodEnd(now, "month").getTime() <
+        options.runningMonth.end
+    );
+  });
+
+  if (due.length === 0) {
+    return [];
+  }
+
   const accounts = await Account.query().findByIds(
-    pending.map((team) => team.accountId),
+    due.map((team) => team.accountId),
   );
   const billings = await getAccountBillings(accounts);
   const bills: StaffRevenueMonthTeam[] = [];
 
-  for (const team of pending) {
+  for (const team of due) {
     const billing = billings.get(team.accountId);
     const period = billing?.periodUsage?.billingPeriods.find(
       (billingPeriod) => !billingPeriod.closed,
@@ -986,6 +1009,176 @@ async function getEstimatedBills(options: {
 export class MirrorCoverageError extends Error {}
 
 /**
+ * What the mirror has to have been swept for before a window can be read off
+ * it: deep enough to hold the contracts that pay for the window's first month,
+ * and recently enough that what it holds is still current. A mirror failing
+ * either reports zeros that read as figures.
+ */
+async function assertMirrorCovers(scanStart: Date, now: Date): Promise<void> {
+  const [deepestSync, freshestSync] = await Promise.all([
+    StripeInvoiceSync.query().orderBy("sinceDate", "asc").first(),
+    StripeInvoiceSync.query().orderBy("completedAt", "desc").first(),
+  ]);
+
+  if (!deepestSync || new Date(deepestSync.sinceDate) > scanStart) {
+    throw new MirrorCoverageError(
+      "The Stripe invoice mirror was never swept deep enough for this window — run stripe/bin/sync-stripe-invoices with a deeper window to backfill it.",
+    );
+  }
+  invariant(freshestSync, "a deepest sync means there is a freshest one");
+  if (
+    now.getTime() - new Date(freshestSync.completedAt).getTime() >
+    STALE_MIRROR_MS
+  ) {
+    throw new MirrorCoverageError(
+      `The Stripe invoice mirror has not been swept since ${freshestSync.completedAt} — the stripe-invoice-sync cron is not running.`,
+    );
+  }
+}
+
+/**
+ * The teams behind one month of the monthly plans, largest first.
+ *
+ * Read a month at a time, on the month a reader opens, rather than beside the
+ * figures: a line carries the usage its team got through, and pricing thirteen
+ * months of that to draw one is the difference between a page that reads a
+ * handful of rows and one that walks every screenshot bucket of the year.
+ * Bounded to the month's own customers, it is the shape the
+ * `(projectId, createdAt)` index was built for.
+ *
+ * The running month also carries the bills its cycles have not raised yet.
+ */
+export async function getStaffRevenueMonthTeams(
+  month: Date,
+): Promise<StaffRevenueMonthTeam[]> {
+  const now = new Date();
+  const start = startOfUTCMonth(month, 0);
+  const end = startOfUTCMonth(month, 1);
+  const bound = { start: start.getTime(), end: end.getTime() };
+  const scanStart = new Date(bound.start - CONTRACT_SCAN_MS);
+
+  await assertMirrorCovers(scanStart, now);
+
+  const [teamCustomers, billedTeams, rows] = await Promise.all([
+    getTeamCustomers(),
+    getBilledTeams(),
+    StripeInvoice.query()
+      .whereIn("status", COUNTED_STATUSES)
+      .whereIn("billingReason", [
+        ...SUBSCRIPTION_BILLING_REASONS,
+        ...SALES_LED_BILLING_REASONS,
+      ])
+      .where("stripeCreatedAt", ">=", start.toISOString())
+      .where("stripeCreatedAt", "<", end.toISOString()),
+  ]);
+
+  const customerIds = [...new Set(rows.map((row) => row.stripeCustomerId))];
+  // The terms are looked up for this month's customers alone, over the same
+  // stretch the whole-window read scans: what tells a period-less sales
+  // invoice from a one-off is a bill of theirs that covers a term, and that
+  // bill can have been raised a year before the month being read.
+  const termRows =
+    customerIds.length === 0
+      ? []
+      : ((await StripeInvoice.query()
+          .select(
+            "stripeCustomerId",
+            "stripeCreatedAt",
+            "periodStart",
+            "periodEnd",
+          )
+          .whereIn("stripeCustomerId", customerIds)
+          .where("stripeCreatedAt", ">=", scanStart.toISOString())
+          .where(
+            "stripeCreatedAt",
+            "<",
+            end.toISOString(),
+          )) as unknown as (ClassifiableInvoice & {
+          stripeCustomerId: string;
+        })[]);
+  const customersWithTerms = getCustomersWithTerms(
+    termRows.map((row) => ({ ...row, billingReason: null })),
+  );
+
+  const accountIds = customerIds
+    .map((customerId) => teamCustomers.get(customerId)?.accountId)
+    .filter((accountId) => accountId !== undefined);
+  const screenshots = await getMonthlyScreenshots({
+    from: start,
+    to: end,
+    accountIds,
+  });
+  const monthKey = getMonthKey(start);
+  const billedTeamsByCustomer = new Map(
+    billedTeams.map((team) => [team.stripeCustomerId, team]),
+  );
+
+  const teams = new Map<string, StaffRevenueMonthTeam>();
+  for (const row of rows) {
+    const team = teamCustomers.get(row.stripeCustomerId);
+    if (!team) {
+      continue;
+    }
+    const revenue = getInvoiceRevenue(row);
+    const classified = classifyInvoice(row, {
+      customerHasTerm: customersWithTerms.has(row.stripeCustomerId),
+    });
+    // A contract belongs to the months it pays for, which the yearly figures
+    // and their own table report. A zero invoice is not a team being invoiced.
+    if (classified.kind === "contract" || revenue.amount === 0) {
+      continue;
+    }
+
+    // A team invoiced twice in one month is one team, one line deeper.
+    let teamRow = teams.get(row.stripeCustomerId);
+    if (!teamRow) {
+      teamRow = {
+        slug: team.slug,
+        name: team.name,
+        stripeCustomerId: row.stripeCustomerId,
+        amount: 0,
+        currency: revenue.currency,
+        revenue: 0,
+        screenshotsCount: screenshots.get(team.accountId)?.get(monthKey) ?? 0,
+        ...getPlanColumns(billedTeamsByCustomer.get(row.stripeCustomerId)),
+        invoices: [],
+        estimatedAt: null,
+      };
+      teams.set(row.stripeCustomerId, teamRow);
+    }
+    teamRow.amount += revenue.amount;
+    if (teamRow.currency !== revenue.currency) {
+      // Mixed currencies make the original sum meaningless; the euro figure
+      // still holds.
+      teamRow.currency = null;
+    }
+    teamRow.revenue += toEuros(revenue);
+    teamRow.invoices.push({
+      amount: revenue.amount,
+      currency: revenue.currency,
+      invoicedAt: new Date(row.stripeCreatedAt),
+    });
+  }
+
+  // The query reads the mirror in no particular order.
+  for (const team of teams.values()) {
+    team.invoices.sort(
+      (a, b) => b.invoicedAt.getTime() - a.invoicedAt.getTime(),
+    );
+  }
+
+  const estimates =
+    bound.start === startOfUTCMonth(now, 0).getTime()
+      ? await getEstimatedBills({ billedTeams, runningMonth: bound })
+      : [];
+
+  // Largest first: the breakdown is read to see who made the month.
+  return [...teams.values(), ...estimates].sort(
+    (a, b) => b.revenue - a.revenue,
+  );
+}
+
+/**
  * What Argos invoiced over the last `monthCount` calendar months, along with
  * the annual contracts the yearly figures are made of.
  *
@@ -1012,55 +1205,14 @@ export async function getStaffRevenue(
   invariant(first, "at least one month is reported");
   const scanStart = new Date(first.getTime() - CONTRACT_SCAN_MS);
 
-  const teamCustomersPromise = getTeamCustomers();
-  const [
-    teamCustomers,
-    billedTeams,
-    deepestSync,
-    freshestSync,
-    marketplaceSubscriptions,
-    monthlyScreenshots,
-  ] = await Promise.all([
-    teamCustomersPromise,
-    getBilledTeams(),
-    StripeInvoiceSync.query().orderBy("sinceDate", "asc").first(),
-    StripeInvoiceSync.query().orderBy("completedAt", "desc").first(),
-    getMarketplaceSubscriptions(),
-    // Chained off the customers rather than read beside them: unbounded, this
-    // sweeps every bucket every project in the database ever produced over the
-    // window. It is still wider than the lines the page draws — which of these
-    // teams has an invoice is not known until the read below returns — but the
-    // accounts that never reached Stripe are the bulk of them.
-    teamCustomersPromise.then((customers) =>
-      // Over the reported months alone, not the contract scan: usage is read
-      // beside the bills of the months on screen, and the year of contracts
-      // behind them has no line to carry a count.
-      getMonthlyScreenshots({
-        from: first,
-        to: end,
-        accountIds: [...customers.values()].map((team) => team.accountId),
-      }),
-    ),
-  ]);
+  const [teamCustomers, billedTeams, marketplaceSubscriptions] =
+    await Promise.all([
+      getTeamCustomers(),
+      getBilledTeams(),
+      getMarketplaceSubscriptions(),
+    ]);
 
-  // Two things have to hold before a figure can be trusted: the mirror was
-  // swept deep enough to hold the contracts that pay for the window, and it
-  // has been swept recently enough that what it holds is still current. A
-  // mirror failing either reports zeros that read as figures.
-  if (!deepestSync || new Date(deepestSync.sinceDate) > scanStart) {
-    throw new MirrorCoverageError(
-      "The Stripe invoice mirror was never swept deep enough for this window — run stripe/bin/sync-stripe-invoices with a deeper window to backfill it.",
-    );
-  }
-  invariant(freshestSync, "a deepest sync means there is a freshest one");
-  if (
-    now.getTime() - new Date(freshestSync.completedAt).getTime() >
-    STALE_MIRROR_MS
-  ) {
-    throw new MirrorCoverageError(
-      `The Stripe invoice mirror has not been swept since ${freshestSync.completedAt} — the stripe-invoice-sync cron is not running.`,
-    );
-  }
+  await assertMirrorCovers(scanStart, now);
 
   const rows = await StripeInvoice.query()
     .whereIn("status", COUNTED_STATUSES)
@@ -1072,15 +1224,12 @@ export async function getStaffRevenue(
     .where("stripeCreatedAt", "<", end.toISOString());
 
   const customersWithTerms = getCustomersWithTerms(rows);
-  const billedTeamsByCustomer = new Map(
-    billedTeams.map((team) => [team.stripeCustomerId, team]),
-  );
 
-  // The months, and the contracts, from the same read.
+  // The months, and the contracts, from the same read. The teams behind a
+  // month are counted here and read one month at a time by the query below:
+  // building them all would price thirteen months of usage to draw one.
   const monthSplits = reported.map(() => createSplit());
-  const monthTeams = reported.map(
-    () => new Map<string, StaffRevenueMonthTeam>(),
-  );
+  const monthCustomers = reported.map(() => new Set<string>());
   const yearlySplits = reported.map(() => createSplit());
   const yearlyMonthCustomers = reported.map(() => new Set<string>());
   const contractReads: ContractRead[] = [];
@@ -1138,46 +1287,14 @@ export async function getStaffRevenue(
       (bound) => created >= bound.start && created < bound.end,
     );
     const split = monthSplits[index];
-    const teams = monthTeams[index];
-    const reportedMonth = reported[index];
+    const customers = monthCustomers[index];
     invariant(
-      split && teams && reportedMonth,
+      split && customers,
       "the query bounds every row to a reported month",
     );
     addToSplit(split, revenue);
-
-    // A team invoiced twice in one month is one team, one line deeper.
-    let teamRow = teams.get(row.stripeCustomerId);
-    if (!teamRow) {
-      teamRow = {
-        slug: team.slug,
-        name: team.name,
-        stripeCustomerId: row.stripeCustomerId,
-        amount: 0,
-        currency: revenue.currency,
-        revenue: 0,
-        screenshotsCount:
-          monthlyScreenshots
-            .get(team.accountId)
-            ?.get(getMonthKey(reportedMonth)) ?? 0,
-        ...getPlanColumns(billedTeamsByCustomer.get(row.stripeCustomerId)),
-        invoices: [],
-        estimatedAt: null,
-      };
-      teams.set(row.stripeCustomerId, teamRow);
-    }
-    teamRow.amount += revenue.amount;
-    if (teamRow.currency !== revenue.currency) {
-      // Mixed currencies make the original sum meaningless; the euro figure
-      // still holds.
-      teamRow.currency = null;
-    }
-    teamRow.revenue += toEuros(revenue);
-    teamRow.invoices.push({
-      amount: revenue.amount,
-      currency: revenue.currency,
-      invoicedAt: new Date(row.stripeCreatedAt),
-    });
+    // A team invoiced twice in one month is one team.
+    customers.add(row.stripeCustomerId);
   }
 
   // Contracts, once their terms no longer overlap: spread each one over the
@@ -1258,18 +1375,12 @@ export async function getStaffRevenue(
   const months = reported.map((start, index) => {
     const monthly = monthSplits[index];
     const yearly = yearlySplits[index];
-    const teams = monthTeams[index];
-    invariant(monthly && yearly && teams, "every month reported has totals");
-    monthly.teamsCount = teams.size;
-    // Beside the month's own lines rather than inside its totals: an estimate
-    // is not revenue, and `monthlyPlans` above is what was invoiced.
-    const estimates = index === runningIndex ? estimatedBills : [];
-    // The query reads the mirror in no particular order.
-    for (const team of teams.values()) {
-      team.invoices.sort(
-        (a, b) => b.invoicedAt.getTime() - a.invoicedAt.getTime(),
-      );
-    }
+    const customers = monthCustomers[index];
+    invariant(
+      monthly && yearly && customers,
+      "every month reported has totals",
+    );
+    monthly.teamsCount = customers.size;
     const bound = monthBounds[index];
     invariant(bound, "every month reported has bounds");
     const githubPlans = getMarketplaceMonthRevenue(
@@ -1285,10 +1396,6 @@ export async function getStaffRevenue(
       // three under it has to arrive at it.
       revenue: monthly.revenue + yearly.revenue + githubPlans.revenue,
       monthlyPlans: monthly,
-      // Largest first: the breakdown is read to see who made the month.
-      teams: [...teams.values(), ...estimates].sort(
-        (a, b) => b.revenue - a.revenue,
-      ),
       yearlyPlans: yearly,
       githubPlans,
     };

--- a/apps/backend/src/util/utc-month.ts
+++ b/apps/backend/src/util/utc-month.ts
@@ -1,0 +1,17 @@
+/**
+ * The first instant of the month `offset` months from `date`, in UTC.
+ *
+ * Deliberately not the calendar helpers, which work in the process's own
+ * timezone: Stripe timestamps every invoice in UTC, so a server running on
+ * anything else would cut its months hours away from where Stripe cuts them and
+ * file the invoices either side of a boundary in the wrong one.
+ *
+ * Here rather than beside the reader that needs it most, so the seeds can cut
+ * their months the same way without the database layer importing the billing
+ * one to do it.
+ */
+export function startOfUTCMonth(date: Date, offset: number): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + offset, 1),
+  );
+}

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -64,6 +64,8 @@ const StaffRevenueQuery = graphql(`
           amount
           currency
           revenue
+          screenshotsCount
+          estimatedAt
           invoices {
             amount
             currency
@@ -215,6 +217,9 @@ function formatInvoiceAmount(invoice: {
   }
   return format.format(invoice.amount);
 }
+
+/** Screenshot counts, grouped like the team directory prints them. */
+const SCREENSHOTS_FORMAT = new Intl.NumberFormat("en-US");
 
 /** A renewal's date, read in UTC like every other date on the page. */
 const DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
@@ -542,7 +547,7 @@ function RevenueChart(props: { months: readonly RevenueMonth[] }) {
   );
 }
 
-type MonthTeamSortKey = "team" | "amount" | "revenue" | "date";
+type MonthTeamSortKey = "team" | "amount" | "revenue" | "screenshots" | "date";
 
 /**
  * Sortable value per column of a month's breakdown.
@@ -564,13 +569,27 @@ function getMonthTeamSortValue(
       return team.currency === null ? -1 : team.amount;
     case "revenue":
       return team.revenue;
+    case "screenshots":
+      return team.screenshotsCount;
     case "date": {
-      // On the date the column prints — the newest, invoices being sent
-      // newest first.
-      const newest = team.invoices[0];
-      return newest ? new Date(newest.invoicedAt).getTime() : -1;
+      // On the date the column prints: the newest invoice, or the day the bill
+      // is expected on a line that has none yet.
+      const date = getMonthTeamDate(team);
+      return date ? date.getTime() : -1;
     }
   }
+}
+
+/**
+ * The day a line is filed under: when its newest invoice was raised, or when
+ * the bill it is still waiting on is expected.
+ */
+function getMonthTeamDate(team: MonthTeam): Date | null {
+  const newest = team.invoices[0];
+  if (newest) {
+    return new Date(newest.invoicedAt);
+  }
+  return team.estimatedAt ? new Date(team.estimatedAt) : null;
 }
 
 function sortMonthTeams(
@@ -600,6 +619,11 @@ function sortMonthTeams(
  * sort being stable. The rank column numbers the rows as they are displayed,
  * so it re-reads as a line number under any other sort rather than pinning a
  * position the sort has moved.
+ *
+ * The running month also carries the bills it is still waiting on — a cycle
+ * that falls later in the month has raised nothing yet — as estimated lines.
+ * Their date is the day the bill is expected, so that order puts them at the
+ * top: they are the only lines of the month that have not happened.
  */
 function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
   const [sortKey, setSortKey] = useState<MonthTeamSortKey>("date");
@@ -633,7 +657,7 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[28%] text-left"
+              className="w-[24%] text-left"
             />
             <SortHeader
               label="Invoiced"
@@ -641,7 +665,7 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[18%] text-right"
+              className="w-[16%] text-right"
             />
             <SortHeader
               label="In euros"
@@ -649,7 +673,15 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[18%] text-right"
+              className="w-[14%] text-right"
+            />
+            <SortHeader
+              label="Screenshots"
+              sortKey="screenshots"
+              activeSortKey={sortKey}
+              direction={sortDirection}
+              onSort={onSort}
+              className="w-[14%] text-right"
             />
             <SortHeader
               label="Date"
@@ -657,14 +689,17 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[18%] text-right"
+              className="w-[16%] text-right"
             />
-            <th className="w-[12%] px-4 py-3 text-right" />
+            <th className="w-[10%] px-4 py-3 text-right" />
           </tr>
         </thead>
         <tbody>
           {teams.map((team, teamIndex) => {
             const newestInvoice = team.invoices[0] ?? null;
+            const expectedAt = team.estimatedAt
+              ? new Date(team.estimatedAt)
+              : null;
 
             return (
               <tr
@@ -672,6 +707,10 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
                 className={clsx(
                   "text-sm",
                   teamIndex !== teams.length - 1 && "border-b",
+                  // A bill that has not been raised is written in grey, so a
+                  // ledger of facts is not read off the same colour as one
+                  // line that is a projection.
+                  expectedAt && "text-low",
                 )}
               >
                 <td className="text-low px-4 py-2.5 text-right tabular-nums">
@@ -681,17 +720,38 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
                   <Link href={`/${team.slug}`}>{team.name ?? team.slug}</Link>
                 </td>
                 <td className="px-4 py-2.5 text-right tabular-nums">
-                  {team.currency !== null ? (
+                  {team.currency === null ? (
+                    <span className="text-low">—</span>
+                  ) : expectedAt ? (
+                    // The grey the row is written in says the amount was not
+                    // invoiced; what it is made of takes a sentence, so it is
+                    // the tooltip that carries it.
+                    <Hint content="Not yet invoiced or included above">
+                      {formatInvoiceAmount({
+                        amount: team.amount,
+                        currency: team.currency,
+                      })}
+                    </Hint>
+                  ) : (
                     formatInvoiceAmount({
                       amount: team.amount,
                       currency: team.currency,
                     })
-                  ) : (
-                    <span className="text-low">—</span>
                   )}
                 </td>
                 <td className="px-4 py-2.5 text-right tabular-nums">
                   {formatEuros(team.revenue)}
+                </td>
+                <td className="px-4 py-2.5 text-right tabular-nums">
+                  {expectedAt ? (
+                    // The period's, not the month's: it is the count the
+                    // estimate beside it was computed on.
+                    <Hint content="To date">
+                      {SCREENSHOTS_FORMAT.format(team.screenshotsCount)}
+                    </Hint>
+                  ) : (
+                    SCREENSHOTS_FORMAT.format(team.screenshotsCount)
+                  )}
                 </td>
                 {/* The dates walk forward with the calendar, like the month
                     names above. */}
@@ -699,7 +759,9 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
                   className="px-4 py-2.5 text-right tabular-nums"
                   data-visual-test="transparent"
                 >
-                  {newestInvoice === null ? (
+                  {expectedAt ? (
+                    DATE_FORMAT.format(expectedAt)
+                  ) : newestInvoice === null ? (
                     <span className="text-low">—</span>
                   ) : team.invoices.length === 1 ? (
                     DATE_FORMAT.format(new Date(newestInvoice.invoicedAt))

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -188,15 +188,17 @@ const AXIS_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
 });
 
 /**
- * Amounts in the contracts table, with cents.
+ * Amounts in the contracts table.
  *
- * The rest of the page rounds to the euro, but this table exists to be added
- * up against the yearly figure, and twelfths carry cents — a rounded list
- * would not sum to its own total.
+ * Rounded to the euro like the rest of the page, so the table's own total can
+ * come out a euro or two off the rows above it: a twelfth of a contract falls
+ * between two of them, and the cents that would make the column add up exactly
+ * are noise on every figure that carries them.
  */
 const CONTRACT_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
   style: "currency",
   currency: "EUR",
+  maximumFractionDigits: 0,
 });
 
 /**
@@ -204,7 +206,9 @@ const CONTRACT_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
  *
  * Local formatters rather than util/intl's `formatCurrency`: that one follows
  * the reader's locale, where every figure on this page is pinned to en-US so
- * the amounts read the same on every staff screen.
+ * the amounts read the same on every staff screen. Rounded to the unit like
+ * every other amount here: this page is read for what a month came to, and
+ * the cents belong to the invoice in Stripe, one click away.
  */
 const INVOICE_PRICE_FORMATS = new Map<string, Intl.NumberFormat>();
 function formatInvoiceAmount(invoice: {
@@ -214,7 +218,11 @@ function formatInvoiceAmount(invoice: {
   const currency = invoice.currency.toUpperCase();
   let format = INVOICE_PRICE_FORMATS.get(currency);
   if (!format) {
-    format = new Intl.NumberFormat("en-US", { style: "currency", currency });
+    format = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 0,
+    });
     INVOICE_PRICE_FORMATS.set(currency, format);
   }
   return format.format(invoice.amount);

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -165,11 +165,21 @@ const MONTH_SHORT_FORMAT = new Intl.DateTimeFormat("en-US", {
 });
 
 /**
+ * The locale every figure on this page is written in.
+ *
+ * Pinned rather than left to the reader, like the currency below and for the
+ * same reason: the book is kept in euros by a team that reads them in French,
+ * and a page whose numbers changed shape from one staff screen to the next
+ * would be quoted back and forth in two notations.
+ */
+const PAGE_LOCALE = "fr-FR";
+
+/**
  * Every amount on this page is in euros — the currency the business is run
  * in — where the other staff pages price plans in dollars. Dollar invoices are
  * converted server-side at a fixed rate, which the foreign-share caveats own.
  */
-const EUR_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
+const EUR_PRICE_FORMAT = new Intl.NumberFormat(PAGE_LOCALE, {
   style: "currency",
   currency: "EUR",
   maximumFractionDigits: 0,
@@ -180,7 +190,7 @@ function formatEuros(amount: number): string {
 }
 
 /** Amounts on the axis, shortened, in the page's euros. */
-const AXIS_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
+const AXIS_PRICE_FORMAT = new Intl.NumberFormat(PAGE_LOCALE, {
   style: "currency",
   currency: "EUR",
   notation: "compact",
@@ -195,7 +205,7 @@ const AXIS_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
  * between two of them, and the cents that would make the column add up exactly
  * are noise on every figure that carries them.
  */
-const CONTRACT_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
+const CONTRACT_PRICE_FORMAT = new Intl.NumberFormat(PAGE_LOCALE, {
   style: "currency",
   currency: "EUR",
   maximumFractionDigits: 0,
@@ -205,8 +215,8 @@ const CONTRACT_PRICE_FORMAT = new Intl.NumberFormat("en-US", {
  * An invoice in the currency it was raised in — the audit trail to Stripe.
  *
  * Local formatters rather than util/intl's `formatCurrency`: that one follows
- * the reader's locale, where every figure on this page is pinned to en-US so
- * the amounts read the same on every staff screen. Rounded to the unit like
+ * the reader's locale, where every figure on this page is pinned to one so the
+ * amounts read the same on every staff screen. Rounded to the unit like
  * every other amount here: this page is read for what a month came to, and
  * the cents belong to the invoice in Stripe, one click away.
  */
@@ -218,9 +228,13 @@ function formatInvoiceAmount(invoice: {
   const currency = invoice.currency.toUpperCase();
   let format = INVOICE_PRICE_FORMATS.get(currency);
   if (!format) {
-    format = new Intl.NumberFormat("en-US", {
+    format = new Intl.NumberFormat(PAGE_LOCALE, {
       style: "currency",
       currency,
+      // `$` rather than `$US`: the column is read for the currency an invoice
+      // was raised in, and the two this page ever sees are told apart by their
+      // symbols alone.
+      currencyDisplay: "narrowSymbol",
       maximumFractionDigits: 0,
     });
     INVOICE_PRICE_FORMATS.set(currency, format);
@@ -229,7 +243,14 @@ function formatInvoiceAmount(invoice: {
 }
 
 /** Screenshot counts, grouped like the team directory prints them. */
-const SCREENSHOTS_FORMAT = new Intl.NumberFormat("en-US");
+const SCREENSHOTS_FORMAT = new Intl.NumberFormat(PAGE_LOCALE);
+
+/** A month's move against the one before it, signed. */
+const GROWTH_FORMAT = new Intl.NumberFormat(PAGE_LOCALE, {
+  style: "percent",
+  maximumFractionDigits: 0,
+  signDisplay: "exceptZero",
+});
 
 /** A renewal's date, read in UTC like every other date on the page. */
 const DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
@@ -415,6 +436,7 @@ function RevenueCards(props: {
         value={readValue(lastMonth?.revenue ?? null)}
         format="currency"
         currency="EUR"
+        locales={PAGE_LOCALE}
         hint={
           unavailable ??
           (lastMonth ? (
@@ -433,6 +455,7 @@ function RevenueCards(props: {
         value={readValue(currentMonth?.revenue ?? null)}
         format="currency"
         currency="EUR"
+        locales={PAGE_LOCALE}
         hint={
           unavailable ??
           (currentMonth ? (
@@ -453,6 +476,7 @@ function RevenueCards(props: {
         value={readValue(projection?.revenue ?? null)}
         format="currency"
         currency="EUR"
+        locales={PAGE_LOCALE}
         hint={
           unavailable ??
           (projection ? (
@@ -929,8 +953,7 @@ function HistoryRow(props: {
             <span
               className={percent < 0 ? "text-danger-low" : "text-success-low"}
             >
-              {percent > 0 ? "+" : ""}
-              {percent}%
+              {GROWTH_FORMAT.format(percent / 100)}
             </span>
           )}
         </td>

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -7,7 +7,6 @@ import {
   CalendarCheckIcon,
   CalendarClockIcon,
   ChevronDownIcon,
-  TrendingDownIcon,
   TrendingUpIcon,
 } from "lucide-react";
 import { Helmet } from "react-helmet";
@@ -90,6 +89,13 @@ const StaffRevenueQuery = graphql(`
           foreignRevenue
         }
       }
+      projection {
+        revenue
+        monthlyPlans
+        yearlyPlans
+        githubPlans
+        estimated
+      }
       yearlyContracts {
         slug
         name
@@ -112,6 +118,7 @@ const StaffRevenueQuery = graphql(`
 
 type RevenueData = DocumentType<typeof StaffRevenueQuery>["staffRevenue"];
 type RevenueMonth = RevenueData["months"][number];
+type RevenueProjection = RevenueData["projection"];
 type YearlyContract = RevenueData["yearlyContracts"][number];
 type Split = RevenueMonth["monthlyPlans"];
 type MonthTeam = RevenueMonth["teams"][number];
@@ -145,18 +152,6 @@ const GITHUB_HINT =
  * moment it arrives.
  */
 const HINT_PLACEHOLDER = " ";
-
-/**
- * The month an amount covers, named.
- *
- * Read in UTC, which is where the server cut the month — formatting in the
- * reader's own zone would name the month before it for anyone west of
- * Greenwich.
- */
-const MONTH_FORMAT = new Intl.DateTimeFormat("en-US", {
-  month: "long",
-  timeZone: "UTC",
-});
 
 const MONTH_YEAR_FORMAT = new Intl.DateTimeFormat("en-US", {
   month: "short",
@@ -233,10 +228,6 @@ const DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
   dateStyle: "medium",
   timeZone: "UTC",
 });
-
-function formatMonth(month: string): string {
-  return MONTH_FORMAT.format(new Date(month));
-}
 
 /** The figures behind a half, appended to its tooltip. */
 function getSplitNote(split: Split): string {
@@ -333,21 +324,57 @@ function MonthSplit(props: { month: RevenueMonth; monthlyHint: string }) {
   );
 }
 
+/**
+ * Where the running month's projection comes from, under the amount.
+ *
+ * The same three parts the months above are split into, so the card can be
+ * read against the one beside it — and the part of the monthly figure no
+ * invoice exists for, which is the only one of the three that is not a
+ * reading of something already raised.
+ */
+function ProjectionSplit(props: { projection: RevenueProjection }) {
+  const { projection } = props;
+
+  return (
+    <>
+      <SplitAmount
+        amount={projection.monthlyPlans}
+        label="Monthly"
+        tooltip={`This month's invoices, plus ${formatEuros(projection.estimated)} the cycles have not raised yet — what the subscriptions still to be billed have run up so far. A floor: their usage keeps accruing until the cycle closes.`}
+      />
+      {" · "}
+      <SplitAmount
+        amount={projection.yearlyPlans}
+        label="Yearly"
+        tooltip="A whole month of the annual contracts, where the card beside this one counts only the days that have gone by."
+      />
+      {projection.githubPlans > 0 ? (
+        <>
+          {" · "}
+          <SplitAmount
+            amount={projection.githubPlans}
+            label="GitHub"
+            tooltip="A whole month of the Marketplace subscriptions, at list price. On top of the figures above, not inside them."
+          />
+        </>
+      ) : null}
+    </>
+  );
+}
+
 /** The three headline figures, rendered from whatever window was read. */
 function RevenueCards(props: {
   /** Oldest first, the running month last. Null while loading. */
   months: readonly RevenueMonth[] | null;
+  /** Where the running month is heading. Null while loading. */
+  projection: RevenueProjection | null;
   error: Error | null;
 }) {
-  const { months, error } = props;
+  const { months, projection, error } = props;
 
   // The last two are the only ones the cards read, whatever the window.
   const currentMonth = months?.at(-1) ?? null;
   const lastMonth = months?.at(-2) ?? null;
-  const growth =
-    currentMonth && lastMonth
-      ? getGrowth(currentMonth.revenue, lastMonth.revenue)
-      : null;
 
   // An em dash on all three rather than a band that disappears: the figures
   // failing to load is worth seeing on a page whose whole subject is what they
@@ -412,22 +439,16 @@ function RevenueCards(props: {
       />
       <StatTile
         data-visual-test="transparent"
-        icon={growth !== null && growth < 0 ? TrendingDownIcon : TrendingUpIcon}
-        color={growth !== null && growth < 0 ? "warning" : "success"}
-        label="Month over month"
-        value={readValue(growth)}
-        format="percent"
+        icon={TrendingUpIcon}
+        color="success"
+        label="Projected"
+        value={readValue(projection?.revenue ?? null)}
+        format="currency"
+        currency="EUR"
         hint={
           unavailable ??
-          (currentMonth && lastMonth && growth !== null ? (
-            <Hint
-              content={`${formatMonth(currentMonth.month)} (${formatEuros(currentMonth.revenue)}) vs ${formatMonth(lastMonth.month)} (${formatEuros(lastMonth.revenue)}). The running month is still filling.`}
-            >
-              {formatMonth(currentMonth.month)} vs{" "}
-              {formatMonth(lastMonth.month)}
-            </Hint>
-          ) : months ? (
-            "nothing to compare"
+          (projection ? (
+            <ProjectionSplit projection={projection} />
           ) : (
             HINT_PLACEHOLDER
           ))
@@ -1198,6 +1219,7 @@ function StaffRevenuePage() {
   });
   const months = data?.staffRevenue.months ?? null;
   const contracts = data?.staffRevenue.yearlyContracts ?? null;
+  const projection = data?.staffRevenue.projection ?? null;
 
   // Told rather than reported as a failed figure, as the other staff pages do:
   // a reader without access has no figures to wait for, and three tiles reading
@@ -1229,7 +1251,11 @@ function StaffRevenuePage() {
           <Heading>Revenue</Heading>
         </PageHeaderContent>
       </PageHeader>
-      <RevenueCards months={months} error={error ?? null} />
+      <RevenueCards
+        months={months}
+        projection={projection}
+        error={error ?? null}
+      />
       {months && contracts ? (
         <>
           <ChartCard className="mb-6" title="Invoiced by month">

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -596,31 +596,6 @@ function getMonthTeamSortValue(
 }
 
 /**
- * What the usage past the plan cost: the bill, less the plan's own price.
- *
- * In money rather than in screenshots, which is what makes it worth reading
- * beside the count. A negotiated plan sells its committed volume far below the
- * rate everything past it is billed at — six or seven times below is ordinary —
- * so a team a modest 46% over its quota can be paying thousands more than it
- * signed for, and the volume alone never says so.
- *
- * Null where there is nothing to read: no price on file, a month mixing
- * currencies — which leaves the invoice with no single figure to subtract from
- * — or a bill still inside the plan it was raised on.
- */
-function getOverage(team: MonthTeam): {
-  amount: number;
-  currency: string;
-} | null {
-  const { planPrice } = team;
-  if (!planPrice || planPrice.amount <= 0 || team.currency === null) {
-    return null;
-  }
-  const amount = team.amount - planPrice.amount;
-  return amount > 0 ? { amount, currency: planPrice.currency } : null;
-}
-
-/**
  * The day a line is filed under: when its newest invoice was raised, or when
  * the bill it is still waiting on is expected.
  */
@@ -700,20 +675,12 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               className="w-[20%] text-left"
             />
             <SortHeader
-              label="Usage"
-              sortKey="usage"
-              activeSortKey={sortKey}
-              direction={sortDirection}
-              onSort={onSort}
-              className="w-[14%] text-right"
-            />
-            <SortHeader
               label="Plan"
               sortKey="plan"
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[14%] text-right"
+              className="w-[13%] text-right"
             />
             <SortHeader
               label="Invoiced"
@@ -732,6 +699,14 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               className="w-[12%] text-right"
             />
             <SortHeader
+              label="Usage"
+              sortKey="usage"
+              activeSortKey={sortKey}
+              direction={sortDirection}
+              onSort={onSort}
+              className="w-[14%] text-right"
+            />
+            <SortHeader
               label="Date"
               sortKey="date"
               activeSortKey={sortKey}
@@ -748,7 +723,6 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
             const expectedAt = team.estimatedAt
               ? new Date(team.estimatedAt)
               : null;
-            const overage = getOverage(team);
             // Pro at list is what nearly every line is billed, so printing it
             // would repeat one figure down the column. An amount that is not
             // it — a commitment, or a price negotiated off the list — is the
@@ -759,12 +733,12 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               team.planPrice.amount === PRO_MONTHLY_PRICE
                 ? null
                 : team.planPrice;
-            // Under the price rather than under the usage: it is what that
-            // price buys, and the pair reads against the one beside it. Printed
-            // only where the price is, for the same reason it is — Pro's quota
-            // is the same figure down nearly every line.
+            // Under the count it is read against, and left out on Pro, whose
+            // quota is the same figure down nearly every line — the team
+            // directory prints it on the same terms.
             const quota =
-              planPrice && team.includedScreenshots !== null
+              team.includedScreenshots !== null &&
+              team.planName !== PRO_PLAN_NAME
                 ? SCREENSHOTS_FORMAT.format(team.includedScreenshots)
                 : null;
 
@@ -787,29 +761,7 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
                   <Link href={`/${team.slug}`}>{team.name ?? team.slug}</Link>
                 </td>
                 <td className="px-4 py-2.5 text-right tabular-nums">
-                  {expectedAt ? (
-                    // The period's, not the month's: it is the count the
-                    // estimate beside it was computed on.
-                    <Hint content="To date">
-                      {SCREENSHOTS_FORMAT.format(team.screenshotsCount)}
-                    </Hint>
-                  ) : (
-                    SCREENSHOTS_FORMAT.format(team.screenshotsCount)
-                  )}
-                  {overage && (
-                    // What the screenshots past the plan's own came to, under
-                    // the count they were consumed as: the volume and what it
-                    // cost are one reading.
-                    <div className="text-low text-xs">
-                      +{formatInvoiceAmount(overage)}
-                    </div>
-                  )}
-                </td>
-                <td className="px-4 py-2.5 text-right tabular-nums">
                   {planPrice ? formatInvoiceAmount(planPrice) : null}
-                  {quota !== null && (
-                    <div className="text-low text-xs">{quota}</div>
-                  )}
                 </td>
                 <td className="px-4 py-2.5 text-right tabular-nums">
                   {team.currency === null ? (
@@ -833,6 +785,20 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
                 </td>
                 <td className="px-4 py-2.5 text-right tabular-nums">
                   {formatEuros(team.revenue)}
+                </td>
+                <td className="px-4 py-2.5 text-right tabular-nums">
+                  {expectedAt ? (
+                    // The period's, not the month's: it is the count the
+                    // estimate beside it was computed on.
+                    <Hint content="To date">
+                      {SCREENSHOTS_FORMAT.format(team.screenshotsCount)}
+                    </Hint>
+                  ) : (
+                    SCREENSHOTS_FORMAT.format(team.screenshotsCount)
+                  )}
+                  {quota !== null && (
+                    <div className="text-low text-xs">/ {quota}</div>
+                  )}
                 </td>
                 {/* The dates walk forward with the calendar, like the month
                     names above. */}

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -40,7 +40,7 @@ import { SortHeader, type SortDirection } from "@/ui/SortHeader";
 import { StatTile } from "@/ui/StatTile";
 import { Tooltip } from "@/ui/Tooltip";
 
-import { PRO_PLAN_NAME } from "./pricing";
+import { PRO_MONTHLY_PRICE, PRO_PLAN_NAME } from "./pricing";
 import { getStripeCustomerURL } from "./stripe";
 
 /**
@@ -228,11 +228,10 @@ function formatInvoiceAmount(invoice: {
 /** Screenshot counts, grouped like the team directory prints them. */
 const SCREENSHOTS_FORMAT = new Intl.NumberFormat("en-US");
 
-/** How far past a quota a team is running. */
-const OVERAGE_FORMAT = new Intl.NumberFormat("en-US", {
-  style: "percent",
-  maximumFractionDigits: 0,
-  signDisplay: "always",
+/** What a bill came to, in multiples of the plan it was raised on. */
+const MULTIPLE_FORMAT = new Intl.NumberFormat("en-US", {
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
 });
 
 /** A renewal's date, read in UTC like every other date on the page. */
@@ -595,9 +594,12 @@ function getMonthTeamSortValue(
     case "screenshots":
       return team.screenshotsCount;
     case "overage":
-      // Below every team that has one, rather than mixed in among them: a line
-      // inside its quota is not a small overage, it is no overage at all.
-      return getOverage(team) ?? -1;
+      // On what the overage is worth rather than on the multiple: the column
+      // is read to pick a team to negotiate with, and a small plan billed ten
+      // times over is not the conversation a large one billed twice is. Below
+      // every team that has one, rather than mixed in among them — a bill
+      // inside its plan is not a small overage, it is no overage at all.
+      return getOverage(team)?.revenue ?? -1;
     case "date": {
       // On the date the column prints: the newest invoice, or the day the bill
       // is expected on a line that has none yet.
@@ -608,24 +610,46 @@ function getMonthTeamSortValue(
 }
 
 /**
- * How far past its quota a line is running, as a share of that quota — 0.6 for
- * a team consuming 8M against the 5M its plan includes.
+ * How far past its plan a line's bill went: the multiple of the plan's own
+ * price the invoice came to, and what the part above that price is worth.
  *
- * Null where nothing is over: under the quota there is no overage to report,
- * and a team whose plan is unknown has nothing to be over.
+ * In money rather than in screenshots, which is the whole point of the column.
+ * A negotiated plan sells its committed volume far below the rate everything
+ * past it is billed at — six or seven times below is ordinary — so a team a
+ * modest 46% over its quota can be paying four times what it signed for. Read
+ * in volume, the teams whose contract has drifted furthest from their usage
+ * are the ones that stand out least; the volume is a column of its own anyway,
+ * beside the quota it is read against.
  *
- * This is the column a negotiated plan is decided from, so it is read against
- * the quota rather than against the bill: what an invoice came to already
- * mixes the plan's own price in, and two teams equally far past their quotas
- * do not read the same once it is.
+ * Null where there is nothing to read: no price on file, a month mixing
+ * currencies — which leaves the invoice with no single figure to compare — or
+ * a bill still inside the plan it was raised on.
  */
-function getOverage(team: MonthTeam): number | null {
-  const { includedScreenshots } = team;
-  if (includedScreenshots === null || includedScreenshots === 0) {
+function getOverage(team: MonthTeam): {
+  /** What the bill came to, over the plan's own price. */
+  multiple: number;
+  amount: number;
+  currency: string;
+  /** The same amount in euros, which is what orders the column. */
+  revenue: number;
+} | null {
+  const { planPrice } = team;
+  if (!planPrice || planPrice.amount <= 0 || team.currency === null) {
     return null;
   }
-  const over = team.screenshotsCount - includedScreenshots;
-  return over > 0 ? over / includedScreenshots : null;
+  const amount = team.amount - planPrice.amount;
+  if (amount <= 0) {
+    return null;
+  }
+  return {
+    multiple: team.amount / planPrice.amount,
+    amount,
+    currency: planPrice.currency,
+    // Converted at the line's own rate rather than at a rate of this page's:
+    // the two figures beside it are one bill stated twice, so what one euro of
+    // it was worth is already there to be read off.
+    revenue: (amount * team.revenue) / team.amount,
+  };
 }
 
 /**
@@ -765,6 +789,16 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               ? new Date(team.estimatedAt)
               : null;
             const overage = getOverage(team);
+            // Pro at list is what nearly every line is billed, so printing it
+            // would repeat one figure down the column. An amount that is not
+            // it — a commitment, or a price negotiated off the list — is the
+            // only one worth reading.
+            const planPrice =
+              team.planPrice &&
+              team.planName === PRO_PLAN_NAME &&
+              team.planPrice.amount === PRO_MONTHLY_PRICE
+                ? null
+                : team.planPrice;
             // Pro includes the same quota on nearly every line, so printing it
             // there would repeat one number down the column. What is left is
             // the contracts, where it was negotiated — and where it is the
@@ -794,11 +828,7 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
                   <Link href={`/${team.slug}`}>{team.name ?? team.slug}</Link>
                 </td>
                 <td className="px-4 py-2.5 text-right tabular-nums">
-                  {team.planPrice ? (
-                    formatInvoiceAmount(team.planPrice)
-                  ) : (
-                    <span className="text-low">—</span>
-                  )}
+                  {planPrice ? formatInvoiceAmount(planPrice) : null}
                 </td>
                 <td className="px-4 py-2.5 text-right tabular-nums">
                   {team.currency === null ? (
@@ -841,7 +871,12 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
                   {overage === null ? (
                     <span className="text-low">—</span>
                   ) : (
-                    OVERAGE_FORMAT.format(overage)
+                    <>
+                      <div>×{MULTIPLE_FORMAT.format(overage.multiple)}</div>
+                      <div className="text-low text-xs">
+                        +{formatInvoiceAmount(overage)}
+                      </div>
+                    </>
                   )}
                 </td>
                 {/* The dates walk forward with the calendar, like the month

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -141,7 +141,7 @@ const YEARLY_HINT =
   "Annual contracts amortized, day by day, over the months they cover. In €.";
 
 const GITHUB_HINT =
-  "The month's Marketplace subscriptions at list price, billed by GitHub. On top of the figure above, not in it.";
+  "The month's Marketplace subscriptions at list price, billed by GitHub rather than invoiced by Argos.";
 
 /**
  * Stands in for the hint line while the figures load.
@@ -354,7 +354,7 @@ function ProjectionSplit(props: { projection: RevenueProjection }) {
           <SplitAmount
             amount={projection.githubPlans}
             label="GitHub"
-            tooltip="A whole month of the Marketplace subscriptions, at list price. On top of the figures above, not inside them."
+            tooltip="A whole month of the Marketplace subscriptions, at list price, billed by GitHub rather than invoiced by Argos."
           />
         </>
       ) : null}
@@ -693,7 +693,7 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[20%] text-left"
+              className="w-[21%] text-left"
             />
             <SortHeader
               label="Plan"

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -1029,9 +1029,6 @@ function HistoryRow(props: {
                 <AlertText>{error.message}</AlertText>
               </Alert>
             ) : (
-              // Sized like the one the lists use, and on the default delay: a
-              // month that answers in a blink shows nothing rather than a
-              // spinner that flashes.
               <div className="flex justify-center py-4">
                 <Loader className="text-low size-6" />
               </div>

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -725,7 +725,7 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[21%] text-left"
+              className="w-[19%] text-left"
             />
             <SortHeader
               label="Plan"
@@ -767,7 +767,10 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               onSort={onSort}
               className="w-[14%] text-right"
             />
-            <th className="w-[6%] px-4 py-3 text-right" />
+            {/* Wide enough for the link it holds: under `table-fixed` a
+                column narrower than its content does not grow, it spills over
+                its own padding and into the table's edge. */}
+            <th className="w-[8%] px-4 py-3 text-right" />
           </tr>
         </thead>
         <tbody>

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -57,27 +57,6 @@ const StaffRevenueQuery = graphql(`
           teamsCount
           foreignRevenue
         }
-        teams {
-          slug
-          name
-          stripeCustomerId
-          amount
-          currency
-          revenue
-          screenshotsCount
-          estimatedAt
-          planPrice {
-            amount
-            currency
-          }
-          includedScreenshots
-          planName
-          invoices {
-            amount
-            currency
-            invoicedAt
-          }
-        }
         yearlyPlans {
           revenue
           teamsCount
@@ -116,12 +95,46 @@ const StaffRevenueQuery = graphql(`
   }
 `);
 
+/**
+ * The teams behind one month, read when a reader opens that month rather than
+ * beside the figures: a line carries the usage its team got through, and a
+ * year of that is the page's whole cost. Closed months never change, so the
+ * Apollo cache holds each one for the session after its first opening.
+ */
+const StaffRevenueMonthTeamsQuery = graphql(`
+  query StaffRevenue_staffRevenueMonthTeams($month: DateTime!) {
+    staffRevenueMonthTeams(month: $month) {
+      slug
+      name
+      stripeCustomerId
+      amount
+      currency
+      revenue
+      screenshotsCount
+      estimatedAt
+      planPrice {
+        amount
+        currency
+      }
+      includedScreenshots
+      planName
+      invoices {
+        amount
+        currency
+        invoicedAt
+      }
+    }
+  }
+`);
+
 type RevenueData = DocumentType<typeof StaffRevenueQuery>["staffRevenue"];
 type RevenueMonth = RevenueData["months"][number];
 type RevenueProjection = RevenueData["projection"];
 type YearlyContract = RevenueData["yearlyContracts"][number];
 type Split = RevenueMonth["monthlyPlans"];
-type MonthTeam = RevenueMonth["teams"][number];
+type MonthTeam = DocumentType<
+  typeof StaffRevenueMonthTeamsQuery
+>["staffRevenueMonthTeams"][number];
 
 /** Months the dedicated page reads — a year, plus the one running. */
 const PAGE_MONTHS = 13;
@@ -912,6 +925,17 @@ function HistoryRow(props: {
 }) {
   const { month, before, isCurrent, index, isLast } = props;
   const [isOpened, setIsOpened] = useState(false);
+  // A month nobody invoiced has nothing to open, and the running month can
+  // still be owed a bill nothing has counted — so it opens whatever its
+  // figures say.
+  const hasTeams = isCurrent || month.monthlyPlans.teamsCount > 0;
+  // Fired on the first opening and never again: a closed month's breakdown is
+  // a fact, and Apollo holds it for the session.
+  const { data, error } = useQuery(StaffRevenueMonthTeamsQuery, {
+    variables: { month: month.month },
+    skip: !isOpened,
+  });
+  const teams = data?.staffRevenueMonthTeams ?? null;
   // On the monthly figure, like every column here: the yearly rate lives in
   // its own table, and a change diluted by a flat rate would understate every
   // move.
@@ -969,7 +993,7 @@ function HistoryRow(props: {
           )}
         </td>
         <td className="p-4 text-right text-sm">
-          {month.teams.length > 0 ? (
+          {hasTeams ? (
             <Button
               variant="secondary"
               size="small"
@@ -998,7 +1022,20 @@ function HistoryRow(props: {
           )}
         >
           <td colSpan={6} className="p-4">
-            <MonthTeamsTable teams={month.teams} />
+            {teams ? (
+              <MonthTeamsTable teams={teams} />
+            ) : error ? (
+              <Alert>
+                <AlertText>{error.message}</AlertText>
+              </Alert>
+            ) : (
+              // Sized like the one the lists use, and on the default delay: a
+              // month that answers in a blink shows nothing rather than a
+              // spinner that flashes.
+              <div className="flex justify-center py-4">
+                <Loader className="text-low size-6" />
+              </div>
+            )}
           </td>
         </tr>
       ) : null}

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -432,7 +432,7 @@ function RevenueCards(props: {
         data-visual-test="transparent"
         icon={CalendarCheckIcon}
         color="primary"
-        label="Last month"
+        label="Last month revenue"
         value={readValue(lastMonth?.revenue ?? null)}
         format="currency"
         currency="EUR"
@@ -451,7 +451,7 @@ function RevenueCards(props: {
         icon={CalendarClockIcon}
         // The storybook token is the design system's pink.
         color="storybook"
-        label="Current month"
+        label="Invoiced this month"
         value={readValue(currentMonth?.revenue ?? null)}
         format="currency"
         currency="EUR"
@@ -518,9 +518,9 @@ const CHART_CONFIG: ChartConfig = Object.fromEntries(
  * carries a slope where twelve separate bars make the reader measure heights
  * against each other.
  *
- * The tooltip totals the three bands, the stack's own height. It therefore
- * reads above the cards, which report what Stripe invoiced alone — the
- * Marketplace band is billed by GitHub and sits on top of them.
+ * The tooltip totals the three bands, the stack's own height — the same figure
+ * the cards state, Marketplace included: what a month was worth is what it was
+ * worth, whoever raised the bill.
  */
 function RevenueChart(props: { months: readonly RevenueMonth[] }) {
   const data = props.months.map((month) => ({
@@ -796,7 +796,10 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
 
             return (
               <tr
-                key={team.stripeCustomerId}
+                // The customer alone is not unique: a team sent a bill this
+                // month can still have its cycle's own bill to come, which is
+                // a second line — one invoiced, one estimated.
+                key={`${team.stripeCustomerId}-${team.estimatedAt ? "estimate" : "invoiced"}`}
                 className={clsx(
                   "text-sm",
                   teamIndex !== teams.length - 1 && "border-b",

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -40,7 +40,7 @@ import { StatTile } from "@/ui/StatTile";
 import { Tooltip } from "@/ui/Tooltip";
 
 import { PRO_MONTHLY_PRICE, PRO_PLAN_NAME } from "./pricing";
-import { getStripeCustomerURL } from "./stripe";
+import { StripeCustomerLink } from "./stripe";
 
 /**
  * Read from the backend's Stripe invoice mirror — this page is the query's
@@ -472,7 +472,7 @@ function RevenueCards(props: {
         data-visual-test="transparent"
         icon={TrendingUpIcon}
         color="success"
-        label="Projected"
+        label="Projected this month"
         value={readValue(projection?.revenue ?? null)}
         format="currency"
         currency="EUR"
@@ -725,7 +725,7 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[19%] text-left"
+              className="w-[20%] text-left"
             />
             <SortHeader
               label="Plan"
@@ -733,7 +733,7 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[13%] text-right"
+              className="w-[14%] text-right"
             />
             <SortHeader
               label="Invoiced"
@@ -741,7 +741,7 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[15%] text-right"
+              className="w-[16%] text-right"
             />
             <SortHeader
               label="In euros"
@@ -749,7 +749,7 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[12%] text-right"
+              className="w-[14%] text-right"
             />
             <SortHeader
               label="Usage"
@@ -757,7 +757,7 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[14%] text-right"
+              className="w-[16%] text-right"
             />
             <SortHeader
               label="Date"
@@ -765,12 +765,8 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[14%] text-right"
+              className="w-[15%] text-right"
             />
-            {/* Wide enough for the link it holds: under `table-fixed` a
-                column narrower than its content does not grow, it spills over
-                its own padding and into the table's edge. */}
-            <th className="w-[8%] px-4 py-3 text-right" />
           </tr>
         </thead>
         <tbody>
@@ -814,7 +810,12 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
                   {teamIndex + 1}
                 </td>
                 <td className="px-4 py-2.5 text-left">
-                  <Link href={`/${team.slug}`}>{team.name ?? team.slug}</Link>
+                  <div className="flex items-center gap-2">
+                    <Link href={`/${team.slug}`}>{team.name ?? team.slug}</Link>
+                    <StripeCustomerLink
+                      stripeCustomerId={team.stripeCustomerId}
+                    />
+                  </div>
                 </td>
                 <td className="px-4 py-2.5 text-right tabular-nums">
                   {planPrice ? formatInvoiceAmount(planPrice) : null}
@@ -887,14 +888,6 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
                       {DATE_FORMAT.format(new Date(newestInvoice.invoicedAt))}
                     </Hint>
                   )}
-                </td>
-                <td className="px-4 py-2.5 text-right">
-                  <Link
-                    href={getStripeCustomerURL(team.stripeCustomerId)}
-                    target="_blank"
-                  >
-                    Stripe
-                  </Link>
                 </td>
               </tr>
             );
@@ -1095,7 +1088,12 @@ function ContractRow(props: { contract: YearlyContract; index: number }) {
   return (
     <tr className={clsx(index % 2 === 0 ? "bg-app" : "bg-subtle", "border-b")}>
       <td className="p-4 text-left text-sm font-medium">
-        <Link href={`/${contract.slug}`}>{contract.name ?? contract.slug}</Link>
+        <div className="flex items-center gap-2">
+          <Link href={`/${contract.slug}`}>
+            {contract.name ?? contract.slug}
+          </Link>
+          <StripeCustomerLink stripeCustomerId={contract.stripeCustomerId} />
+        </div>
       </td>
       <td className="p-4 text-right text-sm tabular-nums">
         {contract.amount !== null ? (
@@ -1155,14 +1153,6 @@ function ContractRow(props: { contract: YearlyContract; index: number }) {
           <span className="text-low">—</span>
         )}
       </td>
-      <td className="p-4 text-right text-sm">
-        <Link
-          href={getStripeCustomerURL(contract.stripeCustomerId)}
-          target="_blank"
-        >
-          Stripe
-        </Link>
-      </td>
     </tr>
   );
 }
@@ -1202,19 +1192,18 @@ function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
             <thead>
               <tr className="text-low border-b text-xs font-semibold">
                 <th className="w-[26%] px-4 py-3 text-left">Team</th>
-                <th className="w-[18%] px-4 py-3 text-right">Invoiced</th>
-                <th className="w-[16%] px-4 py-3 text-right">
+                <th className="w-[20%] px-4 py-3 text-right">Invoiced</th>
+                <th className="w-[18%] px-4 py-3 text-right">
                   <Hint content="Dollars converted at a fixed rate.">
                     In euros
                   </Hint>
                 </th>
-                <th className="w-[16%] px-4 py-3 text-right">
+                <th className="w-[18%] px-4 py-3 text-right">
                   <Hint content="What it adds to this month, in euros.">
                     Per month
                   </Hint>
                 </th>
                 <th className="w-[18%] px-4 py-3 text-right">Last invoice</th>
-                <th className="w-[16%] px-4 py-3 text-right" />
               </tr>
             </thead>
             <tbody>
@@ -1236,7 +1225,6 @@ function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
                 <td className="p-4 text-right tabular-nums">
                   {CONTRACT_PRICE_FORMAT.format(monthlyTotal)}
                 </td>
-                <td />
                 <td />
               </tr>
             </tfoot>

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -228,12 +228,6 @@ function formatInvoiceAmount(invoice: {
 /** Screenshot counts, grouped like the team directory prints them. */
 const SCREENSHOTS_FORMAT = new Intl.NumberFormat("en-US");
 
-/** What a bill came to, in multiples of the plan it was raised on. */
-const MULTIPLE_FORMAT = new Intl.NumberFormat("en-US", {
-  minimumFractionDigits: 1,
-  maximumFractionDigits: 1,
-});
-
 /** A renewal's date, read in UTC like every other date on the page. */
 const DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
   dateStyle: "medium",
@@ -562,11 +556,10 @@ function RevenueChart(props: { months: readonly RevenueMonth[] }) {
 
 type MonthTeamSortKey =
   | "team"
+  | "usage"
   | "plan"
   | "amount"
   | "revenue"
-  | "screenshots"
-  | "overage"
   | "date";
 
 /**
@@ -591,15 +584,8 @@ function getMonthTeamSortValue(
       return team.revenue;
     case "plan":
       return team.planPrice?.amount ?? -1;
-    case "screenshots":
+    case "usage":
       return team.screenshotsCount;
-    case "overage":
-      // On what the overage is worth rather than on the multiple: the column
-      // is read to pick a team to negotiate with, and a small plan billed ten
-      // times over is not the conversation a large one billed twice is. Below
-      // every team that has one, rather than mixed in among them — a bill
-      // inside its plan is not a small overage, it is no overage at all.
-      return getOverage(team)?.revenue ?? -1;
     case "date": {
       // On the date the column prints: the newest invoice, or the day the bill
       // is expected on a line that has none yet.
@@ -610,46 +596,28 @@ function getMonthTeamSortValue(
 }
 
 /**
- * How far past its plan a line's bill went: the multiple of the plan's own
- * price the invoice came to, and what the part above that price is worth.
+ * What the usage past the plan cost: the bill, less the plan's own price.
  *
- * In money rather than in screenshots, which is the whole point of the column.
- * A negotiated plan sells its committed volume far below the rate everything
- * past it is billed at — six or seven times below is ordinary — so a team a
- * modest 46% over its quota can be paying four times what it signed for. Read
- * in volume, the teams whose contract has drifted furthest from their usage
- * are the ones that stand out least; the volume is a column of its own anyway,
- * beside the quota it is read against.
+ * In money rather than in screenshots, which is what makes it worth reading
+ * beside the count. A negotiated plan sells its committed volume far below the
+ * rate everything past it is billed at — six or seven times below is ordinary —
+ * so a team a modest 46% over its quota can be paying thousands more than it
+ * signed for, and the volume alone never says so.
  *
  * Null where there is nothing to read: no price on file, a month mixing
- * currencies — which leaves the invoice with no single figure to compare — or
- * a bill still inside the plan it was raised on.
+ * currencies — which leaves the invoice with no single figure to subtract from
+ * — or a bill still inside the plan it was raised on.
  */
 function getOverage(team: MonthTeam): {
-  /** What the bill came to, over the plan's own price. */
-  multiple: number;
   amount: number;
   currency: string;
-  /** The same amount in euros, which is what orders the column. */
-  revenue: number;
 } | null {
   const { planPrice } = team;
   if (!planPrice || planPrice.amount <= 0 || team.currency === null) {
     return null;
   }
   const amount = team.amount - planPrice.amount;
-  if (amount <= 0) {
-    return null;
-  }
-  return {
-    multiple: team.amount / planPrice.amount,
-    amount,
-    currency: planPrice.currency,
-    // Converted at the line's own rate rather than at a rate of this page's:
-    // the two figures beside it are one bill stated twice, so what one euro of
-    // it was worth is already there to be read off.
-    revenue: (amount * team.revenue) / team.amount,
-  };
+  return amount > 0 ? { amount, currency: planPrice.currency } : null;
 }
 
 /**
@@ -729,7 +697,15 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[19%] text-left"
+              className="w-[20%] text-left"
+            />
+            <SortHeader
+              label="Usage"
+              sortKey="usage"
+              activeSortKey={sortKey}
+              direction={sortDirection}
+              onSort={onSort}
+              className="w-[14%] text-right"
             />
             <SortHeader
               label="Plan"
@@ -737,7 +713,7 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[11%] text-right"
+              className="w-[14%] text-right"
             />
             <SortHeader
               label="Invoiced"
@@ -745,7 +721,7 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[13%] text-right"
+              className="w-[15%] text-right"
             />
             <SortHeader
               label="In euros"
@@ -753,23 +729,7 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[11%] text-right"
-            />
-            <SortHeader
-              label="Screenshots"
-              sortKey="screenshots"
-              activeSortKey={sortKey}
-              direction={sortDirection}
-              onSort={onSort}
-              className="w-[13%] text-right"
-            />
-            <SortHeader
-              label="Overage"
-              sortKey="overage"
-              activeSortKey={sortKey}
-              direction={sortDirection}
-              onSort={onSort}
-              className="w-[10%] text-right"
+              className="w-[12%] text-right"
             />
             <SortHeader
               label="Date"
@@ -777,7 +737,7 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[12%] text-right"
+              className="w-[14%] text-right"
             />
             <th className="w-[6%] px-4 py-3 text-right" />
           </tr>
@@ -799,13 +759,12 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               team.planPrice.amount === PRO_MONTHLY_PRICE
                 ? null
                 : team.planPrice;
-            // Pro includes the same quota on nearly every line, so printing it
-            // there would repeat one number down the column. What is left is
-            // the contracts, where it was negotiated — and where it is the
-            // only thing that makes the count above it mean anything.
+            // Under the price rather than under the usage: it is what that
+            // price buys, and the pair reads against the one beside it. Printed
+            // only where the price is, for the same reason it is — Pro's quota
+            // is the same figure down nearly every line.
             const quota =
-              team.includedScreenshots !== null &&
-              team.planName !== PRO_PLAN_NAME
+              planPrice && team.includedScreenshots !== null
                 ? SCREENSHOTS_FORMAT.format(team.includedScreenshots)
                 : null;
 
@@ -828,7 +787,29 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
                   <Link href={`/${team.slug}`}>{team.name ?? team.slug}</Link>
                 </td>
                 <td className="px-4 py-2.5 text-right tabular-nums">
+                  {expectedAt ? (
+                    // The period's, not the month's: it is the count the
+                    // estimate beside it was computed on.
+                    <Hint content="To date">
+                      {SCREENSHOTS_FORMAT.format(team.screenshotsCount)}
+                    </Hint>
+                  ) : (
+                    SCREENSHOTS_FORMAT.format(team.screenshotsCount)
+                  )}
+                  {overage && (
+                    // What the screenshots past the plan's own came to, under
+                    // the count they were consumed as: the volume and what it
+                    // cost are one reading.
+                    <div className="text-low text-xs">
+                      +{formatInvoiceAmount(overage)}
+                    </div>
+                  )}
+                </td>
+                <td className="px-4 py-2.5 text-right tabular-nums">
                   {planPrice ? formatInvoiceAmount(planPrice) : null}
+                  {quota !== null && (
+                    <div className="text-low text-xs">{quota}</div>
+                  )}
                 </td>
                 <td className="px-4 py-2.5 text-right tabular-nums">
                   {team.currency === null ? (
@@ -852,32 +833,6 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
                 </td>
                 <td className="px-4 py-2.5 text-right tabular-nums">
                   {formatEuros(team.revenue)}
-                </td>
-                <td className="px-4 py-2.5 text-right tabular-nums">
-                  {expectedAt ? (
-                    // The period's, not the month's: it is the count the
-                    // estimate beside it was computed on.
-                    <Hint content="To date">
-                      {SCREENSHOTS_FORMAT.format(team.screenshotsCount)}
-                    </Hint>
-                  ) : (
-                    SCREENSHOTS_FORMAT.format(team.screenshotsCount)
-                  )}
-                  {quota !== null && (
-                    <div className="text-low text-xs">/ {quota}</div>
-                  )}
-                </td>
-                <td className="px-4 py-2.5 text-right tabular-nums">
-                  {overage === null ? (
-                    <span className="text-low">—</span>
-                  ) : (
-                    <>
-                      <div>×{MULTIPLE_FORMAT.format(overage.multiple)}</div>
-                      <div className="text-low text-xs">
-                        +{formatInvoiceAmount(overage)}
-                      </div>
-                    </>
-                  )}
                 </td>
                 {/* The dates walk forward with the calendar, like the month
                     names above. */}

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -40,6 +40,7 @@ import { SortHeader, type SortDirection } from "@/ui/SortHeader";
 import { StatTile } from "@/ui/StatTile";
 import { Tooltip } from "@/ui/Tooltip";
 
+import { PRO_PLAN_NAME } from "./pricing";
 import { getStripeCustomerURL } from "./stripe";
 
 /**
@@ -66,6 +67,12 @@ const StaffRevenueQuery = graphql(`
           revenue
           screenshotsCount
           estimatedAt
+          planPrice {
+            amount
+            currency
+          }
+          includedScreenshots
+          planName
           invoices {
             amount
             currency
@@ -220,6 +227,13 @@ function formatInvoiceAmount(invoice: {
 
 /** Screenshot counts, grouped like the team directory prints them. */
 const SCREENSHOTS_FORMAT = new Intl.NumberFormat("en-US");
+
+/** How far past a quota a team is running. */
+const OVERAGE_FORMAT = new Intl.NumberFormat("en-US", {
+  style: "percent",
+  maximumFractionDigits: 0,
+  signDisplay: "always",
+});
 
 /** A renewal's date, read in UTC like every other date on the page. */
 const DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
@@ -547,7 +561,14 @@ function RevenueChart(props: { months: readonly RevenueMonth[] }) {
   );
 }
 
-type MonthTeamSortKey = "team" | "amount" | "revenue" | "screenshots" | "date";
+type MonthTeamSortKey =
+  | "team"
+  | "plan"
+  | "amount"
+  | "revenue"
+  | "screenshots"
+  | "overage"
+  | "date";
 
 /**
  * Sortable value per column of a month's breakdown.
@@ -569,8 +590,14 @@ function getMonthTeamSortValue(
       return team.currency === null ? -1 : team.amount;
     case "revenue":
       return team.revenue;
+    case "plan":
+      return team.planPrice?.amount ?? -1;
     case "screenshots":
       return team.screenshotsCount;
+    case "overage":
+      // Below every team that has one, rather than mixed in among them: a line
+      // inside its quota is not a small overage, it is no overage at all.
+      return getOverage(team) ?? -1;
     case "date": {
       // On the date the column prints: the newest invoice, or the day the bill
       // is expected on a line that has none yet.
@@ -578,6 +605,27 @@ function getMonthTeamSortValue(
       return date ? date.getTime() : -1;
     }
   }
+}
+
+/**
+ * How far past its quota a line is running, as a share of that quota — 0.6 for
+ * a team consuming 8M against the 5M its plan includes.
+ *
+ * Null where nothing is over: under the quota there is no overage to report,
+ * and a team whose plan is unknown has nothing to be over.
+ *
+ * This is the column a negotiated plan is decided from, so it is read against
+ * the quota rather than against the bill: what an invoice came to already
+ * mixes the plan's own price in, and two teams equally far past their quotas
+ * do not read the same once it is.
+ */
+function getOverage(team: MonthTeam): number | null {
+  const { includedScreenshots } = team;
+  if (includedScreenshots === null || includedScreenshots === 0) {
+    return null;
+  }
+  const over = team.screenshotsCount - includedScreenshots;
+  return over > 0 ? over / includedScreenshots : null;
 }
 
 /**
@@ -650,14 +698,22 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
       <table className="w-full table-fixed border-collapse">
         <thead>
           <tr className="text-low border-b text-xs font-semibold">
-            <th className="w-[6%] px-4 py-3 text-right">#</th>
+            <th className="w-[5%] px-4 py-3 text-right">#</th>
             <SortHeader
               label="Team"
               sortKey="team"
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[24%] text-left"
+              className="w-[19%] text-left"
+            />
+            <SortHeader
+              label="Plan"
+              sortKey="plan"
+              activeSortKey={sortKey}
+              direction={sortDirection}
+              onSort={onSort}
+              className="w-[11%] text-right"
             />
             <SortHeader
               label="Invoiced"
@@ -665,7 +721,7 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[16%] text-right"
+              className="w-[13%] text-right"
             />
             <SortHeader
               label="In euros"
@@ -673,7 +729,7 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[14%] text-right"
+              className="w-[11%] text-right"
             />
             <SortHeader
               label="Screenshots"
@@ -681,7 +737,15 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[14%] text-right"
+              className="w-[13%] text-right"
+            />
+            <SortHeader
+              label="Overage"
+              sortKey="overage"
+              activeSortKey={sortKey}
+              direction={sortDirection}
+              onSort={onSort}
+              className="w-[10%] text-right"
             />
             <SortHeader
               label="Date"
@@ -689,9 +753,9 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
               activeSortKey={sortKey}
               direction={sortDirection}
               onSort={onSort}
-              className="w-[16%] text-right"
+              className="w-[12%] text-right"
             />
-            <th className="w-[10%] px-4 py-3 text-right" />
+            <th className="w-[6%] px-4 py-3 text-right" />
           </tr>
         </thead>
         <tbody>
@@ -700,6 +764,16 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
             const expectedAt = team.estimatedAt
               ? new Date(team.estimatedAt)
               : null;
+            const overage = getOverage(team);
+            // Pro includes the same quota on nearly every line, so printing it
+            // there would repeat one number down the column. What is left is
+            // the contracts, where it was negotiated — and where it is the
+            // only thing that makes the count above it mean anything.
+            const quota =
+              team.includedScreenshots !== null &&
+              team.planName !== PRO_PLAN_NAME
+                ? SCREENSHOTS_FORMAT.format(team.includedScreenshots)
+                : null;
 
             return (
               <tr
@@ -718,6 +792,13 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
                 </td>
                 <td className="px-4 py-2.5 text-left">
                   <Link href={`/${team.slug}`}>{team.name ?? team.slug}</Link>
+                </td>
+                <td className="px-4 py-2.5 text-right tabular-nums">
+                  {team.planPrice ? (
+                    formatInvoiceAmount(team.planPrice)
+                  ) : (
+                    <span className="text-low">—</span>
+                  )}
                 </td>
                 <td className="px-4 py-2.5 text-right tabular-nums">
                   {team.currency === null ? (
@@ -751,6 +832,16 @@ function MonthTeamsTable(props: { teams: readonly MonthTeam[] }) {
                     </Hint>
                   ) : (
                     SCREENSHOTS_FORMAT.format(team.screenshotsCount)
+                  )}
+                  {quota !== null && (
+                    <div className="text-low text-xs">/ {quota}</div>
+                  )}
+                </td>
+                <td className="px-4 py-2.5 text-right tabular-nums">
+                  {overage === null ? (
+                    <span className="text-low">—</span>
+                  ) : (
+                    OVERAGE_FORMAT.format(overage)
                   )}
                 </td>
                 {/* The dates walk forward with the calendar, like the month

--- a/apps/frontend/src/pages/Staff/Trials.tsx
+++ b/apps/frontend/src/pages/Staff/Trials.tsx
@@ -38,7 +38,7 @@ import {
   PageHeaderActions,
   PageHeaderContent,
 } from "@/ui/Layout";
-import { HeadlessLink, Link } from "@/ui/Link";
+import { Link } from "@/ui/Link";
 import { PageLoader } from "@/ui/PageLoader";
 import { SortHeader, type SortDirection } from "@/ui/SortHeader";
 import { StatTile } from "@/ui/StatTile";
@@ -58,8 +58,7 @@ import {
   PRO_PLAN_NAME,
   toMonthlyAmount,
 } from "./pricing";
-import { getStripeCustomerURL } from "./stripe";
-import stripeLogo from "./stripe.svg";
+import { StripeCustomerLink } from "./stripe";
 import { getMailtoUrl, getOutreachEmail } from "./Trials.email";
 
 const TrialPipelineQuery = graphql(`
@@ -652,41 +651,6 @@ function ContactCell(props: { team: PipelineTeam }) {
         />
       </span>
     </div>
-  );
-}
-
-/**
- * Jumps straight to the customer in Stripe.
- *
- * Nothing is rendered without a customer id: a team that never reached checkout
- * has no Stripe page, and a link to `/customers/null` would only look broken.
- */
-function StripeCustomerLink(props: { stripeCustomerId: string | null }) {
-  const { stripeCustomerId } = props;
-
-  if (!stripeCustomerId) {
-    return null;
-  }
-
-  return (
-    <Tooltip content="Open customer in Stripe">
-      <HeadlessLink
-        href={getStripeCustomerURL(stripeCustomerId)}
-        target="_blank"
-        // The generic external arrow would compete with the logo that already
-        // says "this leaves Argos for Stripe".
-        external={false}
-        aria-label="Open customer in Stripe"
-        // Pushed to the cell edge: next to the name the tile reads as a tag on
-        // the team rather than as a way out to Stripe, and following a
-        // variable-width name it lands somewhere different on every row. The
-        // logo carries its own brand color, so hover dims the whole tile rather
-        // than re-tinting it the way a monochrome icon would.
-        className="ml-auto shrink-0 opacity-75 transition hover:opacity-100"
-      >
-        <img src={stripeLogo} alt="" className="size-4 rounded-xs" />
-      </HeadlessLink>
-    </Tooltip>
   );
 }
 

--- a/apps/frontend/src/pages/Staff/pricing.ts
+++ b/apps/frontend/src/pages/Staff/pricing.ts
@@ -21,6 +21,15 @@ export type PricedPlan = {
 };
 
 /**
+ * What Pro costs a month at list.
+ *
+ * The one amount on these pages nearly every team is billed, which is what
+ * makes it worth leaving unprinted where a column would repeat it down every
+ * row — and what makes an amount that is *not* it worth seeing.
+ */
+export const PRO_MONTHLY_PRICE = 100;
+
+/**
  * Monthly price to assume for a plan when the subscription carries no amount of
  * its own — one Stripe has not been asked about since Argos started reading the
  * amount, or that has none to give.
@@ -31,15 +40,6 @@ export type PricedPlan = {
  * plan we sell, and understate itself tenfold in a total that carries no
  * warning.
  */
-/**
- * What Pro costs a month at list.
- *
- * The one amount on these pages nearly every team is billed, which is what
- * makes it worth leaving unprinted where a column would repeat it down every
- * row — and what makes an amount that is *not* it worth seeing.
- */
-export const PRO_MONTHLY_PRICE = 100;
-
 const FALLBACK_MONTHLY_PRICES: Record<string, number | undefined> = {
   [PRO_PLAN_NAME]: PRO_MONTHLY_PRICE,
   enterprise: 1000,

--- a/apps/frontend/src/pages/Staff/pricing.ts
+++ b/apps/frontend/src/pages/Staff/pricing.ts
@@ -31,8 +31,17 @@ export type PricedPlan = {
  * plan we sell, and understate itself tenfold in a total that carries no
  * warning.
  */
+/**
+ * What Pro costs a month at list.
+ *
+ * The one amount on these pages nearly every team is billed, which is what
+ * makes it worth leaving unprinted where a column would repeat it down every
+ * row — and what makes an amount that is *not* it worth seeing.
+ */
+export const PRO_MONTHLY_PRICE = 100;
+
 const FALLBACK_MONTHLY_PRICES: Record<string, number | undefined> = {
-  [PRO_PLAN_NAME]: 100,
+  [PRO_PLAN_NAME]: PRO_MONTHLY_PRICE,
   enterprise: 1000,
 };
 

--- a/apps/frontend/src/pages/Staff/stripe.ts
+++ b/apps/frontend/src/pages/Staff/stripe.ts
@@ -1,8 +1,0 @@
-/**
- * The customer page in the Stripe dashboard, where the trial, the card and the
- * invoices actually live — the questions the staff tables raise are answered
- * there.
- */
-export function getStripeCustomerURL(stripeCustomerId: string) {
-  return `https://dashboard.stripe.com/customers/${stripeCustomerId}`;
-}

--- a/apps/frontend/src/pages/Staff/stripe.tsx
+++ b/apps/frontend/src/pages/Staff/stripe.tsx
@@ -1,0 +1,48 @@
+import { HeadlessLink } from "@/ui/Link";
+import { Tooltip } from "@/ui/Tooltip";
+
+import stripeLogo from "./stripe.svg";
+
+/**
+ * The customer page in the Stripe dashboard, where the trial, the card and the
+ * invoices actually live — the questions the staff tables raise are answered
+ * there.
+ */
+export function getStripeCustomerURL(stripeCustomerId: string) {
+  return `https://dashboard.stripe.com/customers/${stripeCustomerId}`;
+}
+
+/**
+ * Jumps straight to the customer in Stripe.
+ *
+ * Nothing is rendered without a customer id: a team that never reached checkout
+ * has no Stripe page, and a link to `/customers/null` would only look broken.
+ */
+export function StripeCustomerLink(props: { stripeCustomerId: string | null }) {
+  const { stripeCustomerId } = props;
+
+  if (!stripeCustomerId) {
+    return null;
+  }
+
+  return (
+    <Tooltip content="Open customer in Stripe">
+      <HeadlessLink
+        href={getStripeCustomerURL(stripeCustomerId)}
+        target="_blank"
+        // The generic external arrow would compete with the logo that already
+        // says "this leaves Argos for Stripe".
+        external={false}
+        aria-label="Open customer in Stripe"
+        // Pushed to the cell edge: next to the name the tile reads as a tag on
+        // the team rather than as a way out to Stripe, and following a
+        // variable-width name it lands somewhere different on every row. The
+        // logo carries its own brand color, so hover dims the whole tile rather
+        // than re-tinting it the way a monochrome icon would.
+        className="ml-auto shrink-0 opacity-75 transition hover:opacity-100"
+      >
+        <img src={stripeLogo} alt="" className="size-4 rounded-xs" />
+      </HeadlessLink>
+    </Tooltip>
+  );
+}

--- a/apps/frontend/src/ui/StatTile.tsx
+++ b/apps/frontend/src/ui/StatTile.tsx
@@ -83,7 +83,11 @@ export function StatTile({
           )}
         </div>
         {hint ? (
-          <p className="text-low mt-0.5 h-4 text-sm">
+          // A floor rather than a height: the line is reserved while the
+          // figures load, so the card does not grow under the reader when they
+          // land — but a hint that wraps at a narrow width has to take the
+          // room it needs instead of spilling out of the card's padding.
+          <p className="text-low mt-0.5 min-h-5 text-sm">
             {isLoading ? null : hint}
           </p>
         ) : null}

--- a/apps/frontend/src/ui/StatTile.tsx
+++ b/apps/frontend/src/ui/StatTile.tsx
@@ -22,6 +22,12 @@ type StatTileProps = ComponentPropsWithRef<"div"> & {
   format?: "number" | "percent" | "currency";
   /** ISO code for `format="currency"` — the staff pages price in USD, the revenue page in EUR. */
   currency?: string;
+  /**
+   * Locale the figure is written in. Left out, it follows the reader's own —
+   * which is what a page shown to customers wants, and what a page pinned to
+   * one locale has to override so it reads the same on every screen.
+   */
+  locales?: Intl.LocalesArgument;
   hint?: React.ReactNode;
   visual?: React.ReactNode;
 };
@@ -40,6 +46,7 @@ export function StatTile({
   value,
   format = "number",
   currency = "USD",
+  locales,
   hint,
   visual,
   ...rest
@@ -67,11 +74,13 @@ export function StatTile({
           ) : format === "percent" ? (
             <NumberFlow
               value={value}
+              locales={locales}
               format={{ style: "percent", maximumFractionDigits: 0 }}
             />
           ) : format === "currency" ? (
             <NumberFlow
               value={value}
+              locales={locales}
               format={{
                 style: "currency",
                 currency,
@@ -79,7 +88,7 @@ export function StatTile({
               }}
             />
           ) : (
-            <NumberFlow value={value} />
+            <NumberFlow value={value} locales={locales} />
           )}
         </div>
         {hint ? (

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -846,9 +846,11 @@ const revenueTest = staffTest.extend<{ revenueBook: RevenueBook }>({
     // of it is its amount over that stretch, weighted by this month's length.
     const termMs = startOfUTCMonth(12).getTime() - startOfUTCMonth(0).getTime();
     const monthMs = startOfUTCMonth(1).getTime() - startOfUTCMonth(0).getTime();
+    // Rounded to the euro, like every amount the page prints.
     const contractPerMonth = new Intl.NumberFormat("en-US", {
       style: "currency",
       currency: "EUR",
+      maximumFractionDigits: 0,
     }).format((12_000 * monthMs) / termMs);
 
     const dateFormat = new Intl.DateTimeFormat("en-US", {
@@ -943,7 +945,7 @@ const pendingBillTest = staffTest.extend<{
     // at the half-cent the helper prices them at.
     await use({
       team: "Dunder Mifflin",
-      amount: "$150.00",
+      amount: "$150",
       screenshots: "45,000",
     });
   },
@@ -1034,7 +1036,7 @@ revenueTest.describe("staff revenue", () => {
     const breakdown = monthlyPlans.locator("tbody tr").nth(2);
     await expect(breakdown.getByText(revenueBook.monthlyTeam)).toBeVisible();
     // What Stripe charged, beside what the page counts it as.
-    await expect(breakdown.getByText("$1,000.00")).toBeVisible();
+    await expect(breakdown.getByText("$1,000")).toBeVisible();
     await expect(breakdown.getByText("€855")).toBeVisible();
     // Each line carries the day its invoice was raised.
     await expect(
@@ -1061,7 +1063,7 @@ revenueTest.describe("staff revenue", () => {
       .filter({ hasText: revenueBook.contractTeam });
     // Twice over: what Stripe charged, and what the page counts it as — the
     // contract is in euros, so both cells read the same.
-    await expect(contractRow.getByText("€12,000.00")).toHaveCount(2);
+    await expect(contractRow.getByText("€12,000")).toHaveCount(2);
     await expect(
       contractRow.getByText(revenueBook.contractPerMonth),
     ).toBeVisible();

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -138,8 +138,11 @@ async function createBilledTeam(input: {
    * which is precisely the row the Screenshots column has to report anyway.
    */
   trialEndsInDays?: number;
-  /** Where the running period opened, which sets the billing anniversary. */
-  periodStartDaysAgo: number;
+  /**
+   * Where the running period opened, which sets the billing anniversary — the
+   * offset into the month it falls at is the day the cycle bills on.
+   */
+  periodStart: string;
   /** What the plan costs per month, as Stripe holds it — null when Argos has
    * not read it yet, which every subscription is until its next sync. */
   flatPrice: number | null;
@@ -173,7 +176,7 @@ async function createBilledTeam(input: {
     subscriberId: input.subscriberId,
     // The row is as old as the team: periods that predate it are not billed.
     createdAt: daysFromNow(-input.createdDaysAgo),
-    startDate: daysFromNow(-input.periodStartDaysAgo),
+    startDate: input.periodStart,
     endDate: null,
     trialEndDate:
       runningTrial === undefined
@@ -344,7 +347,7 @@ const staffTest = loggedTest.extend<{ pipelineTeams: PipelineTeams }>({
         name: "Soylent",
         createdDaysAgo: 88,
         trialEndedDaysAgo: 85,
-        periodStartDaysAgo: 14,
+        periodStart: daysFromNow(-14),
         flatPrice: 100,
         screenshotsByClosedPeriod: [50_000, 40_000],
         // Well inside the 35k quota with half the period still to run: the
@@ -360,7 +363,7 @@ const staffTest = loggedTest.extend<{ pipelineTeams: PipelineTeams }>({
         name: "Vandelay",
         createdDaysAgo: 70,
         trialEndedDaysAgo: 67,
-        periodStartDaysAgo: 6,
+        periodStart: daysFromNow(-6),
         flatPrice: null,
         screenshotsByClosedPeriod: [20_000],
       }),
@@ -374,7 +377,7 @@ const staffTest = loggedTest.extend<{ pipelineTeams: PipelineTeams }>({
         createdDaysAgo: 80,
         trialEndedDaysAgo: 77,
         flatPrice: 750,
-        periodStartDaysAgo: 9,
+        periodStart: daysFromNow(-9),
         screenshotsByClosedPeriod: [60_000],
         // Already 6k past the quota, which is the whole point of the column:
         // the running amount has started moving with days still left on it.
@@ -395,7 +398,7 @@ const staffTest = loggedTest.extend<{ pipelineTeams: PipelineTeams }>({
         name: "Trialsonic",
         createdDaysAgo: 10,
         trialEndsInDays: 4,
-        periodStartDaysAgo: 10,
+        periodStart: daysFromNow(-10),
         flatPrice: 100,
         screenshotsByClosedPeriod: [],
         screenshotsInRunningPeriod: 5_625,
@@ -407,7 +410,7 @@ const staffTest = loggedTest.extend<{ pipelineTeams: PipelineTeams }>({
         name: "Initrode",
         createdDaysAgo: 400,
         trialEndedDaysAgo: 397,
-        periodStartDaysAgo: 216,
+        periodStart: daysFromNow(-216),
         flatPrice: 12_000,
         screenshotsByClosedPeriod: [],
       }),
@@ -865,6 +868,30 @@ const revenueTest = staffTest.extend<{ revenueBook: RevenueBook }>({
 });
 
 /**
+ * Where a subscription must have started for its period to close later today.
+ *
+ * The anniversary is the offset into the month `startDate` falls at, so the
+ * offset is taken from the moment the period should close and applied to an
+ * earlier month long enough to hold it — February cannot carry a thirtieth.
+ */
+function anchorClosingToday(): string {
+  const monthEnd = startOfUTCMonth(1).getTime();
+  // An hour from now, or the last minute of the month when that hour would
+  // fall outside it: the anniversary has to stay in the month it closes.
+  const closesAt = Math.min(Date.now() + 3_600_000, monthEnd - 60_000);
+  const offset = closesAt - startOfUTCMonth(0).getTime();
+
+  for (let monthsBack = 1; monthsBack <= 12; monthsBack += 1) {
+    const start = startOfUTCMonth(-monthsBack).getTime();
+    if (start + offset < startOfUTCMonth(-monthsBack + 1).getTime()) {
+      return new Date(start + offset).toISOString();
+    }
+  }
+
+  throw new Error("no month in the last year long enough to hold the anchor");
+}
+
+/**
  * A team billed by the month whose cycle has not come round yet, with the usage
  * its bill will be raised on.
  *
@@ -893,9 +920,13 @@ const pendingBillTest = staffTest.extend<{
       name: "Dunder Mifflin",
       createdDaysAgo: 60,
       trialEndedDaysAgo: 57,
-      // The period opened a fortnight ago, so the day it bills on is still
-      // ahead — which is what leaves the month with nothing invoiced to report.
-      periodStartDaysAgo: 14,
+      // Placed so the period closes later today: still ahead of now, and
+      // inside the running month, which is the pair of conditions a bill this
+      // month's projection is waiting on has to meet. Read off the calendar
+      // rather than counted in days — a fortnight from the end of a month
+      // lands the anniversary in the next one, where the bill would not be
+      // this month's at all.
+      periodStart: anchorClosingToday(),
       flatPrice: 100,
       screenshotsByClosedPeriod: [],
       screenshotsInRunningPeriod: 45_000,

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -864,6 +864,107 @@ const revenueTest = staffTest.extend<{ revenueBook: RevenueBook }>({
   },
 });
 
+/**
+ * A team billed by the month whose cycle has not come round yet, with the usage
+ * its bill will be raised on.
+ *
+ * Seeded on its own rather than into the book above: the running month is the
+ * only month that can hold a bill still to come, and the book's assertions are
+ * all about months that have closed.
+ */
+const pendingBillTest = staffTest.extend<{
+  pendingBill: { team: string; amount: string; screenshots: string };
+}>({
+  pendingBill: async ({ user }, use, testInfo) => {
+    const prefix = `pending-${getUniqueTestIdentifier(testInfo)}`;
+    const plan = await PlanModel.query().insertAndFetch({
+      name: "pro",
+      includedScreenshots: 35_000,
+      usageBased: true,
+      githubSsoIncluded: true,
+      fineGrainedAccessControlIncluded: true,
+      samlIncluded: true,
+      interval: "month",
+    });
+    await createBilledTeam({
+      planId: plan.id,
+      subscriberId: user.user.id,
+      slug: `${prefix}-dunder`,
+      name: "Dunder Mifflin",
+      createdDaysAgo: 60,
+      trialEndedDaysAgo: 57,
+      // The period opened a fortnight ago, so the day it bills on is still
+      // ahead — which is what leaves the month with nothing invoiced to report.
+      periodStartDaysAgo: 14,
+      flatPrice: 100,
+      screenshotsByClosedPeriod: [],
+      screenshotsInRunningPeriod: 45_000,
+    });
+
+    // The page refuses a window the mirror was never swept for, so the sweep
+    // has to be on record even though this test reads no invoice at all.
+    await StripeInvoiceSync.query().insert({
+      sinceDate: startOfUTCMonth(-36).toISOString(),
+      completedAt: new Date().toISOString(),
+    });
+
+    // The plan's own amount, plus the ten thousand screenshots past the quota
+    // at the half-cent the helper prices them at.
+    await use({
+      team: "Dunder Mifflin",
+      amount: "$150.00",
+      screenshots: "45,000",
+    });
+  },
+});
+
+pendingBillTest.describe("staff revenue estimates", () => {
+  // One browser project, like the book above: the page has no filter, so the
+  // second run would read the first one's teams as well as its own.
+  pendingBillTest.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "the page sums every team, so it can only be seeded once",
+  );
+
+  pendingBillTest(
+    "the running month lists the bills still to come",
+    async ({ page, pendingBill }) => {
+      await page.goto("/staff/revenue");
+
+      const monthlyPlans = page
+        .locator("table")
+        .filter({ has: page.getByRole("columnheader", { name: "ARPU" }) });
+      await monthlyPlans
+        .locator("tbody tr")
+        .first()
+        .getByRole("button", { name: "View details" })
+        .click();
+
+      // Scoped to the breakdown's own rows: the month row wrapping them
+      // carries the same text, and every other team seeded by the suite has a
+      // line in there too.
+      const line = monthlyPlans
+        .locator("tbody tr")
+        .nth(1)
+        .locator("tbody tr")
+        .filter({ hasText: pendingBill.team });
+      // Priced off the usage the period has accumulated: the cycle has raised
+      // nothing to read.
+      await expect(line.getByText(pendingBill.amount)).toBeVisible();
+      await expect(line.getByText(pendingBill.screenshots)).toBeVisible();
+      // The amount carries what makes it an estimate, the line itself saying
+      // it only in the grey it is written in.
+      await expect(async () => {
+        await page.mouse.move(0, 0);
+        await line.getByText(pendingBill.amount).hover();
+        await expect(
+          page.getByText("Not yet invoiced or included above"),
+        ).toBeVisible({ timeout: 2_000 });
+      }).toPass();
+    },
+  );
+});
+
 revenueTest.describe("staff revenue", () => {
   // One browser project, not both: the page has no filter, so every figure on
   // it is a sum over all the teams in the database — and the projects share

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -625,6 +625,22 @@ staffTest(
   },
 );
 
+/**
+ * The revenue page's own notation, which its assertions have to be written in.
+ *
+ * Built rather than typed out: French groups its thousands with a narrow
+ * no-break space, and a literal one in a spec is a character nobody can see
+ * when the assertion stops matching.
+ */
+function revenueAmount(amount: number, currency: "EUR" | "USD"): string {
+  return new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency,
+    currencyDisplay: "narrowSymbol",
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
 /** The first instant of the month `offset` months from now, in UTC. */
 function startOfUTCMonth(offset: number) {
   const now = new Date();
@@ -846,12 +862,7 @@ const revenueTest = staffTest.extend<{ revenueBook: RevenueBook }>({
     // of it is its amount over that stretch, weighted by this month's length.
     const termMs = startOfUTCMonth(12).getTime() - startOfUTCMonth(0).getTime();
     const monthMs = startOfUTCMonth(1).getTime() - startOfUTCMonth(0).getTime();
-    // Rounded to the euro, like every amount the page prints.
-    const contractPerMonth = new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "EUR",
-      maximumFractionDigits: 0,
-    }).format((12_000 * monthMs) / termMs);
+    const contractPerMonth = revenueAmount((12_000 * monthMs) / termMs, "EUR");
 
     const dateFormat = new Intl.DateTimeFormat("en-US", {
       dateStyle: "medium",
@@ -945,8 +956,8 @@ const pendingBillTest = staffTest.extend<{
     // at the half-cent the helper prices them at.
     await use({
       team: "Dunder Mifflin",
-      amount: "$150",
-      screenshots: "45,000",
+      amount: revenueAmount(150, "USD"),
+      screenshots: new Intl.NumberFormat("fr-FR").format(45_000),
     });
   },
 });
@@ -1016,28 +1027,42 @@ revenueTest.describe("staff revenue", () => {
 
     // €500 from one team and $1,000 from the other, the dollars converted at the
     // page's fixed rate: €500 + €855.
-    await expect(page.getByText("€1,355 monthly").first()).toBeVisible();
+    await expect(
+      page.getByText(`${revenueAmount(1355, "EUR")} Monthly`).first(),
+    ).toBeVisible();
 
     const monthlyPlans = page
       .locator("table")
       .filter({ has: page.getByRole("columnheader", { name: "ARPU" }) });
     const lastMonthRow = monthlyPlans.locator("tbody tr").nth(1);
-    await expect(lastMonthRow.getByText("€1,355")).toBeVisible();
+    await expect(
+      lastMonthRow.getByText(revenueAmount(1355, "EUR")),
+    ).toBeVisible();
     // Two teams invoiced, so the average is half the month. Neither of the two
     // annual bills raised that same month is in either figure — not the current
     // contract, and not the churned team's renewal, whose only mark of being a
     // year's worth is the period on the invoice itself.
-    await expect(lastMonthRow.getByText("€678")).toBeVisible();
+    await expect(
+      lastMonthRow.getByText(revenueAmount(678, "EUR")),
+    ).toBeVisible();
     // €1,000 the month before, so the column reports the climb rather than the
     // em dash it falls back to with nothing to divide by.
-    await expect(lastMonthRow.getByText("+36%")).toBeVisible();
+    await expect(
+      lastMonthRow.getByText(
+        new Intl.NumberFormat("fr-FR", {
+          style: "percent",
+          maximumFractionDigits: 0,
+          signDisplay: "exceptZero",
+        }).format(0.36),
+      ),
+    ).toBeVisible();
 
     await lastMonthRow.getByRole("button", { name: "View details" }).click();
     const breakdown = monthlyPlans.locator("tbody tr").nth(2);
     await expect(breakdown.getByText(revenueBook.monthlyTeam)).toBeVisible();
     // What Stripe charged, beside what the page counts it as.
-    await expect(breakdown.getByText("$1,000")).toBeVisible();
-    await expect(breakdown.getByText("€855")).toBeVisible();
+    await expect(breakdown.getByText(revenueAmount(1000, "USD"))).toBeVisible();
+    await expect(breakdown.getByText(revenueAmount(855, "EUR"))).toBeVisible();
     // Each line carries the day its invoice was raised.
     await expect(
       breakdown.getByText(revenueBook.monthlyInvoiceDate),
@@ -1063,7 +1088,9 @@ revenueTest.describe("staff revenue", () => {
       .filter({ hasText: revenueBook.contractTeam });
     // Twice over: what Stripe charged, and what the page counts it as — the
     // contract is in euros, so both cells read the same.
-    await expect(contractRow.getByText("€12,000")).toHaveCount(2);
+    await expect(
+      contractRow.getByText(revenueAmount(12_000, "EUR")),
+    ).toHaveCount(2);
     await expect(
       contractRow.getByText(revenueBook.contractPerMonth),
     ).toBeVisible();


### PR DESCRIPTION
The running month now carries the bills its cycles have not raised yet, estimated from the usage so far, and a third card says where the month is heading rather than how far behind it is.

Each breakdown line gains the plan it was billed on — its price and its quota — beside the usage it got through, so a team that has outgrown its contract can be picked out.

The breakdown itself is read when a month is opened rather than at load: pricing a year of usage to draw one month was the page's whole cost.

The dev seeds fill both staff pages with one book — teams, invoices, members and the usage those invoices were raised on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)