### PR TITLE
fix(build): drop the story mode switcher when it restates the color scheme

### DIFF
--- a/apps/frontend/src/pages/Build/metadata/utils.test.ts
+++ b/apps/frontend/src/pages/Build/metadata/utils.test.ts
@@ -8,6 +8,7 @@ import {
   getUniqueColorSchemes,
   getUniqueStoryModes,
   getUniqueViewports,
+  storyModeRestatesColorScheme,
 } from "./utils";
 
 /**
@@ -87,5 +88,77 @@ describe("getUniqueStoryModes", () => {
       metadata({ story: story("compact") }),
     ]);
     expect(modes).toEqual(["compact", "wide"]);
+  });
+});
+
+describe("storyModeRestatesColorScheme", () => {
+  const dark = ScreenshotMetadataColorScheme.Dark;
+  const light = ScreenshotMetadataColorScheme.Light;
+
+  it("is true when every mode names the scheme it goes with", () => {
+    expect(
+      storyModeRestatesColorScheme([
+        metadata({ story: story("dark"), colorScheme: dark }),
+        metadata({ story: story("light"), colorScheme: light }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("reads the mode case-insensitively", () => {
+    expect(
+      storyModeRestatesColorScheme([
+        metadata({ story: story("Dark"), colorScheme: dark }),
+        metadata({ story: story("LIGHT"), colorScheme: light }),
+      ]),
+    ).toBe(true);
+  });
+
+  // Light is what a snapshot saying nothing resolves to, so a `light` mode
+  // restates it even where the SDK reported no scheme at all.
+  it("counts the scheme a snapshot leaves unset as light", () => {
+    expect(
+      storyModeRestatesColorScheme([
+        metadata({ story: story("light") }),
+        metadata({ story: story("dark"), colorScheme: dark }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("is false when a mode is named anything else", () => {
+    expect(
+      storyModeRestatesColorScheme([
+        metadata({ story: story("mobile"), colorScheme: light }),
+        metadata({ story: story("desktop"), colorScheme: dark }),
+      ]),
+    ).toBe(false);
+  });
+
+  // The one the naming rule buys over a structural test: these two cut the
+  // snapshots up exactly as the scheme does, and still say something else.
+  it("is false for names that merely line up one-to-one with the schemes", () => {
+    expect(
+      storyModeRestatesColorScheme([
+        metadata({ story: story("night"), colorScheme: dark }),
+        metadata({ story: story("day"), colorScheme: light }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("is false when a mode names the scheme the snapshot does not have", () => {
+    expect(
+      storyModeRestatesColorScheme([
+        metadata({ story: story("dark"), colorScheme: light }),
+        metadata({ story: story("light"), colorScheme: light }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("is false when no snapshot carries a mode", () => {
+    expect(
+      storyModeRestatesColorScheme([
+        metadata({ colorScheme: dark }),
+        metadata({ colorScheme: light }),
+      ]),
+    ).toBe(false);
   });
 });

--- a/apps/frontend/src/pages/Build/metadata/utils.ts
+++ b/apps/frontend/src/pages/Build/metadata/utils.ts
@@ -109,6 +109,36 @@ export function getUniqueStoryModes(metadataList: Metadata[]): string[] {
   return Array.from(modes).sort();
 }
 
+/**
+ * Whether the story mode says nothing the color scheme has not already said.
+ *
+ * A Storybook mode is commonly named after the scheme it sets, and the SDK
+ * records both — so the toolbar ends up carrying two switchers, four buttons
+ * and one binary choice, and the sun/moon pair says it better.
+ *
+ * Judged on the names, not on how the two axes cut the snapshots up. A
+ * `mobile`/`desktop` pair can line up one-to-one with `light`/`dark` by
+ * accident of how the matrix was captured, and dropping it on that evidence
+ * would take away the labels that tell the reviewer what they are looking at.
+ * Only a mode that spells the scheme out is a restatement of it.
+ */
+export function storyModeRestatesColorScheme(
+  metadataList: Metadata[],
+): boolean {
+  let named = false;
+  for (const metadata of metadataList) {
+    const mode = metadata.story?.mode;
+    if (!mode) {
+      continue;
+    }
+    if (mode.toLowerCase() !== resolveColorScheme(metadata)) {
+      return false;
+    }
+    named = true;
+  }
+  return named;
+}
+
 export function useGetDiffPath() {
   const path = "/:accountSlug/:projectName/builds/:buildNumber/:diffId";
   const match = useMatch(path);

--- a/apps/frontend/src/pages/Build/metadata/variants/StoryModeSwitcher.tsx
+++ b/apps/frontend/src/pages/Build/metadata/variants/StoryModeSwitcher.tsx
@@ -12,6 +12,7 @@ import type { Diff } from "../../BuildDiffState";
 import {
   getUniqueStoryModes,
   resolveDiffMetadata,
+  storyModeRestatesColorScheme,
   useGetDiffPath,
 } from "../utils";
 import { findVariantSibling } from "./sibling";
@@ -26,10 +27,15 @@ export function StoryModeSwitcher(props: { diff: Diff; siblingDiffs: Diff[] }) {
   const { diff, siblingDiffs } = props;
   const getDiffPath = useGetDiffPath();
   const metadata = resolveDiffMetadata(diff);
-  const storyModes = getUniqueStoryModes(
-    siblingDiffs.map(resolveDiffMetadata).filter(checkIsNonNullable),
-  );
-  if (storyModes.length < 2) {
+  const siblingMetadata = siblingDiffs
+    .map(resolveDiffMetadata)
+    .filter(checkIsNonNullable);
+  const storyModes = getUniqueStoryModes(siblingMetadata);
+  // Modes named after the scheme they set are the same choice twice over, and
+  // the color scheme switcher is the one that reads without a legend. It is
+  // always there to take over: a mode that spells its scheme out cannot offer
+  // two values without the schemes differing too.
+  if (storyModes.length < 2 || storyModeRestatesColorScheme(siblingMetadata)) {
     return null;
   }
   const activeMode = metadata?.story?.mode ?? null;


### PR DESCRIPTION
A Storybook mode is commonly named after the scheme it sets, and the SDK records both — so the toolbar carried two switchers and four buttons for one binary choice, and both of them landed on the same snapshots.

Judged on the names rather than on how the two axes cut the snapshots up: a `mobile`/`desktop` pair can line up one-to-one with `light`/`dark` by accident of the matrix, and dropping it on that evidence would take away the labels that tell the reviewer what they are looking at. The mode stays stated in the Metadata panel either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)