### PR TITLE
feat(frontend): fade the edges of scroll containers

### DIFF
--- a/apps/frontend/src/containers/Comment/CommentThreadPopover.tsx
+++ b/apps/frontend/src/containers/Comment/CommentThreadPopover.tsx
@@ -27,9 +27,21 @@ export function CommentThreadPopover(props: {
       className="w-80"
     >
       {/* No horizontal padding so the thread (and its full-width reply divider)
-          spans the whole card; the card's sections carry their own insets. */}
-      <div className="bg-app border-thin max-h-96 w-full overflow-y-auto rounded-xl shadow-xl">
-        {children}
+          spans the whole card; the card's sections carry their own insets.
+
+          Two boxes because the fade cannot share one with the card: a mask
+          fades the border and shadow along with the messages. The outer box
+          draws the card and clips the scroller to its corners; the inner one
+          scrolls.
+
+          Top edge only. The composer is the last thing in the thread and it
+          takes focus on open, which scrolls this box to the bottom — so the
+          fade that means something is the one over the earlier messages, and a
+          bottom fade would land on the field being typed in. */}
+      <div className="bg-app border-thin w-full overflow-hidden rounded-xl shadow-xl">
+        <div className="scroll-mask-t-from-90% max-h-96 overflow-y-auto">
+          {children}
+        </div>
       </div>
     </CommentPopoverFrame>
   );

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -25,6 +25,8 @@
 @import "@radix-ui/colors/blue" layer(base);
 @import "@radix-ui/colors/blue-dark" layer(base);
 
