### PR TITLE
feat(staff): price annual contracts against the usage they run up

### DIFF
--- a/apps/backend/src/graphql/definitions/Staff.ts
+++ b/apps/backend/src/graphql/definitions/Staff.ts
@@ -477,6 +477,45 @@ export const typeDefs = gql`
   }
 
   """
+  What a contract's running term has consumed, and where that lands by the
+  renewal if it carries on at the rate it has run so far.
+
+  The term rather than the month: a yearly quota resets once a year, so what
+  says whether a contract is about to be re-priced is the whole year against
+  the whole quota — the question a renewal is negotiated on.
+  """
+  type StaffContractUsage {
+    "The term the figures below are read over, and the day it renews on."
+    periodFrom: DateTime!
+    periodEndsAt: DateTime!
+    "Screenshots consumed since the term opened."
+    screenshotsCount: Int!
+    "What the term includes before overage is billed."
+    includedScreenshots: Int!
+    "What the overage run up so far comes to, in euros."
+    additionalCost: Float!
+    """
+    That same overage in the currency Stripe prices it in — what the contract's
+    own column adds it to, where the euro figure above is what the page's
+    monthly rate is built from.
+    """
+    additionalPrice: StaffRevenuePrice!
+    """
+    That same overage averaged over the months of the term that have gone by,
+    in euros — what a month of the contract's usage has been worth.
+
+    A mean rather than the month's own: the quota is crossed once somewhere in
+    the year and every month after it bills, so a term two months in reads
+    high and one eleven months in reads low.
+    """
+    monthlyAdditionalCost: Float!
+    "Where the count lands by the renewal, at the rate the term has run at."
+    projectedScreenshotsCount: Int!
+    "What that projected overage would come to, in euros."
+    projectedAdditionalCost: Float!
+  }
+
+  """
   One annual contract in force, and the invoices its rate is read from: the
   latest annual bill plus whatever was sold on top of it since.
 
@@ -506,6 +545,13 @@ export const typeDefs = gql`
     Counted all the same: a contract invoice raised is money on its way.
     """
     awaitingPayment: Boolean!
+    """
+    What the team's running term has consumed, and where it lands — null when
+    no yearly subscription of the team's can be read for it: one no longer
+    billed, one on a plan nothing is metered against, or a contract invoiced
+    by hand with no subscription behind it.
+    """
+    usage: StaffContractUsage
   }
 
   """

--- a/apps/backend/src/stripe/revenue.e2e.test.ts
+++ b/apps/backend/src/stripe/revenue.e2e.test.ts
@@ -718,4 +718,110 @@ describe("getStaffRevenue", () => {
     expect(month.yearlyPlans.revenue).toBeCloseTo((1200 * elapsed) / term, 3);
     expect(month.yearlyPlans.teamsCount).toBe(1);
   });
