### PR TITLE
fix(dialog): focus the default action when a dialog opens

### DIFF
--- a/apps/frontend/src/containers/CheckoutStatusDialog.tsx
+++ b/apps/frontend/src/containers/CheckoutStatusDialog.tsx
@@ -60,7 +60,7 @@ export function CheckoutStatusDialog() {
           )}
         </DialogBody>
         <DialogFooter>
-          <DialogDismiss>OK</DialogDismiss>
+          <DialogDismiss autoFocus>OK</DialogDismiss>
         </DialogFooter>
       </Dialog>
     </Modal>

--- a/apps/frontend/src/containers/Project/Transfer.tsx
+++ b/apps/frontend/src/containers/Project/Transfer.tsx
@@ -378,6 +378,7 @@ const SuccessStep = (props: SuccessStepProps) => {
       <DialogFooter>
         <DialogDismiss
           single
+          autoFocus
           onClick={() => {
             props.onContinue();
           }}

--- a/apps/frontend/src/containers/User/Delete.tsx
+++ b/apps/frontend/src/containers/User/Delete.tsx
@@ -118,7 +118,7 @@ function UserDeleteDialog(props: DeleteUserButtonProps) {
           <DialogText>The link expires in 15 minutes.</DialogText>
         </DialogBody>
         <DialogFooter>
-          <DialogDismiss>Close</DialogDismiss>
+          <DialogDismiss autoFocus>Close</DialogDismiss>
         </DialogFooter>
       </Dialog>
     );

--- a/apps/frontend/src/pages/Build/BuildNextReviewDialog.tsx
+++ b/apps/frontend/src/pages/Build/BuildNextReviewDialog.tsx
@@ -188,6 +188,9 @@ function BuildNextReviewDialog(props: { build: ReviewedBuild }) {
         <LinkButton
           href={getBuildOverviewURL(getBuildParams(nextBuild))}
           autoFocus
+          // The dialog opens on its own once a review is submitted, so nothing
+          // marks the link as focused for a pointer user. Keep the ring on.
+          showFocusRing
         >
           Review next build
         </LinkButton>

--- a/apps/frontend/src/pages/Build/BuildPreviousReviewDialog.tsx
+++ b/apps/frontend/src/pages/Build/BuildPreviousReviewDialog.tsx
@@ -99,6 +99,10 @@ function ReapplyPreviousApprovalsButton(props: {
   const { close } = useOverlayTriggerState();
   return (
     <Button
+      autoFocus
+      // The dialog opens on its own when the build loads, so nothing marks the
+      // button as focused for a pointer user. Keep the ring on.
+      showFocusRing
       onClick={() => {
         if (checkIsPending()) {
           return;

--- a/apps/frontend/src/ui/Button.tsx
+++ b/apps/frontend/src/ui/Button.tsx
@@ -1,6 +1,8 @@
 import {
   Children,
   cloneElement,
+  useCallback,
+  useRef,
   useState,
   type ComponentPropsWithRef,
 } from "react";
@@ -9,6 +11,7 @@ import { clsx } from "clsx";
 
 import { toast } from "@/ui/Toaster";
 import { getErrorMessage } from "@/util/error";
+import { mergeRefs } from "@/util/merge-refs";
 
 import { Loader } from "./Loader";
 import { RouterLink } from "./RouterLink";
@@ -379,6 +382,30 @@ export interface LinkButtonProps
 }
 
 /**
+ * React applies `autoFocus` to `button`, `input`, `select` and `textarea` and
+ * to nothing else, so an anchor asking for it is left unfocused without a
+ * word — which is how a dialog whose default action is a link ended up with
+ * nothing for Enter to trigger. Focus it from the ref instead, once, when it
+ * mounts: that is what `autoFocus` means, and a re-render must not pull focus
+ * back from wherever it has since moved.
+ */
+function useAutoFocusRef<T extends HTMLElement>(
+  autoFocus: boolean | undefined,
+) {
+  const focusedRef = useRef(false);
+  return useCallback(
+    (element: T | null) => {
+      if (!autoFocus || !element || focusedRef.current) {
+        return;
+      }
+      focusedRef.current = true;
+      element.focus();
+    },
+    [autoFocus],
+  );
+}
+
+/**
  * A link wearing the button's clothes. `RouterLink` keeps an in-app path on
  * the client router and leaves a scheme like `codex://` a plain anchor —
  * which is what react-aria's `RouterProvider` used to do for every link.
@@ -391,6 +418,8 @@ export function LinkButton({
   showFocusRing,
   onClick,
   disabled,
+  autoFocus,
+  ref,
   ...props
 }: LinkButtonProps) {
   const buttonProps = getButtonProps({
@@ -399,9 +428,11 @@ export function LinkButton({
     iconOnly,
     showFocusRing,
   });
+  const autoFocusRef = useAutoFocusRef<HTMLAnchorElement>(autoFocus);
   return (
     <RouterLink
       {...buttonProps}
+      ref={mergeRefs(ref, autoFocusRef)}
       className={clsx(buttonProps.className, className)}
       aria-disabled={disabled || undefined}
       onClick={(event) => {

--- a/apps/frontend/src/ui/Dialog.stories.tsx
+++ b/apps/frontend/src/ui/Dialog.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, screen, waitFor } from "storybook/test";
 
-import { Button } from "./Button";
+import { Button, LinkButton } from "./Button";
 import {
   Dialog,
   DialogActionButton,
@@ -214,6 +214,48 @@ export const PendingBlocksDismissal: Story = {
     await userEvent.keyboard("{Escape}");
     await waitFor(() => {
       expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    });
+  },
+};
+
+/**
+ * A dialog that offers to move somewhere puts its default action on a link,
+ * and a link is exactly where `autoFocus` stops working on its own: React
+ * applies it to form controls and to nothing else, so the anchor stayed
+ * unfocused and Enter did nothing. `Modal` also aims focus at the popup
+ * itself, which the autofocused element has to win against. Neither shows up
+ * in a screenshot, so it is asserted.
+ */
+export const AutoFocusedLinkTakesFocus: Story = {
+  parameters: openOverlayParameters,
+  render: () => (
+    <div className="flex h-screen w-full items-start justify-center p-16">
+      <DialogTrigger defaultOpen>
+        <Button variant="secondary">Open Dialog</Button>
+        <Modal dismissible>
+          <Dialog>
+            <DialogBody>
+              <DialogTitle>Review the next build</DialogTitle>
+              <DialogText>
+                One more build ran on this commit and still needs your review.
+              </DialogText>
+            </DialogBody>
+            <DialogFooter>
+              <DialogDismiss>Not now</DialogDismiss>
+              <LinkButton href="/builds/2" autoFocus showFocusRing>
+                Review next build
+              </LinkButton>
+            </DialogFooter>
+          </Dialog>
+        </Modal>
+      </DialogTrigger>
+    </div>
+  ),
+  play: async () => {
+    await waitFor(async () => {
+      await expect(
+        screen.getByRole("link", { name: "Review next build" }),
+      ).toHaveFocus();
     });
   },
 };

--- a/apps/frontend/src/ui/Dialog.tsx
+++ b/apps/frontend/src/ui/Dialog.tsx
@@ -117,6 +117,11 @@ export function DialogDismiss(props: {
   onClick?: () => void;
   single?: boolean;
   disabled?: boolean;
+  /**
+   * Focus the button when the dialog opens. For a dialog that only asks to be
+   * acknowledged, dismissing *is* the action, so Enter should do it.
+   */
+  autoFocus?: boolean;
 }) {
   const { ref, ...rest } = props;
   const state = useOverlayTriggerState();
@@ -126,6 +131,7 @@ export function DialogDismiss(props: {
       ref={ref}
       className={rest.single ? "flex-1 justify-center" : undefined}
       variant="secondary"
+      autoFocus={rest.autoFocus}
       onClick={() => {
         props.onClick?.();
         state.close();


### PR DESCRIPTION
Several dialogs opened with focus on the dialog box itself, so Enter did nothing and the action the dialog was asking for had to be reached with the mouse or a Tab.

## The two reported

- **"Reapply previous approvals"** never asked for focus at all.
- **"Review next build"** did — and it was ignored. React applies `autoFocus` to `button`, `input`, `select` and `textarea` and to nothing else, so a `LinkButton` (an anchor) is left unfocused without a word. `LinkButton` now focuses itself from its ref on mount, so this fixes every link that asks for `autoFocus`, not just this dialog.

Both also get `showFocusRing`: these dialogs open on their own, so `:focus-visible` would never match and a pointer user would be looking at an invisible default action.

## The rest of the dialogs

Most were already right — every form dialog autofocuses its first field, and `RejectCommentDialog` / `BuildReviewForm` autofocus their editor.

The same gap showed up in the acknowledgement-only dialogs, where dismissing *is* the action and Enter did nothing. `DialogDismiss` now takes `autoFocus`, used in `CheckoutStatusDialog` ("OK"), `Transfer`'s final step ("OK") and `UserDelete`'s "Check your inbox" ("Close").

**Deliberately left alone:** confirm-and-destroy dialogs (delete, revoke, remove, ignore, disable) keep focus on the box so Enter cannot destroy anything. Same reasoning for the paid actions ("Enable and Pay", "Confirm and Pay") and for the created-token dialog, where Enter would dismiss the one screen that ever shows the token.

## Verification

`pnpm run static-checks` passes.

New guard story `AutoFocusedLinkTakesFocus` in `Dialog.stories.tsx` asserts the autofocused link wins against the `Modal`'s own `initialFocus`, which aims at the popup — neither the focus nor that contest shows up in a screenshot. I reverted the `LinkButton` fix and re-ran it: it fails without the fix, passes with it. Throwaway stories confirmed the same for `Button autoFocus` and `DialogDismiss autoFocus` before being deleted.

Expect new Argos baselines for the story and for any shot of the two build dialogs — the focus ring is now visible in them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)