### PR TITLE
chore(discord): post ops notifications with fetch

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -69,7 +69,6 @@
     "cookies": "^0.9.1",
     "cors": "^2.8.6",
     "dataloader": "^2.2.3",
-    "discord.js": "^14.27.0",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "express-rate-limit": "^8.6.2",

--- a/apps/backend/src/database/services/project.e2e.test.ts
+++ b/apps/backend/src/database/services/project.e2e.test.ts
@@ -8,7 +8,7 @@ import { HTTPError } from "@/util/error";
 
 import { createProject, notifyProjectTransfer } from "./project";
 
-// Real notifications are already disabled in tests (the webhook client is off);
+// Real notifications are already disabled in tests (no webhook URL is set);
 // spy on the sender only to assert what would have been posted.
 const notifyDiscord = vi
   .spyOn(discord, "notifyDiscord")

--- a/apps/backend/src/discord/index.ts
+++ b/apps/backend/src/discord/index.ts
@@ -1,24 +1,44 @@
-import { WebhookClient } from "discord.js";
-
 import config from "@/config";
 
 const webhookUrl = config.get("discord.webhookUrl");
 
-const webhookClient = webhookUrl
-  ? new WebhookClient({
-      url: config.get("discord.webhookUrl"),
-    })
-  : null;
-
 /**
  * Notify a Discord channel via webhook.
+ *
+ * Posted with `fetch` rather than through a Discord client library: executing a
+ * webhook is a single unauthenticated POST, and the library's transport is what
+ * made this fragile — it wraps every response in `new Headers(res.headers)`,
+ * which throws as soon as undici negotiates HTTP/2, because node:http2 stamps
+ * incoming header objects with a `sensitiveHeaders` symbol that cannot be
+ * converted to a header name.
  */
 export async function notifyDiscord(input: { content: string }) {
-  if (webhookClient) {
-    await webhookClient.send({
+  if (!webhookUrl) {
+    return;
+  }
+
+  const response = await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
       content: input.content,
-      allowedMentions: { parse: [] },
-    });
+      // These notifications quote names and emails users chose, so a message
+      // must never be able to ping the channel.
+      allowed_mentions: { parse: [] },
+    }),
+    // Don't let a caller block on Discord being slow.
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  // A successful execute-webhook call answers 204 with no body.
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    const detail = body.slice(0, 500);
+    throw new Error(
+      `Discord rejected the notification (HTTP ${response.status})${
+        detail ? `: ${detail}` : ""
+      }`,
+    );
   }
 }
 

--- a/apps/backend/src/discord/webhook.ts
+++ b/apps/backend/src/discord/webhook.ts
@@ -4,7 +4,7 @@
  *
  * Distinct from `./index.ts`, which posts Argos' own ops notifications to a
  * single webhook we configure ourselves. The URLs here are user-supplied, which
- * is why they are validated rather than handed straight to a client.
+ * is why they are validated before being posted to.
  */
 
 import type { DiscordWebhook } from "@/database/models";

--- a/apps/backend/src/graphql/tests/transferProject.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/transferProject.e2e.test.ts
@@ -9,7 +9,7 @@ import { apolloServer, createApolloMiddleware } from "../apollo";
 import { expectNoGraphQLError } from "../testing";
 import { createApolloServerApp } from "./util";
 
-// Real notifications are already disabled in tests (the webhook client is off);
+// Real notifications are already disabled in tests (no webhook URL is set);
 // spy on the sender only to assert what would have been posted.
 const notifyDiscord = vi
   .spyOn(discord, "notifyDiscord")

--- a/apps/backend/src/mcp/mcp.e2e.test.ts
+++ b/apps/backend/src/mcp/mcp.e2e.test.ts
@@ -22,7 +22,7 @@ import { issueTokens } from "@/oauth/tokens";
 
 import { mcpRouter } from "./router";
 
-// Real notifications are already disabled in tests (the webhook client is off);
+// Real notifications are already disabled in tests (no webhook URL is set);
 // spy on the sender only to assert it is not called.
 const notifyDiscord = vi
   .spyOn(discord, "notifyDiscord")

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,9 +219,6 @@ importers:
       dataloader:
         specifier: ^2.2.3
         version: 2.2.3
-      discord.js:
-        specifier: ^14.27.0
-        version: 14.27.0
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -1337,34 +1334,6 @@ packages:
 
   '@date-fns/tz@1.5.0':
     resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
-
-  '@discordjs/builders@1.14.1':
-    resolution: {integrity: sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==}
-    engines: {node: '>=16.11.0'}
-
-  '@discordjs/collection@1.5.3':
-    resolution: {integrity: sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==}
-    engines: {node: '>=16.11.0'}
-
-  '@discordjs/collection@2.1.1':
-    resolution: {integrity: sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==}
-    engines: {node: '>=18'}
-
-  '@discordjs/formatters@0.6.2':
-    resolution: {integrity: sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==}
-    engines: {node: '>=16.11.0'}
-
-  '@discordjs/rest@2.6.3':
-    resolution: {integrity: sha512-wvOylxNYJkwKjctS/Mn5GP1w9r3/rzyH+ThD1JlAca6zEdlHs8QWBBUQJpU5Q+W6DoIj/Ljh1IPlZs7hTU+UAg==}
-    engines: {node: '>=18'}
-
-  '@discordjs/util@1.2.0':
-    resolution: {integrity: sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==}
-    engines: {node: '>=18'}
-
-  '@discordjs/ws@1.2.3':
-    resolution: {integrity: sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==}
-    engines: {node: '>=16.11.0'}
 
   '@emnapi/core@1.11.2':
     resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
