### PR TITLE
feat(billing): mirror what identifies an invoice to the customer who paid it

### DIFF
--- a/apps/backend/db/migrations/20260824081749_stripe-invoices-customer-fields.js
+++ b/apps/backend/db/migrations/20260824081749_stripe-invoices-customer-fields.js
@@ -1,0 +1,34 @@
+/**
+ * What the mirror needs to show an invoice to the customer who was billed.
+ *
+ * The mirror was built for the revenue page, which only ever adds amounts up,
+ * so it holds nothing that identifies one invoice to a human: the number that
+ * reads on the document, and the two Stripe-hosted copies — the payment page
+ * and the PDF. Reading them back from Stripe on every view would put an API
+ * call in front of a page that is otherwise a single query, and the invoice
+ * webhooks already refresh every row.
+ *
+ * The URLs are `text` rather than `string`: Stripe signs them with a token
+ * whose length it does not commit to, and a truncated payment link is a
+ * customer who cannot pay.
+ *
+ * @param {import('knex').Knex} knex
+ */
+export const up = async (knex) => {
+  await knex.schema.alterTable("stripe_invoices", (table) => {
+    table.string("number");
+    table.text("hostedInvoiceUrl");
+    table.text("invoicePdfUrl");
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+export const down = async (knex) => {
+  await knex.schema.alterTable("stripe_invoices", (table) => {
+    table.dropColumn("number");
+    table.dropColumn("hostedInvoiceUrl");
+    table.dropColumn("invoicePdfUrl");
+  });
+};

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -2,10 +2,10 @@
 -- PostgreSQL database dump
 --
 
-\restrict y0HGAClZuh0p5kDWaPm1UP8FySoT684n31wtUqA6YyKFNCVe8YAQoVkbQiCxkoB
+\restrict jqxvgZ0SmaaAGQGPDX28eFfv8u1rvpY9JgBksmGseQ2x0ZpjffWyjxe0qQC7FTR
 
 -- Dumped from database version 18.4
--- Dumped by pg_dump version 18.4 (Homebrew)
+-- Dumped by pg_dump version 18.6 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -2606,7 +2606,10 @@ CREATE TABLE public.stripe_invoices (
     "totalTaxesAmount" integer,
     "creditedAmountExcludingTax" integer NOT NULL,
     "periodStart" timestamp with time zone,
-    "periodEnd" timestamp with time zone
+    "periodEnd" timestamp with time zone,
+    number character varying(255),
+    "hostedInvoiceUrl" text,
+    "invoicePdfUrl" text
 );
 
 
@@ -6688,7 +6691,7 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-\unrestrict y0HGAClZuh0p5kDWaPm1UP8FySoT684n31wtUqA6YyKFNCVe8YAQoVkbQiCxkoB
+\unrestrict jqxvgZ0SmaaAGQGPDX28eFfv8u1rvpY9JgBksmGseQ2x0ZpjffWyjxe0qQC7FTR
 
 -- Knex migrations
 
@@ -6941,4 +6944,5 @@ INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('2026081
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260822180431_screenshot-buckets-insert-autovacuum.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260823065836_stripe-invoices.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260823133757_github-plan-prices.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260824081749_stripe-invoices-customer-fields.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260830130624_custom-domains.js', 1, NOW());

--- a/apps/backend/src/database/models/StripeInvoice.ts
+++ b/apps/backend/src/database/models/StripeInvoice.ts
@@ -39,6 +39,9 @@ export class StripeInvoice extends Model {
           creditedAmountExcludingTax: { type: "number" },
           periodStart: { type: ["string", "null"] },
           periodEnd: { type: ["string", "null"] },
+          number: { type: ["string", "null"] },
+          hostedInvoiceUrl: { type: ["string", "null"] },
+          invoicePdfUrl: { type: ["string", "null"] },
         },
       },
     ],
@@ -67,4 +70,13 @@ export class StripeInvoice extends Model {
    */
   periodStart!: string | null;
   periodEnd!: string | null;
+  /**
+   * The number that reads on the document, which is how a customer refers to
+   * an invoice. Null on the rare invoice Stripe never numbered — a draft
+   * voided before finalization.
+   */
+  number!: string | null;
+  /** Stripe's hosted copy, where the invoice can be read and paid. */
+  hostedInvoiceUrl!: string | null;
+  invoicePdfUrl!: string | null;
 }

--- a/apps/backend/src/stripe/invoice-mirror.ts
+++ b/apps/backend/src/stripe/invoice-mirror.ts
@@ -24,6 +24,9 @@ const MERGE_COLUMNS = [
   "creditedAmountExcludingTax",
   "periodStart",
   "periodEnd",
+  "number",
+  "hostedInvoiceUrl",
+  "invoicePdfUrl",
 ];
 
 /** How many rows a sweep writes per statement. */
@@ -152,6 +155,11 @@ async function buildStripeInvoiceRow(invoice: Stripe.Invoice) {
     creditedAmountExcludingTax,
     periodStart: period ? timestampToISOString(period.start) : null,
     periodEnd: period ? timestampToISOString(period.end) : null,
+    number: invoice.number,
+    // Absent rather than null on an invoice Stripe has not finalized: the
+    // hosted page and the PDF only exist once it is a document.
+    hostedInvoiceUrl: invoice.hosted_invoice_url ?? null,
+    invoicePdfUrl: invoice.invoice_pdf ?? null,
   };
 }
 


### PR DESCRIPTION
First of two. This one is pure data plumbing — nothing reads the columns yet, so it can be deployed and backfilled before any customer sees an invoice list. The page follows in #2570.

## What

The mirror was built for the revenue page, which only ever adds amounts up, so it holds nothing that names one invoice to a human. Three columns follow:

| Column | Why |
|---|---|
| `number` | what a customer quotes to their accounting |
| `hostedInvoiceUrl` | Stripe's hosted copy, where an open invoice gets paid |
| `invoicePdfUrl` | the document itself |

They are written by `buildStripeInvoiceRow` — the single row builder both the `invoice.*` webhooks and the reconciliation sweep go through — and they join `MERGE_COLUMNS`, so a conflicting upsert refreshes them instead of only writing them once.

The URLs are `text` rather than `string`: Stripe signs them with a token whose length it does not commit to, and a truncated payment link is a customer who cannot pay.

## Deploying

**Run `sync-stripe-invoices 1200` once after this ships**, before the page PR.

The migration lands automatically with the release, and existing rows come out with all three columns null. From there they fill in on their own, but only partly:

- an invoice raised after the deploy is complete immediately — the webhook re-reads it whole;
- one that is paid, voided or credited after the deploy is repaired the same way;
- one created in the last 35 days is repaired by the nightly `stripe-invoice-sync`;
- **anything older is never repaired** — the sweep's window does not reach it.

Hence the deep window, which is the same one-off this table already had when the mirror shipped in #2529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
