### PR TITLE
fix(project): free a deleted project's name, keep its usage counted

### DIFF
--- a/apps/backend/src/database/services/project.ts
+++ b/apps/backend/src/database/services/project.ts
@@ -22,14 +22,19 @@ import { isValidPgBigInt } from "../util/biginteger";
 
 const RESERVED_PROJECT_NAMES = ["new", "settings"];
 
+/**
+ * What a deleted project's name is parked under, so the one it held goes back
+ * to the account. Lowercase, and compared as such: names collide
+ * case-insensitively.
+ */
+export const DELETED_PROJECT_NAME_PREFIX = "deleted-";
+
 const checkProjectName = async (args: { name: string; accountId: string }) => {
   if (RESERVED_PROJECT_NAMES.includes(args.name)) {
     throw new Error("Name is reserved for internal usage");
   }
 
-  // A deleted project no longer holds its name: the account is meant to be able
-  // to recreate the project it just removed under the same name.
-  const sameName = await Project.queryNotDeleted()
+  const sameName = await Project.query()
     .select("id")
     .whereILike("name", args.name)
     .where("accountId", args.accountId)
@@ -378,6 +383,23 @@ async function resolveAvailableProjectName(args: {
       400,
       parsed.error.issues[0]?.message ?? "Invalid project name.",
       { code: "PROJECT_NAME_INVALID", field: "name" },
+    );
+  }
+  // Deleting a project parks it under `DELETED_PROJECT_NAME_PREFIX` + its id, so
+  // a name a user chooses must not be able to land there first — that is the one
+  // way two projects of an account could end up sharing a name.
+  //
+  // Checked here rather than in `checkProjectName`, which `resolveProjectName`
+  // retries by appending `-1`, `-2`, …: a rejection a suffix cannot lift would
+  // make that recursion unbounded.
+  if (parsed.data.toLowerCase().startsWith(DELETED_PROJECT_NAME_PREFIX)) {
+    throw boom(
+      400,
+      `A project name cannot start with "${DELETED_PROJECT_NAME_PREFIX}".`,
+      {
+        code: "PROJECT_NAME_INVALID",
+        field: "name",
+      },
     );
   }
   try {

--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -747,12 +747,16 @@ function createAccountActivationByAccountIdLoader() {
     // Left join so accounts that created projects but never built still get a
     // row. `count(distinct)` is required on projects: the join to builds
     // multiplies project rows.
-    const rows = await Project.queryNotDeleted()
+    const rows = await Project.query()
       .leftJoin("builds", "builds.projectId", "projects.id")
       .join("accounts", "accounts.id", "projects.accountId")
       .select("projects.accountId")
       .select(
-        knex.raw(`count(distinct projects.id) as "projectsCount"`),
+        // Only the live ones are projects the account *has*; everything below
+        // is what it consumed, which a deletion does not take back.
+        knex.raw(
+          `count(distinct projects.id) filter (where projects."deletedAt" is null) as "projectsCount"`,
+        ),
         knex.raw(`count(builds.id) as "buildsCount"`),
         // Only what was built once the account owned the project. A transferred
         // project brings its whole history along, and those screenshots were

--- a/apps/backend/src/graphql/services/project.ts
+++ b/apps/backend/src/graphql/services/project.ts
@@ -1,3 +1,4 @@
+import { PROJECT_NAME_MAX_LENGTH } from "@argos/schemas/project";
 import { invariant } from "@argos/util/invariant";
 import { TransactionOrKnex } from "objection";
 
@@ -25,7 +26,10 @@ import {
   Test,
   User,
 } from "@/database/models";
-import { applyProjectVisibility } from "@/database/services/project";
+import {
+  applyProjectVisibility,
+  DELETED_PROJECT_NAME_PREFIX,
+} from "@/database/services/project";
 import { transaction } from "@/database/transaction";
 import { isValidPgBigInt } from "@/database/util/biginteger";
 import { deleteDomainTenant } from "@/deployment/cloudfront";
@@ -144,20 +148,36 @@ export async function deleteProject(args: {
   const recipients = await getProjectDeleteNotificationRecipients(project);
   invariant(project.account, "project.account is undefined");
 
-  // The domains are the one thing still released for real: a CloudFront tenant
-  // is billed for as long as it exists, and a domain left claimed cannot be
-  // moved to another project. Both are cheap to drop — `project_domains` holds
-  // a handful of rows, none of the tables the hard delete had to walk.
   const cloudfrontTenantIds = await transaction(async (trx) => {
-    const tenantIds = await releaseProjectDomains({
-      projectId: project.id,
-      trx,
-    });
-    await Project.query(trx)
+    // The stamp goes first and carries its own `deletedAt IS NULL`, so it is
+    // the gate rather than the read above it. A second request that got past
+    // that read before this one committed blocks on the row here, re-checks the
+    // predicate, and updates nothing — without it both would get this far and
+    // every owner would be told twice that the project was deleted.
+    const stamped = await Project.query(trx)
       .findById(project.id)
-      .patch({ deletedAt: new Date().toISOString() });
-    return tenantIds;
+      .whereNull("projects.deletedAt")
+      .patch({
+        name: getDeletedProjectName(project),
+        deletedAt: new Date().toISOString(),
+      });
+
+    if (stamped === 0) {
+      return null;
+    }
+
+    // The domains are the one thing still released for real: a CloudFront
+    // tenant is billed for as long as it exists, and a domain left claimed
+    // cannot be moved to another project. Both are cheap to drop —
+    // `project_domains` holds a handful of rows, none of the tables the hard
+    // delete had to walk.
+    return releaseProjectDomains({ projectId: project.id, trx });
   });
+
+  // Lost the race, so the request that won it owns the notification.
+  if (cloudfrontTenantIds === null) {
+    return;
+  }
 
   await Promise.all(cloudfrontTenantIds.map((id) => deleteDomainTenant(id)));
 
@@ -173,6 +193,25 @@ export async function deleteProject(args: {
       recipients,
     });
   }
+}
+
+/**
+ * The name a deleted project is parked under, which frees the one it held: the
+ * account is meant to be able to recreate what it just removed.
+ *
+ * The id leads, so two parked names can never collide — the same name can be
+ * deleted, recreated and deleted again — and it survives the truncation below.
+ * The original trails it because a deleted project is still listed in the usage
+ * charts, and this is the name they label it with.
+ *
+ * Truncated to `PROJECT_NAME_MAX_LENGTH`: the prefix must not push the name
+ * past what the `name` property is validated against on the way in.
+ */
+function getDeletedProjectName(project: Project): string {
+  return `${DELETED_PROJECT_NAME_PREFIX}${project.id}-${project.name}`.slice(
+    0,
+    PROJECT_NAME_MAX_LENGTH,
+  );
 }
 
 /**

--- a/apps/backend/src/graphql/tests/accountMetrics.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/accountMetrics.e2e.test.ts
@@ -127,6 +127,67 @@ describe("GraphQL Account.metrics", () => {
     });
   });
 
+  it("still counts a deleted project's consumption", async () => {
+    // Deleting a project does not hand the screenshots back: the account
+    // consumed them, and the invoice still bills them. If the chart dropped
+    // them it would disagree with the meter on the same page.
+    const user = await factory.User.create();
+    const account = await factory.TeamAccount.create();
+    invariant(account.teamId, "team account should have a team");
+    await factory.TeamUser.create({
+      teamId: account.teamId,
+      userId: user.id,
+      userLevel: "owner",
+    });
+    const project = await factory.Project.create({
+      accountId: account.id,
+      name: "web",
+    });
+    await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      createdAt: new Date("2021-01-01").toISOString(),
+      screenshotCount: 7,
+    });
+    await factory.Build.create({
+      projectId: project.id,
+      createdAt: new Date("2021-01-01").toISOString(),
+    });
+    await project.$query().patch({
+      name: `deleted-${project.id}-web`,
+      deletedAt: new Date().toISOString(),
+    });
+
+    const app = await createApolloServerApp(
+      apolloServer,
+      createApolloMiddleware,
+      { user, account },
+    );
+
+    const result = await request(app)
+      .post("/graphql")
+      .send({
+        query: ACCOUNT_METRICS_QUERY,
+        variables: {
+          accountSlug: account.slug,
+          from: "2020-12-31T00:00:00.000Z",
+          to: "2021-01-02T00:00:00.000Z",
+        },
+      });
+
+    expectNoGraphQLError(result);
+    expect(result.body.data.account.metrics).toMatchObject({
+      screenshots: {
+        all: { total: 7, projects: { [project.id]: 7 } },
+        // Labelled by the parked name, which is what makes the series legible
+        // as a project that is gone.
+        projects: [{ id: project.id, name: `deleted-${project.id}-web` }],
+      },
+      builds: {
+        all: { total: 1, projects: { [project.id]: 1 } },
+      },
+    });
+  });
+
   it("reports invalid date ranges as bad user input", async () => {
     const user = await factory.User.create();
     const account = await factory.UserAccount.create({ userId: user.id });

--- a/apps/backend/src/graphql/tests/deleteProject.e2e.test.ts
+++ b/apps/backend/src/graphql/tests/deleteProject.e2e.test.ts
@@ -1,3 +1,4 @@
+import { PROJECT_NAME_MAX_LENGTH } from "@argos/schemas/project";
 import { invariant } from "@argos/util/invariant";
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -11,6 +12,7 @@ import {
   type User,
 } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
+import { sendNotification } from "@/notification";
 
 import { apolloServer, createApolloMiddleware } from "../apollo";
 import { expectNoGraphQLError } from "../testing";
@@ -19,6 +21,8 @@ import { createApolloServerApp } from "./util";
 vi.mock("@/notification", () => ({
   sendNotification: vi.fn(),
 }));
+
+const mockSendNotification = vi.mocked(sendNotification);
 
 const DeleteProjectMutation = `
   mutation DeleteProject($id: ID!) {
@@ -134,7 +138,8 @@ describe("GraphQL deleteProject", () => {
       BuildReview.query().findById(review.id),
       Screenshot.query().findById(screenshot.id),
     ]);
-    expect(stored?.deletedAt).not.toBeNull();
+    invariant(stored, "the project row must survive the delete");
+    expect(stored.deletedAt).not.toBeNull();
     expect(builds).toBeTruthy();
     expect(reviews).toBeTruthy();
     expect(screenshots).toBeTruthy();
@@ -195,6 +200,12 @@ describe("GraphQL deleteProject", () => {
         variables: { id: project.id },
       });
 
+    // Parked under a prefixed name, so the one it held is genuinely free —
+    // rather than merely skipped by the name check.
+    await expect(Project.query().findById(project.id)).resolves.toMatchObject({
+      name: `deleted-${project.id}-${project.name}`,
+    });
+
     const res = await request(app)
       .post("/graphql")
       .send({
@@ -205,9 +216,83 @@ describe("GraphQL deleteProject", () => {
       });
 
     expectNoGraphQLError(res);
-    // The exact name, not `soft-delete-me-1`: the deleted project no longer
-    // holds it.
+    // The exact name, not `soft-delete-me-1`.
     expect(res.body.data.createProject.name).toBe(project.name);
+  });
+
+  it("keeps the parked name inside the length a project name may be", async () => {
+    // The prefix cannot push the name past what `ProjectNameSchema` allows, or
+    // the patch that stamps the deletion is the thing that fails validation.
+    const { user, userAccount, teamAccount } = await seedProject();
+    const longName = "l".repeat(PROJECT_NAME_MAX_LENGTH);
+    const project = await factory.Project.create({
+      name: longName,
+      accountId: teamAccount.id,
+    });
+    const app = await createApp({ user, account: userAccount });
+
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: DeleteProjectMutation,
+        variables: { id: project.id },
+      });
+
+    expectNoGraphQLError(res);
+    const stored = await Project.query().findById(project.id);
+    invariant(stored, "the project row must survive the delete");
+    expect(stored.deletedAt).not.toBeNull();
+    expect(stored.name).toHaveLength(PROJECT_NAME_MAX_LENGTH);
+    expect(stored.name).toBe(
+      `deleted-${project.id}-${longName}`.slice(0, PROJECT_NAME_MAX_LENGTH),
+    );
+  });
+
+  it("refuses a name that could land on a parked one", async () => {
+    // The parked prefix has to stay out of the namespace a user can claim, or
+    // deleting a project could land it on a name a live one already holds.
+    const { user, userAccount, teamAccount } = await seedProject();
+    const app = await createApp({ user, account: userAccount });
+
+    const res = await request(app)
+      .post("/graphql")
+      .send({
+        query: CreateProjectMutation,
+        variables: {
+          input: { name: "deleted-1-web", accountSlug: teamAccount.slug },
+        },
+      });
+
+    expect(res.body.errors).toHaveLength(1);
+    expect(res.body.errors[0].message).toBe(
+      'A project name cannot start with "deleted-".',
+    );
+  });
+
+  it("notifies once when two deletes race", async () => {
+    // Both requests read a live project before either writes, so only the
+    // conditional stamp can tell them apart — a prior existence check cannot.
+    const { user, userAccount, project } = await seedProject();
+    const app = await createApp({ user, account: userAccount });
+
+    const send = () =>
+      request(app)
+        .post("/graphql")
+        .send({
+          query: DeleteProjectMutation,
+          variables: { id: project.id },
+        });
+
+    const [first, second] = await Promise.all([send(), send()]);
+
+    expectNoGraphQLError(first);
+    expectNoGraphQLError(second);
+    expect(first.body.data.deleteProject).toBe(true);
+    expect(second.body.data.deleteProject).toBe(true);
+    expect(mockSendNotification).toHaveBeenCalledTimes(1);
+    await expect(Project.query().findById(project.id)).resolves.toMatchObject({
+      name: `deleted-${project.id}-${project.name}`,
+    });
   });
 
   it("refuses a viewer who does not administer the project", async () => {
@@ -249,7 +334,9 @@ describe("GraphQL deleteProject", () => {
         variables: { id: project.id },
       });
     expectNoGraphQLError(first);
-    const deletedAt = (await Project.query().findById(project.id))?.deletedAt;
+    const stored = await Project.query().findById(project.id);
+    invariant(stored, "the project row must survive the delete");
+    const { deletedAt } = stored;
     expect(deletedAt).toBeTruthy();
 
     const second = await request(app)

--- a/apps/backend/src/metrics/account.ts
+++ b/apps/backend/src/metrics/account.ts
@@ -46,7 +46,7 @@ async function resolveProjectIds(input: AccountMetricsFilter) {
     return { projectIds: undefined, projectFilterApplied: false };
   }
 
-  const projects = await Project.queryNotDeleted()
+  const projects = await Project.query()
     .select("id")
     .where("accountId", input.accountId)
     .whereIn("name", input.projectNames);
@@ -111,7 +111,6 @@ export async function getAccountScreenshotMetrics(
     FROM screenshot_buckets sb
     LEFT JOIN projects p ON sb."projectId" = p.id
     WHERE p."accountId" = :accountId
-      AND p."deletedAt" IS NULL
       AND sb."createdAt" >= date_trunc(:groupBy, :from::timestamp)
       AND sb."createdAt" <= :to
       ${hasProjectFilter(input) ? `AND sb."projectId" = any(:projectIds)` : ""}
@@ -142,10 +141,7 @@ export async function getAccountScreenshotMetrics(
   ORDER BY s.date
   `;
 
-  const projectsQuery = Project.queryNotDeleted().where(
-    "accountId",
-    input.accountId,
-  );
+  const projectsQuery = Project.query().where("accountId", input.accountId);
   if (hasProjectFilter(input)) {
     const projectIds = input.projectIds;
     invariant(projectIds, "project IDs are required when filtering metrics");
@@ -240,7 +236,6 @@ export async function getAccountBuildMetrics(
         AND lr.state IN ('approved', 'rejected')
     ) r ON TRUE
     WHERE p."accountId" = :accountId
-      AND p."deletedAt" IS NULL
       AND b."createdAt" >= date_trunc(:groupBy, :from::timestamp)
       AND b."createdAt" <= :to
       ${hasProjectFilter(input) ? `AND b."projectId" = any(:projectIds)` : ""}
@@ -275,10 +270,7 @@ export async function getAccountBuildMetrics(
   ORDER BY s.date
   `;
 
-  const projectsQuery = Project.queryNotDeleted().where(
-    "accountId",
-    input.accountId,
-  );
+  const projectsQuery = Project.query().where("accountId", input.accountId);
   if (hasProjectFilter(input)) {
     const projectIds = input.projectIds;
     invariant(projectIds, "project IDs are required when filtering metrics");

--- a/packages/schemas/src/project.ts
+++ b/packages/schemas/src/project.ts
@@ -1,6 +1,13 @@
 import { z } from "zod";
 
 /**
+ * Exported because a name is also *derived* elsewhere — a deleted project is
+ * parked under a prefixed one — and that derivation has to fit the same limit
+ * the schema below validates against.
+ */
+export const PROJECT_NAME_MAX_LENGTH = 100;
+
+/**
  * Validation for a project name, shared between the `Project` model's JSON
  * schema and the public API operation so both enforce the exact same rules.
  *
@@ -12,7 +19,7 @@ export const ProjectNameSchema = z
   .string()
   .trim()
   .min(1)
-  .max(100)
+  .max(PROJECT_NAME_MAX_LENGTH)
   .regex(/^[a-zA-Z0-9_\-.]+$/, {
     message:
       "Project name can only contain letters, numbers, dots, hyphens and underscores.",


### PR DESCRIPTION
Two corrections to the soft delete from #2574.

## The name is now genuinely free

`checkProjectName` skipped soft-deleted rows, so recreating a deleted project's name worked. But the deleted row *still held that name*, so every by-name lookup had two projects to choose from for one `{owner}/{project}` path.

Deleting a project now parks it as `deleted-<id>-<name>`. The id leads, so two parked names can never collide — the same name can be deleted, recreated and deleted again — and it survives truncation to `PROJECT_NAME_MAX_LENGTH`. The original trails it because a deleted project is still listed in the usage charts (below), and that's the name they label it with.

With the name released for real, `checkProjectName` goes back to spanning every row — one mechanism instead of two.

The prefix is **reserved** on the create/rename/transfer path: a name a user picks must not be able to land where a delete will park one, which is the only way two projects of an account could share a name. It's checked in `resolveAvailableProjectName` rather than `checkProjectName`, because `resolveProjectName` retries the latter by appending `-1`, `-2`, … — a rejection no suffix can lift would make that recursion unbounded. Git-imported repo names go through that retry path and so aren't covered; a repo would have to be named `deleted-<another project's exact id>-…` to collide.

## Consumption stays accurate

The account metrics excluded deleted projects while every meter behind them — `Account.$getScreenshotCountBetween`, `period-usage.ts`, `checkIsOutOfCapacity` — has always counted them. So the usage chart and the invoice disagreed *on the same page*: a customer could delete a project, watch the chart drop, and stay billed and blocked.

The screenshots were consumed and are still billed, so the charts count them too, labelled by the parked name. Reverted: `resolveProjectIds`, both `projectsQuery` builders, and both raw-SQL `AND p."deletedAt" IS NULL` predicates.

The staff activation loader keeps the split it actually wants:

```sql
count(distinct projects.id) filter (where projects."deletedAt" is null) as "projectsCount"
```

`projectsCount` counts what the account *has*; `buildsCount` / `screenshotsCount` / `firstComparisonAt` are history a deletion doesn't take back.

## Two things caught on the way

**The stamp is now the gate.** The write carries its own `deletedAt IS NULL` and its row count decides whether to notify, replacing a read-then-write where two concurrent deletes both got through and both emailed every owner. This is the case CLAUDE.md's "never gate an insert on a prior existence check — two concurrent requests can both pass it" covers, and #2574's comment claimed a guard the code didn't have.

**Two assertions could not fail.** `expect(stored?.deletedAt).not.toBeNull()` passes when `stored` is `undefined` — i.e. when the row was hard-deleted, which is exactly the regression the test existed to catch. Now `invariant(stored, …)` first.

## Tests

Five new guards, each verified to fail without its fix: the parked name and the name being reusable; the parked name staying inside `PROJECT_NAME_MAX_LENGTH`; the reserved prefix being refused; one notification when two deletes race; and a deleted project's screenshots still counted in `Account.metrics`.

`pnpm run static-checks` clean; 814 unit and 1282 integration tests pass.

## Not in scope

A review of #2574 surfaced a larger gap neither PR touches: the id- and slug-addressed **child** routes (`api/auth/build.ts`, `api/auth/test.ts`, `graphql/buildAccess.ts`, `mediaAccess.ts`, `testAccess.ts`, `getAutomationRuleForAdmin`, the PR-comment renderer, the GitHub Actions OIDC exchange) reach a project through its build/test/media rather than through a project lookup, so they still serve — and accept writes on — a deleted project. Worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)