@@ -3489,18 +3458,6 @@ packages:
       rollup:
         optional: true
 
-  '@sapphire/async-queue@1.5.5':
-    resolution: {integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==}
-    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
-
-  '@sapphire/shapeshift@4.0.0':
-    resolution: {integrity: sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==}
-    engines: {node: '>=v16'}
-
-  '@sapphire/snowflake@3.5.5':
-    resolution: {integrity: sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==}
-    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
-
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
@@ -4575,10 +4532,6 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
-  '@vladfrangu/async_event_emitter@2.4.7':
-    resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
-    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
-
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
@@ -5407,13 +5360,6 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
-
-  discord-api-types@0.38.52:
-    resolution: {integrity: sha512-uwe9EKfbjsmgWc2fdFjvDbj+dQqx3lp7wqDCmIha0jInuU+xeQjkCK9tMMn+p7RXfdVQORCInq4cD3U2ymDmyg==}
-
-  discord.js@14.27.0:
-    resolution: {integrity: sha512-qHbFlFG2N7y3LjPySYsL6A1+BnX6bkTVgo842EX0CqVPk/KTMwZkojPHEXKsQUpWZNyz5BISNHK1cPpQw0+m4A==}
-    engines: {node: '>=18'}
 
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
@@ -6497,9 +6443,6 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
-  lodash.snakecase@4.1.1:
-    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
-
   lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
 
