### PR TITLE
feat(analytics): show the Storybook share of screenshots

### DIFF
--- a/apps/backend/src/api/handlers/getAccountAnalytics.e2e.test.ts
+++ b/apps/backend/src/api/handlers/getAccountAnalytics.e2e.test.ts
@@ -139,7 +139,11 @@ describe("getAccountAnalytics", () => {
       .set("Authorization", `Bearer ${patToken}`)
       .expect(200);
 
-    expect(res.body.screenshots.all).toEqual({ total: 0, projects: {} });
+    expect(res.body.screenshots.all).toEqual({
+      total: 0,
+      projects: {},
+      storybook: 0,
+    });
     expect(res.body.screenshots.projects).toEqual([]);
     expect(res.body.builds.all.total).toBe(0);
     expect(res.body.builds.all.projects).toEqual({});

--- a/apps/backend/src/api/handlers/getAccountAnalytics.ts
+++ b/apps/backend/src/api/handlers/getAccountAnalytics.ts
@@ -59,7 +59,14 @@ const MetricDataSchema = z.object({
   projects: MetricProjectsSchema,
 });
 
-const MetricDataPointSchema = MetricDataSchema.extend({
+const ScreenshotMetricDataSchema = MetricDataSchema.extend({
+  storybook: z.number().int().meta({
+    description:
+      "Screenshots captured from Storybook stories. Already included in `total`, so the rest of the test suite is `total - storybook`.",
+  }),
+});
+
+const ScreenshotMetricDataPointSchema = ScreenshotMetricDataSchema.extend({
   ts: z.number().int().meta({
     description: "Unix timestamp in milliseconds at the start of the period.",
   }),
@@ -86,8 +93,8 @@ const MetricProjectSchema = z.object({
 const AccountAnalyticsSchema = z
   .object({
     screenshots: z.object({
-      series: z.array(MetricDataPointSchema),
-      all: MetricDataSchema,
+      series: z.array(ScreenshotMetricDataPointSchema),
+      all: ScreenshotMetricDataSchema,
       projects: z.array(MetricProjectSchema),
     }),
     builds: z.object({

--- a/apps/backend/src/config/database.ts
+++ b/apps/backend/src/config/database.ts
@@ -35,10 +35,9 @@ function getPassword(config: Config): string | (() => Promise<string>) {
       // An AWS session expires while the process keeps running, and the SDK
       // failure would otherwise surface as a connection error naming neither
       // AWS nor what to do about it.
-      throw new Error(
-        `No AWS session - could not sign an RDS IAM token for "${username}". Run \`aws login\`, then retry.`,
-        { cause: error },
-      );
+      throw new Error(`No AWS session. ¨Please run \`aws login\` and retry.`, {
+        cause: error,
+      });
     }
   };
 }

--- a/apps/backend/src/database/models/Account.ts
+++ b/apps/backend/src/database/models/Account.ts
@@ -17,7 +17,7 @@ import { MsTeamsWebhook } from "./MsTeamsWebhook";
 import { OriginInstallation } from "./OriginInstallation";
 import { Plan } from "./Plan";
 import { Project } from "./Project";
-import { ScreenshotBucket } from "./ScreenshotBucket";
+import { clampedStorybookCount, ScreenshotBucket } from "./ScreenshotBucket";
 import { SlackInstallation } from "./SlackInstallation";
 import { Subscription } from "./Subscription";
 import { Team, type GetPermissionsOptions } from "./Team";
@@ -752,15 +752,10 @@ export class Account extends Model {
   ): Promise<ScreenshotsCount> {
     const query = ScreenshotBucket.query()
       .sum("screenshot_buckets.screenshotCount as all")
-      // A bucket's Storybook count is clamped to its total before being summed.
-      // The two used to be counted by two separate queries, so buckets written
-      // back then can hold more Storybook screenshots than screenshots, which
-      // would make `neutral` negative.
       .select(
-        raw(`sum(least(coalesce(??, 0), coalesce(??, 0))) as "storybook"`, [
-          "screenshot_buckets.storybookScreenshotCount",
-          "screenshot_buckets.screenshotCount",
-        ]),
+        raw(
+          `sum(${clampedStorybookCount("screenshot_buckets")}) as "storybook"`,
+        ),
       )
       .leftJoinRelated("project")
       .where("screenshot_buckets.createdAt", ">=", from.toISOString())

--- a/apps/backend/src/database/models/ScreenshotBucket.ts
+++ b/apps/backend/src/database/models/ScreenshotBucket.ts
@@ -114,6 +114,6 @@ export class ScreenshotBucket extends Model {
  * back then can hold more Storybook screenshots than screenshots at all. Left
  * unclamped, the non-Storybook half of any split comes out negative.
  */
-export function clampedStorybookCount(alias: string) {
+export function clampedStorybookCount(alias: "sb" | "screenshot_buckets") {
   return `least(coalesce(${alias}."storybookScreenshotCount", 0), coalesce(${alias}."screenshotCount", 0))`;
 }

--- a/apps/backend/src/database/models/ScreenshotBucket.ts
+++ b/apps/backend/src/database/models/ScreenshotBucket.ts
@@ -106,3 +106,14 @@ export class ScreenshotBucket extends Model {
   screenshots?: Screenshot[];
   project?: Project;
 }
+
+/**
+ * A bucket's Storybook count, never above the bucket's own total.
+ *
+ * The two counters used to be written by two separate queries, so buckets from
+ * back then can hold more Storybook screenshots than screenshots at all. Left
+ * unclamped, the non-Storybook half of any split comes out negative.
+ */
+export function clampedStorybookCount(alias: string) {
+  return `least(coalesce(${alias}."storybookScreenshotCount", 0), coalesce(${alias}."screenshotCount", 0))`;
+}

--- a/apps/backend/src/database/seeds.ts
+++ b/apps/backend/src/database/seeds.ts
@@ -3603,3 +3603,67 @@ export async function createInvoicesScenario(input: {
     })),
   );
 }
+
+/**
+ * Three days of capture, part of it from Storybook stories, dated inside the
+ * analytics page's default period so the dashboard has something to aggregate.
+ *
+ * The counts are deliberately round: the page derives a percentage from them,
+ * and a test asserting "25% Storybook" should fail because the aggregation
+ * broke, not because the arithmetic drifted.
+ */
+export async function createAnalyticsScenario(input: {
+  projectId: string;
+}): Promise<{ screenshotCount: number; storybookScreenshotCount: number }> {
+  const { projectId } = input;
+
+  const days = [
+    {
+      daysAgo: 3,
+      commit: "8f14e45fceea167a5a36dedd4bea2543f6e1a2b3",
+      screenshotCount: 120,
+      storybookScreenshotCount: 30,
+    },
+    {
+      daysAgo: 2,
+      commit: "c9f0f895fb98ab9159f51fd0297e236d1a2b3c4d",
+      screenshotCount: 80,
+      storybookScreenshotCount: 20,
+    },
+    {
+      daysAgo: 1,
+      commit: "45c48cce2e2d7fbdea1afc51c7c6ad26a3b4c5d6",
+      screenshotCount: 200,
+      storybookScreenshotCount: 50,
+    },
+  ];
+
+  await ScreenshotBucket.query().insert(
+    days.map((day) => {
+      const createdAt = new Date(
+        Date.now() - day.daysAgo * 24 * 60 * 60 * 1000,
+      ).toISOString();
+      return {
+        name: "default",
+        commit: day.commit,
+        branch: "main",
+        projectId,
+        complete: true,
+        valid: true,
+        screenshotCount: day.screenshotCount,
+        storybookScreenshotCount: day.storybookScreenshotCount,
+        createdAt,
+        updatedAt: createdAt,
+      };
+    }),
+  );
+
+  return days.reduce(
+    (totals, day) => ({
+      screenshotCount: totals.screenshotCount + day.screenshotCount,
+      storybookScreenshotCount:
+        totals.storybookScreenshotCount + day.storybookScreenshotCount,
+    }),
+    { screenshotCount: 0, storybookScreenshotCount: 0 },
+  );
+}

--- a/apps/backend/src/database/services/period-usage.ts
+++ b/apps/backend/src/database/services/period-usage.ts
@@ -2,7 +2,7 @@ import { invariant } from "@argos/util/invariant";
 
 import { knex } from "@/database";
 
-import { Account, Plan, Subscription } from "../models";
+import { Account, clampedStorybookCount, Plan, Subscription } from "../models";
 import { computeAdditionalScreenshots } from "./additional-screenshots";
 
 /** One billing period of an account, priced from the usage it accumulated. */
@@ -163,8 +163,7 @@ type AccountTotals = Map<number, ScreenshotTotals>;
 
 const EMPTY_TOTALS: ScreenshotTotals = { all: 0, storybook: 0 };
 
-/** A bucket's Storybook count, never above the bucket's own total. */
-const CLAMPED_STORYBOOK_COUNT = `least(coalesce(sb."storybookScreenshotCount", 0), coalesce(sb."screenshotCount", 0))`;
+const CLAMPED_STORYBOOK_COUNT = clampedStorybookCount("sb");
 
 /** Rows of `(accountId, index, from, to)` to join the usage tables against. */
 function buildPeriodValues(periods: AccountPeriod[]) {

--- a/apps/backend/src/graphql/definitions/Account.ts
+++ b/apps/backend/src/graphql/definitions/Account.ts
@@ -99,11 +99,15 @@ export const typeDefs = gql`
     ts: Timestamp!
     total: Int!
     projects: JSONObject!
+    "Screenshots captured from Storybook stories, already counted in the total"
+    storybook: Int!
   }
 
   type AccountMetricData {
     total: Int!
     projects: JSONObject!
+    "Screenshots captured from Storybook stories, already counted in the total"
+    storybook: Int!
   }
 
   type AccountBuildsMetricDataPoint {

--- a/apps/backend/src/graphql/definitions/Account.ts
+++ b/apps/backend/src/graphql/definitions/Account.ts
@@ -95,7 +95,7 @@ export const typeDefs = gql`
     view
   }
 
-  type AccountMetricDataPoint {
+  type AccountScreenshotMetricDataPoint {
     ts: Timestamp!
     total: Int!
     projects: JSONObject!
@@ -103,7 +103,7 @@ export const typeDefs = gql`
     storybook: Int!
   }
 
-  type AccountMetricData {
+  type AccountScreenshotMetricData {
     total: Int!
     projects: JSONObject!
     "Screenshots captured from Storybook stories, already counted in the total"
@@ -138,8 +138,8 @@ export const typeDefs = gql`
   }
 
   type AccountScreenshotMetrics {
-    series: [AccountMetricDataPoint!]!
-    all: AccountMetricData!
+    series: [AccountScreenshotMetricDataPoint!]!
+    all: AccountScreenshotMetricData!
     projects: [Project!]!
   }
 

--- a/apps/backend/src/metrics/__snapshots__/account.e2e.test.ts.snap
+++ b/apps/backend/src/metrics/__snapshots__/account.e2e.test.ts.snap
@@ -1786,6 +1786,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1606780800000,
   },
@@ -1793,6 +1794,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1606867200000,
   },
@@ -1800,6 +1802,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1606953600000,
   },
@@ -1807,6 +1810,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607040000000,
   },
@@ -1814,6 +1818,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607126400000,
   },
@@ -1821,6 +1826,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607212800000,
   },
@@ -1828,6 +1834,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607299200000,
   },
@@ -1835,6 +1842,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607385600000,
   },
@@ -1842,6 +1850,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607472000000,
   },
@@ -1849,6 +1858,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607558400000,
   },
@@ -1856,6 +1866,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607644800000,
   },