+
+  it("projects where a contract's term lands at the rate it has run at", async () => {
+    // What a renewal is argued over: a customer already past the quota it was
+    // sold is one nobody should be re-signing at last year's price, and the
+    // figure to open the conversation with is where the year lands, not where
+    // it stands today.
+    //
+    // The clock is pinned to the exact middle of a calendar year and the
+    // subscription anchored to its first day, so the term has run for exactly
+    // half of itself: a trend carried forward doubles, and every figure below
+    // comes out exact rather than approximate. Only `Date` is faked — the
+    // pool's timers have to keep running, and Postgres keeps its own clock.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    const year = new Date().getFullYear();
+    const termStart = new Date(year, 0, 1);
+    const termEnd = new Date(year + 1, 0, 1);
+    vi.setSystemTime(new Date((termStart.getTime() + termEnd.getTime()) / 2));
+
+    try {
+      await factory.StripeInvoiceSync.create({
+        sinceDate: new Date("2020-01-01").toISOString(),
+      });
+
+      const plan = await factory.Plan.create({
+        usageBased: true,
+        interval: "year",
+        includedScreenshots: 400,
+      });
+      const account = await factory.TeamAccount.create({
+        stripeCustomerId: "cus_staff_term",
+      });
+      const user = await factory.User.create();
+      const anchoredAt = new Date(year - 2, 0, 1).toISOString();
+      await factory.Subscription.create({
+        accountId: account.id,
+        planId: plan.id,
+        currency: "eur",
+        provider: "stripe",
+        stripeSubscriptionId: "sub_staff_term",
+        subscriberId: user.id,
+        // The first day of a year, so the anniversary the term opens on is the
+        // first day of this one.
+        startDate: anchoredAt,
+        createdAt: anchoredAt,
+        status: "active",
+        flatPrice: 1200,
+        additionalScreenshotPrice: 0.01,
+      });
+      const project = await factory.Project.create({ accountId: account.id });
+      await factory.ScreenshotBucket.create({
+        projectId: project.id,
+        screenshotCount: 1000,
+        createdAt: new Date(
+          termStart.getTime() + 24 * 3600 * 1000,
+        ).toISOString(),
+      });
+      await factory.StripeInvoice.create({
+        stripeCustomerId: "cus_staff_term",
+        stripeCreatedAt: termStart.toISOString(),
+        billingReason: "subscription_cycle",
+        currency: "eur",
+        total: 120_000,
+        totalExcludingTax: 120_000,
+        periodStart: termStart.toISOString(),
+        periodEnd: termEnd.toISOString(),
+      });
+
+      const result = await getStaffRevenue(1);
+
+      const contract = result.yearlyContracts[0];
+      invariant(contract);
+      const { usage } = contract;
+      invariant(usage);
+      expect(usage.periodFrom.getTime()).toBe(termStart.getTime());
+      expect(usage.periodEndsAt.getTime()).toBe(termEnd.getTime());
+      expect(usage.screenshotsCount).toBe(1000);
+      expect(usage.includedScreenshots).toBe(400);
+      // Six hundred past the quota, at a cent each.
+      expect(usage.additionalCost).toBeCloseTo(6, 6);
+      // Half a year gone, so that overage has averaged a euro a month.
+      expect(usage.monthlyAdditionalCost).toBeCloseTo(1, 6);
+      // Half the term gone, so the year doubles what it has run up — and the
+      // overage is what is left of that once the quota is taken off, priced at
+      // the rate the term has already been billed at.
+      expect(usage.projectedScreenshotsCount).toBe(2000);
+      expect(usage.projectedAdditionalCost).toBeCloseTo(16, 6);
+
+      // The overage reaches the month's yearly band beside the contract, and on
+      // its own denominator: the contract is spread over the term it pays for,
+      // the overage over the stretch of that term it has accrued in.
+      const month = result.months[0];
+      invariant(month);
+      const monthStart = startOfUTCMonth(new Date(), 0).getTime();
+      const elapsedInMonth = Date.now() - monthStart;
+      const contractShare =
+        (1200 * elapsedInMonth) / (termEnd.getTime() - termStart.getTime());
+      const overageShare =
+        (6 * elapsedInMonth) / (Date.now() - termStart.getTime());
+      expect(month.yearlyPlans.revenue).toBeCloseTo(
+        contractShare + overageShare,
+        6,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/apps/backend/src/stripe/revenue.ts
+++ b/apps/backend/src/stripe/revenue.ts
@@ -326,6 +326,15 @@ type BilledTeam = {
    * the same order the usage is metered against.
    */
   includedScreenshots: number;
+  /**
+   * What one screenshot past the quota costs, in `currency` — null on a
+   * subscription Stripe states no unit price for.
+   *
+   * Only ever read to price a projection on a period that has not gone over
+   * yet: past that, what the overage has already cost says more, since it
+   * carries the Storybook mix the period was actually billed at.
+   */
+  additionalScreenshotPrice: number | null;
   /** The plan's name, which is what says whether its quota is worth printing. */
   planName: string;
 };
@@ -353,6 +362,7 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
       "accounts.stripeCustomerId",
       "subscriptions.flatPrice",
       "subscriptions.includedScreenshots",
+      "subscriptions.additionalScreenshotPrice",
       "plan.interval",
       "plan.name as planName",
       "plan.includedScreenshots as planIncludedScreenshots",
@@ -387,6 +397,7 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
     currency: string | null;
     flatPrice: number | null;
     includedScreenshots: number | null;
+    additionalScreenshotPrice: number | null;
     planName: string;
     planIncludedScreenshots: number;
   }[];
@@ -401,6 +412,7 @@ export async function getBilledTeams(): Promise<BilledTeam[]> {
     currency: row.currency,
     flatPrice: row.flatPrice,
     includedScreenshots: row.includedScreenshots ?? row.planIncludedScreenshots,
+    additionalScreenshotPrice: row.additionalScreenshotPrice,
     planName: row.planName,
   }));
 }
@@ -601,6 +613,47 @@ type StaffContractInvoice = {
   awaitingPayment: boolean;
 };
 
