### PR TITLE
fix(build): unlock review submission once every reviewable diff is loaded

### DIFF
--- a/apps/frontend/src/pages/Build/BuildReviewForm.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewForm.tsx
@@ -81,12 +81,9 @@ export function BuildReviewForm(props: {
     },
   });
 
-  // Block submission until every reviewable diff (changed/added/removed) has
-  // been fetched. The server sorts those ahead of unchanged/retryFailure/
-  // ignored, so once a diff from that trailing block is loaded, the review
-  // payload — built from the loaded diffs — is already complete. On subset
-  // builds removed diffs are not reviewable either, so they count as trailing
-  // there too.
+  // The review payload is built from the loaded diffs. The server sorts
+  // reviewable diffs (changed/added/removed) first, so once a trailing-status
+  // diff is loaded the payload is complete and submission can unlock.
   const { isLoading, allDiffs, isSubsetBuild } = useBuildDiffState();
   const waitingForDiffs =
     isLoading &&

--- a/apps/frontend/src/pages/Build/BuildReviewForm.tsx
+++ b/apps/frontend/src/pages/Build/BuildReviewForm.tsx
@@ -4,7 +4,7 @@ import { XIcon } from "lucide-react";
 import { useForm } from "react-hook-form";
 
 import { DocumentType, graphql } from "@/gql";
-import { BuildReviewEvent } from "@/gql/graphql";
+import { BuildReviewEvent, ScreenshotDiffStatus } from "@/gql/graphql";
 import { Button, ButtonIcon } from "@/ui/Button";
 import { useOverlayTriggerState } from "@/ui/Dialog";
 import { type EditorValue } from "@/ui/Editor/Editor";
@@ -81,10 +81,22 @@ export function BuildReviewForm(props: {
     },
   });
 
-  // Block submission until every diff has been fetched: the review progression
-  // and the accept/reject counts are computed from the loaded diffs, so
-  // submitting mid-load could approve or reject an incomplete set of changes.
-  const { isLoading } = useBuildDiffState();
+  // Block submission until every reviewable diff (changed/added/removed) has
+  // been fetched. The server sorts those ahead of unchanged/retryFailure/
+  // ignored, so once a diff from that trailing block is loaded, the review
+  // payload — built from the loaded diffs — is already complete. On subset
+  // builds removed diffs are not reviewable either, so they count as trailing
+  // there too.
+  const { isLoading, allDiffs, isSubsetBuild } = useBuildDiffState();
+  const waitingForDiffs =
+    isLoading &&
+    !allDiffs.some(
+      (diff) =>
+        diff.status === ScreenshotDiffStatus.Unchanged ||
+        diff.status === ScreenshotDiffStatus.RetryFailure ||
+        diff.status === ScreenshotDiffStatus.Ignored ||
+        (isSubsetBuild && diff.status === ScreenshotDiffStatus.Removed),
+    );
 
   // Tracks the action currently being submitted: drives the per-button spinner
   // and disables the rest of the form while the review is in flight.
@@ -109,7 +121,7 @@ export function BuildReviewForm(props: {
     : BuildReviewEvent.Approve;
 
   const submitReview = async (event: BuildReviewEvent) => {
-    if (isLoading) {
+    if (waitingForDiffs) {
       return;
     }
     const { body } = form.getValues();
@@ -198,7 +210,7 @@ export function BuildReviewForm(props: {
         <FormRootError control={form.control} />
         <Tooltip
           content={
-            isLoading
+            waitingForDiffs
               ? "Waiting for all changes to load before you can submit a review…"
               : null
           }
@@ -216,7 +228,7 @@ export function BuildReviewForm(props: {
                   className="shrink-0"
                   pending={pendingEvent === event}
                   disabled={
-                    isLoading || (isSubmitting && pendingEvent !== event)
+                    waitingForDiffs || (isSubmitting && pendingEvent !== event)
                   }
                   autoFocus={isDefault}
                   // Keep the ring on the focused button (not only keyboard focus)


### PR DESCRIPTION
## The Problem
At Cash App, we've recently migrated over to Argos. We have builds that consist of 2,800+ snapshots, and this can be quite annoying to review because:
1. A build can only be approved after all snapshots have loaded
2. Snapshots are loaded in batches of 100

In practice, developers have to open the argos build and wait several minutes for all images to load.

## Proposal
Allow approvals after all reviewable images have loaded. This includes changed/added/removed snapshots.