@@ -1863,6 +1874,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607731200000,
   },
@@ -1870,6 +1882,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607817600000,
   },
@@ -1877,6 +1890,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607904000000,
   },
@@ -1884,6 +1898,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607990400000,
   },
@@ -1891,6 +1906,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608076800000,
   },
@@ -1898,6 +1914,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608163200000,
   },
@@ -1905,6 +1922,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608249600000,
   },
@@ -1912,6 +1930,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608336000000,
   },
@@ -1919,6 +1938,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608422400000,
   },
@@ -1926,6 +1946,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608508800000,
   },
@@ -1933,6 +1954,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608595200000,
   },
@@ -1940,6 +1962,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608681600000,
   },
@@ -1947,6 +1970,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608768000000,
   },
@@ -1954,6 +1978,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608854400000,
   },
@@ -1961,6 +1986,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608940800000,
   },
@@ -1968,6 +1994,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609027200000,
   },
@@ -1975,6 +2002,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609113600000,
   },
@@ -1982,6 +2010,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609200000000,
   },
@@ -1989,6 +2018,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609286400000,
   },
@@ -1996,6 +2026,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609372800000,
   },
@@ -2003,6 +2034,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 20,
     },
+    "storybook": 0,
     "total": 20,
     "ts": 1609459200000,
   },
