### PR TITLE
feat(staff): reach a team's directory row from the team itself

### DIFF
--- a/apps/frontend/src/containers/Breadcrumb/AccountBreadcrumb.tsx
+++ b/apps/frontend/src/containers/Breadcrumb/AccountBreadcrumb.tsx
@@ -14,7 +14,9 @@ import {
   BreadcrumbLink,
   BreadcrumbMenuButton,
 } from "@/ui/Breadcrumb";
+import { LinkButton } from "@/ui/Button";
 import { MenuRoot, MenuTrigger } from "@/ui/menu-kit";
+import { Tooltip } from "@/ui/Tooltip";
 
 import { AccountBreadcrumbMenu } from "./AccountBreadcrumbMenu";
 
@@ -70,6 +72,37 @@ function HomeBreadcrumbLink() {
 }
 
 /**
+ * Takes a staff member from the team they are looking at to its row in the
+ * staff directory, which is otherwise reached by searching for it by hand.
+ *
+ * Reads the account from the same query the link above already ran, so the
+ * cache answers it. Searching by slug rather than name: a name is free text
+ * and may be empty, a slug is neither.
+ */
+function StaffTeamLink({ accountSlug }: { accountSlug: string }) {
+  const { data } = useSuspenseQuery(AccountQuery, {
+    variables: { slug: accountSlug },
+  });
+  if (data.account?.__typename !== "Team") {
+    return null;
+  }
+  const search = new URLSearchParams({ search: data.account.slug }).toString();
+  return (
+    <Tooltip content="Open in staff directory">
+      <LinkButton
+        variant="ghost"
+        size="small"
+        iconOnly
+        aria-label="Open in staff directory"
+        href={`/staff/teams?${search}`}
+      >
+        <ShieldUserIcon />
+      </LinkButton>
+    </Tooltip>
+  );
+}
+
+/**
  * The staff area is a destination of the same nature as an account, so it
  * takes the account's place in the breadcrumb — otherwise the trail would name
  * a personal account while you are browsing staff tooling.
@@ -92,7 +125,7 @@ export function AccountBreadcrumbItem() {
   // Not just authenticated: the menu needs the resolved account, because its
   // rows must all exist the moment it can be opened. The button appears with
   // the answer, a beat after the trail does.
-  const account = auth.status === "authenticated" ? auth.account : null;
+  const me = auth.status === "authenticated" ? auth.account : null;
 
   return (
     <BreadcrumbItem>
@@ -103,13 +136,16 @@ export function AccountBreadcrumbItem() {
       ) : (
         <HomeBreadcrumbLink />
       )}
-      {account ? (
+      {me ? (
         <MenuRoot>
           <MenuTrigger>
             <BreadcrumbMenuButton />
           </MenuTrigger>
-          <AccountBreadcrumbMenu account={account} />
+          <AccountBreadcrumbMenu account={me} />
         </MenuRoot>
+      ) : null}
+      {accountSlug && me?.staff ? (
+        <StaffTeamLink accountSlug={accountSlug} />
       ) : null}
     </BreadcrumbItem>
   );

--- a/apps/frontend/src/pages/Staff/Teams.tsx
+++ b/apps/frontend/src/pages/Staff/Teams.tsx
@@ -5,7 +5,7 @@ import { diffInCalendarDays } from "@argos/util/date";
 import { invariant } from "@argos/util/invariant";
 import clsx from "clsx";
 import { CreditCardIcon, SearchIcon } from "lucide-react";
-import { parseAsStringEnum, useQueryState } from "nuqs";
+import { parseAsString, parseAsStringEnum, useQueryState } from "nuqs";
 import { Helmet } from "react-helmet";
 
 import { AccountAvatar } from "@/containers/AccountAvatar";
@@ -969,7 +969,10 @@ function StaffTeamsTable(props: {
 
 function StaffTeamsList() {
   const [openedTeams, setOpenedTeams] = useState<Record<string, boolean>>({});
-  const [search, setSearch] = useState("");
+  const [search, setSearch] = useQueryState(
+    "search",
+    parseAsString.withDefault(""),
+  );
   const deferredSearch = useDeferredValue(search);
   const [sortKey, setSortKey] = useState<SortKey>("createdAt");
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");


### PR DESCRIPTION
The directory's search moves into the URL, next to the interval and status filters that were already there, so a narrowed list becomes a link that can be shared or bookmarked.

A team's breadcrumb then carries the way into it: a staff-only shortcut to that list, pre-filtered on the team's slug, so reaching a team's row no longer means retyping a slug already on screen. By slug rather than name — a name is free text and may be empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)