### PR TITLE
chore(tests): pin the passkey creation date the baseline renders

### DIFF
--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -115,6 +115,11 @@ export async function createPasskeys(input: {
       aaguid: null,
       name,
       lastUsedAt: new Date("2026-06-15T10:00:00Z").toISOString(),
+      // Pinned like `lastUsedAt`, because the row renders it. Left to default,
+      // it is the seeding instant, so the baseline holds whatever day CI ran —
+      // and the next run on a day of a different width ("Sep 2" then "Sep 12")
+      // shifts the line and reports a change nobody made.
+      createdAt: new Date("2026-05-20T09:00:00Z").toISOString(),
     })),
   );
 }


### PR DESCRIPTION
Spotted while looking at an unrelated Argos build that reported two changed snapshots nobody had touched.

The passkey row prints `Created <date>`, and the seed left `createdAt` to its default — the instant the database was seeded. `Time` blanks the text for visual tests but not its width, so the baseline froze whatever day CI happened to run on, and the next run on a day of a different width ("Sep 2" then "Sep 12", "Aug" then "Sep") shifted the line and reported a change nobody had made.

Pinned like the `lastUsedAt` beside it, which was already fixed for this exact reason.

Measured: with the date pinned, `settings/passkeys.png` came back byte-identical to the standing baseline on both browsers — so this should report no visual change at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)