@@ -2010,6 +2042,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 4,
     },
+    "storybook": 0,
     "total": 4,
     "ts": 1609545600000,
   },
@@ -2017,6 +2050,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 10,
     },
+    "storybook": 0,
     "total": 10,
     "ts": 1609632000000,
   },
@@ -2024,6 +2058,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609718400000,
   },
@@ -2031,6 +2066,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609804800000,
   },
@@ -2038,6 +2074,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609891200000,
   },
@@ -2045,6 +2082,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609977600000,
   },
@@ -2052,6 +2090,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610064000000,
   },
@@ -2059,6 +2098,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610150400000,
   },
@@ -2066,6 +2106,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610236800000,
   },
@@ -2073,6 +2114,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610323200000,
   },
@@ -2080,6 +2122,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610409600000,
   },
@@ -2087,6 +2130,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610496000000,
   },
@@ -2094,6 +2138,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610582400000,
   },
@@ -2101,6 +2146,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610668800000,
   },
@@ -2108,6 +2154,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610755200000,
   },
@@ -2115,6 +2162,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610841600000,
   },
@@ -2122,6 +2170,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610928000000,
   },
@@ -2129,6 +2178,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611014400000,
   },
@@ -2136,6 +2186,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611100800000,
   },
@@ -2143,6 +2194,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611187200000,
   },
@@ -2150,6 +2202,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611273600000,
   },
@@ -2157,6 +2210,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611360000000,
   },
@@ -2164,6 +2218,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611446400000,
   },
@@ -2171,6 +2226,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611532800000,
   },
@@ -2178,6 +2234,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611619200000,
   },
@@ -2185,6 +2242,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611705600000,
   },
@@ -2192,6 +2250,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611792000000,
   },
@@ -2199,6 +2258,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611878400000,
   },
@@ -2206,6 +2266,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611964800000,
   },
@@ -2213,6 +2274,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1612051200000,
   },
@@ -2220,6 +2282,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1612137600000,
   },
@@ -2231,6 +2294,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > with projectIds > retu
   "projects": {
     "1000000": 34,
   },
