### PR TITLE
chore(deployments): use storybook.acme.com as the domain example

### DIFF
--- a/apps/frontend/src/containers/Project/Deployments/Domains.tsx
+++ b/apps/frontend/src/containers/Project/Deployments/Domains.tsx
@@ -402,14 +402,14 @@ function AddCustomDomainDialog(props: { projectId: string }) {
                   return "Enter a domain, not a URL";
                 }
                 if (!domain.includes(".")) {
-                  return "Enter a fully qualified domain, like docs.example.com";
+                  return "Enter a fully qualified domain, like storybook.acme.com";
                 }
                 return true;
               },
             })}
             autoFocus
             label="Domain"
-            placeholder="docs.example.com"
+            placeholder="storybook.acme.com"
           />
         </DialogBody>
         <DialogFooter>


### PR DESCRIPTION
Follow-up to #2566, which is merged: the add-domain dialog's placeholder and validation example now read `storybook.acme.com` instead of `docs.example.com`, matching the example used in the docs (argos-ci/docs#254), the changelog (argos-ci/argos-ci.com#364), and the social announcements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)