### PR TITLE
fix(build): rank baseline candidates by position, not by its text

### DIFF
--- a/apps/backend/src/api/handlers/findBaseline.e2e.test.ts
+++ b/apps/backend/src/api/handlers/findBaseline.e2e.test.ts
@@ -128,6 +128,31 @@ describe("findBaseline", () => {
       });
   });
 
+  test("ranks candidates by position, not by the text of the position", async ({
+    project,
+  }) => {
+    // Twelve candidates put the nearest eligible commit at position 2 and a
+    // decoy at position 10. The positions are bound as parameters, which reach
+    // Postgres untyped, and a VALUES list types those as text - where "10" sorts
+    // before "2". Below ten candidates the two orders agree, which is why no
+    // shorter list can catch this.
+    const commits = Array.from({ length: 12 }, (_, i) => sha(100 + i));
+    await createEligibleBaseline(project, commits[10]!);
+    const nearest = await createEligibleBaseline(project, commits[2]!);
+
+    await request(app)
+      .post("/baseline")
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({ commits })
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.baseline).toMatchObject({
+          id: nearest.id,
+          head: { sha: commits[2] },
+        });
+      });
+  });
+
   test("respects the order of the commits and picks the first match", async ({
     project,
   }) => {

--- a/apps/backend/src/build/strategy/strategies/ci/query.e2e.test.ts
+++ b/apps/backend/src/build/strategy/strategies/ci/query.e2e.test.ts
@@ -283,6 +283,23 @@ describe("#getBucketFromCommits", () => {
     expect(result).toEqual(preferredBucket);
   });
 
+  it("ranks candidates by position, not by the text of the position", async () => {
+    // Twelve candidates put the nearest eligible commit at position 2 and a
+    // decoy at position 10. The positions are bound as parameters, which reach
+    // Postgres untyped, and a VALUES list types those as text - where "10" sorts
+    // before "2". Below ten candidates the two orders agree, which is why no
+    // shorter list can catch this.
+    const shas = Array.from({ length: 12 }, (_, i) =>
+      i.toString(16).padStart(40, "0"),
+    );
+    // The decoy is created last, so it also has the higher id: an ordering that
+    // lets the id decide before the position picks it too.
+    const nearest = await createEligibleBucket(shas[2]!);
+    await createEligibleBucket(shas[10]!);
+    const result = await getBucketFromCommits({ shas, build });
+    expect(result).toEqual(nearest);
+  });
+
   it("returns the most recent bucket when multiple buckets share a commit", async () => {
     const olderBucket = await createEligibleBucket(
       "29f2757a14512b1c07547e6a0f516a731f7518f7",

--- a/apps/backend/src/build/strategy/strategies/ci/query.ts
+++ b/apps/backend/src/build/strategy/strategies/ci/query.ts
@@ -155,6 +155,26 @@ export async function getSameCommitBaseBucket(
 }
 
 /**
+ * VALUES clause pairing each commit with its position in the list, for a join
+ * that ranks matches by that position.
+ *
+ * The position is cast: a bound parameter reaches Postgres untyped, and a VALUES
+ * list resolves an untyped column as text, so "10" sorts before "2". Every list
+ * shorter than ten commits orders the same either way, which is how this went
+ * unnoticed - the candidate lists in production run to hundreds.
+ */
+function rankedValuesClause(shas: string[]): string {
+  return shas.map(() => "(?, ?::int)").join(",");
+}
+
+/**
+ * Bindings for {@link rankedValuesClause}: each commit followed by its position.
+ */
+function rankedBindings(shas: string[]): (string | number)[] {
+  return shas.flatMap((sha, index) => [sha, index]);
+}
+
+/**
  * Get the bucket from a list of commits, ordered by the order of the commits.
  */
 export async function getBucketFromCommits(args: {
@@ -164,17 +184,16 @@ export async function getBucketFromCommits(args: {
   if (args.shas.length === 0) {
     return null;
   }
-  const valuesClause = args.shas.map(() => "(?, ?)").join(",");
-  const bindings: (string | number)[] = [];
-  args.shas.forEach((sha, index) => {
-    bindings.push(sha, index);
-  });
   const bucket = await queryBaseBucket(args.build)
     .whereIn("commit", args.shas)
     .joinRaw(
-      `join (values ${valuesClause}) as ordering(sha, rank) on commit = ordering.sha`,
-      bindings,
+      `join (values ${rankedValuesClause(args.shas)}) as ordering(sha, rank) on commit = ordering.sha`,
+      rankedBindings(args.shas),
     )
+    // queryBaseBucket orders by id to pick the latest bucket of a commit. Here
+    // the position has to decide first, the id only settles ties within one
+    // commit - appended after an existing order, it would never get a say.
+    .clearOrder()
     .orderBy("ordering.rank")
     .orderBy("id", "desc")
     .first();
@@ -199,12 +218,6 @@ export async function getEligibleBaselineBuildFromCommits(args: {
     return null;
   }
 
-  const valuesClause = args.shas.map(() => "(?, ?)").join(",");
-  const bindings: (string | number)[] = [];
-  args.shas.forEach((sha, index) => {
-    bindings.push(sha, index);
-  });
-
   const match = await queryEligibleBaselineBuilds({
     projectId: args.projectId,
     name: args.name,
@@ -217,8 +230,8 @@ export async function getEligibleBaselineBuildFromCommits(args: {
     .where("compareScreenshotBucket.valid", true)
     .whereIn("compareScreenshotBucket.commit", args.shas)
     .joinRaw(
-      `join (values ${valuesClause}) as ordering(sha, rank) on "compareScreenshotBucket"."commit" = ordering.sha`,
-      bindings,
+      `join (values ${rankedValuesClause(args.shas)}) as ordering(sha, rank) on "compareScreenshotBucket"."commit" = ordering.sha`,
+      rankedBindings(args.shas),
     )
     .select("builds.id")
     .orderBy("ordering.rank")


### PR DESCRIPTION
## The bug

The baseline is chosen by walking a list of candidate commits — closest ancestor first — and taking the first one with an eligible build. Both walks apply that order through a `VALUES` join binding each commit with its position, then `orderBy("ordering.rank")`. **In neither one did the position actually decide.**

### `getEligibleBaselineBuildFromCommits` — the `/baseline` endpoint, i.e. every project without content access

The position is bound as a parameter. `pg` sends a JS number as an untyped string, and Postgres resolves an untyped `VALUES` column as **`text`**. Verified against production:

```sql
select rank, pg_typeof(rank) from (values ('a','0'),('b','1'),('c','2'),('e','10'),('f','11'),('g','20')) as o(sha, rank) order by rank;
-- 0, 1, 10, 11, 2, 20   (text)
```

So a match at position 2 loses to any match at positions 10–19; position 3 loses to 10–39. **Only a match at position 0 or 1 is safe.**

### `getBucketFromCommits` — the server's own walk

`queryBaseBucket` already applies `.orderBy("id", "desc")`. The rank order is appended *after* it, so it never gets a say: the most recently created eligible bucket wins, whatever its position. This path runs for content-access projects whenever the merge base has no bucket of its own.

## How it presented (Qonto, `@repo/connect-kit`, build 1342084)

One workflow run, one candidate list, 23 build names. The two whose nearest match sat at **position 0 or 1** got the right baseline. The other **21** got `65ec16f2` — 85 minutes older, and the one commit every kit happened to have a build on. That commit became the baseline of **21 distinct pull requests** for the same reason: it is a universal lexicographic sink.

Replayed on the real connect-kit builds, ranks bound as untyped literals:

```
as the server sorts it (text)  →  65ec16f2   rank "10"   ← what production picked
with the rank cast to int      →  a59619df   rank 2      ← the nearer, compatible baseline
```

The harm is real, not just "older": **three unrelated PRs** on that baseline reported the **same six** `integrationssidebar-last-sync` screenshots as changed — a change none of them made — while **nine** builds on the nearer baseline reported none of them. Across the project, 90% of `master` builds skip 1–5 nearer eligible baselines.

## Why it shipped

No test passed more than 3 candidates. Below ten, text and numeric order agree. Production lists run to hundreds.

## The fix

`(?, ?::int)` in the shared `rankedValuesClause`, and `.clearOrder()` before the rank order in `getBucketFromCommits`. The two guard tests put the nearest match at position 2 with a decoy at 10, created *last* so the id would pick it too — each failed against `main` on its own mechanism, both pass now. `pnpm run static-checks` green; the wider baseline suites (`build/strategy`, `createBuildDiffs`, `job`, `branchApprovedDiffs`) pass 48/48.

## Context

This closes an investigation that first went through three CLI-side hypotheses in `argos-javascript` (#374 closed, #375/#376 open) — all empirically falsified on real runners, because the CLI was never at fault. The pull request payload, `GITHUB_SHA`, `fetch-depth`, the merge ref's lifetime: none of it mattered. The list the CLI sent was fine; the server ranked it as strings. I'll leave a note on those PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