+  "storybook": 0,
   "total": 34,
 }
 `;
@@ -2241,6 +2305,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1606780800000,
   },
@@ -2248,6 +2313,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1606867200000,
   },
@@ -2255,6 +2321,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1606953600000,
   },
@@ -2262,6 +2329,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607040000000,
   },
@@ -2269,6 +2337,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607126400000,
   },
@@ -2276,6 +2345,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607212800000,
   },
@@ -2283,6 +2353,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607299200000,
   },
@@ -2290,6 +2361,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607385600000,
   },
@@ -2297,6 +2369,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607472000000,
   },
@@ -2304,6 +2377,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607558400000,
   },
@@ -2311,6 +2385,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607644800000,
   },
@@ -2318,6 +2393,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607731200000,
   },
@@ -2325,6 +2401,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607817600000,
   },
@@ -2332,6 +2409,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607904000000,
   },
@@ -2339,6 +2417,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607990400000,
   },
@@ -2346,6 +2425,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608076800000,
   },
@@ -2353,6 +2433,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608163200000,
   },
@@ -2360,6 +2441,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608249600000,
   },
@@ -2367,6 +2449,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608336000000,
   },
@@ -2374,6 +2457,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608422400000,
   },
@@ -2381,6 +2465,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608508800000,
   },
@@ -2388,6 +2473,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608595200000,
   },
@@ -2395,6 +2481,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608681600000,
   },
@@ -2402,6 +2489,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608768000000,
   },
@@ -2409,6 +2497,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608854400000,
   },
@@ -2416,6 +2505,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608940800000,
   },
@@ -2423,6 +2513,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609027200000,
   },
@@ -2430,6 +2521,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609113600000,
   },
@@ -2437,6 +2529,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609200000000,
   },
@@ -2444,6 +2537,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609286400000,
   },
@@ -2451,6 +2545,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609372800000,
   },
@@ -2458,6 +2553,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 20,
     },
+    "storybook": 0,
     "total": 20,
     "ts": 1609459200000,
   },
@@ -2465,6 +2561,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 4,
     },
+    "storybook": 0,
     "total": 4,
     "ts": 1609545600000,
   },
@@ -2472,6 +2569,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 10,
     },
+    "storybook": 0,
     "total": 10,
     "ts": 1609632000000,
   },
@@ -2479,6 +2577,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609718400000,
   },
@@ -2486,6 +2585,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609804800000,
   },
@@ -2493,6 +2593,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609891200000,
   },
@@ -2500,6 +2601,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609977600000,
   },
@@ -2507,6 +2609,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610064000000,
   },
@@ -2514,6 +2617,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610150400000,
   },
@@ -2521,6 +2625,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610236800000,
   },
@@ -2528,6 +2633,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610323200000,
   },
@@ -2535,6 +2641,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610409600000,
   },
@@ -2542,6 +2649,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610496000000,
   },
@@ -2549,6 +2657,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610582400000,
   },
@@ -2556,6 +2665,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610668800000,
   },
@@ -2563,6 +2673,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610755200000,
   },
@@ -2570,6 +2681,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610841600000,
   },
@@ -2577,6 +2689,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610928000000,
   },
@@ -2584,6 +2697,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611014400000,
   },
@@ -2591,6 +2705,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611100800000,
   },
@@ -2598,6 +2713,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611187200000,
   },
@@ -2605,6 +2721,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611273600000,
   },
@@ -2612,6 +2729,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611360000000,
   },
@@ -2619,6 +2737,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611446400000,
   },
@@ -2626,6 +2745,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611532800000,
   },
@@ -2633,6 +2753,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611619200000,
   },
@@ -2640,6 +2761,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611705600000,
   },
@@ -2647,6 +2769,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611792000000,
   },
@@ -2654,6 +2777,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611878400000,
   },
@@ -2661,6 +2785,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611964800000,
   },
@@ -2668,6 +2793,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1612051200000,
   },
@@ -2675,6 +2801,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1612137600000,
   },
@@ -2686,6 +2813,7 @@ exports[`getAccountScreenshotMetrics > with groupBy day > without projectIds > r
   "projects": {
     "1000000": 34,
   },
+  "storybook": 0,
   "total": 34,
 }
 `;
@@ -2696,6 +2824,7 @@ exports[`getAccountScreenshotMetrics > with groupBy month > with projectIds > re
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1606780800000,
   },
@@ -2703,6 +2832,7 @@ exports[`getAccountScreenshotMetrics > with groupBy month > with projectIds > re
     "projects": {
       "1000000": 34,
     },
+    "storybook": 0,
     "total": 34,
     "ts": 1609459200000,
   },
@@ -2710,6 +2840,7 @@ exports[`getAccountScreenshotMetrics > with groupBy month > with projectIds > re
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1612137600000,
   },
@@ -2721,6 +2852,7 @@ exports[`getAccountScreenshotMetrics > with groupBy month > with projectIds > re
   "projects": {
     "1000000": 34,
   },
+  "storybook": 0,
   "total": 34,
 }
 `;
@@ -2731,6 +2863,7 @@ exports[`getAccountScreenshotMetrics > with groupBy month > without projectIds >
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1606780800000,
   },
@@ -2738,6 +2871,7 @@ exports[`getAccountScreenshotMetrics > with groupBy month > without projectIds >
     "projects": {
       "1000000": 34,
     },
+    "storybook": 0,
     "total": 34,
     "ts": 1609459200000,
   },
@@ -2745,6 +2879,7 @@ exports[`getAccountScreenshotMetrics > with groupBy month > without projectIds >
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1612137600000,
   },
@@ -2756,6 +2891,7 @@ exports[`getAccountScreenshotMetrics > with groupBy month > without projectIds >
   "projects": {
     "1000000": 34,
   },
+  "storybook": 0,
   "total": 34,
 }
 `;
@@ -2766,6 +2902,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > with projectIds > ret
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1606694400000,
   },
@@ -2773,6 +2910,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > with projectIds > ret
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607299200000,
   },
@@ -2780,6 +2918,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > with projectIds > ret
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607904000000,
   },
@@ -2787,6 +2926,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > with projectIds > ret
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608508800000,
   },
@@ -2794,6 +2934,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > with projectIds > ret
     "projects": {
       "1000000": 34,
     },
+    "storybook": 0,
     "total": 34,
     "ts": 1609113600000,
   },
@@ -2801,6 +2942,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > with projectIds > ret
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609718400000,
   },
@@ -2808,6 +2950,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > with projectIds > ret
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610323200000,
   },
@@ -2815,6 +2958,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > with projectIds > ret
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610928000000,
   },
@@ -2822,6 +2966,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > with projectIds > ret
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611532800000,
   },
@@ -2829,6 +2974,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > with projectIds > ret
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1612137600000,
   },
@@ -2840,6 +2986,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > with projectIds > ret
   "projects": {
     "1000000": 34,
   },
+  "storybook": 0,
   "total": 34,
 }
 `;
@@ -2850,6 +2997,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > without projectIds > 
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1606694400000,
   },
