### PR TITLE
fix(build): keep the snapshot in the list when its review lands

### DIFF
--- a/apps/frontend/src/pages/Build/BuildDiffState.tsx
+++ b/apps/frontend/src/pages/Build/BuildDiffState.tsx
@@ -554,6 +554,16 @@ function groupDiffs(
   );
 }
 
+function findDiffGroup(
+  groups: DiffGroup<Diff>[],
+  diff: Diff | null,
+): DiffGroup<Diff> | null {
+  if (!diff) {
+    return null;
+  }
+  return groups.find((group) => group.diffs.includes(diff)) ?? null;
+}
+
 type SearchModeContextValue = {
   searchMode: boolean;
   setSearchMode: (enabled: boolean) => void;
@@ -735,15 +745,9 @@ export function BuildDiffProvider(props: {
     return groups.flatMap((group) => group.diffs.filter((x) => x !== null));
   }, [groups]);
 
-  const getDiffGroup = useEventCallback((diff: Diff | null) => {
-    if (!diff) {
-      return null;
-    }
-    const group = groups.find((group) =>
-      group.diffs.includes(diff),
-    ) as DiffGroup<Diff>;
-    return group;
-  });
+  const getDiffGroup = useEventCallback((diff: Diff | null) =>
+    findDiffGroup(groups, diff),
+  );
 
   const setActiveDiff = useEventCallback((diff: Diff, scroll?: boolean) => {
     navigate(
@@ -759,13 +763,24 @@ export function BuildDiffProvider(props: {
     if (scroll) {
       startTransition(() => {
         setScrolledDiff(diff);
-        const group = getDiffGroup(diff)!;
+        const group = getDiffGroup(diff);
+        invariant(group, "the active diff always belongs to a group");
         toggleGroup(group.name, true);
       });
     }
   });
 
-  const initialDiffGroup = getDiffGroup(initialDiff);
+  // Read from `groups` rather than through `getDiffGroup`: an event callback
+  // only picks up the new render's closure in a layout effect, so during the
+  // render that moves a diff to another group it still answers with the group
+  // the diff just left. The effect below would then keep the deps it already
+  // had, and the new group would stay collapsed until an unrelated render
+  // happened to recompute this — the snapshot blinking out of the list for a
+  // few frames right after a review is submitted.
+  const initialDiffGroup = useMemo(
+    () => findDiffGroup(groups, initialDiff),
+    [groups, initialDiff],
+  );
 
   const [ready, setReady] = useState(false);
 


### PR DESCRIPTION
Fixes the flaky visual test [`firefox/build-next-review-dialog.png`](https://app.argos-ci.com/argos-ci/argos/tests/ARGOS-IHME4) (24% flakiness over the last 30 days).

## What was non-deterministic

Of the four changes Argos recorded on that test, three are intentional commits already superseded by newer baselines (`showFocusRing` in 3940b320f, the "Review storybook" → "Review next build" relabel in aea96f8ca, and a copy change). The remaining one — 2 occurrences, the highest score — is the **snapshot card in the left sidebar behind the dialog**: fully rendered in some captures, entirely absent in others.

Sampling the DOM per animation frame through the scenario pins the window down:

```
x 41  {"cards":["1•Changed1home.png","home.png"]}   ← before review
x  3  {"cards":["1•Accepted1"]}                      ← card GONE (~50ms)
x111  {"cards":["1•Accepted1home.png","home.png"]}   ← recovered
```

## Root cause

Submitting a review moves the diff from the `changed` group to `accepted`, and `accepted` is not in `INITIAL_EXPANDED`. A layout effect is meant to expand the group of the initial diff — but it read that group through `getDiffGroup`, a `useEventCallback`, **during render**. Those only refresh their ref in a layout effect, so on the very render that regrouped the diff it still answered with the group the diff had just left. The effect kept the deps it already had, never re-ran, and React painted the new group collapsed. The card stayed missing until an unrelated render happened to recompute it.

`useEventCallback`'s own docblock says the returned function should not be used during rendering — that line turns out to be load-bearing.

This is a product bug, not a test artifact: a real reviewer sees the snapshot blink out of the sidebar on every approval. The screenshot test just happened to land inside the window about a quarter of the time.

## The change

Read the group from `groups` during render via `useMemo` over a new pure `findDiffGroup` helper, so the layout effect sees the move in the same commit and expands the group before the browser paints — the window closes entirely rather than getting shorter. `getDiffGroup` now delegates to the same helper, which also drops an `as` cast and turns the `!` at its call site into an `invariant`.

## Verification

- The rAF probe shows one clean transition, 4 runs in a row. Reverting the fix, rebuilding and re-running brings the 3-frame gap straight back — so the probe discriminates.
- `pnpm run static-checks` clean.
- `tests/build.spec.ts`: 49/49 on chromium + firefox.
- A full local e2e run had 6 unrelated failures (auth-guard, passkeys, project-tests, personal-settings); I confirmed those fail identically without this change.

## Note for the reviewer

No guard test. The existing screenshot test is the guard, and a frame-sampling assertion would be brittle to maintain for a state that is now structurally unreachable — the group is expanded in the same commit that creates it. Happy to add one if you'd rather have it pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)