+@import "./scroll-mask.css";
+
 @theme {
   --font-sans:
     "Inter Variable", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",

--- a/apps/frontend/src/pages/AuthCLISuccess.tsx
+++ b/apps/frontend/src/pages/AuthCLISuccess.tsx
@@ -65,7 +65,9 @@ export function Component() {
                 >
                   $
                 </span>
-                <code className="text-default no-scrollbar min-w-0 flex-1 overflow-x-auto font-mono text-sm whitespace-nowrap">
+                {/* The scrollbar is hidden, so the fade is the only thing
+                    saying the command runs past the edge. */}
+                <code className="text-default no-scrollbar scroll-mask-x-from-90% min-w-0 flex-1 overflow-x-auto font-mono text-sm whitespace-nowrap">
                   {SKILL_INSTALL_COMMAND}
                 </code>
                 <CopyButton

--- a/apps/frontend/src/pages/Build/BuildDiffList.tsx
+++ b/apps/frontend/src/pages/Build/BuildDiffList.tsx
@@ -800,17 +800,28 @@ const InternalBuildDiffList = memo(() => {
 
   return (
     <>
-      {stats && !searchMode && (
-        <div className="no-scrollbar border-b-thin flex shrink-0 items-center gap-2 overflow-x-auto px-2">
-          {hasOverview && <OverviewButton />}
-          <BuildStatsIndicator
-            stats={stats}
-            onClickGroup={openGroup}
-            isSubsetBuild={isSubsetBuild}
-          />
-        </div>
-      )}
-      <div ref={containerRef} className="min-h-0 flex-1 overflow-y-auto">
+      {stats &&
+        !searchMode && (
+          // The hairline sits on the wrapper, not on the scroller: the fade would
+          // take the separator's ends with it and leave the rule looking broken.
+          <div className="border-b-thin shrink-0">
+            <div className="no-scrollbar scroll-mask-x-from-90% flex items-center gap-2 overflow-x-auto px-2">
+              {hasOverview && <OverviewButton />}
+              <BuildStatsIndicator
+                stats={stats}
+                onClickGroup={openGroup}
+                isSubsetBuild={isSubsetBuild}
+              />
+            </div>
+          </div>
+        )}
+      {/* Bottom edge only: a group header pins itself to the top of this box
+          while its screenshots scroll under it, and a top fade would dissolve
+          the header that names what you are looking at. */}
+      <div
+        ref={containerRef}
+        className="scroll-mask-b-from-95% min-h-0 flex-1 overflow-y-auto"
+      >
         <div
           style={{
             height: `${rowVirtualizer.getTotalSize()}px`,

--- a/apps/frontend/src/pages/Build/RightSidebar.tsx
+++ b/apps/frontend/src/pages/Build/RightSidebar.tsx
@@ -82,7 +82,7 @@ export function RightSidebar(
           <PillTab value="snapshot">Snapshot</PillTab>
           <PillTab value="review">Review</PillTab>
         </TabList>
-        <SidebarTabPanel value="snapshot">
+        <SidebarTabPanel value="snapshot" className="scroll-mask-b-from-95%">
           <MetadataSection
             diff={activeDiff}
             siblingDiffs={siblingDiffs}
@@ -118,8 +118,11 @@ function SidebarTabPanel(props: React.ComponentProps<typeof TabPanel>) {
   return (
     <TabPanel
       {...props}
+      // Top edge here, and the bottom left to the caller: the review panel ends
+      // in a comment composer, and fading the field someone is typing into is
+      // worse than leaving its cut-off edge to say there is more below.
       className={clsx(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto pr-2 pb-6 empty:hidden",
+        "scroll-mask-t-from-95% flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto pr-2 pb-6 empty:hidden",
         props.className,
       )}
     />

--- a/apps/frontend/src/scroll-mask.css
+++ b/apps/frontend/src/scroll-mask.css
@@ -1,0 +1,192 @@
+/**
+ * Fading edges for scroll containers, driven by scroll position.
+ *
+ * Vendored verbatim from https://twilson.net/scroll-mask, which publishes it as
+ * a snippet to paste rather than a package. Everything below the header is the
+ * author's; keep it that way, so a fix upstream is a re-paste.
+ *
+ * `scroll-mask-y` / `scroll-mask-x` fade both ends of an axis, `scroll-mask-t`
+ * / `-b` / `-l` / `-r` a single edge. Each takes a `-from-<pct>` suffix naming
+ * where the gradient stops being opaque, so `scroll-mask-b-from-90%` fades over
+ * the last tenth of the box. The stop is a share of the *container*, not of the
+ * content, and the default is 80%.
+ *
+ * Two things the utilities cannot say about themselves:
+ *
+ * - **They must land on a transparent box.** `mask-image` fades everything the
+ *   element paints, its background, border and box-shadow included, so putting
+ *   one on a card dissolves the card's own edges. The scroll container has to be
+ *   a bare box inside whatever draws the surface.
+ * - **Tailwind variants do not reach them.** The rule that installs the mask
+ *   matches the class attribute as text (`[class^="scroll-mask-"]`), and
+ *   `lg:scroll-mask-y` is not that string. A prefixed utility sets its custom
+ *   property and nothing reads it.
+ *
+ * Unsupported browsers (no `animation-timeline: scroll()`) get no mask and no
+ * fallback, which is the right way round: the fade is an affordance, and its
+ * absence is the status quo everywhere else.
+ */
+
+@property --scroll-mask-t-from {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+
+@property --scroll-mask-b-from {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+
+@property --scroll-mask-l-from {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+
+@property --scroll-mask-r-from {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+
+@keyframes scroll-mask-y-scroll {
+  0% {
+    --scroll-mask-t-from: 100%;
+  }
+  10%,
+  100% {
+    --scroll-mask-t-from: var(--scroll-mask-fade-from-t, 100%);
+  }
+  0%,
+  90% {
+    --scroll-mask-b-from: var(--scroll-mask-fade-from-b, 100%);
+  }
+  100% {
+    --scroll-mask-b-from: 100%;
+  }
+}
+
+@keyframes scroll-mask-x-scroll {
+  0% {
+    --scroll-mask-l-from: 100%;
+  }
+  10%,
+  100% {
+    --scroll-mask-l-from: var(--scroll-mask-fade-from-l, 100%);
+  }
+  0%,
+  90% {
+    --scroll-mask-r-from: var(--scroll-mask-fade-from-r, 100%);
+  }
+  100% {
+    --scroll-mask-r-from: 100%;
+  }
+}
+
+@supports (animation-timeline: scroll()) {
+  :where([class^="scroll-mask-"], [class*=" scroll-mask-"]) {
+    --scroll-mask-t: linear-gradient(
+      to top,
+      black,
+      black var(--scroll-mask-t-from),
+      transparent
+    );
+    --scroll-mask-b: linear-gradient(
+      to bottom,
+      black,
+      black var(--scroll-mask-b-from),
+      transparent
+    );
+    --scroll-mask-l: linear-gradient(
+      to left,
+      black,
+      black var(--scroll-mask-l-from),
+      transparent
+    );
+    --scroll-mask-r: linear-gradient(
+      to right,
+      black,
+      black var(--scroll-mask-r-from),
+      transparent
+    );
+    mask-image:
+      var(--scroll-mask-t), var(--scroll-mask-b), var(--scroll-mask-l),
+      var(--scroll-mask-r);
+    mask-composite: intersect;
+    -webkit-mask-composite: source-in;
+    animation:
+      scroll-mask-y-scroll linear,
+      scroll-mask-x-scroll linear;
+    animation-timeline: scroll(self block), scroll(self inline);
+  }
+}
+
+@utility scroll-mask-t {
+  --scroll-mask-fade-from-t: 80%;
+}
+
+@utility scroll-mask-t-from-* {
+  --scroll-mask-fade-from-t: --spacing(--value(integer));
+  --scroll-mask-fade-from-t: --value(percentage);
+  --scroll-mask-fade-from-t: --value([length], [percentage]);
+}
+
+@utility scroll-mask-b {
+  --scroll-mask-fade-from-b: 80%;
+}
+
+@utility scroll-mask-b-from-* {
+  --scroll-mask-fade-from-b: --spacing(--value(integer));
+  --scroll-mask-fade-from-b: --value(percentage);
+  --scroll-mask-fade-from-b: --value([length], [percentage]);
+}
+
+@utility scroll-mask-y {
+  --scroll-mask-fade-from-t: 80%;
+  --scroll-mask-fade-from-b: 80%;
+}
+
+@utility scroll-mask-y-from-* {
+  --scroll-mask-fade-from-t: --spacing(--value(integer));
+  --scroll-mask-fade-from-t: --value(percentage);
+  --scroll-mask-fade-from-t: --value([length], [percentage]);
+  --scroll-mask-fade-from-b: --spacing(--value(integer));
+  --scroll-mask-fade-from-b: --value(percentage);
+  --scroll-mask-fade-from-b: --value([length], [percentage]);
+}
+
+@utility scroll-mask-l {
+  --scroll-mask-fade-from-l: 80%;
+}
+
+@utility scroll-mask-l-from-* {
+  --scroll-mask-fade-from-l: --spacing(--value(integer));
+  --scroll-mask-fade-from-l: --value(percentage);
+  --scroll-mask-fade-from-l: --value([length], [percentage]);
+}
+
+@utility scroll-mask-r {
+  --scroll-mask-fade-from-r: 80%;
+}
+
+@utility scroll-mask-r-from-* {
+  --scroll-mask-fade-from-r: --spacing(--value(integer));
+  --scroll-mask-fade-from-r: --value(percentage);
+  --scroll-mask-fade-from-r: --value([length], [percentage]);
+}
+
+@utility scroll-mask-x {
+  --scroll-mask-fade-from-l: 80%;
+  --scroll-mask-fade-from-r: 80%;
+}
+
+@utility scroll-mask-x-from-* {
+  --scroll-mask-fade-from-l: --spacing(--value(integer));
+  --scroll-mask-fade-from-l: --value(percentage);
+  --scroll-mask-fade-from-l: --value([length], [percentage]);
+  --scroll-mask-fade-from-r: --spacing(--value(integer));
+  --scroll-mask-fade-from-r: --value(percentage);
+  --scroll-mask-fade-from-r: --value([length], [percentage]);
+}

--- a/apps/frontend/src/ui/Charts.tsx
+++ b/apps/frontend/src/ui/Charts.tsx
@@ -348,7 +348,7 @@ export function ChartLegendContent({
     <div
       ref={ref}
       className={clsx(
-        "flex max-h-40 flex-wrap items-center justify-center gap-x-6 gap-y-2 overflow-auto",
+        "scroll-mask-y-from-85% flex max-h-40 flex-wrap items-center justify-center gap-x-6 gap-y-2 overflow-auto",
         verticalAlign === "top" ? "pb-3" : "pt-3",
         className,
       )}

--- a/apps/frontend/src/ui/EmojiPickerGrid.tsx
+++ b/apps/frontend/src/ui/EmojiPickerGrid.tsx
@@ -486,7 +486,10 @@ function EmojiPickerGrid(props: EmojiPickerProps) {
         id={listboxId}
         role="listbox"
         aria-label="Emoji"
-        className="relative overflow-x-hidden overflow-y-auto outline-hidden"
+        // Bottom edge only: the category header pins itself to the top of this
+        // box, and a top fade would dissolve the one row that has to stay
+        // readable while the grid scrolls under it.
+        className="scroll-mask-b-from-90% relative overflow-x-hidden overflow-y-auto outline-hidden"
         style={{ height: VIEWPORT_HEIGHT, paddingInline: GRID_PADDING_X }}
       >
         {rows.length === 0 ? (

--- a/apps/frontend/src/ui/menuStyle.ts
+++ b/apps/frontend/src/ui/menuStyle.ts
@@ -14,8 +14,15 @@ import { clsx } from "clsx";
  * @see popupSurface for the box these sit in.
  */
 
-/** The scrolling box the rows live in. */
-export const menuListClassName = "overflow-y-auto p-1.5 outline-hidden";
+/**
+ * The scrolling box the rows live in.
+ *
+ * The fade belongs here rather than on `popupSurface`: a mask fades everything
+ * its element paints, and on the surface that would take the popup's border and
+ * shadow with it.
+ */
+export const menuListClassName =
+  "scroll-mask-y-from-90% overflow-y-auto p-1.5 outline-hidden";
 
 /**
  * Which row the keyboard is on.


### PR DESCRIPTION
Closes ARG-508.

## Why

Scroll containers gave no sign that content ran past their edge. The two that hide their scrollbar — the build's stats bar and the CLI command line — gave none at all.

## What

Vendors the scroll-mask utilities from [twilson.net/scroll-mask](https://twilson.net/scroll-mask) into `apps/frontend/src/scroll-mask.css`. The author publishes them as a snippet to paste, not a package, so there is no new dependency. They mask a scroll container's edges with a gradient driven by `animation-timeline: scroll()` — the fade appears only on the side that actually has more content, and costs no JavaScript.

Everything below the file's header comment is the author's, so a fix upstream is a re-paste.

### Where it is applied

| Place | Class | Why that edge |
|---|---|---|
| `ui/menuStyle.ts` | `scroll-mask-y-from-90%` | One change covers every menu, select and editor suggestion list |
| `ui/EmojiPickerGrid.tsx` | `scroll-mask-b-from-90%` | Bottom only — the category header pins to the top |
| `BuildDiffList` screenshot list | `scroll-mask-b-from-95%` | Bottom only — group headers pin to the top |
| `BuildDiffList` stats bar | `scroll-mask-x-from-90%` | Hides its scrollbar, so it had *no* affordance |
| `CommentThreadPopover` | `scroll-mask-t-from-90%` | Top only — the reply composer is the last child |
| `Build/RightSidebar` | `scroll-mask-t-from-95%`, plus `-b` on Snapshot | The Review tab ends in a composer; Snapshot does not |
| `ui/Charts.tsx` legend | `scroll-mask-y-from-85%` | |
| `AuthCLISuccess` command line | `scroll-mask-x-from-90%` | Hides its scrollbar too |

## What a reviewer should know

Three constraints decided where the class goes, and each is commented at the call site:

- **A mask fades its element's own border and shadow.** The comment card and the stats bar's hairline moved to a wrapper so the fade only touches the content. This is why the mask sits on the menu *list* and not on `popupSurface`.
- **A fade over a pinned header dissolves it.** The emoji grid and the screenshot list both pin a header at `top: 0`, so they get a bottom fade only.
- **A fade over a composer lands on the field being typed in.** The comment thread and the build's Review tab both end in an editor, so they get a top fade only.

Two properties of this implementation worth knowing:

- **The fade is a share of the container**, not a fixed length — the same class gives ~28px in a short sidebar and ~38px in a tall one.
- **Tailwind variants do not reach it.** The rule that installs the mask matches the class attribute as text (`[class^="scroll-mask-"]`), so `lg:scroll-mask-y` silently does nothing. Noted in the CSS header. This version also carries no `prefers-reduced-motion` guard.

Browsers without `animation-timeline: scroll()` get no mask and no fallback, which is the right way round: the fade is an affordance, and its absence is the status quo everywhere else.

## Verification

`pnpm run static-checks` passes. Checked in the running app that `animation-timeline: scroll()` resolves, both timelines attach, and the mask switches correctly:

- vertical — `--scroll-mask-b-from: 95%` mid-scroll, `100%` at the end
- horizontal — `l: 100% / r: 90%` at the left edge, mirrored at the right
- no overflow — no fade at all

The account menu, scrolled to the middle so both ends have more content. Before, the first and last rows are cut off flat; after, they fade — and the popup's own border and shadow are untouched. Argos has posted the pair side by side in a comment below.

| Before | After |
| --- | --- |
| [![before](https://files.argos-ci.com/media/9/74e036b5881f93c52d891631bb4a56cbdaef63256c6ca1e8593b7c7df37d18e3.webp)](https://app.argos-ci.com/m/tjqkcf2z4hsv7v6vupl2) | [![after](https://files.argos-ci.com/media/9/c1f9dcc00896646b01dee3e0330a8e83bbededced479206b7870fc8710ec012e.webp)](https://app.argos-ci.com/m/jeid3guvopp4jyae3yzg) |

## Not done, worth a follow-up

- Staff tables (`Revenue`, `Teams`, `Trials`) — wide `overflow-x-auto`; each needs its border moved off the scroller first.
- `ui/Dialog.tsx` body and `ui/List.tsx` — broad wins, but shared primitives where some callers draw their own surface, so each caller needs checking.
- `BuildOverview`, `Test` sidebar, `GettingStarted`, `AddProjectContributor` — plain tall scrollers, safe `scroll-mask-y`.
- Editors (`CommentDraftPopover`, `BuildReviewForm`, `DiffCommentDraft`) — deliberately skipped: they auto-scroll to keep the caret visible, which parks it exactly in the fade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