@@ -6546,9 +6489,6 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
-
-  magic-bytes.js@1.13.1:
-    resolution: {integrity: sha512-x5sn4UX2k5gCWlcfmoFwG4TPie8+dctESyqOBdhB5p6MsgWXdBKGmt9nXPObj/JI50TTL928lc5Yt1WntMn1bw==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -7957,9 +7897,6 @@ packages:
     resolution: {integrity: sha512-esq6hx2lM66sQV1YcFkIYTqrWWabmqBqobKHyn1CswdI5FgfQhkmiKiRWVGBNlIbdjBxEIkNvMIwLKKPgRYZLQ==}
     engines: {node: '>=20', npm: '>=10'}
 
-  ts-mixer@6.0.4:
-    resolution: {integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==}
-
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
@@ -9267,55 +9204,6 @@ snapshots:
   '@borewit/text-codec@0.2.2': {}
 
   '@date-fns/tz@1.5.0': {}
-
-  '@discordjs/builders@1.14.1':
-    dependencies:
-      '@discordjs/formatters': 0.6.2
-      '@discordjs/util': 1.2.0
-      '@sapphire/shapeshift': 4.0.0
-      discord-api-types: 0.38.52
-      fast-deep-equal: 3.1.3
-      ts-mixer: 6.0.4
-      tslib: 2.8.1
-
-  '@discordjs/collection@1.5.3': {}
-
-  '@discordjs/collection@2.1.1': {}
-
-  '@discordjs/formatters@0.6.2':
-    dependencies:
-      discord-api-types: 0.38.52
-
-  '@discordjs/rest@2.6.3':
-    dependencies:
-      '@discordjs/collection': 2.1.1
-      '@discordjs/util': 1.2.0
-      '@sapphire/async-queue': 1.5.5
-      '@sapphire/snowflake': 3.5.5
-      '@vladfrangu/async_event_emitter': 2.4.7
-      discord-api-types: 0.38.52
-      magic-bytes.js: 1.13.1
-      tslib: 2.8.1
-      undici: 8.10.0
-
-  '@discordjs/util@1.2.0':
-    dependencies:
-      discord-api-types: 0.38.52
-
-  '@discordjs/ws@1.2.3':
-    dependencies:
-      '@discordjs/collection': 2.1.1
-      '@discordjs/rest': 2.6.3
-      '@discordjs/util': 1.2.0
-      '@sapphire/async-queue': 1.5.5
-      '@types/ws': 8.18.1
-      '@vladfrangu/async_event_emitter': 2.4.7
-      discord-api-types: 0.38.52
-      tslib: 2.8.1
-      ws: 8.21.2
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   '@emnapi/core@1.11.2':
     dependencies:
@@ -11101,15 +10989,6 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 4.0.5
 
-  '@sapphire/async-queue@1.5.5': {}
-
-  '@sapphire/shapeshift@4.0.0':
-    dependencies:
-      fast-deep-equal: 3.1.3
-      lodash: 4.18.1
-
-  '@sapphire/snowflake@3.5.5': {}
-
   '@selderee/plugin-htmlparser2@0.11.0':
     dependencies:
       domhandler: 5.0.3
@@ -12230,8 +12109,6 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
-  '@vladfrangu/async_event_emitter@2.4.7': {}
-
   '@webcontainer/env@1.1.1': {}
 
   '@whatwg-node/disposablestack@0.0.6':
@@ -12900,27 +12777,6 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
-
-  discord-api-types@0.38.52: {}
-
-  discord.js@14.27.0:
-    dependencies:
-      '@discordjs/builders': 1.14.1
-      '@discordjs/collection': 1.5.3
-      '@discordjs/formatters': 0.6.2
-      '@discordjs/rest': 2.6.3
-      '@discordjs/util': 1.2.0
-      '@discordjs/ws': 1.2.3
-      '@sapphire/snowflake': 3.5.5
-      discord-api-types: 0.38.52
-      fast-deep-equal: 3.1.3
-      lodash.snakecase: 4.1.1
-      magic-bytes.js: 1.13.1
-      tslib: 2.8.1
-      undici: 8.10.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   doctrine@3.0.0:
     dependencies:
@@ -13931,8 +13787,6 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
-  lodash.snakecase@4.1.1: {}
-
   lodash.sortby@4.7.0: {}
 
   lodash@4.18.1: {}
@@ -13973,8 +13827,6 @@ snapshots:
       react: 19.2.8
 
   lz-string@1.5.0: {}
-
-  magic-bytes.js@1.13.1: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -15528,8 +15380,6 @@ snapshots:
   ts-dedent@2.3.0: {}
 
   ts-log@3.0.2: {}
-
-  ts-mixer@6.0.4: {}
 
   tsconfig-paths@4.2.0:
     dependencies:


### PR DESCRIPTION
## What

`notifyDiscord` no longer goes through discord.js' `WebhookClient` — it posts the webhook with `fetch` — and `discord.js` is removed from `@argos/backend`.

## Why

Sentry [ARGOS-SERVER-YFE](https://argos-ci.sentry.io/issues/7457397013/), firing on `POST /graphql` since undici 8 landed (`3f40fb56d`, 2026-07-19):

```
TypeError: Headers constructor: Key Symbol(sensitiveHeaders) in init is a
symbol, which cannot be converted to a ByteString.
```

The chain:

1. `pnpm-workspace.yaml` overrides `undici: ^8.10.0` tree-wide. `@discordjs/rest@2.6.3` declares `undici: ^6.27.0`, so it runs on a major it was never written for.
2. undici 8 flipped HTTP/2 to on by default (`allowH2 = allowH2 != null ? allowH2 : true`, `lib/core/connect.js:70`; undici 6 had `: false`), so ALPN now offers `h2` and Discord's edge takes it.
3. On the h2 path undici passes the raw `node:http2` header object straight through (`client-h2.js` → `api-request.js`), and Node stamps every incoming h2 header object with `Symbol(sensitiveHeaders)`.
4. `@discordjs/rest` wraps each response with `new Headers(res.headers)`; undici's webidl record converter enumerates symbol keys and `ByteString` throws on them.

Reproduced against a local h2 server, byte-identical to production.

**Impact was Sentry-only.** The breadcrumb shows the webhook POST returning 200 — the message *was* delivered; only the client-side response wrapping threw. `notifyProjectCreation` swallows it into Sentry, so project creation was never affected, and `shouldRetry` matches only `AbortError`/`ECONNRESET`, so there was no retry and no duplicate post.

## Approach

Executing a webhook is a single unauthenticated POST, and `discord.js` was imported in exactly one file for exactly one call whose return value went unused. Posting it with `fetch` — the same thing the customer-facing integration in `discord/webhook.ts` already does — removes the version conflict instead of working around it, and takes 16 packages out of the bundled backend (`discord.js`, 7 × `@discordjs/*`, `discord-api-types`, `@sapphire/*`, `ts-mixer`, `magic-bytes.js`, …).

Narrower alternatives I passed on: scoping the override to `'@discordjs/rest>undici': ^6.28.0` (puts a second undici copy in the bundle and an EOL v6 in the audit surface), or handing the client a `makeRequest` with `new Agent({ allowH2: false })` (keeps a heavy dep for one POST).

## Notes for the reviewer

- Behaviour kept: no-op when `DISCORD_WEBHOOK_URL` is unset, `allowed_mentions: { parse: [] }` so a user-chosen name can't ping the channel, and a throw on non-2xx (now carrying Discord's own reason) so bad config still reaches Sentry. Dropped `?wait=true`, which only existed to read back a message object nobody used.
- The other packages the override lifts off undici 7 — `@slack/socket-mode`, `smee-client` — don't use the `new Headers(res.headers)` pattern, so they need nothing.

## Verification

- `pnpm run static-checks`: 11/11 (types, format, lint, knip).
- `project.e2e` + `transferProject.e2e` + `stripe/events.e2e`: 17 passed. `discord` unit tests: 33 passed. Backend build clean.
- End-to-end against a local TLS server mimicking execute-webhook: **ALPN negotiated h2** — the exact condition that broke `@discordjs/rest` — the POST was accepted (204) with `allowed_mentions: {parse: []}` on the wire, and a 401 surfaced as `Discord rejected the notification (HTTP 401): {"message": "Invalid Webhook Token", "code": 50027}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)