### PR TITLE
fix(dev): name the RDS user in the missing-session error

### DIFF
--- a/apps/backend/src/config/database.ts
+++ b/apps/backend/src/config/database.ts
@@ -22,11 +22,12 @@ function getPassword(config: Config): string | (() => Promise<string>) {
     `cannot derive an AWS region from Postgres host "${hostname}" — PG_IAM_AUTH expects an RDS endpoint`,
   );
 
+  const username = config.get("pg.connection.user");
   const signer = new Signer({
     hostname,
     region,
     port: config.get("pg.connection.port"),
-    username: config.get("pg.connection.user"),
+    username,
   });
   return async () => {
     try {


### PR DESCRIPTION
`static-analysis` has been red on main since #2588: the missing-session error message interpolates `username`, which exists only as a property key in the `Signer` options object, not as a binding. Hoisting it to a const fixes the reference and keeps the message.

Every open PR inherits the failure, so this is worth landing before the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
