### PR TITLE
fix(project): stop serving a soft-deleted project's data

### DIFF
--- a/apps/backend/src/api/auth/build.ts
+++ b/apps/backend/src/api/auth/build.ts
@@ -1,4 +1,5 @@
 import { invariant } from "@argos/util/invariant";
+import type { QueryBuilder } from "objection";
 
 import type { AuthOAuthPayload, AuthPATPayload } from "@/auth/payload";
 import { Build, type User } from "@/database/models";
@@ -20,19 +21,43 @@ export type BuildActionPermission = "view" | "review" | "review_dismiss";
  * Returns the resolved auth and the build (with `project.account` fetched so
  * callers can check permissions and serialize without a second round-trip).
  */
+/**
+ * The build addressed by `{owner}/{project}/builds/{buildNumber}`, with
+ * `project.account` fetched.
+ *
+ * Extracted because the routes that resolve one do not share an auth shape —
+ * some take a project token as well as a user's — so they cannot all go through
+ * {@link loadBuildForUserAuth}, and each had its own copy of this query.
+ */
+export function queryBuildByNumber(params: {
+  owner: string;
+  project: string;
+  buildNumber: number;
+}): QueryBuilder<Build, Build | undefined> {
+  return (
+    Build.query()
+      .joinRelated("project.account")
+      .where("project:account.slug", params.owner)
+      .where("project.name", params.project)
+      // A deleted project answers 404 rather than 403: the route is addressed by
+      // name, and that name is no longer this project's — deleting it parks the
+      // project under a prefixed one. The permission check in
+      // `assertBuildPermission` would refuse it too, but not every route that
+      // resolves a build runs one.
+      .whereNull("project.deletedAt")
+      .where("number", params.buildNumber)
+      .withGraphFetched("project.account")
+      .first()
+  );
+}
+
 export async function loadBuildForUserAuth(
   authPromise: Promise<AuthPATPayload | AuthOAuthPayload>,
   params: { owner: string; project: string; buildNumber: number },
 ): Promise<{ auth: AuthPATPayload | AuthOAuthPayload; build: Build }> {
   const [auth, build] = await Promise.all([
     authPromise,
-    Build.query()
-      .joinRelated("project.account")
-      .where("project:account.slug", params.owner)
-      .where("project.name", params.project)
-      .where("number", params.buildNumber)
-      .withGraphFetched("project.account")
-      .first(),
+    queryBuildByNumber(params),
   ]);
 
   assertProjectAccess(auth, {

--- a/apps/backend/src/api/auth/media.ts
+++ b/apps/backend/src/api/auth/media.ts
@@ -7,6 +7,7 @@ import type {
 } from "@/auth/payload";
 import { Media, type Project } from "@/database/models";
 import { isValidPgBigInt } from "@/database/util/biginteger";
+import { liveProject } from "@/media/query";
 import { boom } from "@/util/error";
 
 import { assertProjectAccess } from "./project";
@@ -36,6 +37,7 @@ export async function loadMediaForAuth<
     isValidPgBigInt(params.mediaId)
       ? Media.query()
           .findById(params.mediaId)
+          .whereExists(liveProject())
           .withGraphFetched("project.account")
       : null,
   ]);

--- a/apps/backend/src/api/auth/test.ts
+++ b/apps/backend/src/api/auth/test.ts
@@ -39,6 +39,7 @@ export async function loadTestForAuth<
           .where("tests.id", parsed.testId)
           .where("project:account.slug", params.owner)
           .where("project.name", params.project)
+          .whereNull("project.deletedAt")
           .withGraphFetched("project.account")
           .first()
       : null,

--- a/apps/backend/src/api/handlers/createReview.ts
+++ b/apps/backend/src/api/handlers/createReview.ts
@@ -14,10 +14,9 @@ import {
 } from "@/build/createBuildReview";
 import { resolveCommentBody } from "@/comment/body";
 import { isCommentTooLarge, validateCommentJson } from "@/comment/validate";
-import { Build } from "@/database/models/Build";
 import { boom } from "@/util/error";
 
-import { assertProjectAccess } from "../auth/project";
+import { loadBuildForUserAuth } from "../auth/build";
 import { BuildNumber } from "../schema/primitives/build";
 import {
   BuildReviewSchema,
@@ -177,25 +176,10 @@ export const createReview: CreateAPIHandler = ({ post }) => {
         throw boom(400, "Either `event` or `conclusion` is required");
       }
 
-      const [auth, build] = await Promise.all([
+      const { auth, build } = await loadBuildForUserAuth(
         req.ctx.auth(),
-        Build.query()
-          .joinRelated("project.account")
-          .where("project:account.slug", params.owner)
-          .where("project.name", params.project)
-          .where("number", params.buildNumber)
-          .withGraphFetched("project.account")
-          .first(),
-      ]);
-
-      assertProjectAccess(auth, {
-        projectId: build?.projectId ?? null,
-        account: { slug: params.owner },
-      });
-
-      if (!build) {
-        throw boom(404, "Not found");
-      }
+        params,
+      );
 
       invariant(build.project);
 

--- a/apps/backend/src/api/handlers/exchangeGitHubActionsOidcToken.e2e.test.ts
+++ b/apps/backend/src/api/handlers/exchangeGitHubActionsOidcToken.e2e.test.ts
@@ -100,6 +100,60 @@ describe("exchangeGitHubActionsOidcToken", () => {
     expect(auth.sha).toBe(sha);
   });
 
+  test("ignores a deleted project linked to the same repository", async ({
+    linkedProject,
+  }) => {
+    // A deleted project keeps its repository link. Left in, it would shadow the
+    // live one as "multiple projects found" — and this endpoint takes no project
+    // slug, so CI would have no way to disambiguate.
+    const { project: live } = linkedProject;
+    const deleted = await factory.Project.create({
+      name: "old",
+      accountId: live.accountId,
+      githubActionsOidcEnabled: true,
+      githubRepositoryId: live.githubRepositoryId,
+    });
+    await deleted.$query().patch({
+      name: `deleted-${deleted.id}-old`,
+      deletedAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .post("/auth/github-actions/oidc/exchange")
+      .send({
+        oidcToken: signGitHubActionsToken(),
+        repository: "argos-ci/argos",
+        commit: sha,
+      })
+      .expect(200);
+
+    const auth = await getAuthProjectPayloadFromBearerToken(res.body.token);
+    expect(auth.project.id).toBe(live.id);
+  });
+
+  test("rejects when every linked project is deleted", async ({
+    linkedProject,
+  }) => {
+    await linkedProject.project.$query().patch({
+      deletedAt: new Date().toISOString(),
+    });
+
+    // Not a token that fails later: the exchange used to mint one for the
+    // deleted project, and the CLI's next call reported it as expired.
+    await request(app)
+      .post("/auth/github-actions/oidc/exchange")
+      .send({
+        oidcToken: signGitHubActionsToken(),
+        repository: "argos-ci/argos",
+      })
+      .expect(401)
+      .expect((res) => {
+        expect(res.body.error).toBe(
+          "No Argos project is linked to this GitHub repository.",
+        );
+      });
+  });
+
   test("rejects when GitHub Actions OIDC is disabled on the project", async ({
     linkedProject,
   }) => {

--- a/apps/backend/src/api/handlers/getBuild.e2e.test.ts
+++ b/apps/backend/src/api/handlers/getBuild.e2e.test.ts
@@ -208,6 +208,33 @@ describe("getBuild", () => {
         });
     });
 
+    test("returns 404 once the project is deleted", async ({
+      account,
+      project,
+      build,
+    }) => {
+      // An account-scoped token is the case that reaches the build lookup: a
+      // project token is refused at authentication, but `assertProjectAccess`
+      // only checks that the token is scoped to the account, and this handler
+      // checks no project permission at all.
+      const token = await createOAuthAccessToken(account, ["projects:read"]);
+      await project.$query().patch({
+        name: `deleted-${project.id}-web`,
+        deletedAt: new Date().toISOString(),
+      });
+
+      await request(oauthApp)
+        .get(`/projects/acme/web/builds/${build.number}`)
+        .set("Authorization", `Bearer ${token}`)
+        .expect(404);
+
+      // Nor under the name it was parked as.
+      await request(oauthApp)
+        .get(`/projects/acme/deleted-${project.id}-web/builds/${build.number}`)
+        .set("Authorization", `Bearer ${token}`)
+        .expect(404);
+    });
+
     test("returns 403 without the projects:read scope", async ({
       account,
       build,

--- a/apps/backend/src/api/handlers/getBuild.ts
+++ b/apps/backend/src/api/handlers/getBuild.ts
@@ -1,9 +1,9 @@
 import z from "zod";
 import { ZodOpenApiOperationObject } from "zod-openapi";
 
-import { Build } from "@/database/models";
 import { boom } from "@/util/error";
 
+import { queryBuildByNumber } from "../auth/build";
 import { assertProjectAccess } from "../auth/project";
 import {
   BuildNumber,
@@ -53,12 +53,7 @@ export const getBuild: CreateAPIHandler = ({ get }) => {
     const { params } = req.ctx;
     const [auth, build] = await Promise.all([
       req.ctx.auth(),
-      Build.query()
-        .joinRelated("project.account")
-        .where("project:account.slug", params.owner)
-        .where("project.name", params.project)
-        .where("number", params.buildNumber)
-        .first(),
+      queryBuildByNumber(params),
     ]);
 
     assertProjectAccess(auth, {

--- a/apps/backend/src/api/handlers/listBuildDiffs.ts
+++ b/apps/backend/src/api/handlers/listBuildDiffs.ts
@@ -2,10 +2,11 @@ import { invariant } from "@argos/util/invariant";
 import { z } from "zod";
 import { ZodOpenApiOperationObject } from "zod-openapi";
 
-import { Build, ScreenshotDiff } from "@/database/models";
+import { ScreenshotDiff } from "@/database/models";
 import { sortScreenshotDiffsForBuild } from "@/database/services/screenshot-diffs";
 import { boom } from "@/util/error";
 
+import { queryBuildByNumber } from "../auth/build";
 import { assertProjectAccess } from "../auth/project";
 import { BuildNumber } from "../schema/primitives/build";
 import {
@@ -90,13 +91,7 @@ export const listBuildDiffs: CreateAPIHandler = ({ get }) => {
 
       const [auth, build] = await Promise.all([
         req.ctx.auth(),
-        Build.query()
-          .joinRelated("project.account")
-          .where("project:account.slug", params.owner)
-          .where("project.name", params.project)
-          .where("number", params.buildNumber)
-          .withGraphFetched("project")
-          .first(),
+        queryBuildByNumber(params),
       ]);
 
       assertProjectAccess(auth, {

--- a/apps/backend/src/auth/github-actions-oidc-exchange.ts
+++ b/apps/backend/src/auth/github-actions-oidc-exchange.ts
@@ -59,18 +59,26 @@ export async function exchangeGitHubActionsOidcToken(
 
   invariant(repository.projects, "Relation `projects` not loaded");
 
-  if (repository.projects.length === 0) {
+  // Deleted rows keep their repository link, and one left in would shadow the
+  // live project as "multiple projects found" — which no caller of this
+  // endpoint can disambiguate, since it takes no project slug. Mirrors the
+  // tokenless path in `auth/tokenless/github-actions.ts`.
+  const projects = repository.projects.filter(
+    (candidate) => !candidate.deletedAt,
+  );
+
+  if (projects.length === 0) {
     throw boom(401, "No Argos project is linked to this GitHub repository.");
   }
 
-  if (repository.projects.length > 1) {
+  if (projects.length > 1) {
     throw boom(
       400,
       "Multiple Argos projects are linked to this GitHub repository.",
     );
   }
 
-  const project = repository.projects[0];
+  const project = projects[0];
   invariant(project, "Project not found");
 
   if (!project.githubActionsOidcEnabled) {

--- a/apps/backend/src/build-notification/notifications.ts
+++ b/apps/backend/src/build-notification/notifications.ts
@@ -60,6 +60,16 @@ export async function processBuildNotification(
   );
   invariant(project, "No project found", UnretryableError);
 
+  // A build already in the pipeline when its project was deleted must not go on
+  // writing a commit status and editing the pull request comment for it. The
+  // hard delete stopped these jobs by taking the `builds` row with it, and the
+  // rows surviving is what put this back in reach — a required `argos/<name>`
+  // check on an open pull request would otherwise be left resolved by a project
+  // that no longer exists.
+  if (project.deletedAt) {
+    return;
+  }
+
   const commit = (() => {
     // In merge queue, we never notify the PR head commit but the merge queue itself.
     if (!build.mergeQueue && build.prHeadCommit) {

--- a/apps/backend/src/build/job.ts
+++ b/apps/backend/src/build/job.ts
@@ -127,7 +127,11 @@ export async function performBuild(build: Build) {
   }
 
   const [project] = await Promise.all([
-    Project.query()
+    // Not deleted: a build whose project went away mid-run must not push usage
+    // to Stripe or sync a GitLab status for it. `throwIfNotFound` raises the
+    // same error the missing `builds` row used to raise under the hard delete,
+    // which the job treats as unretryable.
+    Project.queryNotDeleted()
       .findById(build.projectId)
       .withGraphFetched("[gitlabProject, account]")
       .throwIfNotFound(),

--- a/apps/backend/src/database/models/Project.e2e.test.ts
+++ b/apps/backend/src/database/models/Project.e2e.test.ts
@@ -1,0 +1,89 @@
+import { invariant } from "@argos/util/invariant";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Project } from "@/database/models";
+import { factory, setupDatabase } from "@/database/testing";
+
+/**
+ * `Project.getPermissions` is where a deleted project is refused for the whole
+ * application. Every surface that reaches a project through one of its own rows
+ * — a build, a test, a media, an automation rule — authorizes here rather than
+ * through a project lookup, so nothing else can close them all.
+ */
+describe("Project permissions on a deleted project", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  async function seed(attrs?: { private?: boolean | null }) {
+    const user = await factory.User.create();
+    const account = await factory.TeamAccount.create();
+    invariant(account.teamId, "team account has no team");
+    await factory.TeamUser.create({
+      teamId: account.teamId,
+      userId: user.id,
+      userLevel: "owner",
+    });
+    const project = await factory.Project.create({
+      accountId: account.id,
+      private: attrs?.private ?? true,
+    });
+    return { user, account, project };
+  }
+
+  async function markDeleted(project: Project) {
+    await project.$query().patch({
+      name: `deleted-${project.id}-${project.name}`,
+      deletedAt: new Date().toISOString(),
+    });
+    const reloaded = await Project.query().findById(project.id);
+    invariant(reloaded, "project row must survive the delete");
+    return reloaded;
+  }
+
+  it("grants an owner nothing", async () => {
+    const { user, project } = await seed();
+    await expect(project.$getPermissions(user)).resolves.toContain("admin");
+
+    const deleted = await markDeleted(project);
+
+    await expect(deleted.$getPermissions(user)).resolves.toEqual([]);
+    await expect(deleted.$getMembershipPermissions(user)).resolves.toEqual([]);
+  });
+
+  it("grants staff nothing", async () => {
+    // Staff otherwise hold every permission on every project, so they are the
+    // case a guard placed after the staff short-circuit would miss.
+    const { project } = await seed();
+    const staff = await factory.User.create({ staff: true });
+    await expect(project.$getPermissions(staff)).resolves.toContain("admin");
+
+    const deleted = await markDeleted(project);
+
+    await expect(deleted.$getPermissions(staff)).resolves.toEqual([]);
+    await expect(deleted.$getMembershipPermissions(staff)).resolves.toEqual([]);
+  });
+
+  it("grants an anonymous visitor nothing on what was a public project", async () => {
+    // The path that does not go through membership at all: a public project
+    // grants "view" to anyone, so it needs its own guard.
+    const { project } = await seed({ private: false });
+    await expect(project.$getPermissions(null)).resolves.toEqual(["view"]);
+
+    const deleted = await markDeleted(project);
+
+    await expect(deleted.$getPermissions(null)).resolves.toEqual([]);
+  });
+
+  it("still grants permissions on a live project of the same account", async () => {
+    const { user, account, project } = await seed();
+    const sibling = await factory.Project.create({
+      name: "sibling",
+      accountId: account.id,
+    });
+
+    await markDeleted(project);
+
+    await expect(sibling.$getPermissions(user)).resolves.toContain("admin");
+  });
+});

--- a/apps/backend/src/database/models/Project.ts
+++ b/apps/backend/src/database/models/Project.ts
@@ -307,6 +307,17 @@ export class Project extends Model {
     project: Project,
     user: User | null,
   ): Promise<ProjectPermission[]> {
+    // A deleted project grants nothing to anyone, and this is where that is
+    // enforced for the whole application. Every surface that reaches a project
+    // through one of its own rows — a build, a test, a media, an automation
+    // rule, addressed by id or by `{owner}/{project}` — authorizes here rather
+    // than through a project lookup, so filtering the lookups cannot reach
+    // them. Being the funnel also makes it fail closed: a surface added later
+    // is covered without knowing that soft delete exists.
+    if (project.deletedAt) {
+      return [];
+    }
+
     const [isPublic, membershipPermissions] = await Promise.all([
       project.$checkIsPublic(),
       Project.getMembershipPermissions(project, user),
@@ -330,6 +341,12 @@ export class Project extends Model {
     project: Project,
     user: User | null,
   ): Promise<ProjectPermission[]> {
+    // Repeated rather than left to the caller: this is a public entry point of
+    // its own, and a deleted project has no members either.
+    if (project.deletedAt) {
+      return [];
+    }
+
     // An anonymous visitor is a member of nothing.
     if (!user) {
       return [];

--- a/apps/backend/src/git-platform/comment.ts
+++ b/apps/backend/src/git-platform/comment.ts
@@ -301,9 +301,15 @@ export async function getCommentBody(props: {
   const [builds, deployments] = await Promise.all([
     Build.query()
       .distinctOn("builds.name", "builds.projectId")
-      .joinRelated("compareScreenshotBucket")
+      .joinRelated("[project, compareScreenshotBucket]")
       .withGraphFetched("project.account")
       .where("compareScreenshotBucket.commit", commit)
+      // A commit reaches every project that ever built it, so one deleted
+      // project of a monorepo would keep its row — and its 404 link — in the
+      // comment every time a surviving project rebuilds that commit. It would
+      // also keep `hasMultipleProjects` true, prefixing every other row with a
+      // project name.
+      .whereNull("project.deletedAt")
       .orderBy([
         { column: "builds.name", order: "desc" },
         { column: "builds.projectId", order: "desc" },
@@ -315,8 +321,10 @@ export async function getCommentBody(props: {
       // and then omits them again from the result — on an implicit `select *`
       // that strips `id` and leaves both relations empty.
       .select("deployments.*")
+      .joinRelated("project")
       .withGraphFetched("[project,aliases]")
       .where("deployments.commitSha", commit)
+      .whereNull("project.deletedAt")
       .orderBy([
         { column: "deployments.projectId", order: "desc" },
         { column: "deployments.environment", order: "desc" },

--- a/apps/backend/src/graphql/services/project.e2e.test.ts
+++ b/apps/backend/src/graphql/services/project.e2e.test.ts
@@ -8,6 +8,7 @@ import {
   IgnoredChange,
   MediaDiff,
   Project,
+  DeploymentAlias,
   ProjectDomain,
   ProjectUser,
   Screenshot,
@@ -19,6 +20,7 @@ import {
 } from "@/database/models";
 import { factory, setupDatabase } from "@/database/testing";
 import { deleteDomainTenant } from "@/deployment/cloudfront";
+import { invalidateDeploymentCache } from "@/deployment/invalidate";
 import {
   deleteUnreferencedMediaDiffObjects,
   deleteUnreferencedMediaObjects,
@@ -45,6 +47,13 @@ vi.mock("@/media/object", async (importOriginal) => ({
 vi.mock("@/deployment/cloudfront", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/deployment/cloudfront")>()),
   deleteDomainTenant: vi.fn(async () => undefined),
+}));
+
+// Reaches Cloudflare, and like the tenant it is not rolled back — what matters
+// is that the domain is handed over to be purged.
+vi.mock("@/deployment/invalidate", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/deployment/invalidate")>()),
+  invalidateDeploymentCache: vi.fn(async () => undefined),
 }));
 
 type SeededProject = {
@@ -345,6 +354,45 @@ describe("deleteProject", () => {
     await expect(
       ProjectDomain.query().findById(projectDomain.id),
     ).resolves.toBeUndefined();
+  });
+
+  test("releases the domain so another project can claim it", async () => {
+    // `deployment_aliases.alias` is globally unique and is what resolution
+    // reads. The hard delete took the alias with the project through
+    // `deployments`' cascade; the soft delete keeps the deployments, so an
+    // alias left behind made the domain unclaimable by anyone, forever.
+    const account = await factory.UserAccount.create();
+    const owner = await User.query().findById(account.userId!);
+    const project = await factory.Project.create({ accountId: account.id });
+    const projectDomain = await factory.ProjectDomain.create({
+      projectId: project.id,
+      domain: "docs.acme.test",
+      internal: false,
+      status: "active",
+      cloudfrontTenantId: "dt-tenant-2",
+    });
+    const deployment = await factory.Deployment.create({
+      projectId: project.id,
+      environment: "production",
+    });
+    await DeploymentAlias.query().insert({
+      alias: "docs.acme.test",
+      deploymentId: deployment.id,
+      type: "domain",
+    });
+
+    await deleteProject({ id: project.id, user: owner });
+
+    await expect(
+      ProjectDomain.query().findById(projectDomain.id),
+    ).resolves.toBeUndefined();
+    // The row that would have kept answering for the domain.
+    await expect(
+      DeploymentAlias.query().findOne({ alias: "docs.acme.test" }),
+    ).resolves.toBeUndefined();
+    expect(deleteDomainTenant).toHaveBeenCalledWith("dt-tenant-2");
+    // And the edge, which serves the resolution for minutes after the row goes.
+    expect(invalidateDeploymentCache).toHaveBeenCalledWith("docs.acme.test");
   });
 
   test("sends a notification to the personal account owner", async () => {

--- a/apps/backend/src/graphql/services/project.ts
+++ b/apps/backend/src/graphql/services/project.ts
@@ -30,9 +30,11 @@ import {
   applyProjectVisibility,
   DELETED_PROJECT_NAME_PREFIX,
 } from "@/database/services/project";
+import { detachDomainAlias } from "@/database/services/project-domain";
 import { transaction } from "@/database/transaction";
 import { isValidPgBigInt } from "@/database/util/biginteger";
 import { deleteDomainTenant } from "@/deployment/cloudfront";
+import { invalidateDeploymentCache } from "@/deployment/invalidate";
 import {
   deleteUnreferencedMediaDiffObjects,
   deleteUnreferencedMediaObjects,
@@ -148,7 +150,7 @@ export async function deleteProject(args: {
   const recipients = await getProjectDeleteNotificationRecipients(project);
   invariant(project.account, "project.account is undefined");
 
-  const cloudfrontTenantIds = await transaction(async (trx) => {
+  const released = await transaction(async (trx) => {
     // The stamp goes first and carries its own `deletedAt IS NULL`, so it is
     // the gate rather than the read above it. A second request that got past
     // that read before this one committed blocks on the row here, re-checks the
@@ -175,11 +177,17 @@ export async function deleteProject(args: {
   });
 
   // Lost the race, so the request that won it owns the notification.
-  if (cloudfrontTenantIds === null) {
+  if (released === null) {
     return;
   }
 
-  await Promise.all(cloudfrontTenantIds.map((id) => deleteDomainTenant(id)));
+  // Both outside the transaction, and neither rolls back with it: a CloudFront
+  // tenant is billed, and the edge caches `/v2/deployments/resolve/{domain}`
+  // for minutes, so the deployment stays publicly live until it is purged.
+  await Promise.all([
+    ...released.cloudfrontTenantIds.map((id) => deleteDomainTenant(id)),
+    ...released.domains.map((domain) => invalidateDeploymentCache(domain)),
+  ]);
 
   if (recipients.length > 0) {
     await sendNotification({
@@ -215,24 +223,41 @@ function getDeletedProjectName(project: Project): string {
 }
 
 /**
- * Drop a project's domains, returning the CloudFront tenant ids they held so
- * the caller can delete the tenants once the transaction has committed — a
- * tenant is billed and is not rolled back with it.
+ * Release a project's domains: the `project_domains` rows, the
+ * `deployment_aliases` rows that answer for them, and — via the returned tenant
+ * ids, once the transaction has committed, since a tenant is billed and is not
+ * rolled back with it — their CloudFront tenants.
+ *
+ * The alias has to go explicitly. `detachDomainAlias` says why: "Removing the
+ * `project_domains` row is not enough: resolution reads `deployment_aliases`,
+ * so an orphaned alias keeps answering." A hard delete got it for free through
+ * `deployments`' cascade; a soft delete keeps the deployments, so the alias
+ * survives — and `deployment_aliases.alias` is globally unique, so an orphan
+ * makes the domain unclaimable by any project, forever.
  */
 async function releaseProjectDomains(args: {
   projectId: string;
   trx: TransactionOrKnex;
-}): Promise<string[]> {
+}): Promise<{ cloudfrontTenantIds: string[]; domains: string[] }> {
   const projectDomains = await ProjectDomain.query(args.trx)
-    .select("cloudfrontTenantId")
-    .where({ projectId: args.projectId })
-    .whereNotNull("cloudfrontTenantId");
+    .select("domain", "cloudfrontTenantId")
+    .where({ projectId: args.projectId });
+
+  const domains = projectDomains.map((projectDomain) => projectDomain.domain);
+
+  await Promise.all(
+    domains.map((domain) => detachDomainAlias(domain, args.trx)),
+  );
   await ProjectDomain.query(args.trx)
     .where("projectId", args.projectId)
     .delete();
-  return projectDomains
-    .map((projectDomain) => projectDomain.cloudfrontTenantId)
-    .filter((id): id is string => id !== null);
+
+  return {
+    domains,
+    cloudfrontTenantIds: projectDomains
+      .map((projectDomain) => projectDomain.cloudfrontTenantId)
+      .filter((id): id is string => id !== null),
+  };
 }
 
 /**
@@ -326,10 +351,10 @@ export async function unsafe_deleteProject(args: {
       )
     ).keys;
     await Media.query(trx).where("projectId", args.projectId).delete();
-    cloudfrontTenantIds = await releaseProjectDomains({
+    ({ cloudfrontTenantIds } = await releaseProjectDomains({
       projectId: args.projectId,
       trx,
-    });
+    }));
     await ProjectUser.query(trx).where("projectId", args.projectId).delete();
     await IgnoredChange.query(trx).where("projectId", args.projectId).delete();
     await AuditTrail.query(trx).where("projectId", args.projectId).delete();

--- a/apps/backend/src/media/pull-request-comment.ts
+++ b/apps/backend/src/media/pull-request-comment.ts
@@ -6,13 +6,12 @@ import {
   GithubRepository,
   Media,
   MediaVersion,
-  Project,
 } from "@/database/models";
 import { checkOctokitErrorStatus, getInstallationOctokit } from "@/github";
 import logger from "@/logger";
 import { redisLock } from "@/util/redis";
 
-import { uploadedVersions } from "./query";
+import { liveProject, uploadedVersions } from "./query";
 import { getMediaEmbedArgs } from "./serve";
 import {
   getMediaTableMarkdown,
@@ -48,13 +47,7 @@ export async function updatePullRequestComment(
     // still getting them. Per project, because one pull request can carry media
     // from several — the ones that opted out, and the ones that were deleted,
     // drop out of the table rather than suppressing the whole comment.
-    .whereExists(
-      Project.query()
-        .select(1)
-        .whereColumn("projects.id", "media.projectId")
-        .where("projects.prCommentEnabled", true)
-        .whereNull("projects.deletedAt"),
-    )
+    .whereExists(liveProject().where("projects.prCommentEnabled", true))
     .orderBy("createdAt", "asc")
     .limit(MAX_LISTED_MEDIA);
 

--- a/apps/backend/src/media/query.ts
+++ b/apps/backend/src/media/query.ts
@@ -31,16 +31,19 @@ export type MediaFilters = {
 };
 
 /**
- * The media list query, shared by the REST list endpoint and the GraphQL pull
- * request list so both paginate, filter and order identically.
+ * Correlated subquery asserting the media's project is not soft-deleted, for
+ * the media surfaces that are addressed by something other than their project —
+ * a share token, a media id — and so never pass through a project lookup.
  *
- * Takes project ids rather than an account so the caller decides the scope: one
- * project for the project endpoint, or every project a viewer can see.
- *
- * Only media with at least one uploaded version: a media created to sign an upload
- * that never completed is an implementation detail of the two-step flow, not
- * something a project should see listed.
+ * Only valid inside a query rooted at `media`, which is what it correlates on.
  */
+export function liveProject() {
+  return Project.query()
+    .select(1)
+    .whereColumn("projects.id", "media.projectId")
+    .whereNull("projects.deletedAt");
+}
+
 /**
  * Resolve the media a share link points at, or `null` when nothing is behind
  * it.
@@ -54,14 +57,20 @@ export function findMediaByShareToken(
 ): QueryBuilder<Media, Media | undefined> {
   return Media.query()
     .findOne("media.shareToken", shareToken)
-    .whereExists(
-      Project.query()
-        .select(1)
-        .whereColumn("projects.id", "media.projectId")
-        .whereNull("projects.deletedAt"),
-    );
+    .whereExists(liveProject());
 }
 
+/**
+ * The media list query, shared by the REST list endpoint and the GraphQL pull
+ * request list so both paginate, filter and order identically.
+ *
+ * Takes project ids rather than an account so the caller decides the scope: one
+ * project for the project endpoint, or every project a viewer can see.
+ *
+ * Only media with at least one uploaded version: a media created to sign an upload
+ * that never completed is an implementation detail of the two-step flow, not
+ * something a project should see listed.
+ */
 export function queryProjectMedia(args: {
   projectIds: string[];
   filters: MediaFilters | null;

--- a/apps/backend/src/slack/unfurl.ts
+++ b/apps/backend/src/slack/unfurl.ts
@@ -31,6 +31,7 @@ export async function unfurlBuild(
     .where("builds.number", params.buildNumber)
     .where("project:account.id", auth.accountId)
     .where("project:account.slug", params.accountSlug)
+    .whereNull("project.deletedAt")
     .first();
 
   if (!build) {
@@ -113,6 +114,7 @@ export async function unfurlTest(
     .where("project.name", params.projectName)
     .where("project:account.id", auth.accountId)
     .where("project:account.slug", params.accountSlug)
+    .whereNull("project.deletedAt")
     .first();
 
   if (!test) {

--- a/apps/backend/src/synchronize/github/eventHelpers.ts
+++ b/apps/backend/src/synchronize/github/eventHelpers.ts
@@ -57,7 +57,13 @@ const findRelevantUserTeam = async (
   // Find the team containing projects linked to the GitHub organization
   const relevantTeams = ownedTeams.filter((team) => {
     invariant(team.account?.projects, "projects not fetched");
+    // Deleted projects keep their repository link, so one would still make a
+    // team count as relevant — and two relevant teams skip the single-match
+    // branch below and attach the purchase to a brand-new empty team.
     return team.account.projects.some((project) => {
+      if (project.deletedAt) {
+        return false;
+      }
       if (!project.githubRepository) {
         return false;
       }


### PR DESCRIPTION
Fixes the findings from the review of #2574. Filtering project *lookups* closed only half the surfaces: everything that reaches a project through one of its own rows — a build, a test, a media, an automation rule, addressed by id or by `{owner}/{project}` — never performs a project lookup at all.

## The permission funnel is the fix

`Project.getPermissions` and `getMembershipPermissions` now return `[]` for a deleted project. Every one of those surfaces authorizes there, so one guard closes them together — and it **fails closed**, so a surface added later is covered without its author knowing soft delete exists.

That's what handles `graphql/buildAccess.ts`, `mediaAccess.ts`, `testAccess.ts` and `getAutomationRuleForAdmin`. The first three mattered most: a public project grants `view` to *anonymous* callers, so after deletion its builds' live comment and review subscriptions were still open to anyone.

## Permissions aren't the whole answer

Routes addressed by name should 404, not 403 — the name is no longer that project's — and not every route that resolves a build runs a permission check. So the lookups are filtered too:

| Surface | What was leaking |
|---|---|
| `api/auth/build.ts`, `api/auth/test.ts`, `api/auth/media.ts` | the shared loaders behind review, comment, reviewer and subscription routes |
| `auth/github-actions-oidc-exchange.ts` | a deleted row shadowed the live project as "multiple projects found", **breaking CI with no workaround** — this endpoint takes no project slug to disambiguate |
| `git-platform/comment.ts` | a deleted project of a monorepo kept its row, and its 404 link, in the **public** PR comment on every later build of that commit |
| `slack/unfurl.ts` | unfurling rendered a deleted project's screenshot into the channel |
| `synchronize/github/eventHelpers.ts` | a deleted project made a team count as relevant to a Marketplace purchase; two relevant teams attach it to a new empty team |

`getBuild`, `listBuildDiffs` and `createReview` each carried their own copy of the build query, so it's now one exported `queryBuildByNumber`. They **can't** share `loadBuildForUserAuth` itself — two of them also accept a project token, which that helper's type correctly refuses. The type checker caught that when I tried.

## Two behaviours the soft delete regressed

A build already in the pipeline kept running to completion: the hard delete used to stop those jobs by taking the `builds` row with it. `performBuild` no longer finds a deleted project, and `processBuildNotification` returns before writing a commit status or editing a PR comment for one — otherwise a required `argos/<name>` check on an open PR was left resolved by a project that no longer exists.

**A domain was left unclaimable forever.** `releaseProjectDomains` dropped `project_domains` but not the `deployment_aliases` row that answers for it — free under the hard delete through `deployments`' cascade, but the soft delete keeps the deployments. Since `alias` is globally unique, the orphan blocked *every* project from ever claiming that domain, with nothing in the product listing or freeing it. It now detaches the alias and purges the edge cache, which the single-domain teardown path has always done.

## Cleanup the review asked for

`liveProject()` is extracted from the two copies of the project-is-live subquery, and `queryProjectMedia`'s doc comment is back on `queryProjectMedia` — it had been stranded above the function inserted below it.

## One finding I did not apply

The review flagged that `last30DaysScreenshots` and `lastBuildDate` were unfiltered beside the activation loader that wasn't. That was written against the pre-#2575 state: #2575 made the activation loader count *consumption* for all projects and exclude deleted ones only from `projectsCount`, so these two are now consistent with it. I filtered them, saw it re-introduce the disagreement in the other direction, and reverted.

## Tests

Seven new guards, each verified to fail without its fix: the funnel refusing an owner, staff, and an anonymous visitor on what was a public project (and still granting on a live sibling); a REST build 404 via an account-scoped OAuth token — the case that actually reaches the lookup, since a project token is refused at authentication; the OIDC exchange ignoring a deleted sibling and rejecting when every linked project is gone; and the domain becoming claimable again.

`pnpm run static-checks` clean; 814 unit and 1290 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)