+/**
+ * What a contract's running term has consumed, and where that lands by the
+ * renewal if it carries on at the rate it has run so far.
+ *
+ * The term rather than the month: a yearly quota resets once a year, so what
+ * says whether a contract is about to be re-priced is the whole year against
+ * the whole quota — the question a renewal is negotiated on.
+ */
+type StaffContractUsage = {
+  /** The term the figures below are read over, and the day it renews on. */
+  periodFrom: Date;
+  periodEndsAt: Date;
+  /** Screenshots consumed since the term opened. */
+  screenshotsCount: number;
+  /** What the term includes before overage is billed. */
+  includedScreenshots: number;
+  /** What the overage run up so far comes to, in euros. */
+  additionalCost: number;
+  /**
+   * That same overage in the currency Stripe prices it in — what the contract's
+   * own column adds it to, where the euro figure above is what the page's
+   * monthly rate is built from.
+   */
+  additionalPrice: StaffRevenuePrice;
+  /**
+   * That same overage averaged over the months of the term that have gone by,
+   * in euros — what a month of the contract's usage has been worth, beside the
+   * month of the contract itself that the table reports.
+   *
+   * A mean rather than the month's own: the quota is crossed once somewhere in
+   * the year and every month after it bills, so a term two months in reads
+   * high and one eleven months in reads low. It is the figure that says what
+   * the usage adds to a month, not what this month happened to add.
+   */
+  monthlyAdditionalCost: number;
+  /** Where the count lands by the renewal, at the rate the term has run at. */
+  projectedScreenshotsCount: number;
+  /** What that projected overage would come to, in euros. */
+  projectedAdditionalCost: number;
+};
+
 /** One annual contract, and the invoices its figure is read from. */
 type StaffYearlyContract = {
   /** The team's slug, which names its pages. */
@@ -621,6 +674,13 @@ type StaffYearlyContract = {
   invoices: StaffContractInvoice[];
   /** True when any invoice found is still awaiting payment. */
   awaitingPayment: boolean;
+  /**
+   * What the team's running term has consumed, and where it lands — null when
+   * no yearly subscription of the team's can be read for it: one no longer
+   * billed, one on a plan nothing is metered against, or a contract invoiced by
+   * hand with no subscription behind it.
+   */
+  usage: StaffContractUsage | null;
 };
 
 /** The statuses an invoice counts under: raised, and not written off. */
@@ -1005,6 +1065,134 @@ async function getEstimatedBills(options: {
   return bills;
 }
 
+/**
+ * A contract's usage as the table reports it, with what the month splits need
+ * to spread the overage behind it.
+ *
+ * The raw amounts travel beside the euro ones the table reads: the splits
+ * convert every figure themselves and count what the conversion touched, which
+ * is what the foreign-share caveat on the cards is read off.
+ */
+type ContractUsageRead = {
+  usage: StaffContractUsage;
+  /** The overage run up so far, in the currency Stripe priced it in. */
+  accrued: InvoiceRevenue;
+  /** A whole month of it, on the same terms — what the projection carries. */
+  monthlyAccrued: InvoiceRevenue;
+  /** The stretch it accrued over, which is what it is spread across. */
+  from: number;
+  until: number;
+};
+
+/**
+ * What each annual contract's running term has consumed, keyed by the customer
+ * it is billed on.
+ *
+ * Read off `getAccountBillings`, the same pass the team directory prices a
+ * period with, so the count a contract is quoted against here is the one the
+ * team's own pages state. It costs a scan of two terms of usage per team,
+ * which is why it is asked about the yearly teams alone — a dozen rows, where
+ * the monthly book is hundreds.
+ */
+async function getContractUsages(
+  billedTeams: BilledTeam[],
+): Promise<Map<string, ContractUsageRead>> {
+  const usages = new Map<string, ContractUsageRead>();
+  const yearlyTeams = billedTeams.filter((team) => team.interval === "year");
+
+  if (yearlyTeams.length === 0) {
+    return usages;
+  }
+
+  const accounts = await Account.query().findByIds(
+    yearlyTeams.map((team) => team.accountId),
+  );
+  const billings = await getAccountBillings(accounts);
+
+  for (const team of yearlyTeams) {
+    const billing = billings.get(team.accountId);
+    // A plan nothing is metered against has no usage to report and no overage
+    // to project — a flat contract is worth its invoices and nothing else.
+    if (!billing?.periodUsage || billing.includedScreenshots === null) {
+      continue;
+    }
+    // The two reads shortlist subscriptions differently — a trial counts for
+    // one and not the other — so a disagreement on the interval is a
+    // disagreement on the subscription, and the term would be a month's usage
+    // stretched over a year.
+    if (billing.plan?.interval !== "year") {
+      continue;
+    }
+
+    const period = billing.periodUsage.billingPeriods.find(
+      (billingPeriod) => !billingPeriod.closed,
+    );
+    if (!period) {
+      continue;
+    }
+
+    // How much of the term the count was measured over, and how much of it
+    // there is — `to` is the moment the period was read, so the two are the
+    // ratio the trend is carried forward at.
+    const elapsed = period.to.getTime() - period.from.getTime();
+    const term = period.endsAt.getTime() - period.from.getTime();
+    if (elapsed <= 0 || term <= 0) {
+      continue;
+    }
+
+    const included = billing.includedScreenshots;
+    const projectedScreenshotsCount = Math.round(
+      (period.screenshotsCount * term) / elapsed,
+    );
+    // Storybook screenshots are billed at their own rate, and nothing here
+    // carries the split they were consumed in — so the overage already run up
+    // is what states the blend, at the price the term is actually billed at.
+    // Only a term that has gone over states one; before that the neutral price
+    // is the closest thing there is, and it is what nearly every screenshot
+    // past a quota is billed at.
+    const additional = Math.max(0, period.screenshotsCount - included);
+    const unitPrice =
+      additional > 0
+        ? period.additionalScreenshotCost / additional
+        : (team.additionalScreenshotPrice ?? 0);
+    const projectedAdditional = Math.max(
+      0,
+      projectedScreenshotsCount - included,
+    );
+    const currency = team.currency ?? REPORTING_CURRENCY;
+    const priceInEuros = (amount: number) => toEuros({ amount, currency });
+
+    // The term cut into twelve, so a month of it is the same twelfth the
+    // contract beside it is amortized into — not a calendar month, which a
+    // term running from the 13th never lines up with anyway.
+    const elapsedMonths = (elapsed * 12) / term;
+    const monthlyAmount = period.additionalScreenshotCost / elapsedMonths;
+
+    usages.set(team.stripeCustomerId, {
+      usage: {
+        periodFrom: period.from,
+        periodEndsAt: period.endsAt,
+        screenshotsCount: period.screenshotsCount,
+        includedScreenshots: included,
+        additionalCost: priceInEuros(period.additionalScreenshotCost),
+        additionalPrice: {
+          amount: period.additionalScreenshotCost,
+          currency,
+        },
+        monthlyAdditionalCost: priceInEuros(monthlyAmount),
+        projectedScreenshotsCount,
+        projectedAdditionalCost: priceInEuros(projectedAdditional * unitPrice),
+      },
+      accrued: { amount: period.additionalScreenshotCost, currency },
+      monthlyAccrued: { amount: monthlyAmount, currency },
+      from: period.from.getTime(),
+      until: period.to.getTime(),
+    });
+  }
+
+  return usages;
+}
+
 /** Raised by the reader when the mirror cannot answer for the window asked. */
 export class MirrorCoverageError extends Error {}
 
@@ -1351,13 +1539,49 @@ export async function getStaffRevenue(
     }
   }
 
+  // Two usage reads over two disjoint sets — the monthly cycles about to bill,
+  // and the annual terms running — so neither waits on the other.
+  const [estimatedBills, contractUsages] = await Promise.all([
+    getEstimatedBills({ billedTeams, runningMonth }),
+    getContractUsages(billedTeams),
+  ]);
+
+  // The overage the running terms have run up, spread day by day over the part
+  // of each term that has gone by — the rule the contracts themselves are
+  // amortized by, applied to the one thing on this page no invoice accounts
+  // for. Nothing reaches the months before the running term: a closed term's
+  // overage was billed on the renewal that opened the next one, so it is
+  // already inside the contract invoices and would be counted twice.
+  for (const [customerId, read] of contractUsages) {
+    const accruedMs = read.until - read.from;
+    if (accruedMs <= 0) {
+      continue;
+    }
+    for (const [index, bound] of amortizeBounds.entries()) {
+      const overlap =
+        Math.min(read.until, bound.end) - Math.max(read.from, bound.start);
+      if (overlap <= 0) {
+        continue;
+      }
+      const split = yearlySplits[index];
+      const customers = yearlyMonthCustomers[index];
+      invariant(split && customers, "bounds and splits are built together");
+      addToSplit(split, {
+        amount: (read.accrued.amount * overlap) / accruedMs,
+        currency: read.accrued.currency,
+      });
+      customers.add(customerId);
+    }
+    // A running term holds today, so it is one of the running month's — and
+    // the projection carries a whole month of it, like the contract above.
+    addToSplit(projectedYearly, read.monthlyAccrued);
+  }
+
   for (const [index, split] of yearlySplits.entries()) {
     const customers = yearlyMonthCustomers[index];
     invariant(customers, "splits and customers are built together");
     split.teamsCount = customers.size;
   }
-
-  const estimatedBills = await getEstimatedBills({ billedTeams, runningMonth });
 
   // What the running month is heading for, rather than what it has billed: the
   // bills its cycles have not raised yet, and the two rates carried to the end
@@ -1408,6 +1632,7 @@ export async function getStaffRevenue(
       teamCustomers,
       billedTeams,
       monthlyByCustomer,
+      contractUsages,
       runningMonth,
     }),
     projection: {
@@ -1436,6 +1661,7 @@ function buildYearlyContracts(options: {
   teamCustomers: Map<string, TeamCustomer>;
   billedTeams: BilledTeam[];
   monthlyByCustomer: Map<string, number>;
+  contractUsages: Map<string, ContractUsageRead>;
   runningMonth: { start: number; end: number };
 }): StaffYearlyContract[] {
   const {
@@ -1443,6 +1669,7 @@ function buildYearlyContracts(options: {
     teamCustomers,
     billedTeams,
     monthlyByCustomer,
+    contractUsages,
     runningMonth,
   } = options;
   const reported = contracts.filter(
@@ -1485,6 +1712,7 @@ function buildYearlyContracts(options: {
       // Any of them, not all: the unpaid renewal beside a settled upsell is
       // exactly the one whose collection is worth watching.
       awaitingPayment: invoices.some((invoice) => invoice.awaitingPayment),
+      usage: contractUsages.get(customerId)?.usage ?? null,
     });
   }
 
@@ -1504,6 +1732,9 @@ function buildYearlyContracts(options: {
       monthlyRevenue: 0,
       invoices: [],
       awaitingPayment: false,
+      // Reported all the same: the contract nobody can find is exactly the row
+      // whose usage says what it should have been worth.
+      usage: contractUsages.get(team.stripeCustomerId)?.usage ?? null,
     });
   }
 

--- a/apps/frontend/src/pages/Staff/Revenue.tsx
+++ b/apps/frontend/src/pages/Staff/Revenue.tsx
@@ -37,6 +37,7 @@ import { Link } from "@/ui/Link";
 import { Loader } from "@/ui/Loader";
 import { SortHeader, type SortDirection } from "@/ui/SortHeader";
 import { StatTile } from "@/ui/StatTile";
+import { Time } from "@/ui/Time";
 import { Tooltip } from "@/ui/Tooltip";
 
 import { PRO_MONTHLY_PRICE, PRO_PLAN_NAME } from "./pricing";
@@ -90,6 +91,20 @@ const StaffRevenueQuery = graphql(`
           coveredUntil
           awaitingPayment
         }
+        usage {
+          periodFrom
+          periodEndsAt
+          screenshotsCount
+          includedScreenshots
+          additionalCost
+          additionalPrice {
+            amount
+            currency
+          }
+          monthlyAdditionalCost
+          projectedScreenshotsCount
+          projectedAdditionalCost
+        }
       }
     }
   }
@@ -131,6 +146,7 @@ type RevenueData = DocumentType<typeof StaffRevenueQuery>["staffRevenue"];
 type RevenueMonth = RevenueData["months"][number];
 type RevenueProjection = RevenueData["projection"];
 type YearlyContract = RevenueData["yearlyContracts"][number];
+type ContractUsage = NonNullable<YearlyContract["usage"]>;
 type Split = RevenueMonth["monthlyPlans"];
 type MonthTeam = DocumentType<
   typeof StaffRevenueMonthTeamsQuery
@@ -151,7 +167,7 @@ const CURRENT_MONTHLY_HINT =
   "This month's invoices so far, ex-tax, net of credit notes.";
 
 const YEARLY_HINT =
-  "Annual contracts amortized, day by day, over the months they cover. In €.";
+  "Annual contracts amortized, day by day, over the months they cover, with the overage their terms have run up. In €.";
 
 const GITHUB_HINT =
   "The month's Marketplace subscriptions at list price, billed by GitHub rather than invoiced by Argos.";
@@ -271,6 +287,59 @@ const DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
   timeZone: "UTC",
 });
 
+/** How much of a term has gone by — what a projection off it is worth. */
+const SHARE_FORMAT = new Intl.NumberFormat(PAGE_LOCALE, {
+  style: "percent",
+  maximumFractionDigits: 0,
+});
+
+/**
+ * The figures a projection is stated in, rounded to the hundred and the
+ * thousand.
+ *
+ * A trend carried in a straight line does not know its own last two digits,
+ * and a euro-exact figure invites being quoted back as one. Rounded where it
+ * is written rather than where it is computed, so the arithmetic behind it
+ * stays exact and only the reading is coarse.
+ */
+function roundProjectedEuros(amount: number): number {
+  return Math.round(amount / 100) * 100;
+}
+
+/**
+ * Signed, both of them: what this column states is not what a contract comes
+ * to but what it runs up on top of it, and the sign is what says so on the
+ * figure as well as on the volume under it. `Intl` places it, so a locale that
+ * writes its signs elsewhere still reads right.
+ */
+const PROJECTED_PRICE_FORMAT = new Intl.NumberFormat(PAGE_LOCALE, {
+  style: "currency",
+  currency: "EUR",
+  maximumFractionDigits: 0,
+  signDisplay: "always",
+});
+
+function formatProjectedEuros(amount: number): string {
+  return PROJECTED_PRICE_FORMAT.format(roundProjectedEuros(amount));
+}
+
+function formatProjectedScreenshots(count: number): string {
+  return SCREENSHOTS_FORMAT.format(Math.round(count / 1000) * 1000);
+}
+
+/**
+ * The same count as a column prints it, shortened.
+ *
+ * Millions of screenshots written out set the width of the column they sit in
+ * and read as a precision a straight line does not have. Grouped in full in the
+ * tooltip, where a figure to quote belongs.
+ */
+const COMPACT_SCREENSHOTS_FORMAT = new Intl.NumberFormat(PAGE_LOCALE, {
+  notation: "compact",
+  maximumFractionDigits: 1,
+  signDisplay: "always",
+});
+
 /** The figures behind a half, appended to its tooltip. */
 function getSplitNote(split: Split): string {
   const teams = ` ${split.teamsCount} ${split.teamsCount === 1 ? "team" : "teams"}.`;
@@ -388,7 +457,7 @@ function ProjectionSplit(props: { projection: RevenueProjection }) {
       <SplitAmount
         amount={projection.yearlyPlans}
         label="Yearly"
-        tooltip="A whole month of the annual contracts, where the card beside this one counts only the days that have gone by."
+        tooltip="A whole month of the annual contracts and their overage, where the card beside this one counts only the days that have gone by."
       />
       {projection.githubPlans > 0 ? (
         <>
@@ -1117,10 +1186,241 @@ function getOriginalTotal(
   };
 }
 
+/**
+ * How much of the term has gone by, which is what the projection beside it
+ * rests on: a fortnight into a year, the trend is a rounding error carried
+ * twenty-six times.
+ */
+function getElapsedShare(usage: ContractUsage): number {
+  const from = new Date(usage.periodFrom).getTime();
+  const until = new Date(usage.periodEndsAt).getTime();
+  return Math.min(1, Math.max(0, (Date.now() - from) / (until - from)));
+}
+
+/**
+ * What the term has got through, against what it includes.
+ *
+ * The term rather than the month the rest of the row reports: a yearly quota
+ * resets once a year, so this is the count the contract's renewal will be
+ * argued over — and the one figure on the row that says whether the amount
+ * beside it is still the right price.
+ */
+function ContractUsageCell(props: { usage: ContractUsage | null }) {
+  const { usage } = props;
+
+  if (!usage) {
+    return (
+      <td className="p-4 text-right text-sm tabular-nums">
+        <span className="text-low">—</span>
+      </td>
+    );
+  }
+
+  return (
+    <td className="p-4 text-right text-sm tabular-nums">
+      <Hint
+        content={`Term opened ${DATE_FORMAT.format(new Date(usage.periodFrom))}.`}
+      >
+        {SCREENSHOTS_FORMAT.format(usage.screenshotsCount)}
+      </Hint>
+      <div className="text-low text-xs">
+        / {SCREENSHOTS_FORMAT.format(usage.includedScreenshots)}
+      </div>
+    </td>
+  );
+}
+
+/**
+ * What the contract was sold for, and what it has been worth once the overage
+ * its term has run up is counted.
+ *
+ * One column rather than two: the pair is the same quantity at two moments, and
+ * a second column holding the contract's own amount over again was blank on
+ * every row that had run up nothing. Stacked the way the usage cell is —
+ * what actually happened above what was contracted for.
+ *
+ * In the contract's own currency: the pair is what a renewal is argued from,
+ * and both halves of that argument are quoted at the customer in the money they
+ * are billed in. The euro figure the rest of the page is kept in is in the
+ * tooltip, and in the monthly rate to the right.
+ */
+function ContractPlanCell(props: { contract: YearlyContract }) {
+  const { contract } = props;
+  const { usage } = contract;
+  const contracted = getOriginalTotal(contract);
+
+  if (contract.amount === null) {
+    return (
+      <td className="p-4 text-right text-sm tabular-nums">
+        <Hint className="text-danger-low" content="Counts nothing.">
+          no invoice found
+        </Hint>
+      </td>
+    );
+  }
+
+  // Both amounts come off one Stripe customer, so they disagree on a currency
+  // only when something upstream is wrong — and an overage added at parity to
+  // a total in another currency would be a figure nobody could trace.
+  const overage =
+    contracted &&
+    usage &&
+    usage.additionalPrice.currency === contracted.currency
+      ? usage.additionalPrice.amount
+      : 0;
+
+  const contractedAmount = (
+    <Hint
+      content={
+        <div className="flex flex-col gap-1">
+          {contract.invoices.map((invoice, invoiceIndex) => (
+            <div key={invoiceIndex}>{describeInvoice(invoice)}</div>
+          ))}
+        </div>
+      }
+    >
+      {contracted ? (
+        formatInvoiceAmount(contracted)
+      ) : (
+        // Invoices in more than one currency have no single original amount;
+        // the monthly rate beside this one still holds.
+        <span className="text-low">—</span>
+      )}
+    </Hint>
+  );
+
+  return (
+    <td className="p-4 text-right text-sm tabular-nums">
+      {contracted && overage > 0 ? (
+        <>
+          <ContractToDateAmount
+            contract={contract}
+            amount={{
+              amount: contracted.amount + overage,
+              currency: contracted.currency,
+            }}
+          />
+          <div className="text-low text-xs">{contractedAmount}</div>
+        </>
+      ) : (
+        contractedAmount
+      )}
+      {contract.awaitingPayment ? (
+        <div>
+          <Hint
+            className="text-warning-low"
+            content="Raised, not yet paid. Counted — expected to clear."
+          >
+            Awaiting payment
+          </Hint>
+        </div>
+      ) : null}
+    </td>
+  );
+}
+
+/** The contract once its overage is counted, in the currency it is billed in. */
+function ContractToDateAmount(props: {
+  contract: YearlyContract;
+  amount: { amount: number; currency: string };
+}) {
+  const { contract, amount } = props;
+  const label = formatInvoiceAmount(amount);
+
+  // Nothing to add on a contract already in euros: the tooltip would restate
+  // the figure it is attached to.
+  if (amount.currency === "eur") {
+    return label;
+  }
+
+  invariant(contract.amount !== null, "an amount to date has a contract");
+
+  return (
+    <Hint
+      content={`${CONTRACT_PRICE_FORMAT.format(contract.amount + (contract.usage?.additionalCost ?? 0))} at the fixed rate.`}
+    >
+      {label}
+    </Hint>
+  );
+}
+
+/**
+ * What the contract adds to the month: its own share of it, plus what a month
+ * of the term's usage has been worth.
+ */
+function ContractPerMonthCell(props: {
+  contract: YearlyContract;
+  usage: ContractUsage | null;
+}) {
+  const { contract, usage } = props;
+
+  if (contract.amount === null) {
+    return (
+      <td className="p-4 text-right text-sm tabular-nums">
+        <span className="text-low">—</span>
+      </td>
+    );
+  }
+
+  const overage = usage?.monthlyAdditionalCost ?? 0;
+
+  return (
+    <td className="p-4 text-right text-sm tabular-nums">
+      {usage && overage > 0 ? (
+        <Hint
+          content={`${CONTRACT_PRICE_FORMAT.format(contract.monthlyRevenue)} of contract + ${CONTRACT_PRICE_FORMAT.format(overage)} of overage, averaged over the ${SHARE_FORMAT.format(getElapsedShare(usage))} of the term gone by.`}
+        >
+          {CONTRACT_PRICE_FORMAT.format(contract.monthlyRevenue + overage)}
+        </Hint>
+      ) : (
+        CONTRACT_PRICE_FORMAT.format(contract.monthlyRevenue)
+      )}
+    </td>
+  );
+}
+
+/**
+ * Where the term lands if it carries on at the rate it has run at — the
+ * screenshots it reaches by the renewal, and what the contract would then be
+ * worth.
+ *
+ * A straight line, which is the whole point: it is the figure a renewal is
+ * offered against — this many screenshots a year, at this price — and a
+ * customer already twice past its quota is one nobody should be re-signing at
+ * last year's rate.
+ */
+function ContractAtRenewalCell(props: { usage: ContractUsage | null }) {
+  const { usage } = props;
+
+  // Tested on what the column would print rather than on the figure behind it:
+  // a term on course to stay inside its quota and one whose overage rounds
+  // away to nothing are the same row to read, and a printed zero reads as a
+  // figure rather than as an absence.
+  if (!usage || roundProjectedEuros(usage.projectedAdditionalCost) === 0) {
+    return <td className="p-4" />;
+  }
+
+  // An amount that survived the rounding above was billed on screenshots, so
+  // there are always some to name under it.
+  const screenshots =
+    usage.projectedScreenshotsCount - usage.includedScreenshots;
+
+  return (
+    <td className="p-4 text-right text-sm tabular-nums">
+      <Hint
+        content={`${formatProjectedScreenshots(screenshots)} past the quota, ${formatProjectedScreenshots(usage.projectedScreenshotsCount)} in all, from the ${SHARE_FORMAT.format(getElapsedShare(usage))} of the term gone by.`}
+      >
+        {formatProjectedEuros(usage.projectedAdditionalCost)}
+      </Hint>
+      <div className="text-low text-xs">
+        {COMPACT_SCREENSHOTS_FORMAT.format(screenshots)} screenshots
+      </div>
+    </td>
+  );
+}
+
 function ContractRow(props: { contract: YearlyContract; index: number }) {
   const { contract, index } = props;
-  const newestInvoice = contract.invoices[0] ?? null;
-  const originalTotal = getOriginalTotal(contract);
 
   return (
     <tr className={clsx(index % 2 === 0 ? "bg-app" : "bg-subtle", "border-b")}>
@@ -1132,60 +1432,18 @@ function ContractRow(props: { contract: YearlyContract; index: number }) {
           <StripeCustomerLink stripeCustomerId={contract.stripeCustomerId} />
         </div>
       </td>
-      <td className="p-4 text-right text-sm tabular-nums">
-        {contract.amount !== null ? (
-          <>
-            <Hint
-              content={
-                <div className="flex flex-col gap-1">
-                  {contract.invoices.map((invoice, invoiceIndex) => (
-                    <div key={invoiceIndex}>{describeInvoice(invoice)}</div>
-                  ))}
-                </div>
-              }
-            >
-              {originalTotal ? (
-                formatInvoiceAmount(originalTotal)
-              ) : (
-                // Invoices in more than one currency have no single original
-                // amount; the euro column beside this one still holds.
-                <span className="text-low">—</span>
-              )}
-            </Hint>
-            {contract.awaitingPayment ? (
-              <div>
-                <Hint
-                  className="text-warning-low"
-                  content="Raised, not yet paid. Counted — expected to clear."
-                >
-                  Awaiting payment
-                </Hint>
-              </div>
-            ) : null}
-          </>
-        ) : (
-          <Hint className="text-danger-low" content="Counts nothing.">
-            no invoice found
-          </Hint>
-        )}
-      </td>
-      <td className="p-4 text-right text-sm tabular-nums">
-        {contract.amount === null ? (
-          <span className="text-low">—</span>
-        ) : (
-          CONTRACT_PRICE_FORMAT.format(contract.amount)
-        )}
-      </td>
-      <td className="p-4 text-right text-sm tabular-nums">
-        {contract.amount !== null ? (
-          CONTRACT_PRICE_FORMAT.format(contract.monthlyRevenue)
-        ) : (
-          <span className="text-low">—</span>
-        )}
-      </td>
-      <td className="p-4 text-right text-sm tabular-nums">
-        {newestInvoice ? (
-          DATE_FORMAT.format(new Date(newestInvoice.invoicedAt))
+      <ContractPlanCell contract={contract} />
+      <ContractPerMonthCell contract={contract} usage={contract.usage} />
+      <ContractUsageCell usage={contract.usage} />
+      <ContractAtRenewalCell usage={contract.usage} />
+      {/* How long the term has left: what the quota resets in, and the stretch
+          the projection beside it is carried over. Read as a distance rather
+          than as a date because that is the question — a renewal three weeks
+          out is a call to make now. `Time` carries the date itself in its own
+          tooltip. A contract Argos no longer bills has no next term. */}
+      <td className="p-4 text-right text-sm">
+        {contract.usage ? (
+          <Time date={contract.usage.periodEndsAt} />
         ) : (
           <span className="text-low">—</span>
         )}
@@ -1201,18 +1459,28 @@ function ContractRow(props: { contract: YearlyContract; index: number }) {
  * Stripe, and when it looks wrong, the contract at fault can only be found by
  * seeing each one's renewal — including the contracts that contributed
  * nothing, which the total alone would hide.
+ *
+ * The amounts carry the overage the terms have run up, which no invoice
+ * accounts for yet, so they read above the yearly band on the cards. That is
+ * the point: the cards report what was invoiced, and a contract is worth what
+ * it was sold for plus what its usage ran past the quota.
  */
 function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
   const { contracts } = props;
-  const total = contracts.reduce(
-    (sum, contract) => sum + (contract.amount ?? 0),
-    0,
-  );
   // Summed from what each contract contributes rather than divided by twelve:
   // the months are amortized over the stretch each invoice pays for, and an
   // upsell sold for five months is not a twelfth of anything.
   const monthlyTotal = contracts.reduce(
-    (sum, contract) => sum + contract.monthlyRevenue,
+    (sum, contract) =>
+      sum +
+      contract.monthlyRevenue +
+      (contract.usage?.monthlyAdditionalCost ?? 0),
+    0,
+  );
+  // What the annual book is on course to bill past its quotas by the time the
+  // terms renew — the one figure here that no invoice exists for at all.
+  const projectedOverageTotal = contracts.reduce(
+    (sum, contract) => sum + (contract.usage?.projectedAdditionalCost ?? 0),
     0,
   );
 
@@ -1225,22 +1493,27 @@ function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
         <p className="text-low text-sm">No annual contracts in force.</p>
       ) : (
         <div className="overflow-x-auto rounded-sm border">
-          <table className="w-full min-w-160 table-fixed border-collapse">
+          <table className="w-full min-w-256 table-fixed border-collapse">
             <thead>
               <tr className="text-low border-b text-xs font-semibold">
-                <th className="w-[26%] px-4 py-3 text-left">Team</th>
-                <th className="w-[20%] px-4 py-3 text-right">Invoiced</th>
-                <th className="w-[18%] px-4 py-3 text-right">
-                  <Hint content="Dollars converted at a fixed rate.">
-                    In euros
+                <th className="w-[25%] px-4 py-3 text-left">Team</th>
+                <th className="w-[15%] px-4 py-3 text-right">
+                  <Hint content="What it was sold for, and above it what it has been worth once the overage is counted.">
+                    Plan
                   </Hint>
                 </th>
-                <th className="w-[18%] px-4 py-3 text-right">
-                  <Hint content="What it adds to this month, in euros.">
+                <th className="w-[14%] px-4 py-3 text-right">
+                  <Hint content="What it adds to this month, in euros — contract plus overage.">
                     Per month
                   </Hint>
                 </th>
-                <th className="w-[18%] px-4 py-3 text-right">Last invoice</th>
+                <th className="w-[15%] px-4 py-3 text-right">Usage</th>
+                <th className="w-[19%] px-4 py-3 text-right">
+                  <Hint content="What the term is on course to owe past its quota if usage carries on at this rate. Rounded.">
+                    Overage at renewal
+                  </Hint>
+                </th>
+                <th className="w-[12%] px-4 py-3 text-right">Renewal</th>
               </tr>
             </thead>
             <tbody>
@@ -1255,12 +1528,15 @@ function YearlyContracts(props: { contracts: readonly YearlyContract[] }) {
             <tfoot>
               <tr className="text-sm font-medium">
                 <td className="p-4 text-left">Total</td>
+                {/* The contracts are each stated in their own currency, and a
+                    sum across currencies is not a figure. */}
                 <td />
                 <td className="p-4 text-right tabular-nums">
-                  {CONTRACT_PRICE_FORMAT.format(total)}
-                </td>
-                <td className="p-4 text-right tabular-nums">
                   {CONTRACT_PRICE_FORMAT.format(monthlyTotal)}
+                </td>
+                <td />
+                <td className="p-4 text-right tabular-nums">
+                  {formatProjectedEuros(projectedOverageTotal)}
                 </td>
                 <td />
               </tr>

--- a/tests/staff.spec.ts
+++ b/tests/staff.spec.ts
@@ -1086,13 +1086,21 @@ revenueTest.describe("staff revenue", () => {
     const contractRow = page
       .getByRole("row")
       .filter({ hasText: revenueBook.contractTeam });
-    // Twice over: what Stripe charged, and what the page counts it as — the
-    // contract is in euros, so both cells read the same.
+    // Once: the amount it was sold for. The team has uploaded nothing, so it
+    // has run up no overage — nothing stacks above the contract, and the
+    // renewal column has nothing to owe.
     await expect(
       contractRow.getByText(revenueAmount(12_000, "EUR")),
-    ).toHaveCount(2);
+    ).toHaveCount(1);
     await expect(
       contractRow.getByText(revenueBook.contractPerMonth),
+    ).toBeVisible();
+    // The term's own quota, which is what the count above it is read against —
+    // and what says the row has no overage to carry.
+    await expect(
+      contractRow.getByText(
+        `/ ${new Intl.NumberFormat("fr-FR").format(1_000_000)}`,
+      ),
     ).toBeVisible();
 
     // Scoped to the monthly table: the contracts table below lists every annual


### PR DESCRIPTION
An annual contract is worth what it was sold for plus whatever its term ran past the quota — and Stripe meters that overage all year without billing any of it until the renewal. Nothing on the revenue page saw it: the contracts table reported invoices, so a customer three times past its quota read exactly like one that never touched it.

## The table

`Team | Plan | Per month | Usage | Overage at renewal | Renewal`

- **Plan** — what the contract was sold for, and stacked above it what it has been worth once the overage is counted. Both in the currency it is invoiced in, since that pair is what a renewal is argued from. Only the contracts that have outgrown their price stack; the rest read as before.
- **Usage** — screenshots consumed since the **term** opened, against what the term includes. A yearly quota resets once a year, so this is the whole year against the whole quota.
- **Per month** — its share of the contract plus a month of the overage, in euros.
- **Overage at renewal** — what the term is on course to owe past its quota if usage carries on at the rate it has run at, in money and in screenshots. Blank when the term is on course to owe nothing, tested on what the column would print rather than on the raw figure. This is the column the renewal offer comes out of: "at this rate you will do X screenshots this year, here is a price for that volume."
- **Renewal** — how long the term has left, the date itself in the tooltip.

## The cards and the chart

The yearly band carries the same accrued overage, spread day by day over the part of each term that has gone by — the rule the contracts themselves are amortized by, applied to the one thing on this page no invoice accounts for. The projection carries a whole month of it, so its `Yearly` figure equals the table's `Per month` total exactly.

**Nothing reaches the months before a running term.** A closed term's overage was billed on the renewal that opened the next one, so it is already inside the contract invoices; adding it would count it twice.

## How the figures are arrived at

Usage is read through `getAccountBillings` — the pass the team directory prices a period with — so the count a contract is quoted against here is the one the team's own pages state. It is asked about the yearly teams alone: a dozen rows, where the monthly book is hundreds.

The projected overage is priced at the **blended rate the term is actually being billed at** (`overage cost so far / overage screenshots so far`), which carries the Storybook mix without having to re-derive it. A term that has not gone over yet falls back to the subscription's unit price.

Projections are rounded — to the hundred for money, compact for volumes — because a straight line carried this far does not know its own last digits. The exact figures stay in the tooltips.

## Tests

- A new integration test pins the arithmetic with the clock frozen at the exact middle of a calendar year, so the trend doubles and every figure comes out exact rather than approximate: 1 000 → 2 000 screenshots, €6 → €16 of overage, €1/month.
- It also pins the composition of the yearly band — contract spread over the term it pays for, overage over the stretch of that term it accrued in. Two different denominators, so the assertion fails if either drifts towards the other.
- `tests/staff.spec.ts` updated for the columns that moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)