@@ -2857,6 +3005,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > without projectIds > 
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607299200000,
   },
@@ -2864,6 +3013,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > without projectIds > 
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1607904000000,
   },
@@ -2871,6 +3021,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > without projectIds > 
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1608508800000,
   },
@@ -2878,6 +3029,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > without projectIds > 
     "projects": {
       "1000000": 34,
     },
+    "storybook": 0,
     "total": 34,
     "ts": 1609113600000,
   },
@@ -2885,6 +3037,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > without projectIds > 
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1609718400000,
   },
@@ -2892,6 +3045,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > without projectIds > 
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610323200000,
   },
@@ -2899,6 +3053,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > without projectIds > 
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1610928000000,
   },
@@ -2906,6 +3061,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > without projectIds > 
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1611532800000,
   },
@@ -2913,6 +3069,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > without projectIds > 
     "projects": {
       "1000000": 0,
     },
+    "storybook": 0,
     "total": 0,
     "ts": 1612137600000,
   },
@@ -2924,6 +3081,7 @@ exports[`getAccountScreenshotMetrics > with groupBy week > without projectIds > 
   "projects": {
     "1000000": 34,
   },
+  "storybook": 0,
   "total": 34,
 }
 `;

--- a/apps/backend/src/metrics/account.e2e.test.ts
+++ b/apps/backend/src/metrics/account.e2e.test.ts
@@ -94,15 +94,36 @@ describe("getAccountScreenshotMetrics", () => {
 
     const results = await getAccountScreenshotMetrics({
       accountId: project.accountId,
-      from: new Date("2020-12-01"),
-      to: new Date("2021-02-01"),
-      groupBy: "month",
+      from: new Date("2021-01-04"),
+      to: new Date("2021-01-06"),
+      groupBy: "day",
     });
 
-    // 34 from the shared fixture, plus 8 and 5 here.
+    // Each day keeps its own split rather than the period's, so a count landing
+    // in the wrong bucket does not hide inside the total.
+    expect(results.series).toEqual([
+      {
+        ts: new Date("2021-01-04").getTime(),
+        total: 8,
+        projects: { [project.id]: 8 },
+        storybook: 3,
+      },
+      {
+        ts: new Date("2021-01-05").getTime(),
+        total: 5,
+        projects: { [project.id]: 5 },
+        storybook: 5,
+      },
+      {
+        ts: new Date("2021-01-06").getTime(),
+        total: 0,
+        projects: { [project.id]: 0 },
+        storybook: 0,
+      },
+    ]);
     expect(results.all).toEqual({
-      total: 47,
-      projects: { [project.id]: 47 },
+      total: 13,
+      projects: { [project.id]: 13 },
       storybook: 8,
     });
   });

--- a/apps/backend/src/metrics/account.e2e.test.ts
+++ b/apps/backend/src/metrics/account.e2e.test.ts
@@ -74,6 +74,39 @@ describe("getAccountScreenshotMetrics", () => {
     },
   );
 
+  it("splits the total by source, clamping buckets that over-report Storybook", async () => {
+    await factory.ScreenshotBucket.createMany(2, [
+      {
+        createdAt: new Date("2021-01-04").toISOString(),
+        projectId: project.id,
+        screenshotCount: 8,
+        storybookScreenshotCount: 3,
+      },
+      // Buckets written before the two counters shared a query can claim more
+      // Storybook screenshots than screenshots.
+      {
+        createdAt: new Date("2021-01-05").toISOString(),
+        projectId: project.id,
+        screenshotCount: 5,
+        storybookScreenshotCount: 9,
+      },
+    ]);
+
+    const results = await getAccountScreenshotMetrics({
+      accountId: project.accountId,
+      from: new Date("2020-12-01"),
+      to: new Date("2021-02-01"),
+      groupBy: "month",
+    });
+
+    // 34 from the shared fixture, plus 8 and 5 here.
+    expect(results.all).toEqual({
+      total: 47,
+      projects: { [project.id]: 47 },
+      storybook: 8,
+    });
+  });
+
   it("does not filter when projectIds is empty", async () => {
     const results = await getAccountScreenshotMetrics({
       accountId: project.accountId,
@@ -86,6 +119,7 @@ describe("getAccountScreenshotMetrics", () => {
     expect(results.all).toEqual({
       total: 34,
       projects: { [project.id]: 34 },
+      storybook: 0,
     });
   });
 });
@@ -240,6 +274,7 @@ describe("getAccountMetrics", () => {
     expect(metrics.screenshots.all).toEqual({
       total: 2,
       projects: { [project.id]: 2 },
+      storybook: 0,
     });
     // Creating the builds above bumped `projects."buildNumber"`, so the factory
     // instance is stale — compare against the current row.
@@ -269,7 +304,11 @@ describe("getAccountMetrics", () => {
       groupBy: "day",
     });
 
-    expect(metrics.screenshots.all).toEqual({ total: 0, projects: {} });
+    expect(metrics.screenshots.all).toEqual({
+      total: 0,
+      projects: {},
+      storybook: 0,
+    });
     expect(metrics.screenshots.projects).toEqual([]);
     expect(metrics.builds.all.total).toBe(0);
     expect(metrics.builds.all.projects).toEqual({});

--- a/apps/backend/src/metrics/account.ts
+++ b/apps/backend/src/metrics/account.ts
@@ -1,7 +1,7 @@
 import { invariant } from "@argos/util/invariant";
 
 import { knex } from "@/database";
-import { Project } from "@/database/models";
+import { clampedStorybookCount, Project } from "@/database/models";
 
 type AccountMetricsGroupBy = "month" | "week" | "day";
 
@@ -97,6 +97,10 @@ export async function getAccountMetrics(input: GetAccountMetricsInput) {
 
 /**
  * Get the number of screenshots by projects over time.
+ *
+ * `storybook` counts the same screenshots a second way: how many of the period's
+ * total came from Storybook stories. It is a subset of `total`, not a sibling of
+ * it, so the rest of the suite is `total - storybook`.
  */
 export async function getAccountScreenshotMetrics(
   input: AccountMetricsAggregationInput,
@@ -107,7 +111,8 @@ export async function getAccountScreenshotMetrics(
     SELECT
       date_trunc(:groupBy, sb."createdAt") AS date,
       p.id AS "projectId",
-      SUM(sb."screenshotCount") AS value
+      SUM(sb."screenshotCount") AS value,
+      SUM(${clampedStorybookCount("sb")}) AS storybook
     FROM screenshot_buckets sb
     LEFT JOIN projects p ON sb."projectId" = p.id
     WHERE p."accountId" = :accountId
@@ -132,7 +137,8 @@ export async function getAccountScreenshotMetrics(
   SELECT
     s.date,
     jsonb_object_agg(a."projectId", COALESCE(a.value, 0))
-      FILTER (WHERE a."projectId" IS NOT NULL) AS counts
+      FILTER (WHERE a."projectId" IS NOT NULL) AS counts,
+    COALESCE(SUM(a.storybook), 0)::int AS storybook
   FROM series s
   LEFT JOIN aggregated a
     ON s.date = a.date
@@ -149,7 +155,11 @@ export async function getAccountScreenshotMetrics(
   }
   const [result, inputProjects] = await Promise.all([
     knex.raw<{
-      rows: { date: number; counts: Record<string, number> | null }[];
+      rows: {
+        date: number;
+        counts: Record<string, number> | null;
+        storybook: number;
+      }[];
     }>(query, {
       accountId: input.accountId,
       projectIds: input.projectIds,
@@ -183,21 +193,24 @@ export async function getAccountScreenshotMetrics(
       ts: new Date(row.date).getTime(),
       projects: projectCounts,
       total,
+      storybook: row.storybook,
     };
   });
 
   const all = series.reduce<{
     total: number;
     projects: Record<string, number>;
+    storybook: number;
   }>(
     (acc, serie) => {
       acc.total += serie.total;
+      acc.storybook += serie.storybook;
       Object.entries(serie.projects).forEach(([projectId, count]) => {
         acc.projects[projectId] = (acc.projects[projectId] ?? 0) + count;
       });
       return acc;
     },
-    { total: 0, projects: {} },
+    { total: 0, projects: {}, storybook: 0 },
   );
 
   return { series, all, projects };

--- a/apps/frontend/src/pages/Account/Analytics.stories.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.stories.tsx
@@ -11,6 +11,9 @@ const PROJECTS = [
   { __typename: "Project" as const, id: "4", name: "storybook" },
 ];
 
+/** The one project in the fixture whose screenshots come from stories. */
+const STORYBOOK_PROJECT_ID = "4";
+
 const DAY = 24 * 60 * 60 * 1000;
 const START = new Date("2026-06-01T00:00:00Z").getTime();
 const POINTS = 30;
@@ -31,6 +34,7 @@ function buildFixture() {
     __typename: "AccountMetricData" as const,
     total: 0,
     projects: {} as Record<string, number>,
+    storybook: 0,
   };
 
   // Builds per project per bucket, roughly matching real relative volumes.
@@ -56,6 +60,7 @@ function buildFixture() {
     const screenshotCounts: Record<string, number> = {};
     let total = 0;
     let sTotal = 0;
+    let sStorybook = 0;
     for (const project of PROJECTS) {
       const builds = Math.round(buildWeights[project.id]! * wave) + 1;
       const screenshots = builds * screenshotWeights[project.id]!;
@@ -63,6 +68,9 @@ function buildFixture() {
       screenshotCounts[project.id] = screenshots;
       total += builds;
       sTotal += screenshots;
+      if (project.id === STORYBOOK_PROJECT_ID) {
+        sStorybook += screenshots;
+      }
       buildsAll.projects[project.id] =
         (buildsAll.projects[project.id] ?? 0) + builds;
       screenshotsAll.projects[project.id] =
@@ -97,8 +105,10 @@ function buildFixture() {
       ts,
       total: sTotal,
       projects: screenshotCounts,
+      storybook: sStorybook,
     });
     screenshotsAll.total += sTotal;
+    screenshotsAll.storybook += sStorybook;
   }
 
   return {
@@ -165,7 +175,12 @@ export const Empty: Story = {
       },
       screenshots: {
         __typename: "AccountScreenshotMetrics",
-        all: { __typename: "AccountMetricData", total: 0, projects: {} },
+        all: {
+          __typename: "AccountMetricData",
+          total: 0,
+          projects: {},
+          storybook: 0,
+        },
         series: [],
         projects: [],
       },

--- a/apps/frontend/src/pages/Account/Analytics.stories.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.stories.tsx
@@ -140,7 +140,16 @@ function buildFixture() {
 const meta: Meta<typeof AnalyticsDashboard> = {
   title: "Pages/AnalyticsDashboard",
   component: AnalyticsDashboard,
-  parameters: { layout: "fullscreen" },
+  parameters: {
+    layout: "fullscreen",
+    // A page, not a component. Left to the runner's default the dashboard
+    // renders around 600px wide, where the tile band drops to two columns and
+    // every chart is squeezed into a column thousands of pixels tall. Pin a
+    // desktop viewport and screenshot that, rather than fitting the capture to
+    // content the way a button story wants.
+    viewport: { defaultViewport: 1440 },
+    argos: { fitToContent: false },
+  },
   decorators: [
     (Story) => (
       <div className="bg-subtle min-h-screen p-10">

--- a/apps/frontend/src/pages/Account/Analytics.stories.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.stories.tsx
@@ -11,8 +11,17 @@ const PROJECTS = [
   { __typename: "Project" as const, id: "4", name: "storybook" },
 ];
 
-/** The one project in the fixture whose screenshots come from stories. */
-const STORYBOOK_PROJECT_ID = "4";
+/**
+ * Share of each project's screenshots captured from stories; projects left out
+ * capture none. Storybook counts are per bucket rather than per project, so a
+ * project is never all-or-nothing — and the tile's share must not be readable
+ * off the pie chart's slices.
+ */
+const STORYBOOK_RATIO: Record<string, number | undefined> = {
+  "1": 0.15,
+  "3": 0.4,
+  "4": 0.9,
+};
 
 const DAY = 24 * 60 * 60 * 1000;
 const START = new Date("2026-06-01T00:00:00Z").getTime();
@@ -31,7 +40,7 @@ function buildFixture() {
     rejected: 0,
   };
   const screenshotsAll = {
-    __typename: "AccountMetricData" as const,
+    __typename: "AccountScreenshotMetricData" as const,
     total: 0,
     projects: {} as Record<string, number>,
     storybook: 0,
@@ -68,9 +77,9 @@ function buildFixture() {
       screenshotCounts[project.id] = screenshots;
       total += builds;
       sTotal += screenshots;
-      if (project.id === STORYBOOK_PROJECT_ID) {
-        sStorybook += screenshots;
-      }
+      sStorybook += Math.round(
+        screenshots * (STORYBOOK_RATIO[project.id] ?? 0),
+      );
       buildsAll.projects[project.id] =
         (buildsAll.projects[project.id] ?? 0) + builds;
       screenshotsAll.projects[project.id] =
@@ -101,7 +110,7 @@ function buildFixture() {
     buildsAll.rejected += rejected;
 
     screenshotsSeries.push({
-      __typename: "AccountMetricDataPoint" as const,
+      __typename: "AccountScreenshotMetricDataPoint" as const,
       ts,
       total: sTotal,
       projects: screenshotCounts,
@@ -176,7 +185,7 @@ export const Empty: Story = {
       screenshots: {
         __typename: "AccountScreenshotMetrics",
         all: {
-          __typename: "AccountMetricData",
+          __typename: "AccountScreenshotMetricData",
           total: 0,
           projects: {},
           storybook: 0,

--- a/apps/frontend/src/pages/Account/Analytics.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.tsx
@@ -376,11 +376,7 @@ export function AnalyticsDashboard(props: {
           color="primary"
           label="Builds"
           value={metrics?.builds.all.total ?? null}
-          hint={
-            buildsPerPeriod !== null
-              ? `${buildsPerPeriod.toLocaleString()} avg / ${groupByLabel}`
-              : null
-          }
+          hint={`${buildsPerPeriod.toLocaleString()} avg / ${groupByLabel}`}
           visual={
             metrics && metrics.builds.all.total > 0 ? (
               <Sparkline
@@ -555,10 +551,15 @@ export function AnalyticsDashboard(props: {
                     to,
                     groupBy,
                   }),
+                  // Prefixed because the project columns sitting next to them
+                  // carry raw project names, and "storybook" is a common one.
                   extraColumns: [
-                    { label: "Storybook", get: (serie) => serie.storybook },
                     {
-                      label: "Other",
+                      label: "Source: Storybook",
+                      get: (serie) => serie.storybook,
+                    },
+                    {
+                      label: "Source: other",
                       get: (serie) => serie.total - serie.storybook,
                     },
                   ],
@@ -649,11 +650,7 @@ export function AnalyticsDashboard(props: {
         <ChartCard
           className="col-span-12 lg:col-span-7"
           title="Screenshots per build"
-          description={
-            screenshotsPerBuild !== null
-              ? `${screenshotsPerBuild.toLocaleString()} on average across the period.`
-              : "Average screenshots captured per build."
-          }
+          description={`${screenshotsPerBuild.toLocaleString()} on average across the period.`}
         >
           {screenshotByBuildSeries ? (
             screenshotByBuildSeries.all.total === 0 ? (
@@ -678,9 +675,10 @@ export function AnalyticsDashboard(props: {
  * The Screenshots tile's supporting line.
  *
  * The Storybook share only joins it for accounts that capture stories at all —
- * everywhere else it would be a permanent "0%" saying nothing. `storybook` is
- * clamped to `total` upstream, so a non-zero share always has a total to divide
- * by.
+ * everywhere else it would be a permanent "0%" saying nothing. A share too
+ * small to round up to a percent gets "<1%" for the same reason: "0%" next to a
+ * non-zero count reads as a bug. `storybook` is clamped to `total` upstream, so
+ * a non-zero share always has a total to divide by.
  */
 function getScreenshotsHint(props: {
   perPeriod: number;
@@ -692,12 +690,20 @@ function getScreenshotsHint(props: {
   if (screenshots.storybook === 0) {
     return average;
   }
-  const share = (screenshots.storybook / screenshots.total).toLocaleString(
-    navigator.language,
-    { style: "percent", maximumFractionDigits: 0 },
-  );
-  return `${average} · ${share} Storybook`;
+  const ratio = screenshots.storybook / screenshots.total;
+  const share =
+    Math.round(ratio * 100) === 0
+      ? `<${(0.01).toLocaleString(navigator.language, PERCENT_FORMAT)}`
+      : ratio.toLocaleString(navigator.language, PERCENT_FORMAT);
+  // Non-breaking, so that the tile at its narrowest — four columns at the `lg`
+  // breakpoint — wraps between the two clauses rather than inside this one.
+  return `${average} · ${share}\u00A0Storybook`;
 }
+
+const PERCENT_FORMAT: Intl.NumberFormatOptions = {
+  style: "percent",
+  maximumFractionDigits: 0,
+};
 
 function getCSVName(props: {
   account: string;

--- a/apps/frontend/src/pages/Account/Analytics.tsx
+++ b/apps/frontend/src/pages/Account/Analytics.tsx
@@ -99,11 +99,13 @@ const AccountQuery = graphql(`
           all {
             total
             projects
+            storybook
           }
           series {
             ts
             total
             projects
+            storybook
           }
           projects {
             id
@@ -395,11 +397,11 @@ export function AnalyticsDashboard(props: {
           color="storybook"
           label="Screenshots"
           value={metrics?.screenshots.all.total ?? null}
-          hint={
-            screenshotsPerPeriod !== null
-              ? `${screenshotsPerPeriod.toLocaleString()} avg / ${groupByLabel}`
-              : null
-          }
+          hint={getScreenshotsHint({
+            perPeriod: screenshotsPerPeriod,
+            groupByLabel,
+            screenshots: metrics.screenshots.all,
+          })}
           visual={
             metrics && metrics.screenshots.all.total > 0 ? (
               <Sparkline
@@ -553,6 +555,13 @@ export function AnalyticsDashboard(props: {
                     to,
                     groupBy,
                   }),
+                  extraColumns: [
+                    { label: "Storybook", get: (serie) => serie.storybook },
+                    {
+                      label: "Other",
+                      get: (serie) => serie.total - serie.storybook,
+                    },
+                  ],
                 });
               }}
             />
@@ -663,6 +672,31 @@ export function AnalyticsDashboard(props: {
       </Section>
     </div>
   );
+}
+
+/**
+ * The Screenshots tile's supporting line.
+ *
+ * The Storybook share only joins it for accounts that capture stories at all —
+ * everywhere else it would be a permanent "0%" saying nothing. `storybook` is
+ * clamped to `total` upstream, so a non-zero share always has a total to divide
+ * by.
+ */
+function getScreenshotsHint(props: {
+  perPeriod: number;
+  groupByLabel: string;
+  screenshots: { total: number; storybook: number };
+}) {
+  const { perPeriod, groupByLabel, screenshots } = props;
+  const average = `${perPeriod.toLocaleString()} avg / ${groupByLabel}`;
+  if (screenshots.storybook === 0) {
+    return average;
+  }
+  const share = (screenshots.storybook / screenshots.total).toLocaleString(
+    navigator.language,
+    { style: "percent", maximumFractionDigits: 0 },
+  );
+  return `${average} · ${share} Storybook`;
 }
 
 function getCSVName(props: {

--- a/tests/account.spec.ts
+++ b/tests/account.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "@playwright/test";
 
+import { createAnalyticsScenario } from "../apps/backend/src/database/seeds";
 import { loggedTest } from "./logged-test";
 import { ensureTeamOwner, screenshot } from "./util";
 
@@ -30,3 +31,16 @@ loggedTest("account analytics", async ({ page, team, auth }) => {
   await expect(page.getByText("Screenshots by Project")).toBeVisible();
   await screenshot(page, "account-analytics");
 });
+
+loggedTest(
+  "account analytics with Storybook screenshots",
+  async ({ page, team, project, auth }) => {
+    await ensureTeamOwner({ team: team.team, user: auth.user });
+    // 100 Storybook screenshots out of 400 over the last three days.
+    await createAnalyticsScenario({ projectId: project.id });
+
+    await page.goto(`/${team.account.slug}/~/analytics`);
+    await expect(page.getByText("25% Storybook")).toBeVisible();
+    await screenshot(page, "account-analytics-storybook");
+  },
+);


### PR DESCRIPTION
The Screenshots tile now says how much of the period came from Storybook stories, next to the capture rate — and only for accounts that capture stories, so nobody reads a permanent "0%".

I first tried a dedicated card in the Breakdown section; with only two categories it took more room than it was worth, so the hint carries it instead.

The split also travels in the screenshots CSV export as two columns, and the aggregation exposes it on GraphQL and on `/analytics`.

Left for a follow-up: the Storybook count is still clamped per query because of legacy rows. Fixing the data with a migration and a CHECK constraint would let all three call sites drop the clamp, but that touches the billing table and deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
