### PR TITLE
feat(build): mark the variant switchers that hold a change

### DIFF
--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -1138,6 +1138,11 @@ export async function createFallbackBaselineScenario(input: {
  * another because `getVariantKey` strips both the browser prefix and the
  * ` vw-<width>` suffix from their names, leaving one key.
  *
+ * One variant per status, so every marker a switcher can draw is on screen at
+ * once — and, on the unchanged one, the absence of a marker. Which is why the
+ * matrix is not a square of identical diffs: the reviewer's question is which
+ * of the siblings is worth jumping to.
+ *
  * The snapshot name is long on purpose: the toolbar has to seat it beside the
  * switchers without cropping it, and a short name proves nothing.
  */
@@ -1148,21 +1153,63 @@ export async function createVariantSwitchersScenario(input: {
   const seededAt = getSeedInstant();
   const variantKey = "components/data-table/with-pagination-and-sticky-header";
 
+  // Every variant reuses the one `dummy-*` image, since those are the only keys
+  // that exist in the test bucket. The recorded viewport is therefore the
+  // browser's, not the file's — which is what the switchers read anyway.
+  //
+  // The statuses are placed by where the switchers land, not spread at random:
+  // from the first diff (chromium/1280, the only changed one) the toolbar
+  // reaches chromium/390 and firefox/1280, so those two carry the added and
+  // removed markers. The unchanged one sits behind Firefox, where switching the
+  // viewport shows a segment with nothing to say.
+  const variants = [
+    {
+      browser: CHROMIUM,
+      viewport: { width: 390, height: 844 },
+      status: "added",
+    },
+    {
+      browser: CHROMIUM,
+      viewport: { width: 1280, height: 800 },
+      status: "changed",
+    },
+    {
+      browser: FIREFOX,
+      viewport: { width: 390, height: 844 },
+      status: "unchanged",
+    },
+    {
+      browser: FIREFOX,
+      viewport: { width: 1280, height: 800 },
+      status: "removed",
+    },
+  ].map((variant) => ({
+    ...variant,
+    name: `${variant.browser.name}/${variantKey} vw-${variant.viewport.width}.png`,
+  }));
+
   const bucketProps = {
     name: "default",
     branch: "main",
     projectId,
     complete: true,
     valid: true,
-    screenshotCount: 4,
     storybookScreenshotCount: 0,
     createdAt: seededAt,
     updatedAt: seededAt,
   };
   const [baseBucket, compareBucket] =
     await ScreenshotBucket.query().insertAndFetch([
-      { ...bucketProps, commit: "4f1a9c2d8e5b3a7f6c0d9e8b1a2c3d4e5f6a7b8c" },
-      { ...bucketProps, commit: "9e8d7c6b5a4f3e2d1c0b9a8f7e6d5c4b3a2f1e0d" },
+      {
+        ...bucketProps,
+        commit: "4f1a9c2d8e5b3a7f6c0d9e8b1a2c3d4e5f6a7b8c",
+        screenshotCount: variants.filter((v) => v.status !== "added").length,
+      },
+      {
+        ...bucketProps,
+        commit: "9e8d7c6b5a4f3e2d1c0b9a8f7e6d5c4b3a2f1e0d",
+        screenshotCount: variants.filter((v) => v.status !== "removed").length,
+      },
     ]);
   invariant(baseBucket && compareBucket);
 
@@ -1183,19 +1230,6 @@ export async function createVariantSwitchersScenario(input: {
     }),
   ]);
 
-  // Every variant reuses the one `dummy-*` image, since those are the only keys
-  // that exist in the test bucket. The recorded viewport is therefore the
-  // browser's, not the file's — which is what the switchers read anyway.
-  const variants = [
-    { browser: CHROMIUM, viewport: { width: 390, height: 844 } },
-    { browser: CHROMIUM, viewport: { width: 1280, height: 800 } },
-    { browser: FIREFOX, viewport: { width: 390, height: 844 } },
-    { browser: FIREFOX, viewport: { width: 1280, height: 800 } },
-  ].map((variant) => ({
-    ...variant,
-    name: `${variant.browser.name}/${variantKey} vw-${variant.viewport.width}.png`,
-  }));
-
   const tests = await Test.query().insertAndFetch(
     variants.map((variant) => ({
       name: variant.name,
@@ -1208,6 +1242,7 @@ export async function createVariantSwitchersScenario(input: {
     const test = tests[index];
     invariant(test);
     return {
+      status: variant.status,
       testId: test.id,
       name: variant.name,
       s3Id: imageFile.key,
@@ -1233,16 +1268,26 @@ export async function createVariantSwitchersScenario(input: {
   });
 
   const baseScreenshots = await Screenshot.query().insertAndFetch(
-    screenshotProps.map((props) => ({
-      ...props,
-      screenshotBucketId: baseBucket.id,
-    })),
+    screenshotProps
+      .filter((props) => props.status !== "added")
+      .map(({ status: _status, ...props }) => ({
+        ...props,
+        screenshotBucketId: baseBucket.id,
+      })),
   );
   const compareScreenshots = await Screenshot.query().insertAndFetch(
-    screenshotProps.map((props) => ({
-      ...props,
-      screenshotBucketId: compareBucket.id,
-    })),
+    screenshotProps
+      .filter((props) => props.status !== "removed")
+      .map(({ status: _status, ...props }) => ({
+        ...props,
+        screenshotBucketId: compareBucket.id,
+      })),
+  );
+  const baseScreenshotIdByName = new Map(
+    baseScreenshots.map((screenshot) => [screenshot.name, screenshot.id]),
+  );
+  const compareScreenshotIdByName = new Map(
+    compareScreenshots.map((screenshot) => [screenshot.name, screenshot.id]),
   );
 
   const [build] = await Build.query().insertAndFetch([
@@ -1261,20 +1306,32 @@ export async function createVariantSwitchersScenario(input: {
   invariant(build);
 
   await ScreenshotDiff.query().insert(
-    variants.map((_variant, index) => {
-      const baseScreenshot = baseScreenshots[index];
-      const compareScreenshot = compareScreenshots[index];
+    variants.map((variant, index) => {
       const test = tests[index];
-      invariant(baseScreenshot && compareScreenshot && test);
+      invariant(test);
+      const changed = variant.status === "changed";
       return {
         buildId: build.id,
-        baseScreenshotId: baseScreenshot.id,
-        compareScreenshotId: compareScreenshot.id,
+        baseScreenshotId: baseScreenshotIdByName.get(variant.name) ?? null,
+        compareScreenshotId:
+          compareScreenshotIdByName.get(variant.name) ?? null,
         testId: test.id,
-        score: 0.2,
+        // A missing screenshot on one side is what makes a diff added or
+        // removed, so those carry no score at all; the score only tells changed
+        // from unchanged.
+        score: (() => {
+          switch (variant.status) {
+            case "changed":
+              return 0.2;
+            case "unchanged":
+              return 0;
+            default:
+              return null;
+          }
+        })(),
         jobStatus: "complete" as const,
-        s3Id: diffFile.key,
-        fileId: diffFile.id,
+        s3Id: changed ? diffFile.key : null,
+        fileId: changed ? diffFile.id : null,
         createdAt: seededAt,
         updatedAt: seededAt,
       };

--- a/apps/frontend/src/containers/Build/toolbar/DetailToolbar.tsx
+++ b/apps/frontend/src/containers/Build/toolbar/DetailToolbar.tsx
@@ -62,6 +62,13 @@ export function DetailToolbarTitle(props: {
    * fits beside it. It still grows into whatever the cluster does not use.
    * Without a cluster there is nothing designed to yield, so the name asks for
    * its own length and shrinks like anything else.
+   *
+   * The floor has to be the whole of that guarantee, because the growth beside
+   * it cannot be counted on: a cluster wide enough to wrap keeps claiming its
+   * single-line width — `fit-content` of a wrapped flex container is its
+   * max-content — and hands the name nothing back. `basis-80` is two lines of a
+   * 70-odd character snapshot name, which is what the build toolbar has to
+   * seat.
    */
   crowded?: boolean;
 }) {
@@ -79,7 +86,7 @@ export function DetailToolbarTitle(props: {
     <div
       className={clsx(
         "flex grow",
-        crowded ? "shrink-0 basis-72" : "min-w-0 shrink basis-auto",
+        crowded ? "shrink-0 basis-80" : "min-w-0 shrink basis-auto",
       )}
     >
       {render ? render(title) : title}

--- a/apps/frontend/src/pages/Build/metadata/variants/BrowserSwitcher.tsx
+++ b/apps/frontend/src/pages/Build/metadata/variants/BrowserSwitcher.tsx
@@ -19,6 +19,12 @@ import {
   type MetadataBrowser,
 } from "../utils";
 import { findVariantSibling } from "./sibling";
+import {
+  getVariantStatus,
+  VariantStatusIcon,
+  withVariantStatus,
+  type VariantStatus,
+} from "./VariantStatus";
 
 export function BrowserSwitcher(props: { diff: Diff; siblingDiffs: Diff[] }) {
   const { diff, siblingDiffs } = props;
@@ -51,6 +57,7 @@ export function BrowserSwitcher(props: { diff: Diff; siblingDiffs: Diff[] }) {
           <BrowserLinkButton
             key={key}
             browser={browser}
+            status={getVariantStatus(resolvedDiff)}
             aria-current={isActive ? "page" : undefined}
             href={getDiffPath(resolvedDiff.id) ?? ""}
             shortcutEnabled={isNextActive}
@@ -63,14 +70,18 @@ export function BrowserSwitcher(props: { diff: Diff; siblingDiffs: Diff[] }) {
 
 function BrowserLinkButton(props: {
   browser: MetadataBrowser;
+  status: VariantStatus | null;
   href: string;
   shortcutEnabled: boolean;
   "aria-current"?: "page";
 }) {
-  const { browser, shortcutEnabled, ...rest } = props;
+  const { browser, status, shortcutEnabled, ...rest } = props;
   const navigate = useNavigate();
   const label = getBrowserLabel(browser.name);
-  const tooltipContent = `${label} v${browser.version}`;
+  const tooltipContent = withVariantStatus(
+    `${label} v${browser.version}`,
+    status,
+  );
   const hotkey = useBuildHotkey("switchBrowser", () => navigate(props.href), {
     enabled: shortcutEnabled,
   });
@@ -79,8 +90,19 @@ function BrowserLinkButton(props: {
     // The logo is the label: browsers are the one dimension whose icons anyone
     // reviewing snapshots can already tell apart. The name stays for a screen
     // reader, and the version for the tooltip.
-    <LinkButton {...rest} variant="secondary" iconOnly aria-label={label}>
+    //
+    // Still `iconOnly` with the status marker beside the logo: that is what
+    // sizes both icons alike and keeps the segment as tall as the text ones.
+    // `gap-1` because `iconOnly` expects the one child it is named for.
+    <LinkButton
+      {...rest}
+      variant="secondary"
+      iconOnly
+      className="gap-1"
+      aria-label={withVariantStatus(label, status)}
+    >
       <BrowserIcon browser={browser} />
+      {status ? <VariantStatusIcon status={status} /> : null}
     </LinkButton>
   );
 

--- a/apps/frontend/src/pages/Build/metadata/variants/ColorSchemeSwitcher.tsx
+++ b/apps/frontend/src/pages/Build/metadata/variants/ColorSchemeSwitcher.tsx
@@ -16,6 +16,11 @@ import {
   useGetDiffPath,
 } from "../utils";
 import { findVariantSibling } from "./sibling";
+import {
+  getVariantStatus,
+  VariantStatusIcon,
+  withVariantStatus,
+} from "./VariantStatus";
 
 function getColorSchemeName(colorScheme: ScreenshotMetadataColorScheme) {
   switch (colorScheme) {
@@ -60,7 +65,11 @@ export function ColorSchemeSwitcher(props: {
             });
         invariant(resolvedDiff, "diff cannot be null");
         const Icon = colorSchemeIcons[colorScheme];
-        const label = getColorSchemeLabel(colorScheme);
+        const status = getVariantStatus(resolvedDiff);
+        const label = withVariantStatus(
+          getColorSchemeLabel(colorScheme),
+          status,
+        );
         return (
           // A sun against a moon: with the two side by side, each names the
           // other — the trap of a lone undecodable moon needs a lone moon.
@@ -68,11 +77,13 @@ export function ColorSchemeSwitcher(props: {
             <LinkButton
               variant="secondary"
               iconOnly
+              className="gap-1"
               aria-label={label}
               aria-current={isActive ? "page" : undefined}
               href={getDiffPath(resolvedDiff.id) ?? ""}
             >
               <Icon />
+              {status ? <VariantStatusIcon status={status} /> : null}
             </LinkButton>
           </Tooltip>
         );

--- a/apps/frontend/src/pages/Build/metadata/variants/StoryModeSwitcher.tsx
+++ b/apps/frontend/src/pages/Build/metadata/variants/StoryModeSwitcher.tsx
@@ -3,7 +3,7 @@ import { invariant } from "@argos/util/invariant";
 import { useNavigate } from "react-router";
 
 import { useBuildHotkey } from "@/containers/Build/BuildHotkeys";
-import { LinkButton } from "@/ui/Button";
+import { ButtonIcon, LinkButton } from "@/ui/Button";
 import { ButtonGroup } from "@/ui/ButtonGroup";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 import { Tooltip } from "@/ui/Tooltip";
@@ -15,6 +15,12 @@ import {
   useGetDiffPath,
 } from "../utils";
 import { findVariantSibling } from "./sibling";
+import {
+  getVariantStatus,
+  VariantStatusIcon,
+  withVariantStatus,
+  type VariantStatus,
+} from "./VariantStatus";
 
 export function StoryModeSwitcher(props: { diff: Diff; siblingDiffs: Diff[] }) {
   const { diff, siblingDiffs } = props;
@@ -46,6 +52,7 @@ export function StoryModeSwitcher(props: { diff: Diff; siblingDiffs: Diff[] }) {
           <StoryModeLinkButton
             key={mode}
             mode={mode}
+            status={getVariantStatus(resolvedDiff)}
             aria-current={isActive ? "page" : undefined}
             href={getDiffPath(resolvedDiff.id) ?? ""}
             shortcutEnabled={isNextActive}
@@ -58,22 +65,32 @@ export function StoryModeSwitcher(props: { diff: Diff; siblingDiffs: Diff[] }) {
 
 function StoryModeLinkButton(props: {
   mode: string;
+  status: VariantStatus | null;
   href: string;
   shortcutEnabled: boolean;
   "aria-current"?: "page";
 }) {
-  const { mode, shortcutEnabled, ...rest } = props;
+  const { mode, status, shortcutEnabled, ...rest } = props;
   const navigate = useNavigate();
   const hotkey = useBuildHotkey("switchStoryMode", () => navigate(props.href), {
     enabled: shortcutEnabled,
   });
-  const content = `Story mode: ${mode}`;
+  const content = withVariantStatus(`Story mode: ${mode}`, status);
 
-  // No icon: a mode is named by whoever wrote the story, so the name is the
-  // only thing that tells one from another.
+  // No icon of its own: a mode is named by whoever wrote the story, so the name
+  // is the only thing that tells one from another.
   const button = (
-    <LinkButton {...rest} variant="secondary">
+    <LinkButton
+      {...rest}
+      variant="secondary"
+      aria-label={status ? withVariantStatus(mode, status) : undefined}
+    >
       {mode}
+      {status ? (
+        <ButtonIcon position="right">
+          <VariantStatusIcon status={status} />
+        </ButtonIcon>
+      ) : null}
     </LinkButton>
   );
 

--- a/apps/frontend/src/pages/Build/metadata/variants/StoryModeSwitcher.tsx
+++ b/apps/frontend/src/pages/Build/metadata/variants/StoryModeSwitcher.tsx
@@ -3,7 +3,7 @@ import { invariant } from "@argos/util/invariant";
 import { useNavigate } from "react-router";
 
 import { useBuildHotkey } from "@/containers/Build/BuildHotkeys";
-import { ButtonIcon, LinkButton } from "@/ui/Button";
+import { LinkButton } from "@/ui/Button";
 import { ButtonGroup } from "@/ui/ButtonGroup";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 import { Tooltip } from "@/ui/Tooltip";
@@ -17,7 +17,7 @@ import {
 import { findVariantSibling } from "./sibling";
 import {
   getVariantStatus,
-  VariantStatusIcon,
+  VariantStatusButtonIcon,
   withVariantStatus,
   type VariantStatus,
 } from "./VariantStatus";
@@ -86,11 +86,7 @@ function StoryModeLinkButton(props: {
       aria-label={status ? withVariantStatus(mode, status) : undefined}
     >
       {mode}
-      {status ? (
-        <ButtonIcon position="right">
-          <VariantStatusIcon status={status} />
-        </ButtonIcon>
-      ) : null}
+      {status ? <VariantStatusButtonIcon status={status} /> : null}
     </LinkButton>
   );
 

--- a/apps/frontend/src/pages/Build/metadata/variants/VariantStatus.tsx
+++ b/apps/frontend/src/pages/Build/metadata/variants/VariantStatus.tsx
@@ -1,0 +1,59 @@
+import { getDiffGroupDefinition } from "@/containers/Build/BuildDiffGroup";
+import { ScreenshotDiffStatus } from "@/gql/graphql";
+import type { ButtonIconElementProps } from "@/ui/Button";
+
+import type { Diff } from "../../BuildDiffState";
+
+/**
+ * The statuses a switcher segment is worth marking with: the three a reviewer
+ * is hunting for, and so the three that make jumping to a sibling worthwhile.
+ * The rest — unchanged, ignored, a framework failure — would put a marker on
+ * nearly every segment, which marks none of them.
+ */
+export type VariantStatus =
+  | ScreenshotDiffStatus.Added
+  | ScreenshotDiffStatus.Changed
+  | ScreenshotDiffStatus.Removed;
+
+/** What landing on `diff` would show, or `null` if that is nothing to review. */
+export function getVariantStatus(diff: Diff): VariantStatus | null {
+  switch (diff.status) {
+    case ScreenshotDiffStatus.Added:
+    case ScreenshotDiffStatus.Changed:
+    case ScreenshotDiffStatus.Removed:
+      return diff.status;
+    default:
+      return null;
+  }
+}
+
+/**
+ * A segment's description with what it holds appended — "Changed", "Added",
+ * "Removed", spelled as the sidebar's group headers spell them.
+ *
+ * It goes into the accessible name rather than only the tooltip: Base UI leaves
+ * a tooltip out of the accessibility tree, so the icon would otherwise say
+ * nothing at all to a screen reader.
+ */
+export function withVariantStatus(
+  label: string,
+  status: VariantStatus | null,
+): string {
+  if (!status) {
+    return label;
+  }
+  return `${label}, ${getDiffGroupDefinition(status).label}`;
+}
+
+/**
+ * Deliberately unsized: the button sizes it, so an `iconOnly` segment carries
+ * it at the same 16px as its own icon while a text segment gets `1em` of its
+ * label through `ButtonIcon`.
+ */
+export function VariantStatusIcon(
+  props: ButtonIconElementProps & { status: VariantStatus },
+) {
+  const { status, ...rest } = props;
+  const { icon: Icon } = getDiffGroupDefinition(status);
+  return <Icon aria-hidden {...rest} />;
+}

--- a/apps/frontend/src/pages/Build/metadata/variants/VariantStatus.tsx
+++ b/apps/frontend/src/pages/Build/metadata/variants/VariantStatus.tsx
@@ -1,6 +1,9 @@
-import { getDiffGroupDefinition } from "@/containers/Build/BuildDiffGroup";
+import {
+  getDiffGroupDefinition,
+  type DiffGroupColor,
+} from "@/containers/Build/BuildDiffGroup";
 import { ScreenshotDiffStatus } from "@/gql/graphql";
-import type { ButtonIconElementProps } from "@/ui/Button";
+import { ButtonIcon, type ButtonIconElementProps } from "@/ui/Button";
 
 import type { Diff } from "../../BuildDiffState";
 
@@ -46,14 +49,55 @@ export function withVariantStatus(
 }
 
 /**
- * Deliberately unsized: the button sizes it, so an `iconOnly` segment carries
- * it at the same 16px as its own icon while a text segment gets `1em` of its
- * label through `ButtonIcon`.
+ * Each group's own color, so the marker matches the count it stands for in the
+ * build's stats rather than picking a shade of its own. All three are orange
+ * today; the map is over the colors a group can have because the definitions,
+ * not this file, decide that.
  */
-export function VariantStatusIcon(
-  props: ButtonIconElementProps & { status: VariantStatus },
-) {
+const colorClassNames: Record<DiffGroupColor, string> = {
+  danger: "text-danger-low",
+  warning: "text-warning-low",
+  success: "text-success-low",
+  neutral: "text-low",
+};
+
+function getColorClassName(status: VariantStatus): string {
+  return colorClassNames[getDiffGroupDefinition(status).color];
+}
+
+function StatusIcon(props: ButtonIconElementProps & { status: VariantStatus }) {
   const { status, ...rest } = props;
   const { icon: Icon } = getDiffGroupDefinition(status);
   return <Icon aria-hidden {...rest} />;
+}
+
+/**
+ * The marker for a segment carrying a label — it trails the text at `1em` of
+ * it. Colored through `ButtonIcon`, which is also what marks it
+ * `data-colored-icon`: without that the button dims every icon it holds until
+ * hovered, and a marker that has to be hovered to be seen is no marker.
+ */
+export function VariantStatusButtonIcon(props: { status: VariantStatus }) {
+  const { status } = props;
+  return (
+    <ButtonIcon position="right" colorClassName={getColorClassName(status)}>
+      <StatusIcon status={status} />
+    </ButtonIcon>
+  );
+}
+
+/**
+ * The marker for an `iconOnly` segment, whose own icon is its label. A bare
+ * second child, deliberately unsized and unspaced: there the button sizes both
+ * icons alike, and the segment sets the gap.
+ */
+export function VariantStatusIcon(props: { status: VariantStatus }) {
+  const { status } = props;
+  return (
+    <StatusIcon
+      status={status}
+      data-colored-icon
+      className={getColorClassName(status)}
+    />
+  );
 }

--- a/apps/frontend/src/pages/Build/metadata/variants/ViewportSwitcher.tsx
+++ b/apps/frontend/src/pages/Build/metadata/variants/ViewportSwitcher.tsx
@@ -3,7 +3,7 @@ import { invariant } from "@argos/util/invariant";
 import { useNavigate } from "react-router";
 
 import { useBuildHotkey } from "@/containers/Build/BuildHotkeys";
-import { ButtonIcon, LinkButton } from "@/ui/Button";
+import { LinkButton } from "@/ui/Button";
 import { ButtonGroup } from "@/ui/ButtonGroup";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 import { Tooltip } from "@/ui/Tooltip";
@@ -19,7 +19,7 @@ import {
 import { findVariantSibling } from "./sibling";
 import {
   getVariantStatus,
-  VariantStatusIcon,
+  VariantStatusButtonIcon,
   withVariantStatus,
   type VariantStatus,
 } from "./VariantStatus";
@@ -94,11 +94,7 @@ function ViewportLinkButton(props: {
         {viewport.width}
         <small className="ml-px">px</small>
       </span>
-      {status ? (
-        <ButtonIcon position="right">
-          <VariantStatusIcon status={status} />
-        </ButtonIcon>
-      ) : null}
+      {status ? <VariantStatusButtonIcon status={status} /> : null}
     </LinkButton>
   );
 

--- a/apps/frontend/src/pages/Build/metadata/variants/ViewportSwitcher.tsx
+++ b/apps/frontend/src/pages/Build/metadata/variants/ViewportSwitcher.tsx
@@ -3,7 +3,7 @@ import { invariant } from "@argos/util/invariant";
 import { useNavigate } from "react-router";
 
 import { useBuildHotkey } from "@/containers/Build/BuildHotkeys";
-import { LinkButton } from "@/ui/Button";
+import { ButtonIcon, LinkButton } from "@/ui/Button";
 import { ButtonGroup } from "@/ui/ButtonGroup";
 import { HotkeyTooltip } from "@/ui/HotkeyTooltip";
 import { Tooltip } from "@/ui/Tooltip";
@@ -17,6 +17,12 @@ import {
   type MetadataViewport,
 } from "../utils";
 import { findVariantSibling } from "./sibling";
+import {
+  getVariantStatus,
+  VariantStatusIcon,
+  withVariantStatus,
+  type VariantStatus,
+} from "./VariantStatus";
 
 export function ViewportSwitcher(props: { diff: Diff; siblingDiffs: Diff[] }) {
   const { diff, siblingDiffs } = props;
@@ -49,6 +55,7 @@ export function ViewportSwitcher(props: { diff: Diff; siblingDiffs: Diff[] }) {
           <ViewportLinkButton
             key={key}
             viewport={viewport}
+            status={getVariantStatus(resolvedDiff)}
             aria-current={isActive ? "page" : undefined}
             href={getDiffPath(resolvedDiff.id) ?? ""}
             shortcutEnabled={isNextActive}
@@ -61,25 +68,37 @@ export function ViewportSwitcher(props: { diff: Diff; siblingDiffs: Diff[] }) {
 
 function ViewportLinkButton(props: {
   viewport: MetadataViewport;
+  status: VariantStatus | null;
   href: string;
   shortcutEnabled: boolean;
   "aria-current"?: "page";
 }) {
-  const { viewport, shortcutEnabled, ...rest } = props;
+  const { viewport, status, shortcutEnabled, ...rest } = props;
   const navigate = useNavigate();
   const hotkey = useBuildHotkey("switchViewport", () => navigate(props.href), {
     enabled: shortcutEnabled,
   });
-  const content = tooltipContent(viewport);
+  const content = withVariantStatus(tooltipContent(viewport), status);
 
   const button = (
     // The width alone: it is what tells siblings apart, and the height and the
     // unit are the same for all of them — the tooltip carries both.
-    <LinkButton {...rest} variant="secondary">
+    <LinkButton
+      {...rest}
+      variant="secondary"
+      aria-label={
+        status ? withVariantStatus(`${viewport.width}px`, status) : undefined
+      }
+    >
       <span className="align-baseline">
         {viewport.width}
         <small className="ml-px">px</small>
       </span>
+      {status ? (
+        <ButtonIcon position="right">
+          <VariantStatusIcon status={status} />
+        </ButtonIcon>
+      ) : null}
     </LinkButton>
   );
 

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -461,6 +461,57 @@ loggedTest(
 );
 
 loggedTest(
+  "marks the variants holding a change",
+  async ({ page, auth, team, project }) => {
+    await ensureTeamOwner({ team: team.team, user: auth.user });
+    const { build } = await createVariantSwitchersScenario({
+      projectId: project.id,
+    });
+
+    await page.goto(
+      `/${team.account.slug}/${project.name}/builds/${build.number}`,
+    );
+    await page
+      .getByRole("button", { name: /^(Start review|Browse snapshots)/ })
+      .click();
+
+    const variants = page.getByRole("group", { name: "Snapshot variants" });
+    const segment = (name: string) =>
+      variants.getByRole("link", { name, exact: true });
+
+    // Every marker the switchers can draw, in one toolbar: the reviewer sees
+    // which siblings are worth the jump before making it. The status rides the
+    // accessible name because the tooltip carrying it is out of the
+    // accessibility tree.
+    await expect(segment("Chromium, Changed")).toBeVisible();
+    await expect(segment("Firefox, Removed")).toBeVisible();
+    await expect(segment("390px, Added")).toBeVisible();
+    await expect(segment("1280px, Changed")).toBeVisible();
+
+    await screenshot(page, "build-variant-statuses", {
+      replacements: {
+        [team.account.slug]: "acme",
+      },
+    });
+
+    // And the other half of the rule: Firefox's 390 sibling is unchanged, so
+    // that segment says nothing at all rather than marking itself "unchanged".
+    await segment("Firefox, Removed").click();
+    await expect(segment("390px")).toBeVisible();
+    await expect(segment("Firefox, Removed")).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+
+    await screenshot(page, "build-variant-statuses-unchanged", {
+      replacements: {
+        [team.account.slug]: "acme",
+      },
+    });
+  },
+);
+
+loggedTest(
   "keeps the other variant when switching one",
   async ({ page, auth, team, project }) => {
     await ensureTeamOwner({ team: team.team, user: auth.user });


### PR DESCRIPTION
## What

A snapshot captured across browsers and viewports gave the reviewer no way to tell which siblings were worth the jump: every switcher segment looked the same, so finding the changed one meant clicking through the matrix.

Each segment now carries the status of the diff it lands on — **changed**, **added** or **removed**, with the same icons the sidebar's groups use — and **nothing at all** when there is nothing to review, which is what keeps the marker meaningful. It applies to every axis: browsers, viewports, color schemes and story modes.

The status rides the button's accessible name as well as its tooltip, because a Base UI tooltip is out of the accessibility tree.

## Toolbar layout

The markers widen the switcher cluster by some 80px, and the build toolbar spends its free space on the cluster before the snapshot name — so a 70-odd character name lost its second line. The name's floor (`basis-72` → `basis-80`) is what has to guarantee those two lines: growth beside the cluster cannot be counted on, because `fit-content` of a *wrapped* flex container is still its max-content, so a wrapped cluster keeps claiming its single-line width and hands the name nothing back.

## Seeding

`createVariantSwitchersScenario` was a 2×2 matrix of identical changed diffs. It now carries one variant per status, placed by where the switchers actually land, so every marker — and the absence of one — is on screen at once.

## Tests

New `marks the variants holding a change` spec: asserts the four accessible names, screenshots the toolbar, then switches to Firefox and asserts its unchanged 390px sibling carries no marker at all.

Full `pnpm test:e2e --project=chromium` (120 tests), `pnpm test:unit` and `pnpm run static-checks` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)