### PR TITLE
feat(billing): alert owners at $200 and $500 of overage without a spend limit

### DIFF
--- a/apps/backend/db/migrations/20260909153631_overage-alert.js
+++ b/apps/backend/db/migrations/20260909153631_overage-alert.js
@@ -1,0 +1,17 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+export const up = async (knex) => {
+  await knex.schema.alterTable("accounts", (table) => {
+    table.integer("lastOverageAlertThreshold");
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+export const down = async (knex) => {
+  await knex.schema.alterTable("accounts", (table) => {
+    table.dropColumn("lastOverageAlertThreshold");
+  });
+};

--- a/apps/backend/db/structure.sql
+++ b/apps/backend/db/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict KpjS2jKXTxQgaV2MMwS992ZcqvSv3J5pYvxbsy4hL6CE5lxMr5e9WGe0MUzJrDr
+\restrict 9RtOxyeUu8jhzkjsBQQ5Ur9nRozyDFBofOxHaaPMoGifWmN1aiXM3dnH2fEDWFd
 
 -- Dumped from database version 18.4
 -- Dumped by pg_dump version 18.4 (Homebrew)
@@ -127,6 +127,7 @@ CREATE TABLE public.accounts (
     "meteredSpendLimitByPeriod" integer,
     "blockWhenSpendLimitIsReached" boolean DEFAULT false NOT NULL,
     "originInstallationId" bigint,
+    "lastOverageAlertThreshold" integer,
     CONSTRAINT accounts_only_one_owner CHECK ((num_nonnulls("userId", "teamId") = 1))
 );
 
@@ -6692,7 +6693,7 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-\unrestrict KpjS2jKXTxQgaV2MMwS992ZcqvSv3J5pYvxbsy4hL6CE5lxMr5e9WGe0MUzJrDr
+\unrestrict 9RtOxyeUu8jhzkjsBQQ5Ur9nRozyDFBofOxHaaPMoGifWmN1aiXM3dnH2fEDWFd
 
 -- Knex migrations
 
@@ -6948,3 +6949,4 @@ INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('2026082
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260824081749_stripe-invoices-customer-fields.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260830130624_custom-domains.js', 1, NOW());
 INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260902183811_project-soft-delete.js', 1, NOW());
+INSERT INTO public.knex_migrations(name, batch, migration_time) VALUES ('20260909153631_overage-alert.js', 1, NOW());

--- a/apps/backend/src/build/job.ts
+++ b/apps/backend/src/build/job.ts
@@ -2,6 +2,7 @@ import { invariant } from "@argos/util/invariant";
 
 import { pushBuildNotification } from "@/build-notification";
 import { Build, Project, ScreenshotDiff } from "@/database/models";
+import { claimOverageAlert } from "@/database/services/overage-alert";
 import { getSpendLimitThreshold } from "@/database/services/spend-limit";
 import { githubPullRequestJob } from "@/github-pull-request/job";
 import { formatGlProject, getGitlabClientFromAccount } from "@/gitlab";
@@ -37,7 +38,8 @@ async function pushDiffs(input: {
 }
 
 /**
- * Update the usage in Stripe, also check the spend limit.
+ * Update the usage in Stripe, then send the spend alert that became due: a
+ * spend limit threshold when a limit is set, an overage alert otherwise.
  */
 async function updateUsage(project: Project) {
   const { account } = project;
@@ -68,6 +70,23 @@ async function updateUsage(project: Project) {
           accountSlug: account.slug,
           blockWhenSpendLimitIsReached: account.blockWhenSpendLimitIsReached,
           threshold: spendLimitThreshold,
+        },
+        recipients: ownerIds,
+      });
+    }
+
+    // A claim is not undone by a failed run, so it comes after the Stripe
+    // update, the step that can fail and get retried.
+    const overageAlert = await claimOverageAlert(account);
+    if (overageAlert !== null) {
+      const ownerIds = await account.$getOwnerIds();
+      await sendNotification({
+        type: "overage_alert",
+        data: {
+          accountName: account.name,
+          accountSlug: account.slug,
+          threshold: overageAlert.threshold,
+          currency: overageAlert.currency,
         },
         recipients: ownerIds,
       });

--- a/apps/backend/src/database/models/Account.ts
+++ b/apps/backend/src/database/models/Account.ts
@@ -188,6 +188,7 @@ export class Account extends Model {
             anyOf: [{ type: "null" }, { type: "integer", minimum: 0 }],
           },
           blockWhenSpendLimitIsReached: { type: "boolean" },
+          lastOverageAlertThreshold: { type: ["integer", "null"] },
         },
       },
     ],
@@ -207,6 +208,13 @@ export class Account extends Model {
   originInstallationId!: string | null;
   meteredSpendLimitByPeriod!: number | null;
   blockWhenSpendLimitIsReached!: boolean;
+  /**
+   * Highest overage alert already sent to the owners, null when none was.
+   * Without a spend limit, the owners are nudged once at each threshold and
+   * never again, not once per billing period: the alert exists to get a limit
+   * configured, not to report usage.
+   */
+  lastOverageAlertThreshold!: number | null;
 
   override $formatDatabaseJson(json: Pojo) {
     json = super.$formatDatabaseJson(json);

--- a/apps/backend/src/database/services/overage-alert.e2e.test.ts
+++ b/apps/backend/src/database/services/overage-alert.e2e.test.ts
@@ -134,6 +134,19 @@ describe("claimOverageAlert", () => {
   );
 
   withUsageBasedTeam(
+    "claims nothing when a spend limit is set after the account was loaded",
+    async ({ account, project }) => {
+      await spend(project, 600);
+      const loaded = await Account.query()
+        .findById(account.id)
+        .throwIfNotFound();
+      await account.$query().patch({ meteredSpendLimitByPeriod: 1000 });
+      await expect(claimOverageAlert(loaded)).resolves.toBeNull();
+      await expect(getLastThreshold(account)).resolves.toBeNull();
+    },
+  );
+
+  withUsageBasedTeam(
     "lets a single concurrent run claim a threshold",
     async ({ account, project }) => {
       await spend(project, 200);

--- a/apps/backend/src/database/services/overage-alert.e2e.test.ts
+++ b/apps/backend/src/database/services/overage-alert.e2e.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "vitest";
+
+import { Account, type Plan, type Project } from "@/database/models";
+import { factory, setupDatabase } from "@/database/testing";
+
+import { claimOverageAlert } from "./overage-alert";
+
+const INCLUDED_SCREENSHOTS = 1000;
+const ADDITIONAL_SCREENSHOT_PRICE = 0.5;
+
+type Ctx = {
+  plan: Plan;
+  /** Team on a usage based plan, without a spend limit. */
+  account: Account;
+  /** Project of the team, with the included screenshots already used up. */
+  project: Project;
+};
+
+const withUsageBasedTeam = test.extend<Ctx>({
+  plan: async ({}, use) => {
+    await setupDatabase();
+    const plan = await factory.Plan.create({ usageBased: true });
+    await use(plan);
+  },
+  account: async ({ plan }, use) => {
+    const account = await factory.TeamAccount.create();
+    const subscriber = await factory.User.create();
+    await factory.Subscription.create({
+      accountId: account.id,
+      planId: plan.id,
+      includedScreenshots: INCLUDED_SCREENSHOTS,
+      currency: "usd",
+      additionalScreenshotPrice: ADDITIONAL_SCREENSHOT_PRICE,
+      additionalStorybookScreenshotPrice: ADDITIONAL_SCREENSHOT_PRICE,
+      provider: "stripe",
+      stripeSubscriptionId: "sub_overage",
+      subscriberId: subscriber.id,
+      startDate: new Date("2021-01-01").toISOString(),
+    });
+    await use(account);
+  },
+  project: async ({ account }, use) => {
+    const project = await factory.Project.create({ accountId: account.id });
+    await factory.ScreenshotBucket.create({
+      projectId: project.id,
+      screenshotCount: INCLUDED_SCREENSHOTS,
+    });
+    await use(project);
+  },
+});
+
+/** Take enough additional screenshots to add `amount` to the period's cost. */
+async function spend(project: Project, amount: number) {
+  await factory.ScreenshotBucket.create({
+    projectId: project.id,
+    screenshotCount: amount / ADDITIONAL_SCREENSHOT_PRICE,
+  });
+}
+
+/**
+ * Claim from a freshly loaded account, as the build job does: the subscription
+ * manager caches the cost on the instance.
+ */
+async function claim(account: Account) {
+  const fresh = await Account.query().findById(account.id).throwIfNotFound();
+  return claimOverageAlert(fresh);
+}
+
+async function getLastThreshold(account: Account) {
+  const fresh = await Account.query().findById(account.id).throwIfNotFound();
+  return fresh.lastOverageAlertThreshold;
+}
+
+describe("claimOverageAlert", () => {
+  withUsageBasedTeam(
+    "claims nothing below the first threshold",
+    async ({ account, project }) => {
+      await spend(project, 199.5);
+      await expect(claim(account)).resolves.toBeNull();
+      await expect(getLastThreshold(account)).resolves.toBeNull();
+    },
+  );
+
+  withUsageBasedTeam(
+    "claims a threshold once",
+    async ({ account, project }) => {
+      await spend(project, 200);
+      await expect(claim(account)).resolves.toEqual({
+        threshold: 200,
+        currency: "usd",
+      });
+      await expect(getLastThreshold(account)).resolves.toBe(200);
+      await expect(claim(account)).resolves.toBeNull();
+    },
+  );
+
+  withUsageBasedTeam(
+    "claims the next threshold as the cost grows",
+    async ({ account, project }) => {
+      await spend(project, 200);
+      await expect(claim(account)).resolves.toEqual({
+        threshold: 200,
+        currency: "usd",
+      });
+      await spend(project, 300);
+      await expect(claim(account)).resolves.toEqual({
+        threshold: 500,
+        currency: "usd",
+      });
+      await expect(claim(account)).resolves.toBeNull();
+    },
+  );
+
+  withUsageBasedTeam(
+    "claims only the highest threshold when several are reached at once",
+    async ({ account, project }) => {
+      await spend(project, 600);
+      await expect(claim(account)).resolves.toEqual({
+        threshold: 500,
+        currency: "usd",
+      });
+      await expect(claim(account)).resolves.toBeNull();
+    },
+  );
+
+  withUsageBasedTeam(
+    "leaves accounts with a spend limit to the spend limit alerts",
+    async ({ account, project }) => {
+      await account.$query().patch({ meteredSpendLimitByPeriod: 1000 });
+      await spend(project, 600);
+      await expect(claim(account)).resolves.toBeNull();
+      await expect(getLastThreshold(account)).resolves.toBeNull();
+    },
+  );
+
+  withUsageBasedTeam(
+    "lets a single concurrent run claim a threshold",
+    async ({ account, project }) => {
+      await spend(project, 200);
+      const alerts = await Promise.all([claim(account), claim(account)]);
+      expect(alerts.filter((alert) => alert !== null)).toHaveLength(1);
+    },
+  );
+
+  withUsageBasedTeam(
+    "claims nothing on a flat-rate plan",
+    async ({ plan, account, project }) => {
+      await plan.$query().patch({ usageBased: false });
+      await spend(project, 600);
+      await expect(claim(account)).resolves.toBeNull();
+    },
+  );
+});

--- a/apps/backend/src/database/services/overage-alert.ts
+++ b/apps/backend/src/database/services/overage-alert.ts
@@ -1,0 +1,80 @@
+import { invariant } from "@argos/util/invariant";
+import { z } from "zod";
+
+import { Account, type Subscription } from "../models";
+
+export const OverageAlertThresholdSchema = z.union([
+  z.literal(200),
+  z.literal(500),
+]);
+
+type OverageAlertThreshold = z.infer<typeof OverageAlertThresholdSchema>;
+
+/**
+ * Additional screenshot costs, in the subscription currency, at which the
+ * owners of an account without a spend limit are invited to set one up.
+ */
+const OVERAGE_ALERT_THRESHOLDS = [200, 500] satisfies OverageAlertThreshold[];
+
+type OverageAlert = {
+  threshold: OverageAlertThreshold;
+  currency: NonNullable<Subscription["currency"]>;
+};
+
+/**
+ * Claim the overage alert due for an account without a spend limit: the
+ * highest threshold its additional screenshot cost has reached and that the
+ * owners have not been alerted about yet. Claiming records the threshold on
+ * the account, so each alert is sent once per account.
+ *
+ * Returns null when a spend limit is set (its own alerts take over), when no
+ * new threshold is reached, or when another run claimed it first.
+ */
+export async function claimOverageAlert(
+  account: Account,
+): Promise<OverageAlert | null> {
+  if (account.meteredSpendLimitByPeriod !== null) {
+    return null;
+  }
+
+  const manager = account.$getSubscriptionManager();
+  const [cost, subscription] = await Promise.all([
+    manager.getAdditionalScreenshotCost(),
+    manager.getActiveSubscription(),
+  ]);
+
+  const threshold =
+    OVERAGE_ALERT_THRESHOLDS.findLast((candidate) => cost >= candidate) ?? null;
+  // A claim only raises the value, so the loaded account, even stale, can hide
+  // a claim but never invent one: skipping on it is safe, claiming on it is not.
+  if (
+    threshold === null ||
+    (account.lastOverageAlertThreshold ?? 0) >= threshold
+  ) {
+    return null;
+  }
+
+  invariant(
+    subscription?.currency,
+    "A currency should be set if there is an additional screenshot cost",
+  );
+
+  // The loaded account may predate a claim by a concurrent run, so the update
+  // makes the check itself: no row updated means the alert was already claimed.
+  const claimed = await Account.query()
+    .patch({ lastOverageAlertThreshold: threshold })
+    .where("id", account.id)
+    .whereNull("meteredSpendLimitByPeriod")
+    .where((query) =>
+      query
+        .whereNull("lastOverageAlertThreshold")
+        .orWhere("lastOverageAlertThreshold", "<", threshold),
+    )
+    .returning("id");
+
+  if (claimed.length === 0) {
+    return null;
+  }
+
+  return { threshold, currency: subscription.currency };
+}

--- a/apps/backend/src/notification/categories.ts
+++ b/apps/backend/src/notification/categories.ts
@@ -43,7 +43,7 @@ export const notificationCategoryMetadata: Record<
   },
   billing: {
     label: "Billing",
-    description: "Spend limit alerts for teams you own.",
+    description: "Spend limit and additional usage alerts for teams you own.",
     configurable: true,
   },
   project: {

--- a/apps/backend/src/notification/categories.ts
+++ b/apps/backend/src/notification/categories.ts
@@ -43,7 +43,7 @@ export const notificationCategoryMetadata: Record<
   },
   billing: {
     label: "Billing",
-    description: "Spend limit and additional usage alerts for teams you own.",
+    description: "Spend limit and overage alerts for teams you own.",
     configurable: true,
   },
   project: {

--- a/apps/backend/src/notification/handlers/index.ts
+++ b/apps/backend/src/notification/handlers/index.ts
@@ -6,6 +6,7 @@ import * as comment_replied from "./comment_replied";
 import * as email_added from "./email_added";
 import * as email_removed from "./email_removed";
 import * as invalid_gitlab_token from "./invalid_gitlab_token";
+import * as overage_alert from "./overage_alert";
 import * as project_deleted from "./project_deleted";
 import * as review_dismissed from "./review_dismissed";
 import * as review_requested from "./review_requested";
@@ -24,6 +25,7 @@ export const notificationHandlers = [
   email_added.handler,
   email_removed.handler,
   invalid_gitlab_token.handler,
+  overage_alert.handler,
   project_deleted.handler,
   review_dismissed.handler,
   review_requested.handler,

--- a/apps/backend/src/notification/handlers/overage_alert.tsx
+++ b/apps/backend/src/notification/handlers/overage_alert.tsx
@@ -1,0 +1,107 @@
+import { assertNever } from "@argos/util/assertNever";
+import { Section } from "react-email";
+import { z } from "zod";
+
+import config from "@/config";
+import { OverageAlertThresholdSchema } from "@/database/services/overage-alert";
+
+import {
+  Button,
+  EmailLayout,
+  H1,
+  Hi,
+  Link,
+  Paragraph,
+  Signature,
+} from "../../email/components";
+import { defineNotificationHandler } from "../workflow-types";
+
+const baseUrl = config.get("server.url");
+
+const spendManagementDocsHref =
+  "https://argos-ci.com/docs/learn/billing-and-subscription/spend-management";
+
+export const handler = defineNotificationHandler({
+  type: "overage_alert",
+  category: "billing",
+  schema: z.object({
+    threshold: OverageAlertThresholdSchema,
+    currency: z.enum(["usd", "eur"]),
+    accountName: z.string().nullish(),
+    accountSlug: z.string(),
+  }),
+  previewData: {
+    threshold: 200,
+    currency: "usd",
+    accountName: "Argos",
+    accountSlug: "argos",
+  },
+  email: (props) => {
+    const { threshold, currency, ctx } = props;
+    const accountName = props.accountName || props.accountSlug;
+    const amount = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 0,
+    }).format(threshold);
+    const settingsHref = new URL(
+      `/${props.accountSlug}/settings#spend-management`,
+      baseUrl,
+    ).href;
+    return {
+      subject: `Your team has reached ${amount} of additional screenshot usage`,
+      body: (
+        <EmailLayout
+          preview={`${accountName} has spent ${amount} on additional screenshots this billing period, and no spend limit is set.`}
+          preferencesUrl={ctx.preferencesUrl}
+        >
+          <H1>Your team has reached {amount} of additional screenshot usage</H1>
+          <Hi name={ctx.user.name} />
+          <Paragraph>
+            Your team, <strong>{accountName}</strong>, has used more screenshots
+            than its plan includes this billing period. The additional
+            screenshots now amount to <strong>{amount}</strong>, billed at your
+            plan’s per-screenshot rate on your next invoice. Your builds keep
+            running.
+          </Paragraph>
+          {(() => {
+            switch (threshold) {
+              case 200: {
+                return (
+                  <Paragraph>
+                    <strong>No spend limit is set on your team</strong>, so
+                    nothing caps this cost. Set a spend amount and Argos
+                    notifies you at 50%, 75% and 100% of it, and can pause
+                    builds once it is reached, so your invoice never goes above
+                    what you expect.
+                  </Paragraph>
+                );
+              }
+              case 500: {
+                return (
+                  <Paragraph>
+                    <strong>No spend limit is set on your team</strong>, and
+                    this is the last alert Argos sends without one. Set a spend
+                    amount to stay informed: Argos then notifies you at 50%, 75%
+                    and 100% of it, and can pause builds once it is reached.
+                  </Paragraph>
+                );
+              }
+              default:
+                assertNever(threshold);
+            }
+          })()}
+          <Section className="my-4 text-center">
+            <Button href={settingsHref}>Set up spend management</Button>
+          </Section>
+          <Paragraph>
+            It takes a minute from your team settings. Learn more about{" "}
+            <Link href={spendManagementDocsHref}>spend management</Link> in the
+            documentation.
+          </Paragraph>
+          <Signature />
+        </EmailLayout>
+      ),
+    };
+  },
+});

--- a/apps/backend/src/notification/handlers/overage_alert.tsx
+++ b/apps/backend/src/notification/handlers/overage_alert.tsx
@@ -36,69 +36,111 @@ export const handler = defineNotificationHandler({
     accountName: "Argos",
     accountSlug: "argos",
   },
+  // A heads-up, not a warning: the overage is what a usage-based plan is for,
+  // so the copy informs about the coming invoice instead of urging a cap.
   email: (props) => {
     const { threshold, currency, ctx } = props;
     const accountName = props.accountName || props.accountSlug;
-    const amount = new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency,
-      maximumFractionDigits: 0,
-    }).format(threshold);
-    const settingsHref = new URL(
+    const formatAmount = (value: number) =>
+      new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency,
+        maximumFractionDigits: 0,
+      }).format(value);
+    const amount = formatAmount(threshold);
+    const settingsHref = new URL(`/${props.accountSlug}/settings`, baseUrl)
+      .href;
+    const spendManagementHref = new URL(
       `/${props.accountSlug}/settings#spend-management`,
       baseUrl,
     ).href;
+    const content = (() => {
+      switch (threshold) {
+        case 200: {
+          return {
+            intro: (
+              <>
+                <Paragraph>
+                  Your team, <strong>{accountName}</strong>, has used all the
+                  screenshots included in its plan this billing period, plus
+                  additional screenshots for a total of{" "}
+                  <strong>{amount}</strong> so far. They are billed at your
+                  plan’s per-screenshot rate and will appear on your next
+                  invoice.
+                </Paragraph>
+                <Paragraph>
+                  This is exactly what your usage-based plan is for: your builds
+                  keep running and you only pay for what your team actually
+                  uses. We simply want to make sure nothing on your invoice
+                  comes as a surprise.
+                </Paragraph>
+                <Paragraph>
+                  If you would like more visibility on this, you can set a spend
+                  limit from your team settings. Argos will then let you know
+                  when you reach 50%, 75% and 100% of the amount you choose, and
+                  can pause builds at that point if you prefer.
+                </Paragraph>
+              </>
+            ),
+            outro: (
+              <Paragraph>
+                You can check your current usage at any time in your{" "}
+                <Link href={settingsHref}>team settings</Link>, and learn more
+                about{" "}
+                <Link href={spendManagementDocsHref}>spend management</Link> in
+                the documentation. If you have any questions about your usage or
+                your plan, don’t hesitate to reach out.
+              </Paragraph>
+            ),
+          };
+        }
+        case 500: {
+          return {
+            intro: (
+              <>
+                <Paragraph>
+                  Your team, <strong>{accountName}</strong>, has now used{" "}
+                  <strong>{amount}</strong> of additional screenshots this
+                  billing period, on top of the ones included in its plan. They
+                  are billed at your plan’s per-screenshot rate on your next
+                  invoice, and your builds keep running.
+                </Paragraph>
+                <Paragraph>
+                  Argos sends this heads-up at {formatAmount(200)} and {amount}{" "}
+                  of additional usage, and this is the second and last one. If
+                  you would like to keep being notified as your usage grows, you
+                  can set a spend limit: Argos will then let you know at 50%,
+                  75% and 100% of the amount you choose, and can pause builds at
+                  that point if you prefer.
+                </Paragraph>
+              </>
+            ),
+            outro: (
+              <Paragraph>
+                If you have any questions about your usage or your plan, don’t
+                hesitate to reach out.
+              </Paragraph>
+            ),
+          };
+        }
+        default:
+          assertNever(threshold);
+      }
+    })();
     return {
-      subject: `Your team has reached ${amount} of additional screenshot usage`,
+      subject: `Heads-up: ${amount} of additional screenshots this billing period`,
       body: (
         <EmailLayout
-          preview={`${accountName} has spent ${amount} on additional screenshots this billing period, and no spend limit is set.`}
+          preview={`A quick update on ${accountName}’s usage, so your next invoice holds no surprise.`}
           preferencesUrl={ctx.preferencesUrl}
         >
-          <H1>Your team has reached {amount} of additional screenshot usage</H1>
+          <H1>{amount} of additional screenshots this billing period</H1>
           <Hi name={ctx.user.name} />
-          <Paragraph>
-            Your team, <strong>{accountName}</strong>, has used more screenshots
-            than its plan includes this billing period. The additional
-            screenshots now amount to <strong>{amount}</strong>, billed at your
-            plan’s per-screenshot rate on your next invoice. Your builds keep
-            running.
-          </Paragraph>
-          {(() => {
-            switch (threshold) {
-              case 200: {
-                return (
-                  <Paragraph>
-                    <strong>No spend limit is set on your team</strong>, so
-                    nothing caps this cost. Set a spend amount and Argos
-                    notifies you at 50%, 75% and 100% of it, and can pause
-                    builds once it is reached, so your invoice never goes above
-                    what you expect.
-                  </Paragraph>
-                );
-              }
-              case 500: {
-                return (
-                  <Paragraph>
-                    <strong>No spend limit is set on your team</strong>, and
-                    this is the last alert Argos sends without one. Set a spend
-                    amount to stay informed: Argos then notifies you at 50%, 75%
-                    and 100% of it, and can pause builds once it is reached.
-                  </Paragraph>
-                );
-              }
-              default:
-                assertNever(threshold);
-            }
-          })()}
+          {content.intro}
           <Section className="my-4 text-center">
-            <Button href={settingsHref}>Set up spend management</Button>
+            <Button href={spendManagementHref}>Set up spend management</Button>
           </Section>
-          <Paragraph>
-            It takes a minute from your team settings. Learn more about{" "}
-            <Link href={spendManagementDocsHref}>spend management</Link> in the
-            documentation.
-          </Paragraph>
+          {content.outro}
           <Signature />
         </EmailLayout>
       ),

--- a/apps/backend/src/notification/handlers/overage_alert.tsx
+++ b/apps/backend/src/notification/handlers/overage_alert.tsx
@@ -37,7 +37,9 @@ export const handler = defineNotificationHandler({
     accountSlug: "argos",
   },
   // A heads-up, not a warning: the overage is what a usage-based plan is for,
-  // so the copy informs about the coming invoice instead of urging a cap.
+  // so the copy informs about the coming invoice instead of urging a cap. It
+  // says "overage", never what is metered, so billing something new does not
+  // date it.
   email: (props) => {
     const { threshold, currency, ctx } = props;
     const accountName = props.accountName || props.accountSlug;
@@ -61,24 +63,24 @@ export const handler = defineNotificationHandler({
             intro: (
               <>
                 <Paragraph>
-                  Your team, <strong>{accountName}</strong>, has used all the
-                  screenshots included in its plan this billing period, plus
-                  additional screenshots for a total of{" "}
-                  <strong>{amount}</strong> so far. They are billed at your
-                  plan’s per-screenshot rate and will appear on your next
+                  Your team, <strong>{accountName}</strong>, has used everything
+                  its plan includes this billing period, and the usage beyond
+                  that comes to <strong>{amount} of overage</strong> so far. It
+                  is billed at your plan’s rates and will appear on your next
                   invoice.
                 </Paragraph>
                 <Paragraph>
-                  This is exactly what your usage-based plan is for: your builds
-                  keep running and you only pay for what your team actually
-                  uses. We simply want to make sure nothing on your invoice
-                  comes as a surprise.
+                  This is exactly what your usage-based plan is for:{" "}
+                  <strong>your builds keep running</strong>, and you only pay
+                  for what your team actually uses. We simply want to make sure
+                  nothing on your invoice comes as a surprise.
                 </Paragraph>
                 <Paragraph>
-                  If you would like more visibility on this, you can set a spend
-                  limit from your team settings. Argos will then let you know
-                  when you reach 50%, 75% and 100% of the amount you choose, and
-                  can pause builds at that point if you prefer.
+                  If you would like more visibility on this, you can{" "}
+                  <strong>set a spend limit</strong> from your team settings.
+                  Argos will then let you know when your overage reaches{" "}
+                  <strong>50%, 75% and 100%</strong> of the amount you choose,
+                  and can pause builds at that point if you prefer.
                 </Paragraph>
               </>
             ),
@@ -99,19 +101,20 @@ export const handler = defineNotificationHandler({
             intro: (
               <>
                 <Paragraph>
-                  Your team, <strong>{accountName}</strong>, has now used{" "}
-                  <strong>{amount}</strong> of additional screenshots this
-                  billing period, on top of the ones included in its plan. They
-                  are billed at your plan’s per-screenshot rate on your next
-                  invoice, and your builds keep running.
+                  Your team, <strong>{accountName}</strong>, is now at{" "}
+                  <strong>{amount} of overage</strong> this billing period, for
+                  usage beyond what its plan includes. It is billed at your
+                  plan’s rates on your next invoice, and{" "}
+                  <strong>your builds keep running</strong>.
                 </Paragraph>
                 <Paragraph>
                   Argos sends this heads-up at {formatAmount(200)} and {amount}{" "}
-                  of additional usage, and this is the second and last one. If
-                  you would like to keep being notified as your usage grows, you
-                  can set a spend limit: Argos will then let you know at 50%,
-                  75% and 100% of the amount you choose, and can pause builds at
-                  that point if you prefer.
+                  of overage, and{" "}
+                  <strong>this is the second and last one</strong>. If you would
+                  like to keep being notified as your usage grows, you can{" "}
+                  <strong>set a spend limit</strong>: Argos will then let you
+                  know at 50%, 75% and 100% of the amount you choose, and can
+                  pause builds at that point if you prefer.
                 </Paragraph>
               </>
             ),
@@ -128,13 +131,13 @@ export const handler = defineNotificationHandler({
       }
     })();
     return {
-      subject: `Heads-up: ${amount} of additional screenshots this billing period`,
+      subject: `Heads-up: ${amount} of overage this billing period`,
       body: (
         <EmailLayout
           preview={`A quick update on ${accountName}’s usage, so your next invoice holds no surprise.`}
           preferencesUrl={ctx.preferencesUrl}
         >
-          <H1>{amount} of additional screenshots this billing period</H1>
+          <H1>{amount} of overage this billing period</H1>
           <Hi name={ctx.user.name} />
           {content.intro}
           <Section className="my-4 text-center">


### PR DESCRIPTION
## What

Teams on a usage-based plan that never set a spend limit received no signal about their additional screenshot cost. Owners now get one email when the cost first reaches **$200** and one when it reaches **$500** (in the subscription's currency, like the spend limit itself), inviting them to set up [spend management](https://argos-ci.com/docs/learn/billing-and-subscription/spend-management).

- `claimOverageAlert` (`apps/backend/src/database/services/overage-alert.ts`) picks the highest threshold the period's additional cost has reached and claims it.
- The build job's `updateUsage` calls it after the Stripe usage update and sends the new `overage_alert` notification to the team owners. Accounts with a spend limit are untouched and keep their 50/75/100% alerts.
- New `overage_alert` handler in the configurable `billing` category, whose description is broadened accordingly.
- Migration: `accounts.lastOverageAlertThreshold`, a nullable integer.

## Why it is built this way

- **Once per account, not once per period.** The alert exists to get a limit configured, not to report usage, so it is not repeated every cycle. The existing spend limit alerts use a stateless "cost crossed the threshold since the last Stripe update" comparison, which cannot express "once ever", hence the stored state.
- **A single integer column** holding the highest threshold already sent. A build jumping past both thresholds sends only the $500 email. Rejected: querying `notification_workflows` (a JSON log keyed by slugs that can change, not state) and a dedicated table (more machinery than two thresholds warrant).
- **Claimed with a conditional `UPDATE … RETURNING`.** The job loads the account before taking its per-account Redis lock, so the in-memory value can be stale. The update makes the check itself, and no row returned means another run already claimed it. Skipping early on the loaded value is still safe because a claim only ever raises it.
- **Claimed after the Stripe update.** A claim survives a failed run, so it comes after the step that can fail and get retried.
- Thresholds use `>=` and are formatted in the subscription currency ($200 / €200), mirroring how `meteredSpendLimitByPeriod` is interpreted.

## Verification

- `overage-alert.e2e.test.ts` covers: below threshold, single claim, growing cost, both thresholds at once, spend limit set, two concurrent claims, flat-rate plan.
- `pnpm run static-checks` passes.
- Both variants rendered through `/notification-preview/overage_alert`; subject, settings link (`/<slug>/settings#spend-management`) and docs link checked.

## Screenshots

Copy revised after review to read as a heads-up about the coming invoice rather than a warning. It speaks of overage rather than of what is metered, so billing something new does not date it, and the key facts are in bold.

$200 variant:

[![overage-alert-200.png](https://files.argos-ci.com/media/9/cdeea0db29cd6eee193abfb756a7c2bf2fd2ce3568457d9c01d1ece58ad8171e.webp)](https://app.argos-ci.com/m/ioffv1uwufadi59gigq2)

$500 variant:

[![overage-alert-500.png](https://files.argos-ci.com/media/9/fe90076ae617227e5ffb3feaa9d2e6495ad27b713443fbb42e6f3c05d2a6ae15.webp)](https://app.argos-ci.com/m/2kmx5yixfuwq7ixmt7hs)

## Not in this PR

- The spend management docs page does not mention these alerts yet.
- After pulling, run `pnpm run --filter @argos/backend db:migrate:latest` (and the `NODE_ENV=test` variant for the Playwright database).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


