### PR TITLE
chore(dev): fail fast when there is no AWS session

### DIFF
--- a/.env.prod-ro
+++ b/.env.prod-ro
@@ -11,7 +11,7 @@
 ARGOS_TARGET=prod-ro
 
 # No password in the URL: PG_IAM_AUTH mints a short-lived RDS IAM token per
-# connection from your AWS session (`aws sso login` first). The op:// reference
+# connection from your AWS session (`aws login` first). The op:// reference
 # keeps the RDS hostname out of the repository.
 DATABASE_URL=op://argos-dev/argos-prod-ro/DATABASE_URL
 PG_IAM_AUTH=true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,9 +220,10 @@ once:
 
 - **AWS credentials** for a principal allowed to `rds-db:connect` as
   `argos_dev_ro` (`arn:aws:rds-db:<region>:<account>:dbuser:<db-resource-id>/argos_dev_ro`).
-  Any principal the SDK can find works — an `aws sso login` session or a
+  Any principal the SDK can find works — an `aws login` session or a
   configured IAM user. There is no database password at all: `PG_IAM_AUTH=true`
-  signs a short-lived token per connection.
+  signs a short-lived token per connection, so the command refuses to start
+  without a session and tells you to sign in.
 
 What the mode changes, enforced by the config (`ARGOS_TARGET=prod-ro`):
 

--- a/apps/backend/src/config/database.ts
+++ b/apps/backend/src/config/database.ts
@@ -28,7 +28,19 @@ function getPassword(config: Config): string | (() => Promise<string>) {
     port: config.get("pg.connection.port"),
     username: config.get("pg.connection.user"),
   });
-  return () => signer.getAuthToken();
+  return async () => {
+    try {
+      return await signer.getAuthToken();
+    } catch (error) {
+      // An AWS session expires while the process keeps running, and the SDK
+      // failure would otherwise surface as a connection error naming neither
+      // AWS nor what to do about it.
+      throw new Error(
+        `No AWS session - could not sign an RDS IAM token for "${username}". Run \`aws login\`, then retry.`,
+        { cause: error },
+      );
+    }
+  };
 }
 
 /**

--- a/apps/backend/src/config/index.ts
+++ b/apps/backend/src/config/index.ts
@@ -559,7 +559,7 @@ export function createConfig() {
           default: 5432,
         },
         iamAuth: {
-          doc: "Authenticate with short-lived RDS IAM tokens instead of a password. The Postgres role must have `rds_iam` granted, and the process needs AWS credentials (e.g. `aws sso login`).",
+          doc: "Authenticate with short-lived RDS IAM tokens instead of a password. The Postgres role must have `rds_iam` granted, and the process needs AWS credentials (e.g. `aws login`).",
           format: Boolean,
           default: false,
           env: "PG_IAM_AUTH",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "turbo run watch-build watch-server watch-codegen --concurrency 100",
-    "dev:prod-ro": "op run --env-file=.env.prod-ro -- pnpm run dev",
+    "dev:prod-ro": "scripts/require-aws-session.sh && op run --env-file=.env.prod-ro -- pnpm run dev",
     "build": "turbo run build",
     "test": "vitest",
     "test:unit": "pnpm run test -c vitest/vitest.unit.config.mts",

--- a/scripts/rds-token.sh
+++ b/scripts/rds-token.sh
@@ -74,17 +74,10 @@ if [ ${#PSQL_ARGS[@]} -gt 0 ] && [ "${RUN_PSQL}" = false ]; then
   exit 1
 fi
 
-if ! command -v aws >/dev/null 2>&1; then
-  echo "aws CLI not found - install it with \`brew install awscli\`." >&2
-  exit 1
-fi
-
 # Fail here with a clear message rather than minting a token signed by nothing
-# and letting Postgres report it as a password failure.
-if ! aws sts get-caller-identity >/dev/null 2>&1; then
-  echo "No usable AWS credentials. Sign in first (\`aws sso login\`), then retry." >&2
-  exit 1
-fi
+# and letting Postgres report it as a password failure. The check prints only to
+# stderr, so it never lands in the token TablePlus reads from stdout.
+"$(dirname "$0")/require-aws-session.sh"
 
 TOKEN=$(aws rds generate-db-auth-token \
   --hostname "${HOST}" \

--- a/scripts/require-aws-session.sh
+++ b/scripts/require-aws-session.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Fail with an actionable message when there is no usable AWS session.
+#
+# Production Postgres accepts no passwords: every connection is opened with an
+# RDS IAM token signed from your AWS credentials. Without them the caller only
+# finds out at connection time, as a password failure that names nothing.
+
+set -euo pipefail
+
+# Callers may run from a GUI process, which inherits none of a login shell's
+# PATH - Homebrew included, so `aws` would simply not be found.
+PATH="/opt/homebrew/bin:/usr/local/bin:${PATH}"
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "aws CLI not found - install it with \`brew install awscli\`." >&2
+  exit 1
+fi
+
+if ! aws sts get-caller-identity >/dev/null 2>&1; then
+  echo "No AWS session - the production database needs one. Run \`aws login\`, then retry." >&2
+  exit 1
+fi


### PR DESCRIPTION
`dev:prod-ro` and `rds-token.sh` both sign an RDS IAM token from your AWS credentials, and without a session the failure only surfaced at connection time — as a password error naming neither AWS nor a fix. Both now check upfront, and the config layer catches a session that expires mid-run.

Also aligns the docs and messages on `aws login`, which is what the team actually uses — `aws sso login` was wrong on current AWS CLI versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)