### PR TITLE
fix(team): say when a team name is too long instead of crashing

### DIFF
--- a/apps/backend/src/database/models/Account.ts
+++ b/apps/backend/src/database/models/Account.ts
@@ -1,3 +1,4 @@
+import { ACCOUNT_NAME_MAX_LENGTH } from "@argos/schemas/account";
 import { ACTIVE_SUBSCRIPTION_STATUSES } from "@argos/schemas/subscription-status";
 import { assertNever } from "@argos/util/assertNever";
 import { invariant } from "@argos/util/invariant";
@@ -172,7 +173,11 @@ export class Account extends Model {
           forcedPlanId: { type: ["string", "null"] },
           stripeCustomerId: { type: ["string", "null"] },
           teamId: { type: ["string", "null"] },
-          name: { type: ["string", "null"], maxLength: 255, minLength: 1 },
+          name: {
+            type: ["string", "null"],
+            maxLength: ACCOUNT_NAME_MAX_LENGTH,
+            minLength: 1,
+          },
           slug: slugJsonSchema,
           githubAccountId: { type: ["string", "null"] },
           gitlabBaseUrl: { type: ["string", "null"] },

--- a/apps/backend/src/database/services/account.ts
+++ b/apps/backend/src/database/services/account.ts
@@ -1,4 +1,5 @@
 import type { ErrorCode } from "@argos/error-types";
+import { AccountNameSchema } from "@argos/schemas/account";
 import { assertNever } from "@argos/util/assertNever";
 import { invariant } from "@argos/util/invariant";
 import { slugify } from "@argos/util/slug";
@@ -169,6 +170,24 @@ export async function getOrCreateUserAccountFromSaml(input: {
     lastAuthMethod: "saml",
   });
   return account;
+}
+
+/**
+ * Validate an account name, returning it normalized (the schema trims it).
+ *
+ * Checked here rather than left to the column: the `Account` model rejects an
+ * oversized name as an Objection validation error, which nothing maps — Apollo
+ * reports it as INTERNAL_SERVER_ERROR, Sentry pages on it, and the user is told
+ * nothing they can act on. An `HTTPError` is what both API layers understand.
+ */
+export function parseAccountName(name: string): string {
+  const parsed = AccountNameSchema.safeParse(name);
+  if (!parsed.success) {
+    throw boom(400, parsed.error.issues[0]?.message ?? "Invalid name.", {
+      field: "name",
+    });
+  }
+  return parsed.data;
 }
 
 export async function checkAccountSlug(slug: string, trx?: TransactionOrKnex) {

--- a/apps/backend/src/database/services/team.ts
+++ b/apps/backend/src/database/services/team.ts
@@ -6,6 +6,7 @@ import { Account } from "../models/Account";
 import { Team } from "../models/Team";
 import { TeamUser } from "../models/TeamUser";
 import { transaction } from "../transaction";
+import { parseAccountName } from "./account";
 
 const resolveTeamSlug = async (name: string, index = 0): Promise<string> => {
   const nameSlug = slugify(name);
@@ -28,7 +29,8 @@ export const createTeamAccount = async (props: {
   ownerId: string;
   githubAccountId?: string | null;
 }) => {
-  const slug = await resolveTeamSlug(props.name);
+  const name = parseAccountName(props.name);
+  const slug = await resolveTeamSlug(name);
   return transaction(async (trx) => {
     const team = await Team.query(trx).insertAndFetch({
       defaultUserLevel: "member",
@@ -39,7 +41,7 @@ export const createTeamAccount = async (props: {
       userLevel: "owner",
     });
     const accountData: PartialModelObject<Account> = {
-      name: props.name,
+      name,
       slug,
       teamId: team.id,
     };

--- a/apps/backend/src/graphql/definitions/Account.ts
+++ b/apps/backend/src/graphql/definitions/Account.ts
@@ -14,6 +14,7 @@ import { Account, StripeInvoice } from "@/database/models";
 import {
   authenticateWithEmail,
   checkAccountSlug,
+  parseAccountName,
   requestEmailSignin,
   requestEmailSignup,
 } from "@/database/services/account";
@@ -639,7 +640,13 @@ export const resolvers: IResolvers = {
       }
 
       if (input.name !== undefined) {
-        data.name = input.name;
+        // `null` clears the name, which the column allows; anything else has to
+        // fit it, or the model rejects it as an error nothing maps.
+        try {
+          data.name = input.name === null ? null : parseAccountName(input.name);
+        } catch (error) {
+          throw toGraphQLError(error);
+        }
       }
 
       if (

--- a/apps/backend/src/graphql/definitions/Team.ts
+++ b/apps/backend/src/graphql/definitions/Team.ts
@@ -949,10 +949,15 @@ export const resolvers: IResolvers = {
         throw unauthenticated();
       }
 
-      const teamAccount = await createTeamAccount({
-        name: args.input.name,
-        ownerId: auth.user.id,
-      });
+      let teamAccount;
+      try {
+        teamAccount = await createTeamAccount({
+          name: args.input.name,
+          ownerId: auth.user.id,
+        });
+      } catch (error) {
+        throw toGraphQLError(error);
+      }
 
       if (args.input.autoJoinDomain) {
         invariant(teamAccount.teamId, "team account has no teamId");

--- a/apps/frontend/src/containers/Team/NewForm.tsx
+++ b/apps/frontend/src/containers/Team/NewForm.tsx
@@ -1,4 +1,5 @@
 import { useApolloClient, useQuery } from "@apollo/client/react";
+import { ACCOUNT_NAME_MAX_LENGTH } from "@argos/schemas/account";
 import { invariant } from "@argos/util/invariant";
 import { clsx } from "clsx";
 import { SubmitHandler, useForm } from "react-hook-form";
@@ -90,8 +91,8 @@ export function TeamNewForm(props: {
         {...form.register("name", {
           required: "Team name is required",
           maxLength: {
-            value: 255,
-            message: "Team name must be 255 characters or less",
+            value: ACCOUNT_NAME_MAX_LENGTH,
+            message: `Team name must be ${ACCOUNT_NAME_MAX_LENGTH} characters or less`,
           },
         })}
         label="Team Name"

--- a/apps/frontend/src/pages/NewTeam.tsx
+++ b/apps/frontend/src/pages/NewTeam.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useEffectEvent } from "react";
+import { AccountNameSchema } from "@argos/schemas/account";
 import { Helmet } from "react-helmet";
 import { useSearchParams } from "react-router";
 
@@ -36,7 +37,11 @@ export function Component() {
   const name = searchParams.get("name");
   const autoSubmit = searchParams.get("autoSubmit") === "true";
 
-  if (name && autoSubmit) {
+  // The name comes straight from the URL, so no form has vetted it. Submitting
+  // one the API refuses would only bounce back to this page a round-trip later,
+  // so a name that cannot be a team goes to the form instead, prefilled and
+  // editable.
+  if (name && autoSubmit && AccountNameSchema.safeParse(name).success) {
     return <AutoCreateTeam name={name} />;
   }
 

--- a/apps/frontend/src/pages/Signup.tsx
+++ b/apps/frontend/src/pages/Signup.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useState, type ReactNode } from "react";
+import { ACCOUNT_NAME_MAX_LENGTH } from "@argos/schemas/account";
 import { assertNever } from "@argos/util/assertNever";
 import { Radio } from "@base-ui/react/radio";
 import { RadioGroup } from "@base-ui/react/radio-group";
@@ -218,6 +219,12 @@ function FormStep(props: {
   const registerName = form.register("name", {
     required: { value: true, message: "Name is required" },
     minLength: { value: 2, message: "Too short" },
+    // A Pro signup carries this name to `/teams/new` in a URL that submits
+    // itself, so this is the only form standing between it and the API.
+    maxLength: {
+      value: ACCOUNT_NAME_MAX_LENGTH,
+      message: `Name must be ${ACCOUNT_NAME_MAX_LENGTH} characters or less`,
+    },
   });
   const nameRef = useObjectRef(registerName.ref);
   useEffect(() => {

--- a/packages/schemas/src/account.ts
+++ b/packages/schemas/src/account.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+/**
+ * Exported because the bound has to be enforced where a name is *typed* as well
+ * as where it is stored: the signup page carries a team name through a URL to
+ * `/teams/new`, which submits it without a form in between.
+ */
+export const ACCOUNT_NAME_MAX_LENGTH = 255;
+
+/**
+ * Validation for an account name — a person's display name, or a team's —
+ * shared between the `Account` model's JSON schema and the services that write
+ * it, so an oversized name is refused as user input instead of failing the
+ * model's validation as an Objection error nothing maps.
+ */
+export const AccountNameSchema = z
+  .string()
+  .trim()
+  .min(1, { message: "Name is required." })
+  .max(ACCOUNT_NAME_MAX_LENGTH, {
+    message: `Name must be ${ACCOUNT_NAME_MAX_LENGTH} characters or less.`,
+  });


### PR DESCRIPTION
Fixes [ARG-507](https://linear.app/argos/issue/ARG-507). Sentry: [GraphQLError: name: must NOT have more than 255 characters](https://argos.sentry.io/issues/7689484811/).

## What was wrong

A user signed up on `/signup`, chose Pro, and pasted a ~900-character mermaid diagram into **Team Name**. That field only enforced `required` and `minLength: 2`, so the name went straight into the redirect URL `/teams/new?name=…&autoSubmit=true`. That page fires `createTeam` immediately — no form in between — and `createTeamAccount` handed the name to `Account.query().insert()`.

The model's `maxLength: 255` then rejected it as an Objection `ValidationError`, which no layer maps. Apollo reported it as `INTERNAL_SERVER_ERROR`, Sentry paged on it, and the user got an error they could do nothing with.

`updateAccount` had the same unguarded write.

## What changed

The bound now lives in one place — `AccountNameSchema` in `@argos/schemas/account` — shared by the model, the services that write a name and the forms that collect one. This follows the `ProjectNameSchema` precedent.

**API (service layer).** `parseAccountName` throws `boom(400, …, { field: "name" })` — the `HTTPError` both API layers already understand — and returns the name trimmed. `createTeamAccount` runs it before the transaction opens.

**GraphQL.** `createTeam` and `updateAccount` route it through `toGraphQLError`, so clients get `BAD_USER_INPUT` with a `field` extension that `handleFormError` already maps onto the offending input. `updateAccount` still clears the name on `null`.

**Frontend.** `maxLength` on the signup name field — the actual entry point — and `/teams/new` only auto-submits a name that passes the schema, otherwise dropping to the prefilled, editable form rather than round-tripping an error.

A blank name is refused too: `"   "` passed the column's `minLength` untrimmed and landed as a team named `""`, because the trim happens on the way to the database.

## Verified in the running app

- Signup with a 300-character name: field flagged, _"Name must be 255 characters or less"_, submission blocked — the name never reaches the URL.
- `/teams/new?name=<300 chars>&autoSubmit=true`: renders the editable form, no `createTeam` sent, no account row created.
- `/teams/new?name=Valid%20Team%20Name&autoSubmit=true`: still auto-submits and creates the team, so the Pro signup path is intact.

I had e2e coverage confirming both mutations returned exactly the `INTERNAL_SERVER_ERROR` from the Sentry report before the fix, and removed it on request — we're not testing this.

## For the reviewer

`createAccount` writes a provider display name from GitHub/GitLab/Google OAuth without a bound, so the same latent crash exists there. Deliberately left alone: there's no user input to reject on that path, so truncating would be the right call rather than a 400 — a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)