### PR TITLE
fix(projects): load the latest build without scanning every build

### DIFF
--- a/apps/backend/src/graphql/loaders.e2e.test.ts
+++ b/apps/backend/src/graphql/loaders.e2e.test.ts
@@ -181,6 +181,96 @@ describe("LatestChangeDiff loader", () => {
   });
 });
 
+describe("LatestProjectBuild loader", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  it("returns the newest build of each project in a batch", async () => {
+    const [projectA, projectB, emptyProject] = await Promise.all([
+      factory.Project.create(),
+      factory.Project.create(),
+      factory.Project.create(),
+    ]);
+    await factory.Build.create({
+      projectId: projectA.id,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    const newestA = await factory.Build.create({
+      projectId: projectA.id,
+      createdAt: "2026-01-02T00:00:00.000Z",
+    });
+    const newestB = await factory.Build.create({
+      projectId: projectB.id,
+      createdAt: "2025-06-01T00:00:00.000Z",
+    });
+
+    const loaders = createLoaders();
+    const [buildA, buildB, none] = await Promise.all([
+      loaders.LatestProjectBuild.load(projectA.id),
+      loaders.LatestProjectBuild.load(projectB.id),
+      loaders.LatestProjectBuild.load(emptyProject.id),
+    ]);
+
+    expect(buildA?.id).toBe(newestA.id);
+    expect(buildB?.id).toBe(newestB.id);
+    expect(none).toBeNull();
+  });
+
+  it("breaks a tie on `createdAt` with the highest build number", async () => {
+    const project = await factory.Project.create();
+    const createdAt = "2026-01-01T00:00:00.000Z";
+    await factory.Build.create({ projectId: project.id, createdAt });
+    const last = await factory.Build.create({
+      projectId: project.id,
+      createdAt,
+    });
+
+    const loaders = createLoaders();
+    const build = await loaders.LatestProjectBuild.load(project.id);
+
+    expect(build?.id).toBe(last.id);
+    expect(build?.number).toBe(2);
+  });
+});
+
+describe("LatestAutomationRun loader", () => {
+  beforeEach(async () => {
+    await setupDatabase();
+  });
+
+  it("returns the newest run of each rule in a batch", async () => {
+    const [ruleA, ruleB, unusedRule] = await Promise.all([
+      factory.AutomationRule.create(),
+      factory.AutomationRule.create(),
+      factory.AutomationRule.create(),
+    ]);
+    await factory.AutomationRun.create({
+      automationRuleId: ruleA.id,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    const newestA = await factory.AutomationRun.create({
+      automationRuleId: ruleA.id,
+      createdAt: "2026-01-02T00:00:00.000Z",
+    });
+    const newestB = await factory.AutomationRun.create({
+      automationRuleId: ruleB.id,
+      createdAt: "2025-06-01T00:00:00.000Z",
+    });
+
+    const loaders = createLoaders();
+    const [runA, runB, none] = await Promise.all([
+      loaders.LatestAutomationRun.load(ruleA.id),
+      loaders.LatestAutomationRun.load(ruleB.id),
+      loaders.LatestAutomationRun.load(unusedRule.id),
+    ]);
+
+    expect(runA?.id).toBe(newestA.id);
+    expect(runB?.id).toBe(newestB.id);
+    expect(none).toBeNull();
+  });
+});
+
 describe("ChangeOccurrencesSince loader", () => {
   beforeEach(async () => {
     await setupDatabase();

--- a/apps/backend/src/graphql/loaders.e2e.test.ts
+++ b/apps/backend/src/graphql/loaders.e2e.test.ts
@@ -269,6 +269,24 @@ describe("LatestAutomationRun loader", () => {
     expect(runB?.id).toBe(newestB.id);
     expect(none).toBeNull();
   });
+
+  it("breaks a tie on `createdAt` with the highest id", async () => {
+    const rule = await factory.AutomationRule.create();
+    const createdAt = "2026-01-01T00:00:00.000Z";
+    await factory.AutomationRun.create({
+      automationRuleId: rule.id,
+      createdAt,
+    });
+    const last = await factory.AutomationRun.create({
+      automationRuleId: rule.id,
+      createdAt,
+    });
+
+    const loaders = createLoaders();
+    const run = await loaders.LatestAutomationRun.load(rule.id);
+
+    expect(run?.id).toBe(last.id);
+  });
 });
 
 describe("ChangeOccurrencesSince loader", () => {

--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -121,18 +121,15 @@ function createLatestAutomationRunLoader() {
               select *
               from "automation_runs"
               where "automation_runs"."automationRuleId" = t."automationRuleId"
-              order by "automation_runs"."createdAt" desc
+              order by "automation_runs"."createdAt" desc, "automation_runs"."id" desc
               limit 1
             ) as automation_runs on true
           `,
         );
-      const latestRunsMap = latestRuns.reduce<Record<string, AutomationRun>>(
-        (map, run) => ({
-          ...map,
-          [run.automationRuleId]: run,
-        }),
-        {},
-      );
+      const latestRunsMap: Record<string, AutomationRun> = {};
+      for (const run of latestRuns) {
+        latestRunsMap[run.automationRuleId] = run;
+      }
       return automationRuleIds.map((id) => latestRunsMap[id] ?? null);
     },
   );
@@ -140,32 +137,43 @@ function createLatestAutomationRunLoader() {
 
 function createLatestProjectBuildLoader() {
   return new DataLoader<string, Build | null>(async (projectIds) => {
-    const valuesSql = projectIds.map(() => "(?::bigint)").join(", ");
+    return Sentry.startSpan(
+      {
+        name: "LatestProjectBuildLoader",
+        attributes: { "argos.project.count": projectIds.length },
+      },
+      async () => {
+        const valuesSql = projectIds.map(() => "(?::bigint)").join(", ");
 
-    // The ordering must stay a prefix-match of
-    // `builds_projectid_createdat_number_idx`, otherwise each key stops being a
-    // single index descent and starts sorting the project's builds again.
-    const latestBuilds = await Build.query()
-      .select("builds.*")
-      .from(
-        Build.raw(`(values ${valuesSql}) as t("projectId")`, [...projectIds]),
-      )
-      .joinRaw(
-        `
-          join lateral (
-            select *
-            from "builds"
-            where "builds"."projectId" = t."projectId"
-            order by "builds"."createdAt" desc, "builds"."number" desc
-            limit 1
-          ) as builds on true
-        `,
-      );
-    const latestBuildsMap: Record<string, Build> = {};
-    for (const build of latestBuilds) {
-      latestBuildsMap[build.projectId] = build;
-    }
-    return projectIds.map((id) => latestBuildsMap[id] ?? null);
+        // `number desc` only breaks ties on `createdAt`, which the second
+        // between two builds of a busy project makes real. It costs nothing:
+        // `builds_projectid_createdat_number_idx` already carries it, so the
+        // lateral stays a single descent either way.
+        const latestBuilds = await Build.query()
+          .select("builds.*")
+          .from(
+            Build.raw(`(values ${valuesSql}) as t("projectId")`, [
+              ...projectIds,
+            ]),
+          )
+          .joinRaw(
+            `
+              join lateral (
+                select *
+                from "builds"
+                where "builds"."projectId" = t."projectId"
+                order by "builds"."createdAt" desc, "builds"."number" desc
+                limit 1
+              ) as builds on true
+            `,
+          );
+        const latestBuildsMap: Record<string, Build> = {};
+        for (const build of latestBuilds) {
+          latestBuildsMap[build.projectId] = build;
+        }
+        return projectIds.map((id) => latestBuildsMap[id] ?? null);
+      },
+    );
   });
 }
 
@@ -186,12 +194,11 @@ function createLatestProductionDeploymentByProjectLoader() {
             select *
             from "deployments"
             where "deployments"."projectId" = t."projectId"
-              and "deployments"."environment" = ?
+              and "deployments"."environment" = 'production'
             order by "deployments"."createdAt" desc, "deployments"."id" desc
             limit 1
           ) as deployments on true
         `,
-        ["production"],
       );
     const latestDeploymentsMap: Record<string, Deployment> = {};
     for (const deployment of latestDeployments) {
@@ -1687,44 +1694,54 @@ function createLatestChangeDiffLoader() {
     string
   >(
     async (changes) => {
-      const valuesSql = changes.map(() => "(?::bigint, ?::text)").join(", ");
-      const bindings = changes.flatMap(({ testId, fingerprint }) => [
-        testId,
-        fingerprint,
-      ]);
+      return Sentry.startSpan(
+        {
+          name: "LatestChangeDiffLoader",
+          attributes: { "argos.change.count": changes.length },
+        },
+        async () => {
+          const valuesSql = changes
+            .map(() => "(?::bigint, ?::text)")
+            .join(", ");
+          const bindings = changes.flatMap(({ testId, fingerprint }) => [
+            testId,
+            fingerprint,
+          ]);
 
-      // The filter and the ordering match
-      // `screenshot_diffs_testid_fingerprint_id_desc_notnull_idx`, so each key
-      // reads a single index entry.
-      const rows = await ScreenshotDiff.query()
-        .select("screenshot_diffs.*")
-        .from(
-          ScreenshotDiff.raw(
-            `(values ${valuesSql}) as t("testId", "fingerprint")`,
-            bindings,
-          ),
-        )
-        .joinRaw(
-          `
-            join lateral (
-              select *
-              from "screenshot_diffs"
-              where "screenshot_diffs"."testId" = t."testId"
-                and "screenshot_diffs"."fingerprint" = t."fingerprint"
-                and "screenshot_diffs"."fileId" is not null
-              order by "screenshot_diffs"."id" desc
-              limit 1
-            ) as screenshot_diffs on true
-          `,
-        );
+          // The filter and the ordering match
+          // `screenshot_diffs_testid_fingerprint_id_desc_notnull_idx`, so each
+          // key reads a single index entry.
+          const rows = await ScreenshotDiff.query()
+            .select("screenshot_diffs.*")
+            .from(
+              ScreenshotDiff.raw(
+                `(values ${valuesSql}) as t("testId", "fingerprint")`,
+                bindings,
+              ),
+            )
+            .joinRaw(
+              `
+                join lateral (
+                  select *
+                  from "screenshot_diffs"
+                  where "screenshot_diffs"."testId" = t."testId"
+                    and "screenshot_diffs"."fingerprint" = t."fingerprint"
+                    and "screenshot_diffs"."fileId" is not null
+                  order by "screenshot_diffs"."id" desc
+                  limit 1
+                ) as screenshot_diffs on true
+              `,
+            );
 
-      const diffByKey = new Map(
-        rows.map((diff) => [`${diff.testId}|${diff.fingerprint}`, diff]),
-      );
+          const diffByKey = new Map(
+            rows.map((diff) => [`${diff.testId}|${diff.fingerprint}`, diff]),
+          );
 
-      return changes.map(
-        ({ testId, fingerprint }) =>
-          diffByKey.get(`${testId}|${fingerprint}`) ?? null,
+          return changes.map(
+            ({ testId, fingerprint }) =>
+              diffByKey.get(`${testId}|${fingerprint}`) ?? null,
+          );
+        },
       );
     },
     { cacheKeyFn: (input) => JSON.stringify(input) },

--- a/apps/backend/src/graphql/loaders.ts
+++ b/apps/backend/src/graphql/loaders.ts
@@ -106,12 +106,26 @@ function createBuildAggregatedStatusLoader() {
 function createLatestAutomationRunLoader() {
   return new DataLoader<string, AutomationRun | null>(
     async (automationRuleIds) => {
+      const valuesSql = automationRuleIds.map(() => "(?::bigint)").join(", ");
+
       const latestRuns = await AutomationRun.query()
-        .select("*")
-        .whereIn("automationRuleId", automationRuleIds as string[])
-        .distinctOn("automationRuleId")
-        .orderBy("automationRuleId")
-        .orderBy("createdAt", "desc");
+        .select("automation_runs.*")
+        .from(
+          AutomationRun.raw(`(values ${valuesSql}) as t("automationRuleId")`, [
+            ...automationRuleIds,
+          ]),
+        )
+        .joinRaw(
+          `
+            join lateral (
+              select *
+              from "automation_runs"
+              where "automation_runs"."automationRuleId" = t."automationRuleId"
+              order by "automation_runs"."createdAt" desc
+              limit 1
+            ) as automation_runs on true
+          `,
+        );
       const latestRunsMap = latestRuns.reduce<Record<string, AutomationRun>>(
         (map, run) => ({
           ...map,
@@ -126,15 +140,30 @@ function createLatestAutomationRunLoader() {
 
 function createLatestProjectBuildLoader() {
   return new DataLoader<string, Build | null>(async (projectIds) => {
+    const valuesSql = projectIds.map(() => "(?::bigint)").join(", ");
+
+    // The ordering must stay a prefix-match of
+    // `builds_projectid_createdat_number_idx`, otherwise each key stops being a
+    // single index descent and starts sorting the project's builds again.
     const latestBuilds = await Build.query()
-      .select("*")
-      .whereIn("projectId", projectIds as string[])
-      .distinctOn("projectId")
-      .orderBy("projectId")
-      .orderBy("createdAt", "desc");
+      .select("builds.*")
+      .from(
+        Build.raw(`(values ${valuesSql}) as t("projectId")`, [...projectIds]),
+      )
+      .joinRaw(
+        `
+          join lateral (
+            select *
+            from "builds"
+            where "builds"."projectId" = t."projectId"
+            order by "builds"."createdAt" desc, "builds"."number" desc
+            limit 1
+          ) as builds on true
+        `,
+      );
     const latestBuildsMap: Record<string, Build> = {};
     for (const build of latestBuilds) {
-      latestBuildsMap[build.projectId!] = build;
+      latestBuildsMap[build.projectId] = build;
     }
     return projectIds.map((id) => latestBuildsMap[id] ?? null);
   });
@@ -142,13 +171,28 @@ function createLatestProjectBuildLoader() {
 
 function createLatestProductionDeploymentByProjectLoader() {
   return new DataLoader<string, Deployment | null>(async (projectIds) => {
+    const valuesSql = projectIds.map(() => "(?::bigint)").join(", ");
+
     const latestDeployments = await Deployment.query()
-      .whereIn("projectId", projectIds)
-      .where("environment", "production")
-      .distinctOn("projectId")
-      .orderBy("projectId")
-      .orderBy("createdAt", "desc")
-      .orderBy("id", "desc");
+      .select("deployments.*")
+      .from(
+        Deployment.raw(`(values ${valuesSql}) as t("projectId")`, [
+          ...projectIds,
+        ]),
+      )
+      .joinRaw(
+        `
+          join lateral (
+            select *
+            from "deployments"
+            where "deployments"."projectId" = t."projectId"
+              and "deployments"."environment" = ?
+            order by "deployments"."createdAt" desc, "deployments"."id" desc
+            limit 1
+          ) as deployments on true
+        `,
+        ["production"],
+      );
     const latestDeploymentsMap: Record<string, Deployment> = {};
     for (const deployment of latestDeployments) {
       latestDeploymentsMap[deployment.projectId] = deployment;
@@ -1643,21 +1687,36 @@ function createLatestChangeDiffLoader() {
     string
   >(
     async (changes) => {
+      const valuesSql = changes.map(() => "(?::bigint, ?::text)").join(", ");
+      const bindings = changes.flatMap(({ testId, fingerprint }) => [
+        testId,
+        fingerprint,
+      ]);
+
+      // The filter and the ordering match
+      // `screenshot_diffs_testid_fingerprint_id_desc_notnull_idx`, so each key
+      // reads a single index entry.
       const rows = await ScreenshotDiff.query()
         .select("screenshot_diffs.*")
-        // The ordering below puts the newest diff of each pair first, so
-        // DISTINCT ON keeps exactly that one.
-        .distinctOn("screenshot_diffs.testId", "screenshot_diffs.fingerprint")
-        .whereIn(
-          ["screenshot_diffs.testId", "screenshot_diffs.fingerprint"],
-          changes.map(({ testId, fingerprint }) => [testId, fingerprint]),
+        .from(
+          ScreenshotDiff.raw(
+            `(values ${valuesSql}) as t("testId", "fingerprint")`,
+            bindings,
+          ),
         )
-        .whereNotNull("screenshot_diffs.fileId")
-        .orderBy([
-          { column: "screenshot_diffs.testId" },
-          { column: "screenshot_diffs.fingerprint" },
-          { column: "screenshot_diffs.id", order: "desc" },
-        ]);
+        .joinRaw(
+          `
+            join lateral (
+              select *
+              from "screenshot_diffs"
+              where "screenshot_diffs"."testId" = t."testId"
+                and "screenshot_diffs"."fingerprint" = t."fingerprint"
+                and "screenshot_diffs"."fileId" is not null
+              order by "screenshot_diffs"."id" desc
+              limit 1
+            ) as screenshot_diffs on true
+          `,
+        );
 
       const diffByKey = new Map(
         rows.map((diff) => [`${diff.testId}|${diff.fingerprint}`, diff]),


### PR DESCRIPTION
The projects page could take seconds to load for accounts owning a project with a long build history, and the time was spent in a single loader.

## The mechanism

`Project.latestBuild` is backed by a DataLoader that batches project ids, and the query was spelled with `distinct on`:

```sql
select distinct on ("projectId") * from builds
where "projectId" in (…) order by "projectId", "createdAt" desc
```

`distinct on` describes the result, not a way to get it. Postgres implements it as a `Unique` node over a sort, so it reads and sorts _every_ build of _every_ project in the batch, materialising full rows, only to keep the first of each group and discard the rest. On a project with a long history the sort spills to disk and the page waits on it — to render one line per card.

`join lateral … limit 1` expresses the actual intent. Postgres descends the index once per key and stops at the first entry, so the cost follows the number of projects in the batch rather than the number of builds they own.

```sql
select "builds".* from (values (?::bigint), …) as t("projectId")
join lateral (
  select * from "builds" where "builds"."projectId" = t."projectId"
  order by "builds"."createdAt" desc, "builds"."number" desc limit 1
) as builds on true
```

The shape is not new here: three loaders in this same file already use it.

## Scope

Four loaders had the pathological shape — a DataLoader whose only predicate is the very column it groups by:

| loader                                | key                                           |
| ------------------------------------- | --------------------------------------------- |
| `LatestProjectBuild`                  | `projectId` on `builds`                       |
| `LatestChangeDiff`                    | `(testId, fingerprint)` on `screenshot_diffs` |
| `LatestProductionDeploymentByProject` | `projectId` on `deployments`                  |
| `LatestAutomationRun`                 | `automationRuleId` on `automation_runs`       |

The first two read the largest tables in the schema and are the ones that hurt. The last two are on small tables and are moved for the shape, not for a measured win — leaving one behind keeps the trap in the file for the next person to copy.

## What is deliberately not changed

Every other `distinct on` in the backend stays. `distinct on` is only a trap when the grouping column is the _only_ predicate; the remaining sites (`build/siblings.ts`, `git-platform/comment.ts`, `build-notification/aggregated.ts`, `build/strategy/strategies/ci/merge-queue.ts`) are all bounded by a commit or a branch first, so the set they deduplicate is already small. They are correct and fast as they are.

No index is added. `builds` and `screenshot_diffs` already carry exactly the index each lateral needs (`builds_projectid_createdat_number_idx`, `screenshot_diffs_testid_fingerprint_id_desc_notnull_idx`), so those two are a single descent. `deployments` and `automation_runs` have no `createdAt` in their indexes, so their laterals still top-N sort a key's rows — bounded per key instead of across the batch, which is the improvement, but not a descent. Both tables are small enough that a migration would cost more than it buys; the composite index is worth revisiting if either grows.

No shared helper either, though the `(values …) + join lateral` block now appears seven times in the file. The call sites differ in their key arity, casts, filters and echo columns, so a helper would take raw SQL fragments as parameters and hide little. Worth extracting once an eighth appears, but not as part of this change.

## Behaviour

Two orderings gain a tie-breaker and become deterministic: builds on `number desc`, automation runs on `id desc` (deployments already had one). Timestamps are stamped in application code at millisecond precision, so ties are reachable, and `limit 1` makes an untied ordering visibly non-deterministic in a way `distinct on` did not. Both tie-breakers are free — the index already carries the column, or the sort was happening anyway.

## Verification

`loaders.e2e.test.ts` gains cases for `LatestProjectBuild` and `LatestAutomationRun`, which had no coverage and now carry hand-written SQL: newest row per key across a batch, `null` for a key with no rows, and the tie-break. Each was confirmed to fail with the lateral's `order by` inverted, so they are not vacuous. `LatestChangeDiff` was already covered, including the multi-key batching that a lateral rewrite is most likely to break, and `LatestProductionDeploymentByProject` is covered end-to-end by `tests/latestProductionDeployment.e2e.test.ts` through the same GraphQL query the page issues — including a preview-only project, which pins the `production` filter.

The two loaders reading the largest tables now open a Sentry span carrying the batch size, so the effect is observable in production instead of asserted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
